### PR TITLE
Revert "attributions as derived state"

### DIFF
--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/AttributionButton.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/AttributionButton.kt
@@ -26,7 +26,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -142,9 +141,7 @@ public fun ExpandingAttributionButton(
   expand: (Alignment) -> EnterTransition = AttributionButtonDefaults.expand,
   collapse: (Alignment) -> ExitTransition = AttributionButtonDefaults.collapse,
 ) {
-  val attributions by remember {
-    derivedStateOf { styleState.sources.values.flatMap { it.attributionLinks }.distinct() }
-  }
+  val attributions = styleState.sources.values.flatMap { it.attributionLinks }.distinct()
   if (attributions.isEmpty()) return
 
   Surface(


### PR DESCRIPTION
Reverts maplibre/maplibre-compose#380 to fix #388 