### PR TITLE
Setting serialized GeoJson as a source

### DIFF
--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/AnimatedLayerDemo.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/AnimatedLayerDemo.kt
@@ -18,6 +18,7 @@ import dev.sargunv.maplibrecompose.compose.rememberCameraState
 import dev.sargunv.maplibrecompose.compose.rememberStyleState
 import dev.sargunv.maplibrecompose.compose.source.rememberGeoJsonSource
 import dev.sargunv.maplibrecompose.core.CameraPosition
+import dev.sargunv.maplibrecompose.core.source.Uri
 import dev.sargunv.maplibrecompose.demoapp.DEFAULT_STYLE
 import dev.sargunv.maplibrecompose.demoapp.Demo
 import dev.sargunv.maplibrecompose.demoapp.DemoMapControls
@@ -56,7 +57,7 @@ object AnimatedLayerDemo : Demo {
           ornamentSettings = DemoOrnamentSettings(),
         ) {
           val routeSource =
-            rememberGeoJsonSource(id = "amtrak-routes", uri = Res.getUri(ROUTES_FILE))
+            rememberGeoJsonSource(id = "amtrak-routes", uri = Uri(Res.getUri(ROUTES_FILE)))
 
           val infiniteTransition = rememberInfiniteTransition()
           val animatedColor by

--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/ClusteredPointsDemo.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/ClusteredPointsDemo.kt
@@ -2,14 +2,17 @@ package dev.sargunv.maplibrecompose.demoapp.demos
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
@@ -34,13 +37,14 @@ import dev.sargunv.maplibrecompose.expressions.dsl.const
 import dev.sargunv.maplibrecompose.expressions.dsl.feature
 import dev.sargunv.maplibrecompose.expressions.dsl.not
 import dev.sargunv.maplibrecompose.expressions.dsl.offset
-import dev.sargunv.maplibrecompose.expressions.dsl.plus
 import dev.sargunv.maplibrecompose.expressions.dsl.step
 import io.github.dellisd.spatialk.geojson.Feature
 import io.github.dellisd.spatialk.geojson.FeatureCollection
 import io.github.dellisd.spatialk.geojson.Point
 import io.github.dellisd.spatialk.geojson.Position
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonPrimitive
@@ -66,6 +70,7 @@ object ClusteredPointsDemo : Demo {
       val cameraState =
         rememberCameraState(firstPosition = CameraPosition(target = SEATTLE, zoom = 10.0))
       val styleState = rememberStyleState()
+      val isLoading = remember { mutableStateOf(true) }
 
       val coroutineScope = rememberCoroutineScope()
 
@@ -76,7 +81,7 @@ object ClusteredPointsDemo : Demo {
           styleState = styleState,
           ornamentSettings = DemoOrnamentSettings(),
         ) {
-          val gbfsData by rememberGbfsFeatureState(GBFS_FILE)
+          val gbfsData by rememberGbfsFeatureState(GBFS_FILE, isLoading)
 
           val bikeSource =
             rememberGeoJsonSource(
@@ -162,23 +167,33 @@ object ClusteredPointsDemo : Demo {
           )
         }
         DemoMapControls(cameraState, styleState)
+        if (isLoading.value) {
+          CircularProgressIndicator(Modifier.align(Alignment.Center))
+        }
       }
     }
   }
 }
 
 @Composable
-private fun rememberGbfsFeatureState(gbfsFilePath: String): State<FeatureCollection> {
-  val dataState = remember { mutableStateOf(FeatureCollection()) }
+private fun rememberGbfsFeatureState(
+  gbfsFilePath: String,
+  isLoading: MutableState<Boolean>,
+): State<String> {
+  val dataState = remember { mutableStateOf(FeatureCollection().json()) }
   LaunchedEffect(gbfsFilePath) {
-    val response = readGbfsData(gbfsFilePath)
-    dataState.value = response
+    withContext(Dispatchers.Default) {
+      isLoading.value = true
+      val response = readGbfsData(gbfsFilePath)
+      dataState.value = response
+      isLoading.value = false
+    }
   }
   return dataState
 }
 
 @OptIn(ExperimentalResourceApi::class)
-private suspend fun readGbfsData(gbfsFilePath: String): FeatureCollection {
+private suspend fun readGbfsData(gbfsFilePath: String): String {
   val bodyString = Res.readBytes(gbfsFilePath).decodeToString()
   val body = Json.parseToJsonElement(bodyString).jsonObject
   val bikes = body["data"]!!.jsonObject["bikes"]!!.jsonArray.map { it.jsonObject }
@@ -204,5 +219,5 @@ private suspend fun readGbfsData(gbfsFilePath: String): FeatureCollection {
           ),
       )
     }
-  return FeatureCollection(features)
+  return FeatureCollection(features).json()
 }

--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/MarkersDemo.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/MarkersDemo.kt
@@ -20,6 +20,7 @@ import dev.sargunv.maplibrecompose.compose.rememberCameraState
 import dev.sargunv.maplibrecompose.compose.rememberStyleState
 import dev.sargunv.maplibrecompose.compose.source.rememberGeoJsonSource
 import dev.sargunv.maplibrecompose.core.CameraPosition
+import dev.sargunv.maplibrecompose.core.source.Uri
 import dev.sargunv.maplibrecompose.demoapp.DEFAULT_STYLE
 import dev.sargunv.maplibrecompose.demoapp.Demo
 import dev.sargunv.maplibrecompose.demoapp.DemoMapControls
@@ -64,7 +65,9 @@ object MarkersDemo : Demo {
             rememberGeoJsonSource(
               id = "amtrak-stations",
               uri =
-                "https://raw.githubusercontent.com/datanews/amtrak-geojson/refs/heads/master/amtrak-stations.geojson",
+                Uri(
+                  "https://raw.githubusercontent.com/datanews/amtrak-geojson/refs/heads/master/amtrak-stations.geojson"
+                ),
             )
           SymbolLayer(
             id = "amtrak-stations",

--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/docs/Layers.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/docs/Layers.kt
@@ -12,6 +12,7 @@ import dev.sargunv.maplibrecompose.compose.layer.CircleLayer
 import dev.sargunv.maplibrecompose.compose.layer.LineLayer
 import dev.sargunv.maplibrecompose.compose.source.getBaseSource
 import dev.sargunv.maplibrecompose.compose.source.rememberGeoJsonSource
+import dev.sargunv.maplibrecompose.core.source.Uri
 import dev.sargunv.maplibrecompose.demoapp.generated.Res
 import dev.sargunv.maplibrecompose.expressions.dsl.const
 import dev.sargunv.maplibrecompose.expressions.dsl.exponential
@@ -35,14 +36,14 @@ fun Layers() {
     val amtrakStations =
       rememberGeoJsonSource(
         id = "amtrak-stations",
-        uri = Res.getUri("files/data/amtrak_stations.geojson"),
+        uri = Uri(Res.getUri("files/data/amtrak_stations.geojson")),
       )
 
     // -8<- [start:amtrak-1]
     val amtrakRoutes =
       rememberGeoJsonSource(
         id = "amtrak-routes",
-        uri = Res.getUri("files/data/amtrak_routes.geojson"),
+        uri = Uri(Res.getUri("files/data/amtrak_routes.geojson")),
       )
     LineLayer(
       id = "amtrak-routes-casing",

--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/source/GeoJsonSource.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/source/GeoJsonSource.kt
@@ -15,12 +15,16 @@ public actual class GeoJsonSource : Source {
     impl = source
   }
 
-  public actual constructor(id: String, uri: String, options: GeoJsonOptions) {
-    impl = MLNGeoJsonSource(id, URI(uri.correctedAndroidUri()), buildOptionMap(options))
+  public actual constructor(id: String, uri: Uri, options: GeoJsonOptions) {
+    impl = MLNGeoJsonSource(id, URI(uri.uri), buildOptionMap(options))
   }
 
   public actual constructor(id: String, data: GeoJson, options: GeoJsonOptions) {
     impl = MLNGeoJsonSource(id, data.json(), buildOptionMap(options))
+  }
+
+  public actual constructor(id: String, data: String, options: GeoJsonOptions) {
+    impl = MLNGeoJsonSource(id, data, buildOptionMap(options))
   }
 
   private fun buildOptionMap(options: GeoJsonOptions) =
@@ -42,11 +46,15 @@ public actual class GeoJsonSource : Source {
       }
     }
 
-  public actual fun setUri(uri: String) {
-    impl.setUri(uri.correctedAndroidUri())
+  public actual fun setUri(uri: Uri) {
+    impl.setUri(uri.uri.correctedAndroidUri())
   }
 
   public actual fun setData(geoJson: GeoJson) {
     impl.setGeoJson(geoJson.json())
+  }
+
+  public actual fun setData(geoJson: String) {
+    impl.setGeoJson(geoJson)
   }
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/source/rememberGeoJsonSource.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/source/rememberGeoJsonSource.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.key
 import dev.sargunv.maplibrecompose.core.source.GeoJsonOptions
 import dev.sargunv.maplibrecompose.core.source.GeoJsonSource
+import dev.sargunv.maplibrecompose.core.source.Uri
 import io.github.dellisd.spatialk.geojson.GeoJson
 
 /**
@@ -15,7 +16,7 @@ import io.github.dellisd.spatialk.geojson.GeoJson
 @Composable
 public fun rememberGeoJsonSource(
   id: String,
-  uri: String,
+  uri: Uri,
   options: GeoJsonOptions = GeoJsonOptions(),
 ): GeoJsonSource =
   key(id, options) {
@@ -34,6 +35,19 @@ public fun rememberGeoJsonSource(
 public fun rememberGeoJsonSource(
   id: String,
   data: GeoJson,
+  options: GeoJsonOptions = GeoJsonOptions(),
+): GeoJsonSource =
+  key(id, options) {
+    rememberUserSource(
+      factory = { GeoJsonSource(id = id, data = data, options = options) },
+      update = { setData(data) },
+    )
+  }
+
+@Composable
+public fun rememberGeoJsonSource(
+  id: String,
+  data: String,
   options: GeoJsonOptions = GeoJsonOptions(),
 ): GeoJsonSource =
   key(id, options) {

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/source/GeoJsonSource.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/source/GeoJsonSource.kt
@@ -9,7 +9,7 @@ public expect class GeoJsonSource : Source {
    * @param uri URI pointing to a GeoJson file
    * @param options see [GeoJsonOptions]
    */
-  public constructor(id: String, uri: String, options: GeoJsonOptions)
+  public constructor(id: String, uri: Uri, options: GeoJsonOptions)
 
   /**
    * @param id Unique identifier for this source
@@ -18,7 +18,16 @@ public expect class GeoJsonSource : Source {
    */
   public constructor(id: String, data: GeoJson, options: GeoJsonOptions)
 
-  public fun setUri(uri: String)
+  /**
+   * @param id Unique identifier for this source
+   * @param data Serialized GeoJson data
+   * @param options see [GeoJsonOptions]
+   */
+  public constructor(id: String, data: String, options: GeoJsonOptions)
+
+  public fun setUri(uri: Uri)
 
   public fun setData(geoJson: GeoJson)
+
+  public fun setData(geoJson: String)
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/source/Uri.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/source/Uri.kt
@@ -1,0 +1,3 @@
+package dev.sargunv.maplibrecompose.core.source
+
+public data class Uri(val uri: String)

--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/source/GeoJsonSource.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/source/GeoJsonSource.kt
@@ -24,12 +24,21 @@ public actual class GeoJsonSource : Source {
     impl = source
   }
 
-  public actual constructor(id: String, uri: String, options: GeoJsonOptions) {
+  public actual constructor(id: String, uri: Uri, options: GeoJsonOptions) {
     impl =
-      MLNShapeSource(identifier = id, URL = NSURL(string = uri), options = buildOptionMap(options))
+      MLNShapeSource(
+        identifier = id,
+        URL = NSURL(string = uri.uri),
+        options = buildOptionMap(options),
+      )
   }
 
   public actual constructor(id: String, data: GeoJson, options: GeoJsonOptions) {
+    impl =
+      MLNShapeSource(identifier = id, shape = data.toMLNShape(), options = buildOptionMap(options))
+  }
+
+  public actual constructor(id: String, data: String, options: GeoJsonOptions) {
     impl =
       MLNShapeSource(identifier = id, shape = data.toMLNShape(), options = buildOptionMap(options))
   }
@@ -55,11 +64,15 @@ public actual class GeoJsonSource : Source {
       )
     }
 
-  public actual fun setUri(uri: String) {
-    impl.setURL(NSURL(string = uri))
+  public actual fun setUri(uri: Uri) {
+    impl.setURL(NSURL(string = uri.uri))
   }
 
   public actual fun setData(geoJson: GeoJson) {
+    impl.setShape(geoJson.toMLNShape())
+  }
+
+  public actual fun setData(geoJson: String) {
     impl.setShape(geoJson.toMLNShape())
   }
 }

--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/util/util.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/util/util.kt
@@ -133,6 +133,14 @@ internal fun GeoJson.toMLNShape(): MLNShape {
   )!!
 }
 
+internal fun String.toMLNShape(): MLNShape {
+  return MLNShape.shapeWithData(
+    data = encodeToByteArray().toNSData(),
+    encoding = NSUTF8StringEncoding,
+    error = null,
+  )!!
+}
+
 internal fun CompiledExpression<*>.toNSExpression(): NSExpression =
   if (this == NullLiteral) NSExpression.expressionForConstantValue(null)
   else NSExpression.expressionWithMLNJSONObject(normalizeJsonLike(false)!!)


### PR DESCRIPTION
## Description

This PR allows the user to pass serialized GeoJson to `rememberGeoJsonSource`.

Use cases:
- Setting `GeoJsonSource` when the user has only serialized GeoJson
- GeoJson can be serialized before passing to the `rememberGeoJsonSource`. It gives more control over the process of serialization. As it can take some time to serialize it, the user may want to serialize it in the background thread, cache the serialized string, and display a loading indicator during serialization. In the `ClusteredPointsDemo` I demonstrated serializing in the background thread (which eliminates UI freeze during the loading) and displaying a loading indicator. Caching doesn't make sense in this case, but it's possible now.


## Test plan

Run `ClusteredPointsDemo` and check if everything is smooth.

## Checklist

This pull request primarily:

- [x] Adds a feature. Partially related to #72

To your knowledge, are you making any breaking changes?

- [x] Yes (please describe)

Adding a new overload of `rememberGeoJsonSource`, created conflicting overloads, so I needed to wrap `Uri` into the data class, so now we need to do:
``` kotlin
rememberGeoJsonSource(id = "id", uri = Uri(Res.getUri(ROUTES_FILE)))
```
instead of
``` kotlin
rememberGeoJsonSource(id = "id", uri = Res.getUri(ROUTES_FILE))
```

Do you have access to a macOS device to develop and test iOS changes?

- [x] Yes

Have you tested the changes, if applicable? On which platforms?

- [x] Android 14 - Xiaomi Redmi Note 13
- [x] iOS 18.5 - iPhone SE 2022
