### PR TITLE
refactor camera state initialization api

### DIFF
--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/docs/Interaction.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/docs/Interaction.kt
@@ -70,7 +70,7 @@ fun Interaction() {
   MaplibreMap(
     cameraState = camera,
     onMapClick = { pos, offset ->
-      val features = camera.queryRenderedFeatures(offset)
+      val features = camera.projection!!.queryRenderedFeatures(offset)
       if (features.isNotEmpty()) {
         println("Clicked on ${features[0].json()}")
         ClickResult.Consume // (1)!

--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/docs/Interaction.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/docs/Interaction.kt
@@ -70,8 +70,8 @@ fun Interaction() {
   MaplibreMap(
     cameraState = camera,
     onMapClick = { pos, offset ->
-      val features = camera.projection!!.queryRenderedFeatures(offset)
-      if (features.isNotEmpty()) {
+      val features = camera.projection?.queryRenderedFeatures(offset)
+      if (!features.isNullOrEmpty()) {
         println("Clicked on ${features[0].json()}")
         ClickResult.Consume // (1)!
       } else {

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/PointerPinButton.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/PointerPinButton.kt
@@ -86,7 +86,8 @@ public fun PointerPinButton(
   interactionSource: MutableInteractionSource? = null,
   content: @Composable (BoxScope.() -> Unit),
 ) {
-  val target = cameraState.screenLocationFromPosition(targetPosition)?.toOffset() ?: return
+  val target =
+    cameraState.projection?.screenLocationFromPosition(targetPosition)?.toOffset() ?: return
   var area by remember { mutableStateOf<Rect?>(null) }
 
   Box(modifier = modifier.fillMaxSize().onGloballyPositioned { area = it.boundsInParent() }) {

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/CameraProjection.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/CameraProjection.kt
@@ -1,0 +1,101 @@
+package dev.sargunv.maplibrecompose.compose
+
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.DpRect
+import dev.sargunv.maplibrecompose.core.StandardMaplibreMap
+import dev.sargunv.maplibrecompose.core.VisibleRegion
+import dev.sargunv.maplibrecompose.expressions.ExpressionContext
+import dev.sargunv.maplibrecompose.expressions.ast.Expression
+import dev.sargunv.maplibrecompose.expressions.dsl.const
+import dev.sargunv.maplibrecompose.expressions.value.BooleanValue
+import io.github.dellisd.spatialk.geojson.BoundingBox
+import io.github.dellisd.spatialk.geojson.Feature
+import io.github.dellisd.spatialk.geojson.Position
+
+/**
+ * Provides an imperative API to interact with the projection of the map, such as converting
+ * coordinates or querying what's visible.
+ */
+public class CameraProjection internal constructor(internal val map: StandardMaplibreMap) {
+  /**
+   * Returns an offset from the top-left corner of the map composable that corresponds to the given
+   * [position]. This works for positions that are off-screen, too. Returns `null` if the map is not
+   * initialized yet.
+   */
+  public fun screenLocationFromPosition(position: Position): DpOffset? {
+    return map.screenLocationFromPosition(position)
+  }
+
+  /**
+   * Returns a position that corresponds to the given [offset] from the top-left corner of the map
+   * composable. Returns `null` if the map is not initialized yet.
+   */
+  public fun positionFromScreenLocation(offset: DpOffset): Position? {
+    return map.positionFromScreenLocation(offset)
+  }
+
+  /**
+   * Returns a list of features that are rendered at the given [offset] from the top-left corner of
+   * the map composable, optionally limited to layers with the given [layerIds] and filtered by the
+   * given [predicate]. The result is sorted by render order, i.e. the feature in front is first in
+   * the list.
+   *
+   * @param offset position from the top-left corner of the map composable to query for
+   * @param layerIds the ids of the layers to limit the query to. If not specified, features in
+   *   *any* layer are returned
+   * @param predicate expression that has to evaluate to true for a feature to be included in the
+   *   result
+   */
+  public fun queryRenderedFeatures(
+    offset: DpOffset,
+    layerIds: Set<String>? = null,
+    predicate: Expression<BooleanValue> = const(true),
+  ): List<Feature> {
+    val predicateOrNull =
+      predicate.takeUnless { it == const(true) }?.compile(ExpressionContext.None)
+    return map.queryRenderedFeatures(offset, layerIds, predicateOrNull) ?: emptyList()
+  }
+
+  /**
+   * Returns a list of features whose rendered geometry intersect with the given [rect], optionally
+   * limited to layers with the given [layerIds] and filtered by the given [predicate]. The result
+   * is sorted by render order, i.e. the feature in front is first in the list.
+   *
+   * @param rect rectangle to intersect with rendered geometry
+   * @param layerIds the ids of the layers to limit the query to. If not specified, features in
+   *   *any* layer are returned
+   * @param predicate expression that has to evaluate to true for a feature to be included in the
+   *   result
+   */
+  public fun queryRenderedFeatures(
+    rect: DpRect,
+    layerIds: Set<String>? = null,
+    predicate: Expression<BooleanValue> = const(true),
+  ): List<Feature> {
+    val predicateOrNull =
+      predicate.takeUnless { it == const(true) }?.compile(ExpressionContext.None)
+    return map.queryRenderedFeatures(rect, layerIds, predicateOrNull) ?: emptyList()
+  }
+
+  /**
+   * Returns the smallest bounding box that contains the currently visible area.
+   *
+   * Note that the bounding box is always a north-aligned rectangle. I.e. if the map is rotated or
+   * tilted, the returned bounding box will always be larger than the actually visible area. See
+   * [queryVisibleRegion]. Returns `null` if the map is not initialized yet.
+   */
+  public fun queryVisibleBoundingBox(): BoundingBox? {
+    // TODO at some point, this should be refactored to State, just like the camera position
+    return map.getVisibleBoundingBox()
+  }
+
+  /**
+   * Returns the currently visible area, which is a four-sided polygon spanned by the four points
+   * each at one corner of the map composable. If the camera has tilt (pitch), this polygon is a
+   * trapezoid instead of a rectangle. Returns `null` if the map is not initialized yet.
+   */
+  public fun queryVisibleRegion(): VisibleRegion? {
+    // TODO at some point, this should be refactored to State, just like the camera position
+    return map.getVisibleRegion()
+  }
+}

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/CameraState.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/CameraState.kt
@@ -4,24 +4,16 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.ui.unit.DpOffset
-import androidx.compose.ui.unit.DpRect
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.unit.dp
 import dev.sargunv.maplibrecompose.core.CameraMoveReason
 import dev.sargunv.maplibrecompose.core.CameraPosition
 import dev.sargunv.maplibrecompose.core.MaplibreMap
 import dev.sargunv.maplibrecompose.core.StandardMaplibreMap
-import dev.sargunv.maplibrecompose.core.VisibleRegion
-import dev.sargunv.maplibrecompose.expressions.ExpressionContext
-import dev.sargunv.maplibrecompose.expressions.ast.Expression
-import dev.sargunv.maplibrecompose.expressions.dsl.const
-import dev.sargunv.maplibrecompose.expressions.value.BooleanValue
 import io.github.dellisd.spatialk.geojson.BoundingBox
-import io.github.dellisd.spatialk.geojson.Feature
-import io.github.dellisd.spatialk.geojson.Position
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
-import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.first
 
 /** Remember a new [CameraState] in the initial state as given in [firstPosition]. */
 @Composable
@@ -30,30 +22,38 @@ public fun rememberCameraState(firstPosition: CameraPosition = CameraPosition())
 
 /** Use this class to access information about the map in relation to the camera. */
 public class CameraState(firstPosition: CameraPosition) {
-  internal var map: MaplibreMap? = null
-    set(map) {
-      val previousField = field
-      field = map
-
-      if (map != null && map !== previousField) {
-        (map as StandardMaplibreMap).setCameraPosition(position)
-        mapAttachSignal.trySend(map)
-      }
-    }
-
-  private val mapAttachSignal = Channel<MaplibreMap>()
-
+  internal val mapState = mutableStateOf<MaplibreMap?>(null)
+  internal val projectionState = mutableStateOf<CameraProjection?>(null)
   internal val positionState = mutableStateOf(firstPosition)
   internal val moveReasonState = mutableStateOf(CameraMoveReason.NONE)
   internal val metersPerDpAtTargetState = mutableStateOf(0.0)
   internal val isCameraMovingState = mutableStateOf(false)
+
+  internal var map: MaplibreMap?
+    get() = mapState.value
+    set(map) {
+      val prevMap = mapState.value
+      mapState.value = map
+
+      if (map !== prevMap && map is StandardMaplibreMap) {
+        // apply deferred state
+        map.setCameraPosition(position)
+
+        // initialize imperative API
+        projectionState.value = CameraProjection(map)
+      }
+    }
+
+  /** null until the CameraState has been attached to a map */
+  public val projection: CameraProjection?
+    get() = projectionState.value
 
   /** how the camera is oriented towards the map */
   // if the map is not yet initialized, we store the value to apply it later
   public var position: CameraPosition
     get() = positionState.value
     set(value) {
-      mapOrNull()?.setCameraPosition(value)
+      (map as? StandardMaplibreMap)?.setCameraPosition(value)
       positionState.value = value
     }
 
@@ -69,9 +69,13 @@ public class CameraState(firstPosition: CameraPosition) {
   public val isCameraMoving: Boolean
     get() = isCameraMovingState.value
 
-  /** suspends until the map has been initialized */
-  public suspend fun awaitInitialized() {
-    map ?: mapAttachSignal.receive()
+  internal suspend fun awaitMap(): MaplibreMap {
+    return snapshotFlow { map }.first { it != null }!!
+  }
+
+  /** Suspends until the CameraState has been attached to the map. */
+  public suspend fun awaitProjection(): CameraProjection {
+    return snapshotFlow { projection }.first { it != null }!!
   }
 
   /** Animates the camera towards the [finalPosition] in [duration] time. */
@@ -79,8 +83,7 @@ public class CameraState(firstPosition: CameraPosition) {
     finalPosition: CameraPosition,
     duration: Duration = 300.milliseconds,
   ) {
-    val map = map ?: mapAttachSignal.receive()
-    map.animateCameraPosition(finalPosition, duration)
+    awaitMap().animateCameraPosition(finalPosition, duration)
   }
 
   /**
@@ -100,101 +103,6 @@ public class CameraState(firstPosition: CameraPosition) {
     padding: PaddingValues = PaddingValues(0.dp),
     duration: Duration = 300.milliseconds,
   ) {
-    val map = map ?: mapAttachSignal.receive()
-    map.animateCameraPosition(boundingBox, bearing, tilt, padding, duration)
-  }
-
-  private fun requireMap(): StandardMaplibreMap {
-    check(map != null) {
-      "Map requested before it was initialized; try calling awaitInitialization() first"
-    }
-    return map as? StandardMaplibreMap ?: error("Desktop not supported yet")
-  }
-
-  private fun mapOrNull(): StandardMaplibreMap? {
-    if (map == null) return null
-    return requireMap()
-  }
-
-  /**
-   * Returns an offset from the top-left corner of the map composable that corresponds to the given
-   * [position]. This works for positions that are off-screen, too. Returns `null` if the map is not
-   * initialized yet.
-   */
-  public fun screenLocationFromPosition(position: Position): DpOffset? {
-    return mapOrNull()?.screenLocationFromPosition(position)
-  }
-
-  /**
-   * Returns a position that corresponds to the given [offset] from the top-left corner of the map
-   * composable. Returns `null` if the map is not initialized yet.
-   */
-  public fun positionFromScreenLocation(offset: DpOffset): Position? {
-    return mapOrNull()?.positionFromScreenLocation(offset)
-  }
-
-  /**
-   * Returns a list of features that are rendered at the given [offset] from the top-left corner of
-   * the map composable, optionally limited to layers with the given [layerIds] and filtered by the
-   * given [predicate]. The result is sorted by render order, i.e. the feature in front is first in
-   * the list.
-   *
-   * @param offset position from the top-left corner of the map composable to query for
-   * @param layerIds the ids of the layers to limit the query to. If not specified, features in
-   *   *any* layer are returned
-   * @param predicate expression that has to evaluate to true for a feature to be included in the
-   *   result
-   */
-  public fun queryRenderedFeatures(
-    offset: DpOffset,
-    layerIds: Set<String>? = null,
-    predicate: Expression<BooleanValue> = const(true),
-  ): List<Feature> {
-    val predicateOrNull =
-      predicate.takeUnless { it == const(true) }?.compile(ExpressionContext.None)
-    return mapOrNull()?.queryRenderedFeatures(offset, layerIds, predicateOrNull) ?: emptyList()
-  }
-
-  /**
-   * Returns a list of features whose rendered geometry intersect with the given [rect], optionally
-   * limited to layers with the given [layerIds] and filtered by the given [predicate]. The result
-   * is sorted by render order, i.e. the feature in front is first in the list.
-   *
-   * @param rect rectangle to intersect with rendered geometry
-   * @param layerIds the ids of the layers to limit the query to. If not specified, features in
-   *   *any* layer are returned
-   * @param predicate expression that has to evaluate to true for a feature to be included in the
-   *   result
-   */
-  public fun queryRenderedFeatures(
-    rect: DpRect,
-    layerIds: Set<String>? = null,
-    predicate: Expression<BooleanValue> = const(true),
-  ): List<Feature> {
-    val predicateOrNull =
-      predicate.takeUnless { it == const(true) }?.compile(ExpressionContext.None)
-    return mapOrNull()?.queryRenderedFeatures(rect, layerIds, predicateOrNull) ?: emptyList()
-  }
-
-  /**
-   * Returns the smallest bounding box that contains the currently visible area.
-   *
-   * Note that the bounding box is always a north-aligned rectangle. I.e. if the map is rotated or
-   * tilted, the returned bounding box will always be larger than the actually visible area. See
-   * [queryVisibleRegion]. Returns `null` if the map is not initialized yet.
-   */
-  public fun queryVisibleBoundingBox(): BoundingBox? {
-    // TODO at some point, this should be refactored to State, just like the camera position
-    return mapOrNull()?.getVisibleBoundingBox()
-  }
-
-  /**
-   * Returns the currently visible area, which is a four-sided polygon spanned by the four points
-   * each at one corner of the map composable. If the camera has tilt (pitch), this polygon is a
-   * trapezoid instead of a rectangle. Returns `null` if the map is not initialized yet.
-   */
-  public fun queryVisibleRegion(): VisibleRegion? {
-    // TODO at some point, this should be refactored to State, just like the camera position
-    return mapOrNull()?.getVisibleRegion()
+    awaitMap().animateCameraPosition(boundingBox, bearing, tilt, padding, duration)
   }
 }


### PR DESCRIPTION
See discussion in this comment thread: https://github.com/maplibre/maplibre-compose/pull/364#discussion_r2106361485

This PR moves all the APIs for imperatively querying the camera projection to a new CameraProjection class, and provides a reference via a State that gets initialized when the map is attached. So the most intuitive way to use this API is now also correct wrt awaiting and recomposing on initialization.
