### PR TITLE
Document and fix clusterproperties interface

### DIFF
--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/ClusteredPointsDemo.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/ClusteredPointsDemo.kt
@@ -82,7 +82,23 @@ object ClusteredPointsDemo : Demo {
             rememberGeoJsonSource(
               "bikes",
               gbfsData,
-              GeoJsonOptions(cluster = true, clusterRadius = 32, clusterMaxZoom = 16),
+              GeoJsonOptions(
+                cluster = true,
+                clusterRadius = 32,
+                clusterMaxZoom = 16,
+                // TODO on Android, this segfaults when the mapper is anything but a constant
+                // See https://github.com/maplibre/maplibre-native/issues/3493
+                // clusterProperties =
+                //   mapOf(
+                //     "total_range" to
+                //       GeoJsonOptions.ClusterPropertyAggregator(
+                //         mapper = feature.get("current_range_meters").asNumber(),
+                //         reducer =
+                //           feature.accumulated().asNumber() +
+                //             feature.get("current_range_meters").asNumber(),
+                //       )
+                //   ),
+              ),
             )
 
           CircleLayer(

--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/ClusteredPointsDemo.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/ClusteredPointsDemo.kt
@@ -34,6 +34,7 @@ import dev.sargunv.maplibrecompose.expressions.dsl.convertToString
 import dev.sargunv.maplibrecompose.expressions.dsl.feature
 import dev.sargunv.maplibrecompose.expressions.dsl.not
 import dev.sargunv.maplibrecompose.expressions.dsl.offset
+import dev.sargunv.maplibrecompose.expressions.dsl.plus
 import dev.sargunv.maplibrecompose.expressions.dsl.step
 import io.github.dellisd.spatialk.geojson.Feature
 import io.github.dellisd.spatialk.geojson.FeatureCollection
@@ -81,19 +82,7 @@ object ClusteredPointsDemo : Demo {
             rememberGeoJsonSource(
               "bikes",
               gbfsData,
-              GeoJsonOptions(
-                cluster = true,
-                clusterRadius = 32,
-                clusterMaxZoom = 16,
-                clusterProperties =
-                  mapOf(
-                    "total_range" to
-                      GeoJsonOptions.ClusterPropertyAggregator(
-                        reducer = "+",
-                        mapper = feature.get("current_range_meters"),
-                      )
-                  ),
-              ),
+              GeoJsonOptions(cluster = true, clusterRadius = 32, clusterMaxZoom = 16),
             )
 
           CircleLayer(

--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/ClusteredPointsDemo.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/ClusteredPointsDemo.kt
@@ -95,7 +95,7 @@ object ClusteredPointsDemo : Demo {
                 //         mapper = feature.get("current_range_meters").asNumber(),
                 //         reducer =
                 //           feature.accumulated().asNumber() +
-                //             feature.get("current_range_meters").asNumber(),
+                //             feature.get("total_range").asNumber(),
                 //       )
                 //   ),
               ),

--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/ClusteredPointsDemo.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/ClusteredPointsDemo.kt
@@ -29,8 +29,8 @@ import dev.sargunv.maplibrecompose.demoapp.DemoOrnamentSettings
 import dev.sargunv.maplibrecompose.demoapp.DemoScaffold
 import dev.sargunv.maplibrecompose.demoapp.generated.Res
 import dev.sargunv.maplibrecompose.expressions.dsl.asNumber
+import dev.sargunv.maplibrecompose.expressions.dsl.asString
 import dev.sargunv.maplibrecompose.expressions.dsl.const
-import dev.sargunv.maplibrecompose.expressions.dsl.convertToString
 import dev.sargunv.maplibrecompose.expressions.dsl.feature
 import dev.sargunv.maplibrecompose.expressions.dsl.not
 import dev.sargunv.maplibrecompose.expressions.dsl.offset
@@ -120,7 +120,7 @@ object ClusteredPointsDemo : Demo {
             id = "clustered-bikes-count",
             source = bikeSource,
             filter = feature.has("point_count"),
-            textField = feature.get("total_range").convertToString(),
+            textField = feature.get("point_count_abbreviated").asString(),
             textFont = const(listOf("Noto Sans Regular")),
             textColor = const(MaterialTheme.colorScheme.onBackground),
           )

--- a/lib/maplibre-compose-expressions/src/commonMain/kotlin/dev/sargunv/maplibrecompose/expressions/dsl/feature.kt
+++ b/lib/maplibre-compose-expressions/src/commonMain/kotlin/dev/sargunv/maplibrecompose/expressions/dsl/feature.kt
@@ -97,15 +97,7 @@ public object Feature {
    * `clusterProperties` option of a clustered GeoJSON source, see
    * [GeoJsonOptions][dev.sargunv.maplibrecompose.core.source.GeoJsonOptions].
    */
-  public fun accumulated(key: Expression<StringValue>): Expression<*> =
-    FunctionCall.of("accumulated", key)
-
-  /**
-   * Gets the value of a cluster property accumulated so far. Can only be used in the
-   * `clusterProperties` option of a clustered GeoJSON source, see
-   * [GeoJsonOptions][dev.sargunv.maplibrecompose.core.source.GeoJsonOptions].
-   */
-  public fun accumulated(key: String): Expression<*> = accumulated(const(key))
+  public fun accumulated(): Expression<*> = FunctionCall.of("accumulated")
 }
 
 /** Accesses to feature-related data */

--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/source/GeoJsonSource.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/source/GeoJsonSource.kt
@@ -37,8 +37,6 @@ public actual class GeoJsonSource : Source {
         withClusterProperty(
           name,
           aggregator.reducer.compile(ExpressionContext.None).toMLNExpression()!!,
-          // TODO the app segfaults when the mapper is anything but a constant
-          // See https://github.com/maplibre/maplibre-native/issues/3493
           aggregator.mapper.compile(ExpressionContext.None).toMLNExpression()!!,
         )
       }

--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/source/GeoJsonSource.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/source/GeoJsonSource.kt
@@ -3,7 +3,8 @@ package dev.sargunv.maplibrecompose.core.source
 import dev.sargunv.maplibrecompose.core.util.correctedAndroidUri
 import dev.sargunv.maplibrecompose.core.util.toMLNExpression
 import dev.sargunv.maplibrecompose.expressions.ExpressionContext
-import dev.sargunv.maplibrecompose.expressions.dsl.const
+import dev.sargunv.maplibrecompose.expressions.ast.FunctionCall
+import dev.sargunv.maplibrecompose.expressions.dsl.feature
 import io.github.dellisd.spatialk.geojson.GeoJson
 import java.net.URI
 import org.maplibre.android.style.sources.GeoJsonOptions as MLNGeoJsonOptions
@@ -34,11 +35,13 @@ public actual class GeoJsonSource : Source {
       withCluster(options.cluster)
       withClusterMaxZoom(options.clusterMaxZoom)
       withClusterRadius(options.clusterRadius)
-      options.clusterProperties.forEach { (key, value) ->
+      options.clusterProperties.forEach { (name, aggregator) ->
         withClusterProperty(
-          key,
-          const(value.operator).toMLNExpression()!!,
-          value.mapper.compile(ExpressionContext.None).toMLNExpression()!!,
+          name,
+          FunctionCall.of(aggregator.reducer, FunctionCall.of("accumulated"), feature.get(name))
+            .compile(ExpressionContext.None)
+            .toMLNExpression()!!,
+          aggregator.mapper.compile(ExpressionContext.None).toMLNExpression()!!,
         )
       }
     }

--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/source/GeoJsonSource.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/source/GeoJsonSource.kt
@@ -38,7 +38,7 @@ public actual class GeoJsonSource : Source {
           name,
           aggregator.reducer.compile(ExpressionContext.None).toMLNExpression()!!,
           // TODO the app segfaults when the mapper is anything but a constant
-          // See https://github.com/maplibre/maplibre-compose/issues/236
+          // See https://github.com/maplibre/maplibre-native/issues/3493
           aggregator.mapper.compile(ExpressionContext.None).toMLNExpression()!!,
         )
       }

--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/source/GeoJsonSource.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/source/GeoJsonSource.kt
@@ -3,8 +3,6 @@ package dev.sargunv.maplibrecompose.core.source
 import dev.sargunv.maplibrecompose.core.util.correctedAndroidUri
 import dev.sargunv.maplibrecompose.core.util.toMLNExpression
 import dev.sargunv.maplibrecompose.expressions.ExpressionContext
-import dev.sargunv.maplibrecompose.expressions.ast.FunctionCall
-import dev.sargunv.maplibrecompose.expressions.dsl.feature
 import io.github.dellisd.spatialk.geojson.GeoJson
 import java.net.URI
 import org.maplibre.android.style.sources.GeoJsonOptions as MLNGeoJsonOptions
@@ -38,9 +36,7 @@ public actual class GeoJsonSource : Source {
       options.clusterProperties.forEach { (name, aggregator) ->
         withClusterProperty(
           name,
-          FunctionCall.of(aggregator.reducer, FunctionCall.of("accumulated"), feature.get(name))
-            .compile(ExpressionContext.None)
-            .toMLNExpression()!!,
+          aggregator.reducer.compile(ExpressionContext.None).toMLNExpression()!!,
           aggregator.mapper.compile(ExpressionContext.None).toMLNExpression()!!,
         )
       }

--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/source/GeoJsonSource.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/source/GeoJsonSource.kt
@@ -37,6 +37,7 @@ public actual class GeoJsonSource : Source {
         withClusterProperty(
           name,
           aggregator.reducer.compile(ExpressionContext.None).toMLNExpression()!!,
+          // TODO the app segfaults when the mapper is anything but a constant
           aggregator.mapper.compile(ExpressionContext.None).toMLNExpression()!!,
         )
       }

--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/source/GeoJsonSource.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/source/GeoJsonSource.kt
@@ -38,6 +38,7 @@ public actual class GeoJsonSource : Source {
           name,
           aggregator.reducer.compile(ExpressionContext.None).toMLNExpression()!!,
           // TODO the app segfaults when the mapper is anything but a constant
+          // See https://github.com/maplibre/maplibre-compose/issues/236
           aggregator.mapper.compile(ExpressionContext.None).toMLNExpression()!!,
         )
       }

--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/source/GeoJsonSource.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/source/GeoJsonSource.kt
@@ -14,6 +14,7 @@ import dev.sargunv.maplibrecompose.core.util.toMLNShape
 import dev.sargunv.maplibrecompose.core.util.toNSExpression
 import dev.sargunv.maplibrecompose.expressions.ExpressionContext
 import dev.sargunv.maplibrecompose.expressions.ast.FunctionCall
+import dev.sargunv.maplibrecompose.expressions.dsl.feature
 import io.github.dellisd.spatialk.geojson.GeoJson
 import platform.Foundation.NSNumber
 import platform.Foundation.NSURL
@@ -47,8 +48,13 @@ public actual class GeoJsonSource : Source {
       put(MLNShapeSourceOptionClusterRadius, NSNumber(options.clusterRadius))
       put(
         MLNShapeSourceOptionClusterProperties,
-        options.clusterProperties.mapValues { (_, p) ->
-          FunctionCall.of(p.operator, p.mapper).compile(ExpressionContext.None).toNSExpression()
+        options.clusterProperties.mapValues { (name, aggregator) ->
+          listOf(
+            FunctionCall.of(aggregator.reducer, FunctionCall.of("accumulated"), feature.get(name))
+              .compile(ExpressionContext.None)
+              .toNSExpression(),
+            aggregator.mapper.compile(ExpressionContext.None).toNSExpression(),
+          )
         },
       )
     }

--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/source/GeoJsonSource.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/source/GeoJsonSource.kt
@@ -13,8 +13,6 @@ import cocoapods.MapLibre.MLNShapeSourceOptionSimplificationTolerance
 import dev.sargunv.maplibrecompose.core.util.toMLNShape
 import dev.sargunv.maplibrecompose.core.util.toNSExpression
 import dev.sargunv.maplibrecompose.expressions.ExpressionContext
-import dev.sargunv.maplibrecompose.expressions.ast.FunctionCall
-import dev.sargunv.maplibrecompose.expressions.dsl.feature
 import io.github.dellisd.spatialk.geojson.GeoJson
 import platform.Foundation.NSNumber
 import platform.Foundation.NSURL
@@ -50,9 +48,7 @@ public actual class GeoJsonSource : Source {
         MLNShapeSourceOptionClusterProperties,
         options.clusterProperties.mapValues { (name, aggregator) ->
           listOf(
-            FunctionCall.of(aggregator.reducer, FunctionCall.of("accumulated"), feature.get(name))
-              .compile(ExpressionContext.None)
-              .toNSExpression(),
+            aggregator.reducer.compile(ExpressionContext.None).toNSExpression(),
             aggregator.mapper.compile(ExpressionContext.None).toNSExpression(),
           )
         },


### PR DESCRIPTION
<!-- Thanks for the PR! Please fill out the template below. -->

## Description

Supersedes #237. Partial fix for #236.

I managed to get this working on iOS, but it still crashes on Android with a segfault. Reported upstream, https://github.com/maplibre/maplibre-native/issues/3493. Interestingly, it doesn't crash if the mapper is a literal, like `const(1)`. In that case, it seems to work on Android too, so I think we've got the usage right, it's just broken upstream.

## Test plan

Take the example from the docs, and use it in the cluster properties demo (instead of point count).