### PR TITLE
add translations for compass

### DIFF
--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-af/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-af/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Kompas</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-an/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-an/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Bruixula</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ar/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ar/strings.xml
@@ -1,4 +1,5 @@
 <resources>
   <string name="meters_symbol">متر</string>
   <string name="kilometers_symbol">كم</string>
+  <string name="compass">بوصلة</string>
 </resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ast/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ast/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Brúxula</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-az/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-az/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Kompas</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-b+sr+Latn/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-b+sr+Latn/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Kompas</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ba/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ba/strings.xml
@@ -1,4 +1,5 @@
 <resources>
   <string name="meters_symbol">м</string>
   <string name="kilometers_symbol">км</string>
+  <string name="compass">Компас</string>
 </resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-be/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-be/strings.xml
@@ -1,4 +1,5 @@
 <resources>
   <string name="meters_symbol">м</string>
   <string name="kilometers_symbol">км</string>
+  <string name="compass">Компас</string>
 </resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-bg/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-bg/strings.xml
@@ -1,4 +1,5 @@
 <resources>
   <string name="meters_symbol">м</string>
   <string name="kilometers_symbol">км</string>
+  <string name="compass">Компас</string>
 </resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-bho/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-bho/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">कुतुबनुमा</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-bn/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-bn/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">কম্পাস</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-br/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-br/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Nadoz-vor</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-bs/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-bs/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Kompas</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-bxr/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-bxr/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Луужин</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ca/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ca/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Brúixola</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-cdo/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-cdo/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Lò̤-buàng</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ckb/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ckb/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">قیبلەنما</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-cs/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-cs/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Kompas</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-cv/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-cv/strings.xml
@@ -1,4 +1,5 @@
 <resources>
   <string name="meters_symbol">м</string>
   <string name="kilometers_symbol">км</string>
+  <string name="compass">Компас</string>
 </resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-cy/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-cy/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Cwmpawd</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-da/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-da/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Kompas</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-de/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-de/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Kompass</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-el/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-el/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Πυξίδα</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-en/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-en/strings.xml
@@ -1,0 +1,10 @@
+<resources>
+  <string name="library_name">MapLibre Compose</string>
+  <string name="attribution">Map Attribution</string>
+  <string name="compass">Compass</string>
+  <string name="meters_symbol">m</string>
+  <string name="kilometers_symbol">km</string>
+  <string name="feet_symbol">ft</string>
+  <string name="yards_symbol">yd</string>
+  <string name="miles_symbol">mi</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-eo/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-eo/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Kompaso</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-es/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-es/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Brújula</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-et/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-et/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Kompass</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-eu/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-eu/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Iparrorratz</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-fa/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-fa/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">قطب‌نما</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-fi/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-fi/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Kompassi</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-fo/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-fo/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Kumpass</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-fr/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-fr/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Boussole</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-fy/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-fy/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Kompas</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ga/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ga/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Compás</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-gan/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-gan/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">羅盤</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-gcr/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-gcr/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Konpa</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-gd/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-gd/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Combaist</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-gl/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-gl/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Compás</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-gu/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-gu/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">હોકાયંત્ર</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ha/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ha/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Kamfas</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-hbs/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-hbs/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Kompas</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-he/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-he/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">מצפן</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-hi/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-hi/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">दिक्सूचक</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-hr/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-hr/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Kompas</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-hu/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-hu/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Iránytű</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-hy/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-hy/strings.xml
@@ -1,4 +1,5 @@
 <resources>
   <string name="meters_symbol">մ</string>
   <string name="kilometers_symbol">կմ</string>
+  <string name="compass">Կողմնացույց</string>
 </resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ia/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ia/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Bussola</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-id/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-id/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Kompas</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-io/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-io/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Busolo</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-is/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-is/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Áttaviti</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-it/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-it/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Bussola</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ja/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ja/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">方位磁針</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-jam/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-jam/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Kompas</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-jbo/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-jbo/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Makfartci</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-jv/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-jv/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Pandom</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ka/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ka/strings.xml
@@ -1,4 +1,5 @@
 <resources>
   <string name="meters_symbol">მ</string>
   <string name="kilometers_symbol">კმ</string>
+  <string name="compass">კომპასი</string>
 </resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-kaa/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-kaa/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Kompas</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-kg/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-kg/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Busula</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-kk/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-kk/strings.xml
@@ -1,4 +1,5 @@
 <resources>
   <string name="meters_symbol">м</string>
   <string name="kilometers_symbol">км</string>
+  <string name="compass">Компас</string>
 </resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-km/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-km/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">ត្រីវិស័យ</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-kn/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-kn/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">ದಿಕ್ಸೂಚಿ</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ko/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ko/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">나침반</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ky/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ky/strings.xml
@@ -1,4 +1,5 @@
 <resources>
   <string name="meters_symbol">м</string>
   <string name="kilometers_symbol">км</string>
+  <string name="compass">Компас</string>
 </resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-la/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-la/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Pyxis nautica</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-lo/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-lo/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">ເຂັມທິດ</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-lt/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-lt/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Kompass</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-lv/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-lv/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Kompass</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-mg/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-mg/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Tondroavaratra</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-mk/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-mk/strings.xml
@@ -1,4 +1,5 @@
 <resources>
   <string name="meters_symbol">м</string>
   <string name="kilometers_symbol">км</string>
+  <string name="compass">Компас</string>
 </resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ml/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ml/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">വടക്കുനോക്കിയന്ത്രം</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-mn/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-mn/strings.xml
@@ -1,4 +1,5 @@
 <resources>
   <string name="meters_symbol">м</string>
   <string name="kilometers_symbol">км</string>
+  <string name="compass">Луужин</string>
 </resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-mr/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-mr/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">होकायंत्र</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ms/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ms/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Kompas</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-my/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-my/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">သံလိုက်အိမ်မြှောင်</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ne/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ne/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">कम्पास</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-nl/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-nl/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Kompas</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-nn/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-nn/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Kompass</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-no/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-no/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Kompass</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-oc/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-oc/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Bossòla</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-om/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-om/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Koompaasii</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-or/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-or/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">କମ୍ପାସ</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-pa/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-pa/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">ਦਿਸ਼ਾ ਸੂਚਕ</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-pam/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-pam/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Paraluman</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-pap/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-pap/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Compas</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-pl/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-pl/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Kompas</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-pnb/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-pnb/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">قطب نما</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ps/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ps/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">قطب نما</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-pt/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-pt/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Bússola</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-qu/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-qu/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Suyu rikuchiq</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ro/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ro/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Busolă</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ru/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ru/strings.xml
@@ -1,4 +1,5 @@
 <resources>
   <string name="meters_symbol">м</string>
   <string name="kilometers_symbol">км</string>
+  <string name="compass">Компас</string>
 </resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-sd/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-sd/strings.xml
@@ -1,0 +1,5 @@
+<resources>
+  <string name="meters_symbol">м</string>
+  <string name="kilometers_symbol">км</string>
+  <string name="compass">قطب نما</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-se/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-se/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Kompássa</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-si/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-si/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">මාලිමාව</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-sk/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-sk/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Kompas</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-sl/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-sl/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Kompas</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-sq/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-sq/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Busulla</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-sr/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-sr/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Компас</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-su/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-su/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Kompas</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-sv/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-sv/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Kompass</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-sw/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-sw/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Dira</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ta/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ta/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">திசைகாட்டி</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-te/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-te/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">దిక్సూచి</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-tg/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-tg/strings.xml
@@ -1,4 +1,5 @@
 <resources>
   <string name="meters_symbol">м</string>
   <string name="kilometers_symbol">км</string>
+  <string name="compass">Компас</string>
 </resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-th/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-th/strings.xml
@@ -1,4 +1,5 @@
 <resources>
   <string name="meters_symbol">ม</string>
   <string name="kilometers_symbol">กม</string>
+  <string name="compass">เข็มทิศ</string>
 </resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-tl/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-tl/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Aguhon</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-tr/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-tr/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Pusula</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-tt/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-tt/strings.xml
@@ -1,4 +1,5 @@
 <resources>
   <string name="meters_symbol">м</string>
   <string name="kilometers_symbol">км</string>
+  <string name="compass">Компас</string>
 </resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-uk/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-uk/strings.xml
@@ -1,4 +1,5 @@
 <resources>
   <string name="meters_symbol">м</string>
   <string name="kilometers_symbol">км</string>
+  <string name="compass">Компас</string>
 </resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ur/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-ur/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">قطب نما</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-uz/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-uz/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Kompas</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-vi/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-vi/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">La bàn</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-war/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-war/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">Kompas</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-wuu/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-wuu/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">指南针</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-yi/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-yi/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">קאמפאס</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-yue/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-yue/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="compass">羅經</string>
+</resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-zh/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-zh/strings.xml
@@ -1,4 +1,5 @@
 <resources>
   <string name="meters_symbol">米</string>
   <string name="kilometers_symbol">千米</string>
+  <string name="compass">指南针</string>
 </resources>


### PR DESCRIPTION
## Description

source: https://www.wikidata.org/wiki/Q34735

## Checklist

This pull request adds translations for the default `contentDescription` of the material3 compass button

To your knowledge, I am not making any breaking changes.
I don't have a macOS device to develop right now.
I have not tested the changes.