### PR TITLE
Remove unused property access in AndroidScaleBar.updateLayout()

### DIFF
--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/AndroidScaleBar.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/AndroidScaleBar.kt
@@ -38,8 +38,6 @@ internal class AndroidScaleBar(ctx: Context, private val mapView: MapView, map: 
       val right = (padding.calculateRightPadding(layoutDir).coerceAtLeast(0.dp) + 8.dp).roundToPx()
       val bottom = (padding.calculateBottomPadding().coerceAtLeast(0.dp) + 8.dp).roundToPx()
 
-      scaleBar.barHeight
-
       val offset =
         alignment.align(
           size =


### PR DESCRIPTION

## Description

The scaleBar.barHeight property was being accessed without using the result.

## Checklist

This pull request primarily:

- [ ] Updates documentation.
- [x] Fixes a bug. (please link to the issue)
- [ ] Adds a feature. (please link to the issue or discussion)

<!-- If you're just updating documentation, delete the rest of this checklist. -->

To your knowledge, are you making any breaking changes?

- [ ] Yes (please describe)
- [x] No

Do you have access to a macOS device to develop and test iOS changes?

- [ ] Yes
- [x] No

Have you tested the changes, if applicable? On which platforms?

- [ ] Android (describe the device and OS version)
- [ ] iOS (describe the device and OS version)
- [ ] Desktop (describe the device and OS version)
- [ ] Web (describe the browser version)
