### PR TITLE
fix: update style state for programmatic styles

### DIFF
--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/LocalTilesDemo.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/LocalTilesDemo.kt
@@ -48,7 +48,13 @@ object LocalTilesDemo : Demo {
                     Res.getUri("files/data/fantasy-map/0/0-0-fs8.png")
                       .replace("0/0-0", "{z}/{x}-{y}")
                   ),
-                options = TileSetOptions(minZoom = 0, maxZoom = 4),
+                options =
+                  TileSetOptions(
+                    minZoom = 0,
+                    maxZoom = 4,
+                    attributionHtml =
+                      """<a href="https://watabou.github.io/realm.html">Procgen Arena</a>""",
+                  ),
               )
 
             RasterLayer(id = "fantasy-map", source = tiles)

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/MaplibreMap.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/MaplibreMap.kt
@@ -116,7 +116,7 @@ public fun MaplibreMap(
           map as StandardMaplibreMap
           rememberedStyle?.unload()
           val safeStyle = style?.let { SafeStyle(it) }
-          styleState.attach(safeStyle)
+          styleState.updateSources()
           rememberedStyle = safeStyle
           cameraState.metersPerDpAtTargetState.value =
             map.metersPerDpAtLatitude(map.getCameraPosition().target.latitude)
@@ -195,6 +195,7 @@ public fun MaplibreMap(
       when (map) {
         is StandardMaplibreMap -> {
           cameraState.map = map
+          styleState.attach(styleComposition)
           map.setDebugEnabled(isDebugEnabled)
           map.setMinZoom(zoomRange.start.toDouble())
           map.setMaxZoom(zoomRange.endInclusive.toDouble())
@@ -220,6 +221,7 @@ public fun MaplibreMap(
     },
     onReset = {
       cameraState.map = null
+      styleState.attach(null)
       rememberedStyle = null
     },
     logger = logger,

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/StyleState.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/StyleState.kt
@@ -3,7 +3,7 @@ package dev.sargunv.maplibrecompose.compose
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import dev.sargunv.maplibrecompose.core.Style
+import dev.sargunv.maplibrecompose.compose.engine.StyleNode
 import dev.sargunv.maplibrecompose.core.source.Source
 
 /** Remember a new [StyleState]. */
@@ -14,22 +14,24 @@ public fun rememberStyleState(): StyleState {
 
 /** Use this class to access information about the style, such as sources and layers. */
 public class StyleState internal constructor() {
-  private var style: Style? = null
+  private var styleNode: StyleNode? = null
 
   public val sources: List<Source>
     get() = sourcesState.value
 
   private val sourcesState = mutableStateOf(emptyList<Source>())
 
-  internal fun attach(style: Style?) {
-    if (this.style != style) {
-      this.style = style
+  internal fun attach(styleNode: StyleNode?) {
+    if (this.styleNode != styleNode) {
+      this.styleNode?.onEndChangesCallback = null
+      this.styleNode = styleNode
+      this.styleNode?.onEndChangesCallback = { updateSources() }
       updateSources()
     }
   }
 
   internal fun updateSources() {
-    sourcesState.value = style?.getSources().orEmpty()
+    sourcesState.value = styleNode?.style?.getSources().orEmpty()
   }
 
   /**
@@ -38,5 +40,5 @@ public class StyleState internal constructor() {
    * @param id The ID of the source to retrieve.
    * @return The source with the specified ID, or null if no such source exists.
    */
-  public fun getSource(id: String): Source? = style?.getSource(id)
+  public fun getSource(id: String): Source? = styleNode?.style?.getSource(id)
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/engine/StyleNode.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/engine/StyleNode.kt
@@ -9,6 +9,8 @@ internal class StyleNode(var style: SafeStyle, internal var logger: Logger?) : M
   internal val layerManager = LayerManager(this)
   internal val imageManager = ImageManager(this)
 
+  internal var onEndChangesCallback: (() -> Unit)? = null
+
   override fun allowsChild(node: MapNode) = node is LayerNode<*>
 
   override fun onChildRemoved(oldIndex: Int, node: MapNode) {
@@ -29,5 +31,6 @@ internal class StyleNode(var style: SafeStyle, internal var logger: Logger?) : M
   override fun onEndChanges() {
     sourceManager.applyChanges()
     layerManager.applyChanges()
+    onEndChangesCallback?.invoke()
   }
 }


### PR DESCRIPTION
Fixes #353 

I added attribution to the local tile set, and noticed the style state wasn't updating for sources added via the style composition; only from the base style.