### PR TITLE
format number of scale bar locale-aware

### DIFF
--- a/lib/maplibre-compose-material3/src/androidMain/kotlin/dev/sargunv/maplibrecompose/material3/util/NumberFormatter.android.kt
+++ b/lib/maplibre-compose-material3/src/androidMain/kotlin/dev/sargunv/maplibrecompose/material3/util/NumberFormatter.android.kt
@@ -1,0 +1,16 @@
+package dev.sargunv.maplibrecompose.material3.util
+
+import androidx.compose.ui.text.intl.Locale
+import java.text.NumberFormat
+
+private class NumberFormatterAndroid(locale: Locale, maximumFractionDigits: Int): NumberFormatter {
+
+  private val format = NumberFormat.getInstance(locale.platformLocale).also {
+    it.maximumFractionDigits = maximumFractionDigits
+  }
+
+  override fun format(value: Number): String = format.format(value)
+}
+
+internal actual fun NumberFormatter(locale: Locale, maximumFractionDigits: Int): NumberFormatter =
+  NumberFormatterAndroid(locale, maximumFractionDigits)

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/ScaleBar.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/ScaleBar.kt
@@ -72,7 +72,7 @@ public fun ScaleBar(
   val textMeasurer = rememberTextMeasurer()
   // longest possible text
   val maxTextSizePx =
-    remember(textMeasurer, textStyle) { textMeasurer.measure("5000 km", textStyle).size }
+    remember(textMeasurer, textStyle) { textMeasurer.measure("5 000 km", textStyle).size }
   val maxTextSize = with(LocalDensity.current) { maxTextSizePx.toSize().toDpSize() }
 
   // padding of text to bar stroke

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/ScaleBarMeasure.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/ScaleBarMeasure.kt
@@ -1,12 +1,15 @@
 package dev.sargunv.maplibrecompose.material3.controls
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.text.intl.Locale
 import dev.sargunv.maplibrecompose.material3.generated.Res
 import dev.sargunv.maplibrecompose.material3.generated.feet_symbol
 import dev.sargunv.maplibrecompose.material3.generated.kilometers_symbol
 import dev.sargunv.maplibrecompose.material3.generated.meters_symbol
 import dev.sargunv.maplibrecompose.material3.generated.miles_symbol
 import dev.sargunv.maplibrecompose.material3.generated.yards_symbol
+import dev.sargunv.maplibrecompose.material3.util.NumberFormatter
 import io.github.kevincianfarini.alchemist.scalar.centimeters
 import io.github.kevincianfarini.alchemist.scalar.kilometers
 import io.github.kevincianfarini.alchemist.scalar.toLength
@@ -93,50 +96,51 @@ public interface ScaleBarMeasure {
 
     /** Get the formatted text to show for a given generated stop and length. */
     @Composable
-    protected open fun getText(stop: Double, unit: LengthUnit): String =
-      "${stop.toShortString()}\u202F${unit.symbol}"
-
-    /** Stringify a [Double], removing the decimal point if it's a whole number. */
-    protected fun Double.toShortString(): String =
-      if (this % 1.0 == 0.0) this.toLong().toString() else this.toString()
+    protected open fun getText(stop: Double, unit: LengthUnit): String {
+      val formatter = remember(Locale.current) { NumberFormatter(Locale.current) }
+      return "${formatter.format(stop)}\u202F${unit.symbol}"
+    }
   }
 
   public data object Metric : Default(Meter, Kilometer) {
     @Composable
     override fun getText(stop: Double, unit: LengthUnit): String {
+      val formatter = remember(Locale.current) { NumberFormatter(Locale.current) }
       val symbol =
         when (unit) {
           Meter -> stringResource(Res.string.meters_symbol)
           Kilometer -> stringResource(Res.string.kilometers_symbol)
           else -> error("impossible")
         }
-      return "${stop.toShortString()}\u202F$symbol"
+      return "${formatter.format(stop)}\u202F$symbol"
     }
   }
 
   public data object FeetAndMiles : Default(Foot, Mile) {
     @Composable
     override fun getText(stop: Double, unit: LengthUnit): String {
+      val formatter = remember(Locale.current) { NumberFormatter(Locale.current) }
       val symbol =
         when (unit) {
           Foot -> stringResource(Res.string.feet_symbol)
           Mile -> stringResource(Res.string.miles_symbol)
           else -> error("impossible")
         }
-      return "${stop.toShortString()}\u202F$symbol"
+      return "${formatter.format(stop)}\u202F$symbol"
     }
   }
 
   public data object YardsAndMiles : Default(Yard, Mile) {
     @Composable
     override fun getText(stop: Double, unit: LengthUnit): String {
+      val formatter = remember(Locale.current) { NumberFormatter(Locale.current) }
       val symbol =
         when (unit) {
           Yard -> stringResource(Res.string.yards_symbol)
           Mile -> stringResource(Res.string.miles_symbol)
           else -> error("impossible")
         }
-      return "${stop.toShortString()}\u202F$symbol"
+      return "${formatter.format(stop)}\u202F$symbol"
     }
   }
 }

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/util/NumberFormatter.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/util/NumberFormatter.kt
@@ -1,0 +1,14 @@
+package dev.sargunv.maplibrecompose.material3.util
+
+import androidx.compose.ui.text.intl.Locale
+
+internal interface NumberFormatter {
+  /** Format the given [value] locale-aware. */
+  fun format(value: Number): String
+}
+
+/** Create a new [NumberFormatter] instance with the given [locale] */
+internal expect fun NumberFormatter(
+  locale: Locale,
+  maximumFractionDigits: Int = Int.MAX_VALUE
+): NumberFormatter

--- a/lib/maplibre-compose-material3/src/commonTest/kotlin/dev/sargunv/maplibrecompose/material3/util/NumberFormatterTest.kt
+++ b/lib/maplibre-compose-material3/src/commonTest/kotlin/dev/sargunv/maplibrecompose/material3/util/NumberFormatterTest.kt
@@ -1,0 +1,24 @@
+package dev.sargunv.maplibrecompose.material3.util
+
+import androidx.compose.ui.text.intl.Locale
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class NumberFormatterTest {
+  val en = Locale("en-US")
+  val fr = Locale("fr-FR")
+  val de = Locale("de-DE")
+  val ar = Locale("ar-SA")
+  
+  @Test fun format() {
+    assertEquals("1", NumberFormatter(en).format(1.0))
+    assertEquals("1.5", NumberFormatter(en).format(1.5))
+    assertEquals("1,5", NumberFormatter(fr).format(1.5))
+    assertEquals("١٫٥", NumberFormatter(ar).format(1.5))
+
+    assertEquals("1,000,000", NumberFormatter(en).format(1_000_000))
+    assertEquals("1 000 000", NumberFormatter(fr).format(1_000_000))
+    assertEquals("1.000.000", NumberFormatter(de).format(1_000_000))
+    assertEquals("١٬٠٠٠٬٠٠٠", NumberFormatter(ar).format(1_000_000))
+  }
+}

--- a/lib/maplibre-compose-material3/src/desktopMain/kotlin/dev/sargunv/maplibrecompose/material3/util/NumberFormatter.desktop.kt
+++ b/lib/maplibre-compose-material3/src/desktopMain/kotlin/dev/sargunv/maplibrecompose/material3/util/NumberFormatter.desktop.kt
@@ -1,0 +1,16 @@
+package dev.sargunv.maplibrecompose.material3.util
+
+import androidx.compose.ui.text.intl.Locale
+import java.text.NumberFormat
+
+private class NumberFormatterDesktop(locale: Locale, maximumFractionDigits: Int): NumberFormatter {
+
+  private val format = NumberFormat.getInstance(locale.platformLocale).also {
+    it.maximumFractionDigits = maximumFractionDigits
+  }
+
+  override fun format(value: Number): String = format.format(value)
+}
+
+internal actual fun NumberFormatter(locale: Locale, maximumFractionDigits: Int): NumberFormatter =
+  NumberFormatterDesktop(locale, maximumFractionDigits)

--- a/lib/maplibre-compose-material3/src/iosMain/kotlin/dev/sargunv/maplibrecompose/material3/util/NumberFormatter.ios.kt
+++ b/lib/maplibre-compose-material3/src/iosMain/kotlin/dev/sargunv/maplibrecompose/material3/util/NumberFormatter.ios.kt
@@ -1,0 +1,21 @@
+package dev.sargunv.maplibrecompose.material3.util
+
+import androidx.compose.ui.text.intl.Locale
+import platform.Foundation.NSNumber
+import platform.Foundation.NSNumberFormatter
+import platform.Foundation.NSNumberFormatterDecimalStyle
+
+private class NumberFormatterIos(locale: Locale, maximumFractionDigits: Int): NumberFormatter {
+
+  private val format = NSNumberFormatter().also {
+    it.numberStyle = NSNumberFormatterDecimalStyle
+    it.maximumFractionDigits = maximumFractionDigits.toULong()
+    it.locale = locale.platformLocale
+  }
+
+  override fun format(value: Number): String =
+    format.stringFromNumber(value as NSNumber) ?: value.toString()
+}
+
+internal actual fun NumberFormatter(locale: Locale, maximumFractionDigits: Int): NumberFormatter =
+  NumberFormatterIos(locale, maximumFractionDigits)

--- a/lib/maplibre-compose-material3/src/jsMain/kotlin/dev/sargunv/maplibrecompose/material3/util/NumberFormatter.js.kt
+++ b/lib/maplibre-compose-material3/src/jsMain/kotlin/dev/sargunv/maplibrecompose/material3/util/NumberFormatter.js.kt
@@ -1,0 +1,17 @@
+package dev.sargunv.maplibrecompose.material3.util
+
+import androidx.compose.ui.text.intl.Locale
+
+private class NumberFormatterJs(locale: Locale, maximumFractionDigits: Int): NumberFormatter {
+
+  val format = NumberFormat(
+    locales = locale.toLanguageTag(),
+    numberFormatOptions = NumberFormatOptions(maximumFractionDigits = maximumFractionDigits)
+  )
+
+  override fun format(value: Number): String =
+    format.format(value)
+}
+
+internal actual fun NumberFormatter(locale: Locale, maximumFractionDigits: Int): NumberFormatter =
+  NumberFormatterJs(locale, maximumFractionDigits)


### PR DESCRIPTION
## Description

In different languages, there are...
- different decimal separators (e.g. 12.5 vs 12,5)
- different digits (e.g. in Arabic)
- different grouping separators (e.g. 1,000,000 vs 1'000'000)

## Test plan

- Execute the unit test on all platforms
- Switch the language and return to the app: Did the formatting change?

## Checklist

This pull request primarily fixes a bug: Numbers should be formatted locale-aware.

To my knowledge, I am not making breaking changes.

I don't have access to a macOS device right now.

I have tested the changes only on Android.

## TODO / Help!?

The `NumberFormatter.js.kt` does not compile. I don't know why. The classes exist:
- https://jetbrains.github.io/kotlin-wrappers/kotlin-js/js.intl/-number-format/index.html
- https://jetbrains.github.io/kotlin-wrappers/kotlin-js/js.intl/-number-format-options/index.html
Do I need some import statement? I don't know.