### PR TITLE
CompassButton: allow customizing home orientation

### DIFF
--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/app.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/app.kt
@@ -54,7 +54,7 @@ import dev.sargunv.maplibrecompose.material3.controls.DisappearingCompassButton
 import dev.sargunv.maplibrecompose.material3.controls.DisappearingScaleBar
 import dev.sargunv.maplibrecompose.material3.controls.ExpandingAttributionButton
 import dev.sargunv.maplibrecompose.material3.controls.ScaleBarMeasures
-import dev.sargunv.maplibrecompose.material3.defaultScaleBarMeasures
+import dev.sargunv.maplibrecompose.material3.util.defaultScaleBarMeasures
 import org.jetbrains.compose.resources.vectorResource
 
 private val DEMOS = buildList {

--- a/lib/maplibre-compose-material3/src/androidMain/kotlin/dev/sargunv/maplibrecompose/material3/util/util.android.kt
+++ b/lib/maplibre-compose-material3/src/androidMain/kotlin/dev/sargunv/maplibrecompose/material3/util/util.android.kt
@@ -1,4 +1,4 @@
-package dev.sargunv.maplibrecompose.material3
+package dev.sargunv.maplibrecompose.material3.util
 
 import android.icu.util.LocaleData
 import android.icu.util.ULocale

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/AttributionButton.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/AttributionButton.kt
@@ -50,10 +50,10 @@ import dev.sargunv.maplibrecompose.core.source.AttributionLink
 import dev.sargunv.maplibrecompose.material3.generated.Res
 import dev.sargunv.maplibrecompose.material3.generated.attribution
 import dev.sargunv.maplibrecompose.material3.generated.info
-import dev.sargunv.maplibrecompose.material3.horizontal
-import dev.sargunv.maplibrecompose.material3.reverse
-import dev.sargunv.maplibrecompose.material3.toArrangement
-import dev.sargunv.maplibrecompose.material3.vertical
+import dev.sargunv.maplibrecompose.material3.util.horizontal
+import dev.sargunv.maplibrecompose.material3.util.reverse
+import dev.sargunv.maplibrecompose.material3.util.toArrangement
+import dev.sargunv.maplibrecompose.material3.util.vertical
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.resources.vectorResource
 

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/DisappearingScaleBar.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/DisappearingScaleBar.kt
@@ -17,8 +17,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import dev.sargunv.maplibrecompose.material3.backgroundColorFor
-import dev.sargunv.maplibrecompose.material3.defaultScaleBarMeasures
+import dev.sargunv.maplibrecompose.material3.util.backgroundColorFor
+import dev.sargunv.maplibrecompose.material3.util.defaultScaleBarMeasures
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.delay

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/PointerPinButton.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/PointerPinButton.kt
@@ -33,11 +33,11 @@ import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import dev.sargunv.maplibrecompose.compose.CameraState
-import dev.sargunv.maplibrecompose.material3.findEllipsisIntersection
-import dev.sargunv.maplibrecompose.material3.proportionalAbsoluteOffset
-import dev.sargunv.maplibrecompose.material3.proportionalPadding
-import dev.sargunv.maplibrecompose.material3.toDpOffset
-import dev.sargunv.maplibrecompose.material3.toOffset
+import dev.sargunv.maplibrecompose.material3.util.findEllipsisIntersection
+import dev.sargunv.maplibrecompose.material3.util.proportionalAbsoluteOffset
+import dev.sargunv.maplibrecompose.material3.util.proportionalPadding
+import dev.sargunv.maplibrecompose.material3.util.toDpOffset
+import dev.sargunv.maplibrecompose.material3.util.toOffset
 import io.github.dellisd.spatialk.geojson.Position
 import kotlin.math.PI
 import kotlin.math.cos

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/ScaleBar.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/ScaleBar.kt
@@ -20,10 +20,10 @@ import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.toSize
-import dev.sargunv.maplibrecompose.material3.backgroundColorFor
-import dev.sargunv.maplibrecompose.material3.defaultScaleBarMeasures
-import dev.sargunv.maplibrecompose.material3.drawPathsWithHalo
-import dev.sargunv.maplibrecompose.material3.drawTextWithHalo
+import dev.sargunv.maplibrecompose.material3.util.backgroundColorFor
+import dev.sargunv.maplibrecompose.material3.util.defaultScaleBarMeasures
+import dev.sargunv.maplibrecompose.material3.util.drawPathsWithHalo
+import dev.sargunv.maplibrecompose.material3.util.drawTextWithHalo
 import io.github.kevincianfarini.alchemist.scalar.meters
 import io.github.kevincianfarini.alchemist.type.Length
 import io.github.kevincianfarini.alchemist.unit.LengthUnit

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/util/AngleMath.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/util/AngleMath.kt
@@ -1,0 +1,18 @@
+package dev.sargunv.maplibrecompose.material3.util
+
+@Suppress("NOTHING_TO_INLINE")
+internal object AngleMath {
+  /**
+   * The **least positive residue**, or the remainder of Euclidean division.
+   *
+   * [Double.rem] is the remainder of truncated division; [Double.mod] is of floored division.
+   * Kotlin provides no built-in Euclidean division remainder function.
+   */
+  inline fun Double.leastPositiveResidue(other: Double) = ((this % other) + other) % other
+
+  /** Wrap an angle to [0,360). */
+  inline fun Double.wrap() = leastPositiveResidue(360.0)
+
+  /** Get the size of the smallest angle between two angles. */
+  inline fun Double.diff(other: Double) = -((other - this) + 180.0).wrap() + 180.0
+}

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/util/Arrangement.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/util/Arrangement.kt
@@ -1,4 +1,4 @@
-package dev.sargunv.maplibrecompose.material3
+package dev.sargunv.maplibrecompose.material3.util
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.ui.Alignment

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/util/ColorScheme.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/util/ColorScheme.kt
@@ -1,4 +1,4 @@
-package dev.sargunv.maplibrecompose.material3
+package dev.sargunv.maplibrecompose.material3.util
 
 import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.MaterialTheme

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/util/Dp.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/util/Dp.kt
@@ -1,4 +1,4 @@
-package dev.sargunv.maplibrecompose.material3
+package dev.sargunv.maplibrecompose.material3.util
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ReadOnlyComposable

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/util/DrawScope.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/util/DrawScope.kt
@@ -1,4 +1,4 @@
-package dev.sargunv.maplibrecompose.material3
+package dev.sargunv.maplibrecompose.material3.util
 
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.BlendMode

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/util/Intersection.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/util/Intersection.kt
@@ -1,4 +1,4 @@
-package dev.sargunv.maplibrecompose.material3
+package dev.sargunv.maplibrecompose.material3.util
 
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/util/Modifier.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/util/Modifier.kt
@@ -1,4 +1,4 @@
-package dev.sargunv.maplibrecompose.material3
+package dev.sargunv.maplibrecompose.material3.util
 
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.layout

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/util/measures.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/util/measures.kt
@@ -1,4 +1,4 @@
-package dev.sargunv.maplibrecompose.material3
+package dev.sargunv.maplibrecompose.material3.util
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.text.intl.Locale

--- a/lib/maplibre-compose-material3/src/commonTest/kotlin/dev/sargunv/maplibrecompose/material3/util/AngleMathTest.kt
+++ b/lib/maplibre-compose-material3/src/commonTest/kotlin/dev/sargunv/maplibrecompose/material3/util/AngleMathTest.kt
@@ -1,0 +1,68 @@
+package dev.sargunv.maplibrecompose.material3.util
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AngleMathTest {
+  @Test
+  fun testLeastPositiveResidue() {
+    // Test with positive numbers
+    assertEquals(1.0, AngleMath.run { 1.0.leastPositiveResidue(5.0) })
+    assertEquals(3.0, AngleMath.run { 8.0.leastPositiveResidue(5.0) })
+
+    // Test with negative numbers
+    assertEquals(4.0, AngleMath.run { (-1.0).leastPositiveResidue(5.0) })
+    assertEquals(2.0, AngleMath.run { (-3.0).leastPositiveResidue(5.0) })
+
+    // Test with zero
+    assertEquals(0.0, AngleMath.run { 0.0.leastPositiveResidue(5.0) })
+
+    // Test with large numbers
+    assertEquals(1.0, AngleMath.run { 361.0.leastPositiveResidue(360.0) })
+    assertEquals(359.0, AngleMath.run { (-1.0).leastPositiveResidue(360.0) })
+  }
+
+  @Test
+  fun testWrap() {
+    // Test with angles in range [0,360)
+    assertEquals(0.0, AngleMath.run { 0.0.wrap() })
+    assertEquals(90.0, AngleMath.run { 90.0.wrap() })
+    assertEquals(180.0, AngleMath.run { 180.0.wrap() })
+    assertEquals(270.0, AngleMath.run { 270.0.wrap() })
+
+    // Test with angles >= 360
+    assertEquals(0.0, AngleMath.run { 360.0.wrap() })
+    assertEquals(1.0, AngleMath.run { 361.0.wrap() })
+    assertEquals(0.0, AngleMath.run { 720.0.wrap() })
+
+    // Test with negative angles
+    assertEquals(359.0, AngleMath.run { (-1.0).wrap() })
+    assertEquals(270.0, AngleMath.run { (-90.0).wrap() })
+    assertEquals(180.0, AngleMath.run { (-180.0).wrap() })
+    assertEquals(90.0, AngleMath.run { (-270.0).wrap() })
+    assertEquals(0.0, AngleMath.run { (-360.0).wrap() })
+  }
+
+  @Test
+  fun testDiff() {
+    // Test with angles in the same quadrant
+    assertEquals(-10.0, AngleMath.run { 80.0.diff(90.0) })
+    assertEquals(10.0, AngleMath.run { 90.0.diff(80.0) })
+
+    // Test with angles in different quadrants
+    assertEquals(-90.0, AngleMath.run { 0.0.diff(90.0) })
+    assertEquals(90.0, AngleMath.run { 90.0.diff(0.0) })
+
+    // Test with angles on opposite sides
+    assertEquals(180.0, AngleMath.run { 0.0.diff(180.0) })
+    assertEquals(180.0, AngleMath.run { 180.0.diff(0.0) })
+
+    // Test with wrap-around cases
+    assertEquals(-20.0, AngleMath.run { 350.0.diff(10.0) })
+    assertEquals(20.0, AngleMath.run { 10.0.diff(350.0) })
+
+    // Test with negative angles
+    assertEquals(-90.0, AngleMath.run { (-45.0).diff(45.0) })
+    assertEquals(90.0, AngleMath.run { 45.0.diff(-45.0) })
+  }
+}

--- a/lib/maplibre-compose-material3/src/desktopMain/kotlin/dev/sargunv/maplibrecompose/material3/util/util.desktop.kt
+++ b/lib/maplibre-compose-material3/src/desktopMain/kotlin/dev/sargunv/maplibrecompose/material3/util/util.desktop.kt
@@ -1,4 +1,4 @@
-package dev.sargunv.maplibrecompose.material3
+package dev.sargunv.maplibrecompose.material3.util
 
 import androidx.compose.runtime.Composable
 import dev.sargunv.maplibrecompose.material3.controls.ScaleBarMeasure

--- a/lib/maplibre-compose-material3/src/iosMain/kotlin/dev/sargunv/maplibrecompose/material3/util/util.ios.kt
+++ b/lib/maplibre-compose-material3/src/iosMain/kotlin/dev/sargunv/maplibrecompose/material3/util/util.ios.kt
@@ -1,4 +1,4 @@
-package dev.sargunv.maplibrecompose.material3
+package dev.sargunv.maplibrecompose.material3.util
 
 import androidx.compose.runtime.Composable
 import dev.sargunv.maplibrecompose.material3.controls.ScaleBarMeasure

--- a/lib/maplibre-compose-material3/src/jsMain/kotlin/dev/sargunv/maplibrecompose/material3/util/util.js.kt
+++ b/lib/maplibre-compose-material3/src/jsMain/kotlin/dev/sargunv/maplibrecompose/material3/util/util.js.kt
@@ -1,4 +1,4 @@
-package dev.sargunv.maplibrecompose.material3
+package dev.sargunv.maplibrecompose.material3.util
 
 import androidx.compose.runtime.Composable
 import dev.sargunv.maplibrecompose.material3.controls.ScaleBarMeasure


### PR DESCRIPTION
<!-- Thanks for the PR! Please fill out the template below. -->

## Description

Maps focused on Manhattan may want 29.9 degrees. [Sociopolitical statement maps](https://en.wikipedia.org/wiki/South-up_map_orientation) may want 180 degrees. Medieval maps may want 90 degrees.

I also moved all the utils in the material3 module to the .util package.
