### PR TITLE
Attribution button stretch fix

### DIFF
--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/AttributionButton.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/AttributionButton.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.absolutePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -118,11 +119,11 @@ public fun AttributionButton(
       val density = LocalDensity.current
       var alignLeft by remember { mutableStateOf(false) }
       var alignTop by remember { mutableStateOf(false) }
-      var popupWidth by remember { mutableStateOf(Dp.Unspecified) }
-      val popupPositionProvider = SuperimposingPopupPositionProvider { left, top, width ->
+      var maxPopupWidth by remember { mutableStateOf(Dp.Unspecified) }
+      val popupPositionProvider = SuperimposingPopupPositionProvider { left, top, maxWidth ->
         alignLeft = left
         alignTop = top
-        popupWidth = with(density) { width.toDp() }
+        maxPopupWidth = with(density) { maxWidth.toDp() }
       }
       val verticalAlignment = if (alignTop) Alignment.Top else Alignment.Bottom
       val horizontalArrangement =
@@ -137,7 +138,7 @@ public fun AttributionButton(
       ) {
         AnimatedVisibility(
           modifier =
-            Modifier.widthIfSpecified(popupWidth).paddingEndOfPopup(popupEndPadding, alignLeft),
+            Modifier.widthIn(max = maxPopupWidth).paddingEndOfPopup(popupEndPadding, alignLeft),
           visibleState = expanded,
           enter = fadeIn(),
           exit = fadeOut(),
@@ -184,9 +185,6 @@ public fun AttributionButton(
 
 private fun Modifier.paddingEndOfPopup(padding: Dp, alignLeft: Boolean) =
   if (alignLeft) absolutePadding(right = padding) else absolutePadding(left = padding)
-
-private fun Modifier.widthIfSpecified(width: Dp) =
-  if (width != Dp.Unspecified) width(width) else this
 
 @Composable
 private fun InfoIcon(modifier: Modifier = Modifier) {

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/SuperimposingPopupPositionProvider.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/SuperimposingPopupPositionProvider.kt
@@ -6,7 +6,6 @@ import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.window.PopupPositionProvider
-import kotlin.math.absoluteValue
 
 /**
  * Places the popup on top of the anchor, superimposing it. I.e. not like a tooltip next to the
@@ -18,7 +17,7 @@ import kotlin.math.absoluteValue
  */
 @Immutable
 internal class SuperimposingPopupPositionProvider(
-  private val onAlignment: (alignLeft: Boolean, alignTop: Boolean, popupWidth: Int) -> Unit =
+  private val onAlignment: (alignLeft: Boolean, alignTop: Boolean, maxWidth: Int) -> Unit =
     { _, _, _ ->
     }
 ) : PopupPositionProvider {
@@ -38,12 +37,10 @@ internal class SuperimposingPopupPositionProvider(
         y = if (alignTop) anchorBounds.top else anchorBounds.bottom - popupContentSize.height,
       )
 
-    val overflow =
-      if (alignLeft) (position.x + popupContentSize.width - windowSize.width).coerceAtLeast(0)
-      else position.x.coerceAtMost(0).absoluteValue
+    val offset = if (alignLeft) anchorBounds.left else windowSize.width - anchorBounds.right
+    val maxWidth = windowSize.width - offset
 
-    val popupWidth = popupContentSize.width - overflow
-    onAlignment(alignLeft, alignTop, popupWidth)
+    onAlignment(alignLeft, alignTop, maxWidth)
     return position
   }
 }


### PR DESCRIPTION
<!-- Thanks for the PR! Please fill out the template below. -->

## Description

Marges into #293

Fixes https://github.com/maplibre/maplibre-compose/pull/293#issuecomment-2888529761

It wasn't a compose bug as I initially thought, and it was happening both on Android and iOS. It occurred on iOS, because of a different screen size. It was actually a rare case when the popup's width was larger than the screen, but not large enough to properly break line. In short. Because we were setting the width which was calculated in `SuperimposingPopupPositionProvider` based on the content size, it couldn't properly update it.

This PR fixes this.

There is a small issue with this that I couldn't figure out how to fix, but it's not a big deal, I guess. When opening a map, sometimes for a split second, you can see a change in the popup from 1 line to 2 lines.

https://github.com/user-attachments/assets/32af3036-60dd-46f7-8f22-2e8d71b41d1f

It happens in the same case as above (again, a rare case, but you will see it when you open the demo app on iPhone 16 Pro Simulator). This time it happens only on iOS.

## Test plan

Ideally check it on different screen sizes

## Checklist

This pull request primarily:

- [ ] Updates documentation.
- [x] Fixes a bug. (please link to the issue)
- [ ] Adds a feature. (please link to the issue or discussion)

<!-- If you're just updating documentation, delete the rest of this checklist. -->

To your knowledge, are you making any breaking changes?

- [ ] Yes (please describe)
- [x] No

Do you have access to a macOS device to develop and test iOS changes?

- [x] Yes
- [ ] No

Have you tested the changes, if applicable? On which platforms?

- [x] Android (describe the device and OS version)
- [x] iOS (describe the device and OS version)
- [ ] Desktop (describe the device and OS version)
- [ ] Web (describe the browser version)
