### PR TITLE
add some enum overloads

### DIFF
--- a/lib/maplibre-compose-expressions/src/commonMain/kotlin/dev/sargunv/maplibrecompose/expressions/dsl/decision.kt
+++ b/lib/maplibre-compose-expressions/src/commonMain/kotlin/dev/sargunv/maplibrecompose/expressions/dsl/decision.kt
@@ -5,6 +5,7 @@ import dev.sargunv.maplibrecompose.expressions.ast.FunctionCall
 import dev.sargunv.maplibrecompose.expressions.value.BooleanValue
 import dev.sargunv.maplibrecompose.expressions.value.CollatorValue
 import dev.sargunv.maplibrecompose.expressions.value.ComparableValue
+import dev.sargunv.maplibrecompose.expressions.value.EnumValue
 import dev.sargunv.maplibrecompose.expressions.value.EquatableValue
 import dev.sargunv.maplibrecompose.expressions.value.ExpressionValue
 import dev.sargunv.maplibrecompose.expressions.value.FloatValue
@@ -132,6 +133,12 @@ public fun <O : ExpressionValue> case(label: String, output: Expression<O>): Cas
   Case(const(label), output)
 
 /** Create a [Case], see [switch] */
+public fun <O : ExpressionValue, E : EnumValue<E>> case(
+  label: E,
+  output: Expression<O>,
+): Case<EnumValue<E>, O> = Case(const(label), output)
+
+/** Create a [Case], see [switch] */
 public fun <O : ExpressionValue> case(label: Number, output: Expression<O>): Case<FloatValue, O> =
   Case(const(label.toFloat()), output)
 
@@ -139,6 +146,13 @@ public fun <O : ExpressionValue> case(label: Number, output: Expression<O>): Cas
 @JvmName("stringsCase")
 public fun <O : ExpressionValue> case(
   label: List<String>,
+  output: Expression<O>,
+): Case<StringValue, O> = Case(const(label), output)
+
+/** Create a [Case], see [switch] */
+@JvmName("enumsCase")
+public fun <O : ExpressionValue, E : EnumValue<E>> case(
+  label: List<E>,
   output: Expression<O>,
 ): Case<StringValue, O> = Case(const(label), output)
 

--- a/lib/maplibre-compose-expressions/src/commonMain/kotlin/dev/sargunv/maplibrecompose/expressions/dsl/literals.kt
+++ b/lib/maplibre-compose-expressions/src/commonMain/kotlin/dev/sargunv/maplibrecompose/expressions/dsl/literals.kt
@@ -85,6 +85,11 @@ public fun <T : ExpressionValue> const(list: List<Literal<T, *>>): ListLiteral<T
 @JvmName("constStringList")
 public fun const(list: List<String>): ListLiteral<StringValue> = const(list.map { const(it) })
 
+/** Creates a literal expression for a list of strings. */
+@JvmName("constEnumList")
+public fun <T : EnumValue<T>> const(list: List<EnumValue<T>>): ListLiteral<EnumValue<T>> =
+  const(list.map { const(it) })
+
 /** Creates a literal expression for a list of numbers. */
 @JvmName("constNumberList")
 public fun const(list: List<Number>): Literal<VectorValue<Number>, *> =


### PR DESCRIPTION
Based on feedback here: https://osmus.slack.com/archives/C08SEMXV37S/p1750192486471089

This example now compiles:

```kt
switch(
  input = feature.type(),
  case(
    listOf(GeometryType.LineString, GeometryType.MultiLineString),
    const(SymbolPlacement.LineCenter),
  ),
  fallback = const(SymbolPlacement.Point),
)
```

