### PR TITLE
Use HtmlConverterCompose to parse HTML to an AnnotatedString for the expanding attribution button

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ alchemist = "0.2.0"
 androidx-activity = "1.10.1"
 bytesize = "2.0.0-beta04"
 compass = "2.3.0"
+htmlConverterCompose = "1.0.4"
 kermit = "2.0.5"
 kotlin-wrappers = "2025.6.4"
 kotlinx-browser = "0.3"
@@ -50,6 +51,7 @@ bytesize = { module = "me.saket.bytesize:bytesize", version.ref = "bytesize" }
 compass-geolocation-core = { module = "dev.jordond.compass:geolocation", version.ref = "compass" }
 compass-geolocation-mobile = { module = "dev.jordond.compass:geolocation-mobile", version.ref = "compass" }
 compass-geolocation-browser = { module = "dev.jordond.compass:geolocation-browser", version.ref = "compass" }
+htmlConverterCompose = { module = "be.digitalia.compose.htmlconverter:htmlconverter", version.ref = "htmlConverterCompose" }
 kotlinx-browser = { module = "org.jetbrains.kotlinx:kotlinx-browser", version.ref = "kotlinx-browser" }
 webview = { module = "io.github.kevinnzou:compose-webview-multiplatform", version.ref = "webview" }
 kermit = { group = "co.touchlab", name = "kermit", version.ref = "kermit" }

--- a/lib/maplibre-compose-material3/build.gradle.kts
+++ b/lib/maplibre-compose-material3/build.gradle.kts
@@ -51,11 +51,29 @@ kotlin {
 
     val maplibreNativeMain by creating { dependsOn(commonMain.get()) }
 
-    iosMain { dependsOn(maplibreNativeMain) }
+    val webMain by creating { dependsOn(commonMain.get()) }
 
-    androidMain { dependsOn(maplibreNativeMain) }
+    val nonWebMain by creating {
+      dependsOn(commonMain.get())
+      dependencies { implementation(libs.htmlConverterCompose) }
+    }
 
-    jsMain.dependencies { implementation(libs.kotlin.wrappers.js) }
+    iosMain {
+      dependsOn(maplibreNativeMain)
+      dependsOn(nonWebMain)
+    }
+
+    androidMain {
+      dependsOn(maplibreNativeMain)
+      dependsOn(nonWebMain)
+    }
+
+    get("desktopMain").apply { dependsOn(nonWebMain) }
+
+    jsMain {
+      dependsOn(webMain)
+      dependencies { implementation(libs.kotlin.wrappers.js) }
+    }
 
     commonTest.dependencies {
       implementation(kotlin("test"))

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/util/htmlToAnnotatedString.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/util/htmlToAnnotatedString.kt
@@ -1,0 +1,9 @@
+package dev.sargunv.maplibrecompose.material3.util
+
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.TextLinkStyles
+
+internal expect fun htmlToAnnotatedString(
+  html: String,
+  textLinkStyles: TextLinkStyles?,
+): AnnotatedString

--- a/lib/maplibre-compose-material3/src/nonWebMain/kotlin/dev/sargunv/maplibrecompose/material3/util/htmlToAnnotatedString.nonWeb.kt
+++ b/lib/maplibre-compose-material3/src/nonWebMain/kotlin/dev/sargunv/maplibrecompose/material3/util/htmlToAnnotatedString.nonWeb.kt
@@ -1,0 +1,12 @@
+package dev.sargunv.maplibrecompose.material3.util
+
+import androidx.compose.ui.text.TextLinkStyles
+import androidx.compose.ui.unit.TextUnit
+import be.digitalia.compose.htmlconverter.HtmlStyle
+
+internal actual fun htmlToAnnotatedString(html: String, textLinkStyles: TextLinkStyles?) =
+  be.digitalia.compose.htmlconverter.htmlToAnnotatedString(
+    html,
+    compactMode = true,
+    style = HtmlStyle(indentUnit = TextUnit.Unspecified, textLinkStyles = textLinkStyles),
+  )

--- a/lib/maplibre-compose-material3/src/webMain/kotlin/dev/sargunv/maplibrecompose/material3/util/htmlToAnnotatedString.web.kt
+++ b/lib/maplibre-compose-material3/src/webMain/kotlin/dev/sargunv/maplibrecompose/material3/util/htmlToAnnotatedString.web.kt
@@ -1,0 +1,9 @@
+package dev.sargunv.maplibrecompose.material3.util
+
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.TextLinkStyles
+
+internal actual fun htmlToAnnotatedString(
+  html: String,
+  textLinkStyles: TextLinkStyles?,
+): AnnotatedString = TODO("Not implemented")

--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/source/Source.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/source/Source.kt
@@ -1,7 +1,5 @@
 package dev.sargunv.maplibrecompose.core.source
 
-import android.text.Html
-import android.text.style.URLSpan
 import org.maplibre.android.style.sources.Source as MLNSource
 
 public actual sealed class Source {
@@ -9,18 +7,7 @@ public actual sealed class Source {
 
   internal actual val id: String by lazy { impl.id }
 
-  public actual val attributionLinks: List<AttributionLink> by lazy {
-    // TODO minSdk 24 to get rid of deprecation warning
-    @Suppress("DEPRECATION") val spanned = Html.fromHtml(impl.attribution)
-
-    val spans = spanned.getSpans(0, spanned.length, URLSpan::class.java)
-    spans.map {
-      AttributionLink(
-        title = spanned.slice(spanned.getSpanStart(it)..<spanned.getSpanEnd(it)).toString(),
-        url = it.url,
-      )
-    }
-  }
+  public actual val attributionHtml: String by lazy { impl.attribution }
 
   override fun toString(): String = "${this::class.simpleName}(id=\"$id\")"
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/source/AttributionLink.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/source/AttributionLink.kt
@@ -1,3 +1,0 @@
-package dev.sargunv.maplibrecompose.core.source
-
-public data class AttributionLink(val title: String, val url: String)

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/source/Source.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/source/Source.kt
@@ -3,5 +3,5 @@ package dev.sargunv.maplibrecompose.core.source
 /** A data source for map data */
 public expect sealed class Source {
   internal val id: String
-  public val attributionLinks: List<AttributionLink>
+  public val attributionHtml: String
 }

--- a/lib/maplibre-compose/src/desktopMain/kotlin/dev/sargunv/maplibrecompose/core/source/Source.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/dev/sargunv/maplibrecompose/core/source/Source.kt
@@ -6,10 +6,8 @@ public actual sealed class Source {
   internal actual val id: String
     get() = TODO()
 
-  public actual val attributionLinks: List<AttributionLink>
-    get() {
-      TODO()
-    }
+  public actual val attributionHtml: String
+    get() = TODO()
 
   override fun toString(): String = "${this::class.simpleName}(id=\"$id\")"
 }

--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/source/Source.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/source/Source.kt
@@ -1,6 +1,5 @@
 package dev.sargunv.maplibrecompose.core.source
 
-import MapLibre.MLNAttributionInfo
 import MapLibre.MLNSource
 import MapLibre.MLNTileSource
 
@@ -8,12 +7,10 @@ public actual sealed class Source {
   internal abstract val impl: MLNSource
   internal actual val id: String by lazy { impl.identifier }
 
-  public actual val attributionLinks: List<AttributionLink> by lazy {
-    (impl as? MLNTileSource)?.attributionInfos?.mapNotNull {
-      it as MLNAttributionInfo
-      if (it.URL == null) return@mapNotNull null
-      AttributionLink(title = it.title.string(), url = it.URL.toString())
-    } ?: emptyList()
+  public actual val attributionHtml: String by lazy {
+    // https://github.com/maplibre/maplibre-native/pull/3551
+    @Suppress("USELESS_CAST")
+    ((impl as? MLNTileSource)?.attributionHTMLString as? String?) ?: ""
   }
 
   override fun toString(): String = "${this::class.simpleName}(id=\"$id\")"

--- a/lib/maplibre-compose/src/jsMain/kotlin/dev/sargunv/maplibrecompose/core/source/Source.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/dev/sargunv/maplibrecompose/core/source/Source.kt
@@ -6,10 +6,8 @@ public actual sealed class Source {
   internal actual val id: String
     get() = TODO()
 
-  public actual val attributionLinks: List<AttributionLink>
-    get() {
-      TODO()
-    }
+  public actual val attributionHtml: String
+    get() = TODO()
 
   override fun toString(): String = "${this::class.simpleName}(id=\"$id\")"
 }


### PR DESCRIPTION

## Description

Resolves #382 and fixes #388, but reveals oddities about how we currently lay out text on the expanding attribution bar.

Will play with it and follow up with fixes for layout in another PR

## Test plan

![CleanShot 2025-06-12 at 19 36 07@2x](https://github.com/user-attachments/assets/1ca141db-a899-4358-898b-9fe7f5ab9791)

![CleanShot 2025-06-12 at 19 36 20@2x](https://github.com/user-attachments/assets/13600c48-29dd-4ba8-a57c-1f273115321a)
