### PR TITLE
update foojay-resolver-convention

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -33,7 +33,8 @@ dependencyResolutionManagement {
   }
 }
 
-plugins { id("org.gradle.toolchains.foojay-resolver-convention") version ("0.10.0") }
+// Versions: https://plugins.gradle.org/plugin/org.gradle.toolchains.foojay-resolver-convention
+plugins { id("org.gradle.toolchains.foojay-resolver-convention") version ("1.0.0") }
 
 include(
   ":",


### PR DESCRIPTION
I think settings.gradle doesn't support reading from the version catalog, so we have to keep this up to date separately