### PR TITLE
typo: fix asyng to async

### DIFF
--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/MaplibreMap.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/MaplibreMap.kt
@@ -217,7 +217,7 @@ public fun MaplibreMap(
             map.asyncSetMaxPitch(pitchRange.endInclusive.toDouble())
             map.asyncSetGestureSettings(gestureSettings)
             map.asyncSetOrnamentSettings(ornamentSettings)
-            map.asyngSetMaximumFps(maximumFps)
+            map.asyncSetMaximumFps(maximumFps)
           }
       }
     },

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/MaplibreMap.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/MaplibreMap.kt
@@ -41,7 +41,7 @@ internal interface MaplibreMap {
 
   suspend fun asyncGetVisibleRegion(): VisibleRegion
 
-  suspend fun asyngSetMaximumFps(maximumFps: Int)
+  suspend fun asyncSetMaximumFps(maximumFps: Int)
 
   suspend fun asyncSetOrnamentSettings(value: OrnamentSettings)
 
@@ -106,7 +106,7 @@ internal interface StandardMaplibreMap : MaplibreMap {
 
   override suspend fun asyncGetVisibleRegion(): VisibleRegion = getVisibleRegion()
 
-  override suspend fun asyngSetMaximumFps(maximumFps: Int) = setMaximumFps(maximumFps)
+  override suspend fun asyncSetMaximumFps(maximumFps: Int) = setMaximumFps(maximumFps)
 
   override suspend fun asyncSetOrnamentSettings(value: OrnamentSettings) =
     setOrnamentSettings(value)

--- a/lib/maplibre-compose/src/desktopMain/kotlin/dev/sargunv/maplibrecompose/core/WebviewMap.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/dev/sargunv/maplibrecompose/core/WebviewMap.kt
@@ -59,7 +59,7 @@ internal class WebviewMap(private val bridge: WebviewBridge) : MaplibreMap {
     )
   }
 
-  override suspend fun asyngSetMaximumFps(maximumFps: Int) {
+  override suspend fun asyncSetMaximumFps(maximumFps: Int) {
     // Not supported on web
   }
 


### PR DESCRIPTION
## Description

Typo fix of asyng to async in `map.asyngSetMaximumFps(maximumFps)`


## Checklist

This pull request primarily:

- [ ] Updates documentation.
- [x] Fixes a bug. (please link to the issue)
- [ ] Adds a feature. (please link to the issue or discussion)

<!-- If you're just updating documentation, delete the rest of this checklist. -->

To your knowledge, are you making any breaking changes?

- [ ] Yes (please describe)
- [ ] No
- [x] Unknown

Do you have access to a macOS device to develop and test iOS changes?

- [ ] Yes
- [x] No

Have you tested the changes, if applicable? On which platforms?

- [ ] Android (describe the device and OS version)
- [ ] iOS (describe the device and OS version)
- [ ] Desktop (describe the device and OS version)
- [ ] Web (describe the browser version)
