### PR TITLE
Add pointer pin widget

### DIFF
--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/CameraFollowDemo.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/CameraFollowDemo.kt
@@ -95,20 +95,13 @@ object CameraFollowDemo : Demo {
               )
             }
           }
-          // TODO, urgh, this is ugly... why can't this just return null if the map is not available
-          //  yet?? awaitInitialized() doesn't really help, I'm in the middle of the composition
-          //  here after all...
-          val targetPosition =
-            try {
-              cameraState.screenLocationFromPosition(animatedPosition)
-            } catch (_: Exception) {
-              null
-            }
 
-          if (targetPosition != null) {
-            PointerPinButton(onClick = { isFollowing = true }, targetPosition = targetPosition) {
-              Text("🚊", fontSize = 28.sp)
-            }
+          PointerPinButton(
+            cameraState = cameraState,
+            targetPosition = animatedPosition,
+            onClick = { isFollowing = true },
+          ) {
+            Text("🚊", fontSize = 28.sp)
           }
 
           DemoMapControls(

--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/CameraFollowDemo.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/CameraFollowDemo.kt
@@ -5,6 +5,7 @@ import androidx.compose.animation.core.animateValue
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -25,6 +26,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import dev.sargunv.maplibrecompose.compose.CameraState
 import dev.sargunv.maplibrecompose.compose.MaplibreMap
 import dev.sargunv.maplibrecompose.compose.layer.CircleLayer
@@ -41,11 +43,15 @@ import dev.sargunv.maplibrecompose.demoapp.DemoOrnamentSettings
 import dev.sargunv.maplibrecompose.demoapp.DemoScaffold
 import dev.sargunv.maplibrecompose.demoapp.Platform
 import dev.sargunv.maplibrecompose.demoapp.PositionVectorConverter
+import dev.sargunv.maplibrecompose.demoapp.generated.Res
+import dev.sargunv.maplibrecompose.demoapp.generated.info
 import dev.sargunv.maplibrecompose.demoapp.supportsLayers
 import dev.sargunv.maplibrecompose.expressions.dsl.const
 import dev.sargunv.maplibrecompose.expressions.dsl.offset
+import dev.sargunv.maplibrecompose.material3.controls.PointerPinButton
 import io.github.dellisd.spatialk.geojson.Point
 import io.github.dellisd.spatialk.geojson.Position
+import org.jetbrains.compose.resources.painterResource
 import kotlin.math.roundToInt
 
 private val START_POINT = Position(longitude = -122.4194, latitude = 37.7749)
@@ -93,6 +99,22 @@ object CameraFollowDemo : Demo {
               )
             }
           }
+          // TODO, urgh, this is ugly... why can't this just return null if the map is not available
+          //  yet?? awaitInitialized() doesn't really help, I'm in the middle of the composition
+          //  here after all...
+          val targetPosition = try {
+            cameraState.screenLocationFromPosition(animatedPosition)
+          } catch (_: Exception) { null }
+
+          if (targetPosition != null) {
+            PointerPinButton(
+              onClick = { isFollowing = true },
+              targetPosition = targetPosition,
+            ) {
+              Text("🚊", fontSize = 28.sp)
+            }
+          }
+
           DemoMapControls(
             cameraState,
             styleState,

--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/CameraFollowDemo.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/CameraFollowDemo.kt
@@ -5,7 +5,6 @@ import androidx.compose.animation.core.animateValue
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -43,15 +42,12 @@ import dev.sargunv.maplibrecompose.demoapp.DemoOrnamentSettings
 import dev.sargunv.maplibrecompose.demoapp.DemoScaffold
 import dev.sargunv.maplibrecompose.demoapp.Platform
 import dev.sargunv.maplibrecompose.demoapp.PositionVectorConverter
-import dev.sargunv.maplibrecompose.demoapp.generated.Res
-import dev.sargunv.maplibrecompose.demoapp.generated.info
 import dev.sargunv.maplibrecompose.demoapp.supportsLayers
 import dev.sargunv.maplibrecompose.expressions.dsl.const
 import dev.sargunv.maplibrecompose.expressions.dsl.offset
 import dev.sargunv.maplibrecompose.material3.controls.PointerPinButton
 import io.github.dellisd.spatialk.geojson.Point
 import io.github.dellisd.spatialk.geojson.Position
-import org.jetbrains.compose.resources.painterResource
 import kotlin.math.roundToInt
 
 private val START_POINT = Position(longitude = -122.4194, latitude = 37.7749)
@@ -102,15 +98,15 @@ object CameraFollowDemo : Demo {
           // TODO, urgh, this is ugly... why can't this just return null if the map is not available
           //  yet?? awaitInitialized() doesn't really help, I'm in the middle of the composition
           //  here after all...
-          val targetPosition = try {
-            cameraState.screenLocationFromPosition(animatedPosition)
-          } catch (_: Exception) { null }
+          val targetPosition =
+            try {
+              cameraState.screenLocationFromPosition(animatedPosition)
+            } catch (_: Exception) {
+              null
+            }
 
           if (targetPosition != null) {
-            PointerPinButton(
-              onClick = { isFollowing = true },
-              targetPosition = targetPosition,
-            ) {
+            PointerPinButton(onClick = { isFollowing = true }, targetPosition = targetPosition) {
               Text("🚊", fontSize = 28.sp)
             }
           }

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/Dp.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/Dp.kt
@@ -13,5 +13,4 @@ internal fun Offset.toDpOffset(): DpOffset =
 
 @Composable
 @ReadOnlyComposable
-internal fun DpOffset.toOffset(): Offset =
-  with(LocalDensity.current) { Offset(x.toPx(), y.toPx()) }
+internal fun DpOffset.toOffset(): Offset = with(LocalDensity.current) { Offset(x.toPx(), y.toPx()) }

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/Dp.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/Dp.kt
@@ -1,0 +1,17 @@
+package dev.sargunv.maplibrecompose.material3
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.DpOffset
+
+@Composable
+@ReadOnlyComposable
+internal fun Offset.toDpOffset(): DpOffset =
+  with(LocalDensity.current) { DpOffset(x.toDp(), y.toDp()) }
+
+@Composable
+@ReadOnlyComposable
+internal fun DpOffset.toOffset(): Offset =
+  with(LocalDensity.current) { Offset(x.toPx(), y.toPx()) }

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/Intersection.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/Intersection.kt
@@ -1,0 +1,31 @@
+package dev.sargunv.maplibrecompose.material3
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import kotlin.math.PI
+import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.sin
+import kotlin.math.sqrt
+
+/**
+ * Given an imaginary line drawn from the center of [screen] to [target], returns the point and
+ * angle at which the line intersects with an ellipsis filling the [screen].
+ */
+internal fun findEllipsisIntersection(screen: Rect, target: Offset): Intersection? {
+  val delta = target - screen.center
+  val theta = atan2(delta.y, delta.x) + PI / 2
+  val radius = ellipsisRadius(screen.height / 2.0, screen.width / 2.0, theta)
+  val ellipsisDelta = Offset((sin(theta) * radius).toFloat(), (-cos(theta) * radius).toFloat())
+  if (delta.getDistanceSquared() < ellipsisDelta.getDistanceSquared()) return null
+
+  return Intersection(ellipsisDelta + screen.center, theta)
+}
+
+private fun ellipsisRadius(a: Double, b: Double, angle: Double): Double {
+  val x = sin(angle)
+  val y = cos(angle)
+  return a * b / sqrt(a * a * x * x + b * b * y * y)
+}
+
+internal data class Intersection(val position: Offset, val angle: Double)

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/Intersection.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/Intersection.kt
@@ -9,17 +9,17 @@ import kotlin.math.sin
 import kotlin.math.sqrt
 
 /**
- * Given an imaginary line drawn from the center of [screen] to [target], returns the point and
- * angle at which the line intersects with an ellipsis filling the [screen].
+ * Given an imaginary line drawn from the center of [area] to [target], returns the point and angle
+ * at which the line intersects with an ellipsis filling the [area].
  */
-internal fun findEllipsisIntersection(screen: Rect, target: Offset): Intersection? {
-  val delta = target - screen.center
+internal fun findEllipsisIntersection(area: Rect, target: Offset): Intersection? {
+  val delta = target - area.center
   val theta = atan2(delta.y, delta.x) + PI / 2
-  val radius = ellipsisRadius(screen.height / 2.0, screen.width / 2.0, theta)
+  val radius = ellipsisRadius(area.height / 2.0, area.width / 2.0, theta)
   val ellipsisDelta = Offset((sin(theta) * radius).toFloat(), (-cos(theta) * radius).toFloat())
   if (delta.getDistanceSquared() < ellipsisDelta.getDistanceSquared()) return null
 
-  return Intersection(ellipsisDelta + screen.center, theta)
+  return Intersection(ellipsisDelta + area.center, theta)
 }
 
 private fun ellipsisRadius(a: Double, b: Double, angle: Double): Double {

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/Modifier.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/Modifier.kt
@@ -1,0 +1,46 @@
+package dev.sargunv.maplibrecompose.material3
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.layout
+
+/** set padding proportional to the composable's size */
+internal fun Modifier.proportionalPadding(
+  start: Float = 0f,
+  top: Float = 0f,
+  end: Float = 0f,
+  bottom: Float = 0f
+) = layout { measurable, constraints ->
+  val placeable = measurable.measure(constraints)
+  val width = placeable.width
+  val height = placeable.height
+  val startPad = (start * width).toInt()
+  val endPad = (end * width).toInt()
+  val topPad = (top * height).toInt()
+  val bottomPad = (bottom * height).toInt()
+  layout(
+    width = width + startPad + endPad,
+    height = height + topPad + bottomPad,
+  ) {
+    placeable.placeRelative(x = startPad, y = topPad)
+  }
+}
+
+/** set padding proportional to the composable's size */
+internal fun Modifier.proportionalPadding(all: Float = 0f) =
+  proportionalPadding(all, all, all, all)
+
+/** set absolute offset proportional to the composable's size */
+internal fun Modifier.proportionalAbsoluteOffset(
+  x: Float = 0f,
+  y: Float = 0f
+) = layout { measurable, constraints ->
+  val placeable = measurable.measure(constraints)
+  val width = placeable.width
+  val height = placeable.height
+  layout(width, height) {
+    placeable.place(
+      x = (x * width).toInt(),
+      y = (y * height).toInt()
+    )
+  }
+}

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/Modifier.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/Modifier.kt
@@ -8,7 +8,7 @@ internal fun Modifier.proportionalPadding(
   start: Float = 0f,
   top: Float = 0f,
   end: Float = 0f,
-  bottom: Float = 0f
+  bottom: Float = 0f,
 ) = layout { measurable, constraints ->
   val placeable = measurable.measure(constraints)
   val width = placeable.width
@@ -17,30 +17,19 @@ internal fun Modifier.proportionalPadding(
   val endPad = (end * width).toInt()
   val topPad = (top * height).toInt()
   val bottomPad = (bottom * height).toInt()
-  layout(
-    width = width + startPad + endPad,
-    height = height + topPad + bottomPad,
-  ) {
+  layout(width = width + startPad + endPad, height = height + topPad + bottomPad) {
     placeable.placeRelative(x = startPad, y = topPad)
   }
 }
 
 /** set padding proportional to the composable's size */
-internal fun Modifier.proportionalPadding(all: Float = 0f) =
-  proportionalPadding(all, all, all, all)
+internal fun Modifier.proportionalPadding(all: Float = 0f) = proportionalPadding(all, all, all, all)
 
 /** set absolute offset proportional to the composable's size */
-internal fun Modifier.proportionalAbsoluteOffset(
-  x: Float = 0f,
-  y: Float = 0f
-) = layout { measurable, constraints ->
-  val placeable = measurable.measure(constraints)
-  val width = placeable.width
-  val height = placeable.height
-  layout(width, height) {
-    placeable.place(
-      x = (x * width).toInt(),
-      y = (y * height).toInt()
-    )
+internal fun Modifier.proportionalAbsoluteOffset(x: Float = 0f, y: Float = 0f) =
+  layout { measurable, constraints ->
+    val placeable = measurable.measure(constraints)
+    val width = placeable.width
+    val height = placeable.height
+    layout(width, height) { placeable.place(x = (x * width).toInt(), y = (y * height).toInt()) }
   }
-}

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/PointerPinButton.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/PointerPinButton.kt
@@ -1,0 +1,159 @@
+package dev.sargunv.maplibrecompose.material3.controls
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.interaction.Interaction
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.absoluteOffset
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ButtonColors
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ButtonElevation
+import androidx.compose.material3.ColorScheme
+import androidx.compose.material3.ElevatedButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Matrix
+import androidx.compose.ui.graphics.Outline
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.vector.PathParser
+import androidx.compose.ui.graphics.vector.toPath
+import androidx.compose.ui.layout.boundsInParent
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import dev.sargunv.maplibrecompose.material3.findEllipsisIntersection
+import dev.sargunv.maplibrecompose.material3.proportionalAbsoluteOffset
+import dev.sargunv.maplibrecompose.material3.proportionalPadding
+import dev.sargunv.maplibrecompose.material3.toDpOffset
+import dev.sargunv.maplibrecompose.material3.toOffset
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.sin
+
+/**
+ * An elevated button in the shape of a pointer pin on the edge of an ellipsis drawn inside the
+ * parent layout, pointing towards some [targetPosition] off-screen. Only shown if the
+ * [targetPosition] is outside of the ellipsis.
+ *
+ * Note that this composable should fill the whole area in which the pointer pin button will be
+ * **placed**, i.e. usually the whole map screen.
+ *
+ * @param onClick called when this button is clicked
+ * @param targetPosition position (off-screen) the pin should point at
+ * @param modifier the [Modifier] to be applied to this button
+ * @param enabled controls the enabled state of this button. When `false`, this component will not
+ *   respond to user input, and it will appear visually disabled and disabled to accessibility
+ *   services.
+ * @param colors [ButtonColors] that will be used to resolve the colors for this button in different
+ *   states. See [ButtonDefaults.elevatedButtonColors].
+ * @param elevation [ButtonElevation] used to resolve the elevation for this button in different
+ *   states. This controls the size of the shadow below the button. Additionally, when the container
+ *   color is [ColorScheme.surface], this controls the amount of primary color applied as an
+ *   overlay. See [ButtonDefaults.elevatedButtonElevation].
+ * @param border the border to draw around the container of this button
+ * @param contentPadding the spacing values to apply internally between the container and the
+ *   content
+ * @param interactionSource an optional hoisted [MutableInteractionSource] for observing and
+ *   emitting [Interaction]s for this button. You can use this to change the button's appearance or
+ *   preview the button in different states. Note that if `null` is provided, interactions will
+ *   still happen internally.
+ */
+@Composable
+public fun PointerPinButton(
+  onClick: () -> Unit,
+  targetPosition: DpOffset,
+  modifier: Modifier = Modifier,
+  enabled: Boolean = true,
+  colors: ButtonColors = ButtonDefaults.elevatedButtonColors(),
+  elevation: ButtonElevation? = ButtonDefaults.elevatedButtonElevation(),
+  border: BorderStroke? = null,
+  contentPadding: PaddingValues = PaddingValues(12.dp),
+  interactionSource: MutableInteractionSource? = null,
+  content: @Composable (BoxScope.() -> Unit),
+) {
+  val target = targetPosition.toOffset()
+  var area by remember { mutableStateOf<Rect?>(null) }
+
+  Box(
+    modifier = modifier
+      .fillMaxSize()
+      .onGloballyPositioned { area = it.boundsInParent() },
+  ) {
+    val intersection = remember(target, area) { area?.let { findEllipsisIntersection(it, target) } }
+
+    intersection?.let { (offset, angle) ->
+      val rotation = angle * 180 / PI
+      val dpOffset = offset.toDpOffset()
+
+      val pointerPinShape = remember(rotation) { PointerPinShape(rotation.toFloat()) }
+
+      ElevatedButton(
+        onClick = onClick,
+        modifier = modifier
+          // offsetting it to account for the pointy side of the pin depending on the rotation. (The
+          // tip of the pin should be exactly on the ellipsis outline)
+          .proportionalAbsoluteOffset(
+            x = (-sin(angle) / 2.0 - 0.5).toFloat(),
+            y = (cos(angle) / 2.0 - 0.5).toFloat(),
+          )
+          // offsetting the whole pin to place it correctly within the parent layout
+          .absoluteOffset(dpOffset.x, dpOffset.y),
+        enabled = enabled,
+        shape = pointerPinShape,
+        colors = colors,
+        elevation = elevation,
+        border = border,
+        contentPadding = PaddingValues(0.dp),
+        interactionSource = interactionSource
+      ) {
+        Box(modifier = Modifier
+          // padding to place the content within the pin correctly, taking into account that the
+          // center of the pointer shape is not the center of to-be-placed icon (due to the pointy
+          // side)
+          .proportionalPadding(PointerPinShape.POINTY_SIZE)
+          .padding(contentPadding)
+        ) {
+          content()
+        }
+      }
+    }
+  }
+}
+
+/** A kind of map-📍 shape, but rotatable */
+private class PointerPinShape(val rotation: Float = 0f) : Shape {
+  override fun createOutline(
+    size: Size,
+    layoutDirection: LayoutDirection,
+    density: Density
+  ): Outline {
+    val m = Matrix()
+    val halfWidth = size.width / 2
+    val halfHeight = size.height / 2
+    m.translate(halfWidth, halfHeight)
+    m.rotateZ(rotation)
+    m.translate(-halfWidth, -halfHeight)
+    m.scale(x = size.width / PATH_SIZE, y = size.height / PATH_SIZE)
+    val p = PATH.toPath()
+    p.transform(m)
+    return Outline.Generic(p)
+  }
+
+  companion object {
+    val PATH_SIZE = 76f
+    val POINTY_SIZE = 14f / 76f
+    val PATH = PathParser().parsePathString("M 38,62 C 24.745,62 14,51.255 14,38 14.003,32.6405 15.7995,27.4365 19.1035,23.217 L 38,0 56.914,23.2715 C 60.2005,27.4785 61.99,32.6615 62,38 62,51.255 51.255,62 38,62 Z").toNodes()
+  }
+}

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/PointerPinButton.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/PointerPinButton.kt
@@ -120,8 +120,7 @@ public fun PointerPinButton(
             Modifier
               // padding to place the content within the pin correctly, taking into account that the
               // center of the pointer shape is not the center of to-be-placed icon (due to the
-              // pointy
-              // side)
+              // pointy side)
               .proportionalPadding(PointerPinShape.POINTY_SIZE)
               .padding(contentPadding)
         ) {

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/PointerPinButton.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/PointerPinButton.kt
@@ -86,11 +86,7 @@ public fun PointerPinButton(
   val target = targetPosition.toOffset()
   var area by remember { mutableStateOf<Rect?>(null) }
 
-  Box(
-    modifier = modifier
-      .fillMaxSize()
-      .onGloballyPositioned { area = it.boundsInParent() },
-  ) {
+  Box(modifier = modifier.fillMaxSize().onGloballyPositioned { area = it.boundsInParent() }) {
     val intersection = remember(target, area) { area?.let { findEllipsisIntersection(it, target) } }
 
     intersection?.let { (offset, angle) ->
@@ -101,29 +97,34 @@ public fun PointerPinButton(
 
       ElevatedButton(
         onClick = onClick,
-        modifier = modifier
-          // offsetting it to account for the pointy side of the pin depending on the rotation. (The
-          // tip of the pin should be exactly on the ellipsis outline)
-          .proportionalAbsoluteOffset(
-            x = (-sin(angle) / 2.0 - 0.5).toFloat(),
-            y = (cos(angle) / 2.0 - 0.5).toFloat(),
-          )
-          // offsetting the whole pin to place it correctly within the parent layout
-          .absoluteOffset(dpOffset.x, dpOffset.y),
+        modifier =
+          modifier
+            // offsetting it to account for the pointy side of the pin depending on the rotation.
+            // (The
+            // tip of the pin should be exactly on the ellipsis outline)
+            .proportionalAbsoluteOffset(
+              x = (-sin(angle) / 2.0 - 0.5).toFloat(),
+              y = (cos(angle) / 2.0 - 0.5).toFloat(),
+            )
+            // offsetting the whole pin to place it correctly within the parent layout
+            .absoluteOffset(dpOffset.x, dpOffset.y),
         enabled = enabled,
         shape = pointerPinShape,
         colors = colors,
         elevation = elevation,
         border = border,
         contentPadding = PaddingValues(0.dp),
-        interactionSource = interactionSource
+        interactionSource = interactionSource,
       ) {
-        Box(modifier = Modifier
-          // padding to place the content within the pin correctly, taking into account that the
-          // center of the pointer shape is not the center of to-be-placed icon (due to the pointy
-          // side)
-          .proportionalPadding(PointerPinShape.POINTY_SIZE)
-          .padding(contentPadding)
+        Box(
+          modifier =
+            Modifier
+              // padding to place the content within the pin correctly, taking into account that the
+              // center of the pointer shape is not the center of to-be-placed icon (due to the
+              // pointy
+              // side)
+              .proportionalPadding(PointerPinShape.POINTY_SIZE)
+              .padding(contentPadding)
         ) {
           content()
         }
@@ -137,7 +138,7 @@ private class PointerPinShape(val rotation: Float = 0f) : Shape {
   override fun createOutline(
     size: Size,
     layoutDirection: LayoutDirection,
-    density: Density
+    density: Density,
   ): Outline {
     val m = Matrix()
     val halfWidth = size.width / 2
@@ -154,6 +155,11 @@ private class PointerPinShape(val rotation: Float = 0f) : Shape {
   companion object {
     val PATH_SIZE = 76f
     val POINTY_SIZE = 14f / 76f
-    val PATH = PathParser().parsePathString("M 38,62 C 24.745,62 14,51.255 14,38 14.003,32.6405 15.7995,27.4365 19.1035,23.217 L 38,0 56.914,23.2715 C 60.2005,27.4785 61.99,32.6615 62,38 62,51.255 51.255,62 38,62 Z").toNodes()
+    val PATH =
+      PathParser()
+        .parsePathString(
+          "M 38,62 C 24.745,62 14,51.255 14,38 14.003,32.6405 15.7995,27.4365 19.1035,23.217 L 38,0 56.914,23.2715 C 60.2005,27.4785 61.99,32.6615 62,38 62,51.255 51.255,62 38,62 Z"
+        )
+        .toNodes()
   }
 }

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/PointerPinButton.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/PointerPinButton.kt
@@ -100,8 +100,7 @@ public fun PointerPinButton(
         modifier =
           modifier
             // offsetting it to account for the pointy side of the pin depending on the rotation.
-            // (The
-            // tip of the pin should be exactly on the ellipsis outline)
+            // (The tip of the pin should be exactly on the ellipsis outline)
             .proportionalAbsoluteOffset(
               x = (-sin(angle) / 2.0 - 0.5).toFloat(),
               y = (cos(angle) / 2.0 - 0.5).toFloat(),

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/CameraState.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/CameraState.kt
@@ -53,7 +53,7 @@ public class CameraState(firstPosition: CameraPosition) {
   public var position: CameraPosition
     get() = positionState.value
     set(value) {
-      maybeMap { it.setCameraPosition(value) }
+      mapOrNull()?.setCameraPosition(value)
       positionState.value = value
     }
 
@@ -111,28 +111,26 @@ public class CameraState(firstPosition: CameraPosition) {
     return map as? StandardMaplibreMap ?: error("Desktop not supported yet")
   }
 
-  private fun <T> maybeMap(block: (StandardMaplibreMap) -> T): T? {
-    return map?.let { block(it as? StandardMaplibreMap ?: error("Desktop not supported yet")) }
+  private fun mapOrNull(): StandardMaplibreMap? {
+    if (map == null) return null
+    return requireMap()
   }
 
   /**
    * Returns an offset from the top-left corner of the map composable that corresponds to the given
-   * [position]. This works for positions that are off-screen, too.
-   *
-   * @throws IllegalStateException if the map is not initialized yet. See [awaitInitialized].
+   * [position]. This works for positions that are off-screen, too. Returns `null` if the map is not
+   * initialized yet.
    */
-  public fun screenLocationFromPosition(position: Position): DpOffset {
-    return requireMap().screenLocationFromPosition(position)
+  public fun screenLocationFromPosition(position: Position): DpOffset? {
+    return mapOrNull()?.screenLocationFromPosition(position)
   }
 
   /**
    * Returns a position that corresponds to the given [offset] from the top-left corner of the map
-   * composable.
-   *
-   * @throws IllegalStateException if the map is not initialized yet. See [awaitInitialized].
+   * composable. Returns `null` if the map is not initialized yet.
    */
-  public fun positionFromScreenLocation(offset: DpOffset): Position {
-    return requireMap().positionFromScreenLocation(offset)
+  public fun positionFromScreenLocation(offset: DpOffset): Position? {
+    return mapOrNull()?.positionFromScreenLocation(offset)
   }
 
   /**
@@ -154,7 +152,7 @@ public class CameraState(firstPosition: CameraPosition) {
   ): List<Feature> {
     val predicateOrNull =
       predicate.takeUnless { it == const(true) }?.compile(ExpressionContext.None)
-    return maybeMap { it.queryRenderedFeatures(offset, layerIds, predicateOrNull) } ?: emptyList()
+    return mapOrNull()?.queryRenderedFeatures(offset, layerIds, predicateOrNull) ?: emptyList()
   }
 
   /**
@@ -175,7 +173,7 @@ public class CameraState(firstPosition: CameraPosition) {
   ): List<Feature> {
     val predicateOrNull =
       predicate.takeUnless { it == const(true) }?.compile(ExpressionContext.None)
-    return maybeMap { it.queryRenderedFeatures(rect, layerIds, predicateOrNull) } ?: emptyList()
+    return mapOrNull()?.queryRenderedFeatures(rect, layerIds, predicateOrNull) ?: emptyList()
   }
 
   /**
@@ -183,24 +181,20 @@ public class CameraState(firstPosition: CameraPosition) {
    *
    * Note that the bounding box is always a north-aligned rectangle. I.e. if the map is rotated or
    * tilted, the returned bounding box will always be larger than the actually visible area. See
-   * [queryVisibleRegion]
-   *
-   * @throws IllegalStateException if the map is not initialized yet. See [awaitInitialized].
+   * [queryVisibleRegion]. Returns `null` if the map is not initialized yet.
    */
-  public fun queryVisibleBoundingBox(): BoundingBox {
+  public fun queryVisibleBoundingBox(): BoundingBox? {
     // TODO at some point, this should be refactored to State, just like the camera position
-    return requireMap().getVisibleBoundingBox()
+    return mapOrNull()?.getVisibleBoundingBox()
   }
 
   /**
    * Returns the currently visible area, which is a four-sided polygon spanned by the four points
    * each at one corner of the map composable. If the camera has tilt (pitch), this polygon is a
-   * trapezoid instead of a rectangle.
-   *
-   * @throws IllegalStateException if the map is not initialized yet. See [awaitInitialized].
+   * trapezoid instead of a rectangle. Returns `null` if the map is not initialized yet.
    */
-  public fun queryVisibleRegion(): VisibleRegion {
+  public fun queryVisibleRegion(): VisibleRegion? {
     // TODO at some point, this should be refactored to State, just like the camera position
-    return requireMap().getVisibleRegion()
+    return mapOrNull()?.getVisibleRegion()
   }
 }


### PR DESCRIPTION
## Description

Add a new widget to the material3 library. A pointer pin:

https://github.com/user-attachments/assets/da7cb4d5-023d-40cd-b6c8-7d162b9e5652

## Test plan

- Test on both platforms.
- Might want to test different sizes for the pointer pin content, too. 
- Might want to check if it works fine with rotation and tilt
- Might want to check if it works fine in edge-to-edge

## Checklist

This pull request primarily adds a feature.

To my knowledge, I am not making breaking changes.

I don't have access to a macOS device to test iOS changes right now.

I have tested the changes insofar as can be seen in the video (Android only).