### PR TITLE
fix attribution text layout

### DIFF
--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/AttributionButton.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/AttributionButton.kt
@@ -192,7 +192,9 @@ public fun ExpandingAttributionButton(
           exit = collapse(animationAlignment),
         ) {
           Box(Modifier.padding(start = 0.dp, end = 16.dp, top = 8.dp, bottom = 8.dp)) {
-            expandedContent(attributions)
+            CompositionLocalProvider(LocalLayoutDirection provides layoutDir) {
+              expandedContent(attributions)
+            }
           }
         }
       }

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/AttributionButton.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/AttributionButton.kt
@@ -8,11 +8,13 @@ import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.expandIn
 import androidx.compose.animation.shrinkOut
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -211,7 +213,9 @@ public fun AttributionLinks(
 ) {
   val texts = remember(attributions) { attributions.map { htmlToAnnotatedString(it, linkStyles) } }
   FlowRow(modifier = modifier, horizontalArrangement = Arrangement.spacedBy(spacing)) {
-    texts.forEach { Text(it) }
+    texts.forEach {
+      Text(it, maxLines = 1, modifier = Modifier.horizontalScroll(rememberScrollState()))
+    }
   }
 }
 


### PR DESCRIPTION
<!-- Thanks for the PR! Please fill out the template below. -->

## Description

Fixes incorrect layout direction, and also avoid breaking inside an attribution (we can still do separate lines for multiple attributions if they're long enough).

I'm not super happy with the scrolling solution, but anything else I tried looked wonky in certain cases.

## Test plan

![CleanShot 2025-06-12 at 20 10 34@2x](https://github.com/user-attachments/assets/2a01457b-1e59-4086-85ab-fefc7ea43104)

![image](https://github.com/user-attachments/assets/8ea174db-d437-4696-b4a8-f55726cb61f1)

![image](https://github.com/user-attachments/assets/450c2db0-8444-4f5e-88b7-d8b7632b5c8b)


