### PR TITLE
fix programmatic vector source not correctly handling Compose resources

### DIFF
--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/source/VectorSource.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/source/VectorSource.kt
@@ -26,17 +26,18 @@ public actual class VectorSource : Source {
     impl =
       MLNVectorSource(
         id,
-        TileSet("{\"type\": \"vector\"}", *tiles.toTypedArray()).apply {
-          minZoom = options.minZoom.toFloat()
-          maxZoom = options.maxZoom.toFloat()
-          scheme =
-            when (options.tileCoordinateSystem) {
-              TileCoordinateSystem.XYZ -> "xyz"
-              TileCoordinateSystem.TMS -> "tms"
-            }
-          options.boundingBox?.let { setBounds(it.toLatLngBounds()) }
-          attribution = options.attributionHtml
-        },
+        TileSet("{\"type\": \"vector\"}", *tiles.map { it.correctedAndroidUri() }.toTypedArray())
+          .apply {
+            minZoom = options.minZoom.toFloat()
+            maxZoom = options.maxZoom.toFloat()
+            scheme =
+              when (options.tileCoordinateSystem) {
+                TileCoordinateSystem.XYZ -> "xyz"
+                TileCoordinateSystem.TMS -> "tms"
+              }
+            options.boundingBox?.let { setBounds(it.toLatLngBounds()) }
+            attribution = options.attributionHtml
+          },
       )
   }
 


### PR DESCRIPTION
<!-- Thanks for the PR! Please fill out the template below. -->

## Description

Anywhere we pass an asset URL to MapLibre Android, we need to use the `asset://` protocol. We missed this in the tiles list on the vector source.
