### PR TITLE
feat: overhaul scale bar measure api with alchemist library

### DIFF
--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/LocalTilesDemo.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/LocalTilesDemo.kt
@@ -17,6 +17,8 @@ import dev.sargunv.maplibrecompose.demoapp.DemoScaffold
 import dev.sargunv.maplibrecompose.demoapp.generated.Res
 import dev.sargunv.maplibrecompose.material3.controls.ScaleBarMeasure
 import dev.sargunv.maplibrecompose.material3.controls.ScaleBarMeasures
+import io.github.kevincianfarini.alchemist.scalar.kilometers
+import io.github.kevincianfarini.alchemist.unit.LengthUnit
 
 object LocalTilesDemo : Demo {
   override val name = "Local Tiles"
@@ -51,14 +53,21 @@ object LocalTilesDemo : Demo {
 
             RasterLayer(id = "fantasy-map", source = tiles)
           }
-          DemoMapControls(cameraState, styleState, scaleBarMeasures = ScaleBarMeasures(FakeMetric))
+          DemoMapControls(
+            cameraState,
+            styleState,
+            scaleBarMeasures = ScaleBarMeasures(LeaguesMeasure),
+          )
         }
       }
     }
   }
 }
 
-data object FakeMetric : ScaleBarMeasure by ScaleBarMeasure.Metric {
-  // hack to scale it down for the fantasy map
-  override val unitInMeters: Double = 20.0
+data object League : LengthUnit {
+  // roman league (2.22km) scaled 20x to better fit the map data
+  override val nanometerScale = (2.22.kilometers * 20).toLong(LengthUnit.International.Nanometer)
+  override val symbol = "lea"
 }
+
+data object LeaguesMeasure : ScaleBarMeasure.Default(League)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,7 @@
 # https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-compatibility-and-versioning.html#jetpack-compose-artifacts-used
 
 [versions]
+alchemist = "0.2.0"
 androidx-activity = "1.10.1"
 androidx-composeUi = "1.8.1"
 androidx-navigation = "2.9.0-beta01"
@@ -33,6 +34,7 @@ gradle-spotless = "7.0.3"
 tool-prettier = "3.5.3"
 
 [libraries]
+alchemist = { module = "io.github.kevincianfarini.alchemist:alchemist", version.ref = "alchemist" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
 androidx-composeUi-testManifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "androidx-composeUi" }
 androidx-navigation-compose = { module = "org.jetbrains.androidx.navigation:navigation-compose", version.ref = "androidx-navigation" }

--- a/lib/maplibre-compose-material3/build.gradle.kts
+++ b/lib/maplibre-compose-material3/build.gradle.kts
@@ -45,6 +45,7 @@ kotlin {
 
   sourceSets {
     commonMain.dependencies {
+      api(libs.alchemist)
       implementation(compose.material3)
       implementation(compose.components.resources)
       api(project(":lib:maplibre-compose"))

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/ScaleBar.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/ScaleBar.kt
@@ -24,6 +24,9 @@ import dev.sargunv.maplibrecompose.material3.backgroundColorFor
 import dev.sargunv.maplibrecompose.material3.defaultScaleBarMeasures
 import dev.sargunv.maplibrecompose.material3.drawPathsWithHalo
 import dev.sargunv.maplibrecompose.material3.drawTextWithHalo
+import io.github.kevincianfarini.alchemist.scalar.meters
+import io.github.kevincianfarini.alchemist.type.Length
+import io.github.kevincianfarini.alchemist.unit.LengthUnit
 import kotlin.math.ceil
 import kotlin.math.roundToInt
 
@@ -109,7 +112,7 @@ public fun ScaleBar(
       val alignmentSpacePx = ceil(size.width - fullStrokeWidthPx).toInt()
 
       if (true) { // just want a scope here
-        val barLengthPx = params1.barLength.toPx().roundToInt()
+        val barLengthPx = params1.barWidth.toPx().roundToInt()
         val offsetX =
           alignment.align(
             size = barLengthPx,
@@ -135,7 +138,7 @@ public fun ScaleBar(
       }
 
       if (params2 != null) {
-        val barLengthPx = params2.barLength.toPx().roundToInt()
+        val barLengthPx = params2.barWidth.toPx().roundToInt()
         val offsetX =
           alignment.align(
             size = barLengthPx,
@@ -189,7 +192,7 @@ public fun ScaleBar(
   }
 }
 
-private data class ScaleBarParams(val barLength: Dp, val text: String)
+private data class ScaleBarParams(val barWidth: Dp, val text: String)
 
 @Composable
 private fun scaleBarParameters(
@@ -197,16 +200,17 @@ private fun scaleBarParameters(
   metersPerDp: Double,
   maxBarLength: Dp,
 ): ScaleBarParams {
-  val max = maxBarLength.value * metersPerDp / measure.unitInMeters
+  val max = metersPerDp.meters * maxBarLength.value.toDouble()
   val stop = findStop(max, measure.stops)
-  return ScaleBarParams((stop * measure.unitInMeters / metersPerDp).dp, measure.getText(stop))
+  val stopMeters = stop.toDouble(LengthUnit.International.Meter)
+  return ScaleBarParams(barWidth = (stopMeters / metersPerDp).dp, text = measure.getText(stop))
 }
 
 /**
  * find the largest stop in the list of stops (sorted in ascending order) that is below or equal
  * [max].
  */
-private fun findStop(max: Double, stops: List<Double>): Double {
+private fun findStop(max: Length, stops: List<Length>): Length {
   val i = stops.binarySearch { it.compareTo(max) }
   return if (i >= 0) stops[i] else stops[(-i - 2).coerceAtLeast(0)]
 }

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/ScaleBar.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/ScaleBar.kt
@@ -212,5 +212,7 @@ private fun scaleBarParameters(
  */
 private fun findStop(max: Length, stops: List<Length>): Length {
   val i = stops.binarySearch { it.compareTo(max) }
+  // i is the inverted insertion point if the value is not found
+  // -i - 2 inverts it back
   return if (i >= 0) stops[i] else stops[(-i - 2).coerceAtLeast(0)]
 }

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/ScaleBarMeasure.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/ScaleBarMeasure.kt
@@ -7,86 +7,136 @@ import dev.sargunv.maplibrecompose.material3.generated.kilometers_symbol
 import dev.sargunv.maplibrecompose.material3.generated.meters_symbol
 import dev.sargunv.maplibrecompose.material3.generated.miles_symbol
 import dev.sargunv.maplibrecompose.material3.generated.yards_symbol
+import io.github.kevincianfarini.alchemist.scalar.centimeters
+import io.github.kevincianfarini.alchemist.scalar.kilometers
+import io.github.kevincianfarini.alchemist.scalar.toLength
+import io.github.kevincianfarini.alchemist.type.Length
+import io.github.kevincianfarini.alchemist.unit.LengthUnit
+import io.github.kevincianfarini.alchemist.unit.LengthUnit.International.Kilometer
+import io.github.kevincianfarini.alchemist.unit.LengthUnit.International.Meter
+import io.github.kevincianfarini.alchemist.unit.LengthUnit.UnitedStatesCustomary.Foot
+import io.github.kevincianfarini.alchemist.unit.LengthUnit.UnitedStatesCustomary.Mile
+import io.github.kevincianfarini.alchemist.unit.LengthUnit.UnitedStatesCustomary.Yard
 import kotlin.math.pow
 import org.jetbrains.compose.resources.stringResource
 
-/** A measure to show in the scale bar */
+/** A measurement system to show in the scale bar. */
 public interface ScaleBarMeasure {
-  /** one unit of this measure in meters */
-  public val unitInMeters: Double
+  /**
+   * List of stops, sorted ascending, at which the scalebar should show. For best results, each stop
+   * should be no more than 2.5x times as big as the one before.
+   */
+  public val stops: List<Length>
 
-  /** List of stops, sorted ascending, at which the scalebar should show */
-  public val stops: List<Double>
+  /** Get the formatted text to show for a given stop. */
+  @Composable public fun getText(stop: Length): String
 
-  @Composable public fun getText(stop: Double): String
+  /**
+   * A scale bar measurement system that generates stops based on given units and m * 10^e.
+   *
+   * For example, if the units are [Meter, Kilometer] and the mantissas are [1, 2, 5], the stops
+   * will be: 0.1m, 0.2m, 0.5m, 1m, 2m, 5m, 10m, 20m, 50m, 100m, 200m, 500m, 1km, 2km, 5km, 10km,
+   * ...
+   *
+   * @param units the units to generate stops for.
+   * @param mantissas the mantissas to generate stops for. Must be single digit positive integers.
+   */
+  public open class Default(
+    units: Set<LengthUnit>,
+    mantissas: Set<Int> = setOf(1, 2, 5),
+    lowerBound: Length = 100.centimeters,
+    upperBound: Length = 50000.kilometers,
+  ) : ScaleBarMeasure {
 
-  /** A measure of meters and kilometers */
-  public data object Metric : ScaleBarMeasure {
-    override val unitInMeters: Double = 1.0
+    public constructor(vararg units: LengthUnit) : this(units.toSet())
 
-    override val stops: List<Double> = buildStops(mantissas = listOf(1, 2, 5), exponents = -1..7)
+    init {
+      require(units.isNotEmpty()) { "At least one unit must be provided" }
+      require(mantissas.isNotEmpty()) { "At least one mantissa must be provided" }
+      require(mantissas.all { it in 1..<10 }) { "Mantissas must be single digit positive integers" }
+    }
+
+    private val sortedUnits = units.sortedBy { it.nanometerScale }
+    private val sortedMantissas = mantissas.sorted()
+
+    override val stops: List<Length> = buildList {
+      // select the largest e that results in a stop below the lower bound
+      val firstE =
+        (0 downTo Int.MIN_VALUE).first { e ->
+          sortedMantissas.first().toLength(sortedUnits.first()) * 10.0.pow(e) <= lowerBound
+        }
+
+      // generate stops, switching units when the next larger unit is reached
+      val unboundedStops = sequence {
+        sortedUnits.forEachIndexed { i, unit ->
+          val unitStops = sequence {
+            val e1 = if (i > 0) 0 else firstE
+            for (e in e1..<Int.MAX_VALUE) {
+              for (m in sortedMantissas) yield((m * 10.0.pow(e)).toLength(unit))
+            }
+          }
+
+          val threshold = sortedUnits.getOrNull(i + 1)?.let { sortedMantissas.first().toLength(it) }
+          unitStops.takeWhile { threshold == null || it < threshold }.forEach { yield(it) }
+        }
+      }
+
+      // take stops until the upper bound
+      unboundedStops.takeWhile { it <= upperBound }.forEach { add(it) }
+    }
 
     @Composable
-    override fun getText(stop: Double): String =
-      if (stop >= 1000) {
-        (stop / 1000).formatForDisplay(stringResource(Res.string.kilometers_symbol))
-      } else {
-        stop.formatForDisplay(stringResource(Res.string.meters_symbol))
-      }
-  }
+    final override fun getText(stop: Length): String {
+      val unit = sortedUnits.lastOrNull { 1.toLength(it) <= stop } ?: sortedUnits.last()
+      return getText(stop.toDouble(unit), unit)
+    }
 
-  /** A measure of international feet and miles */
-  public data object FeetAndMiles : ScaleBarMeasure {
-
-    private const val FEET_IN_MILE: Int = 5280
-
-    override val unitInMeters: Double = 0.3048
-
-    override val stops: List<Double> =
-      listOf(
-          buildStops(mantissas = listOf(1, 2, 5), exponents = -1..3).dropLast(1),
-          buildStops(mantissas = listOf(1, 2, 5), exponents = 0..4).map { it * FEET_IN_MILE },
-        )
-        .flatten()
-
+    /** Get the formatted text to show for a given generated stop and length. */
     @Composable
-    override fun getText(stop: Double): String =
-      if (stop >= FEET_IN_MILE) {
-        (stop / FEET_IN_MILE).formatForDisplay(stringResource(Res.string.miles_symbol))
-      } else {
-        stop.formatForDisplay(stringResource(Res.string.feet_symbol))
-      }
+    protected open fun getText(stop: Double, unit: LengthUnit): String =
+      "${stop.toShortString()}\u202F${unit.symbol}"
+
+    /** Stringify a [Double], removing the decimal point if it's a whole number. */
+    protected fun Double.toShortString(): String =
+      if (this % 1.0 == 0.0) this.toLong().toString() else this.toString()
   }
 
-  /** A measure of international yard and miles */
-  public data object YardsAndMiles : ScaleBarMeasure {
-
-    private const val YARDS_IN_MILE: Int = 1760
-
-    override val unitInMeters: Double = 0.9144
-
-    override val stops: List<Double> =
-      listOf(
-          buildStops(mantissas = listOf(1, 2, 5), exponents = -1..3).dropLast(2),
-          buildStops(mantissas = listOf(1, 2, 5), exponents = 0..4).map { it * YARDS_IN_MILE },
-        )
-        .flatten()
-
+  public data object Metric : Default(Meter, Kilometer) {
     @Composable
-    override fun getText(stop: Double): String =
-      if (stop >= YARDS_IN_MILE) {
-        (stop / YARDS_IN_MILE).formatForDisplay(stringResource(Res.string.miles_symbol))
-      } else {
-        stop.formatForDisplay(stringResource(Res.string.yards_symbol))
-      }
+    override fun getText(stop: Double, unit: LengthUnit): String {
+      val symbol =
+        when (unit) {
+          Meter -> stringResource(Res.string.meters_symbol)
+          Kilometer -> stringResource(Res.string.kilometers_symbol)
+          else -> error("impossible")
+        }
+      return "${stop.toShortString()}\u202F$symbol"
+    }
   }
-}
 
-/** format a number with a unit symbol, not showing the decimal point if it's an integer */
-private fun Double.formatForDisplay(symbol: String) =
-  if (this.toInt().toDouble() == this) "${this.toInt()} $symbol" else "${this} $symbol"
+  public data object FeetAndMiles : Default(Foot, Mile) {
+    @Composable
+    override fun getText(stop: Double, unit: LengthUnit): String {
+      val symbol =
+        when (unit) {
+          Foot -> stringResource(Res.string.feet_symbol)
+          Mile -> stringResource(Res.string.miles_symbol)
+          else -> error("impossible")
+        }
+      return "${stop.toShortString()}\u202F$symbol"
+    }
+  }
 
-/** build a list of stops by multiplying mantissas by 10^exponents, like scientific notation */
-private fun buildStops(mantissas: List<Int>, exponents: IntRange) = buildList {
-  for (e in exponents) for (m in mantissas) add(m * 10.0.pow(e))
+  public data object YardsAndMiles : Default(Yard, Mile) {
+    @Composable
+    override fun getText(stop: Double, unit: LengthUnit): String {
+      val symbol =
+        when (unit) {
+          Yard -> stringResource(Res.string.yards_symbol)
+          Mile -> stringResource(Res.string.miles_symbol)
+          else -> error("impossible")
+        }
+      return "${stop.toShortString()}\u202F$symbol"
+    }
+  }
 }


### PR DESCRIPTION


based on #234, but only the material3 part; not pulling this library into core rn.

This overhauls the `ScaleBarMeasure` interface to support `Length` units from [alchemist](https://github.com/kevincianfarini/alchemist). As a demo, I also updated the local tiles (fantasy map) demo with a fictional unit.