### PR TITLE
fix: work around native crash with retrieving ios attribution info during rotation

### DIFF
--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/source/Source.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/source/Source.kt
@@ -8,13 +8,13 @@ public actual sealed class Source {
   internal abstract val impl: MLNSource
   internal actual val id: String by lazy { impl.identifier }
 
-  public actual val attributionLinks: List<AttributionLink>
-    get() =
-      (impl as? MLNTileSource)?.attributionInfos?.mapNotNull {
-        it as MLNAttributionInfo
-        if (it.URL == null) return@mapNotNull null
-        AttributionLink(title = it.title.string(), url = it.URL.toString())
-      } ?: emptyList()
+  public actual val attributionLinks: List<AttributionLink> by lazy {
+    (impl as? MLNTileSource)?.attributionInfos?.mapNotNull {
+      it as MLNAttributionInfo
+      if (it.URL == null) return@mapNotNull null
+      AttributionLink(title = it.title.string(), url = it.URL.toString())
+    } ?: emptyList()
+  }
 
   override fun toString(): String = "${this::class.simpleName}(id=\"$id\")"
 }


### PR DESCRIPTION
fix #355 by just caching the attribution links (we already do this on android)

still unsure of the root cause