### PR TITLE
default text link style for attribution button

### DIFF
--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/AttributionButton.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/AttributionButton.kt
@@ -68,7 +68,7 @@ import org.jetbrains.compose.resources.vectorResource
  * @param toggleButton Composable that defines the button used to toggle the attribution display.
  *   Takes an onClick function parameter that should be called to switch states.
  * @param expandedContent Composable that defines how the attribution content is displayed when
- *   expanded. Takes a list of HTML strings as parameter.
+ *   expanded. Takes a list of HTML strings as a parameter.
  * @param expandedStyle Style of the attribution [Surface] when it is expanded
  * @param collapsedStyle Style of the attribution [Surface] when it is collapsed
  * @param expand Function that returns an [EnterTransition] for the expanding animation based on the
@@ -121,7 +121,7 @@ public fun ExpandingAttributionButton(
  * @param toggleButton Composable that defines the button used to toggle the attribution display.
  *   Takes an onClick function parameter that should be called to switch states.
  * @param expandedContent Composable that defines how the attribution content is displayed when
- *   expanded. Takes a list of HTML string as parameter.
+ *   expanded. Takes a list of HTML strings as a parameter.
  * @param expandedStyle Style of the attribution [Surface] when it is expanded
  * @param collapsedStyle Style of the attribution [Surface] when it is collapsed
  * @param expand Function that returns an [EnterTransition] for the expanding animation based on the

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/AttributionButton.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/dev/sargunv/maplibrecompose/material3/controls/AttributionButton.kt
@@ -38,7 +38,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextLinkStyles
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
@@ -66,7 +68,7 @@ import org.jetbrains.compose.resources.vectorResource
  * @param toggleButton Composable that defines the button used to toggle the attribution display.
  *   Takes an onClick function parameter that should be called to switch states.
  * @param expandedContent Composable that defines how the attribution content is displayed when
- *   expanded. Takes a list of AttributionLink as parameter.
+ *   expanded. Takes a list of HTML strings as parameter.
  * @param expandedStyle Style of the attribution [Surface] when it is expanded
  * @param collapsedStyle Style of the attribution [Surface] when it is collapsed
  * @param expand Function that returns an [EnterTransition] for the expanding animation based on the
@@ -119,7 +121,7 @@ public fun ExpandingAttributionButton(
  * @param toggleButton Composable that defines the button used to toggle the attribution display.
  *   Takes an onClick function parameter that should be called to switch states.
  * @param expandedContent Composable that defines how the attribution content is displayed when
- *   expanded. Takes a list of AttributionLink as parameter.
+ *   expanded. Takes a list of HTML string as parameter.
  * @param expandedStyle Style of the attribution [Surface] when it is expanded
  * @param collapsedStyle Style of the attribution [Surface] when it is collapsed
  * @param expand Function that returns an [EnterTransition] for the expanding animation based on the
@@ -204,17 +206,30 @@ public fun ExpandingAttributionButton(
   }
 }
 
+/**
+ * A composable function that displays a collection of attribution links as a flow layout.
+ *
+ * @param attributions A list of HTML strings representing the attributions that need to be
+ *   displayed as links. See: [dev.sargunv.maplibrecompose.core.source.Source.attributionHtml].
+ * @param linkStyles Optional style for hyperlinks. Default is primary color and underlined.
+ * @param spacing The horizontal spacing between items in the flow layout.
+ * @param breakWithinAttribution Whether the text within an individual attribution should break
+ *   lines or scroll horizontally. Line breaks may still be inserted between attributions even when
+ *   this is `true`.
+ */
 @Composable
 public fun AttributionLinks(
   attributions: List<String>,
-  linkStyles: TextLinkStyles? = null,
+  linkStyles: TextLinkStyles? = AttributionButtonDefaults.linkStyles(),
   spacing: Dp = 8.dp,
+  breakWithinAttribution: Boolean = false,
   modifier: Modifier = Modifier,
 ) {
   val texts = remember(attributions) { attributions.map { htmlToAnnotatedString(it, linkStyles) } }
   FlowRow(modifier = modifier, horizontalArrangement = Arrangement.spacedBy(spacing)) {
     texts.forEach {
-      Text(it, maxLines = 1, modifier = Modifier.horizontalScroll(rememberScrollState()))
+      if (breakWithinAttribution) Text(it)
+      else Text(it, maxLines = 1, modifier = Modifier.horizontalScroll(rememberScrollState()))
     }
   }
 }
@@ -250,6 +265,16 @@ public object AttributionButtonDefaults {
     AttributionButtonStyle(
       containerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0f),
       contentColor = contentColorFor(MaterialTheme.colorScheme.surface).copy(alpha = 0f),
+    )
+
+  @Composable
+  public fun linkStyles(): TextLinkStyles =
+    TextLinkStyles(
+      style =
+        SpanStyle(
+          color = MaterialTheme.colorScheme.primary,
+          textDecoration = TextDecoration.Underline,
+        )
     )
 
   public val expand: (Alignment) -> EnterTransition = { expandIn(expandFrom = it) }


### PR DESCRIPTION
## Description

https://github.com/maplibre/maplibre-compose/pull/426#discussion_r2148608937

Also added an option for line breaking behavior, see https://github.com/maplibre/maplibre-compose/pull/427#issuecomment-2974324083

## Test plan

![image](https://github.com/user-attachments/assets/4aba87de-0181-46c1-a018-16c2c81e8f53)
![image](https://github.com/user-attachments/assets/2695f795-cbc7-4552-a254-63a92ec37a53)

