### PR TITLE
Adding camera bounding box

### DIFF
--- a/lib/kotlin-maplibre-js/src/commonMain/kotlin/dev/sargunv/maplibrejs/external.kt
+++ b/lib/kotlin-maplibre-js/src/commonMain/kotlin/dev/sargunv/maplibrejs/external.kt
@@ -57,6 +57,8 @@ public external class Map public constructor(options: MapOptions) {
 
   public fun setMinPitch(min: Double)
 
+  public fun setMaxBounds(bounds: Array<DoubleArray>?)
+
   public fun jumpTo(options: JumpToOptions)
 
   public fun easeTo(options: EaseToOptions)

--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/AndroidMap.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/AndroidMap.kt
@@ -26,6 +26,16 @@ import dev.sargunv.maplibrecompose.expressions.value.BooleanValue
 import io.github.dellisd.spatialk.geojson.BoundingBox
 import io.github.dellisd.spatialk.geojson.Feature
 import io.github.dellisd.spatialk.geojson.Position
+import org.maplibre.android.camera.CameraUpdateFactory
+import org.maplibre.android.gestures.MoveGestureDetector
+import org.maplibre.android.gestures.RotateGestureDetector
+import org.maplibre.android.gestures.ShoveGestureDetector
+import org.maplibre.android.gestures.StandardScaleGestureDetector
+import org.maplibre.android.maps.MapLibreMap
+import org.maplibre.android.maps.MapLibreMap.OnCameraMoveStartedListener
+import org.maplibre.android.maps.MapLibreMap.OnMoveListener
+import org.maplibre.android.maps.MapLibreMap.OnScaleListener
+import org.maplibre.android.maps.MapView
 import kotlin.coroutines.Continuation
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
@@ -33,19 +43,9 @@ import kotlin.math.roundToInt
 import kotlin.time.Duration
 import kotlin.time.DurationUnit
 import org.maplibre.android.camera.CameraPosition as MLNCameraPosition
-import org.maplibre.android.camera.CameraUpdateFactory
 import org.maplibre.android.geometry.VisibleRegion as MLNVisibleRegion
-import org.maplibre.android.gestures.MoveGestureDetector
-import org.maplibre.android.gestures.RotateGestureDetector
-import org.maplibre.android.gestures.ShoveGestureDetector
-import org.maplibre.android.gestures.StandardScaleGestureDetector
 import org.maplibre.android.log.Logger as MLNLogger
 import org.maplibre.android.maps.MapLibreMap as MLNMap
-import org.maplibre.android.maps.MapLibreMap
-import org.maplibre.android.maps.MapLibreMap.OnCameraMoveStartedListener
-import org.maplibre.android.maps.MapLibreMap.OnMoveListener
-import org.maplibre.android.maps.MapLibreMap.OnScaleListener
-import org.maplibre.android.maps.MapView
 import org.maplibre.android.maps.Style as MlnStyle
 import org.maplibre.android.style.expressions.Expression as MLNExpression
 import org.maplibre.geojson.Feature as MLNFeature
@@ -207,6 +207,10 @@ internal class AndroidMap(
 
   override fun setMaxZoom(maxZoom: Double) {
     map.setMaxZoomPreference(maxZoom)
+  }
+
+  override fun setCameraBoundingBox(boundingBox: BoundingBox?) {
+    map.setLatLngBoundsForCameraTarget(boundingBox?.toLatLngBounds())
   }
 
   override fun getVisibleBoundingBox(): BoundingBox {

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/MaplibreMap.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/MaplibreMap.kt
@@ -19,6 +19,7 @@ import dev.sargunv.maplibrecompose.core.MaplibreMap
 import dev.sargunv.maplibrecompose.core.SafeStyle
 import dev.sargunv.maplibrecompose.core.StandardMaplibreMap
 import dev.sargunv.maplibrecompose.core.Style
+import io.github.dellisd.spatialk.geojson.BoundingBox
 import io.github.dellisd.spatialk.geojson.Position
 import kotlinx.coroutines.launch
 
@@ -32,6 +33,10 @@ import kotlinx.coroutines.launch
  * @param pitchRange The allowable bounds for the camera pitch.
  * @param cameraState The camera state specifies what position of the map is rendered, at what zoom,
  *   at what tilt, etc.
+ * @param cameraBoundingBox The allowable bounds for the camera position. Behaves differently on
+ *   android and iOS:
+ *   android: prevents the camera center target from going outside of bounds
+ *   iOS: prevents the camera edges from going outside of bounds.
  * @param onMapClick Invoked when the map is clicked. A click callback can be defined per layer,
  *   too, see e.g. the `onClick` parameter for
  *   [LineLayer][dev.sargunv.maplibrecompose.compose.layer.LineLayer]. However, this callback is
@@ -85,6 +90,7 @@ public fun MaplibreMap(
   zoomRange: ClosedRange<Float> = 0f..20f,
   pitchRange: ClosedRange<Float> = 0f..60f,
   cameraState: CameraState = rememberCameraState(),
+  cameraBoundingBox: BoundingBox? = null,
   styleState: StyleState = rememberStyleState(),
   onMapClick: MapClickHandler = { _, _ -> ClickResult.Pass },
   onMapLongClick: MapClickHandler = { _, _ -> ClickResult.Pass },
@@ -189,6 +195,7 @@ public fun MaplibreMap(
           map.setRenderSettings(options.renderOptions)
           map.setGestureSettings(options.gestureOptions)
           map.setOrnamentSettings(options.ornamentOptions)
+          map.setCameraBoundingBox(cameraBoundingBox)
         }
 
         else ->
@@ -200,6 +207,7 @@ public fun MaplibreMap(
             map.asyncSetRenderSettings(options.renderOptions)
             map.asyncSetGestureSettings(options.gestureOptions)
             map.asyncSetOrnamentSettings(options.ornamentOptions)
+            map.asyncSetCameraBoundingBox(cameraBoundingBox)
           }
       }
     },

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/MaplibreMap.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/MaplibreMap.kt
@@ -35,6 +35,8 @@ internal interface MaplibreMap {
 
   suspend fun asyncSetMaxPitch(maxPitch: Double)
 
+  suspend fun asyncSetCameraBoundingBox(boundingBox: BoundingBox?)
+
   suspend fun asyncGetVisibleBoundingBox(): BoundingBox
 
   suspend fun asyncGetVisibleRegion(): VisibleRegion
@@ -98,6 +100,8 @@ internal interface StandardMaplibreMap : MaplibreMap {
 
   override suspend fun asyncSetMaxPitch(maxPitch: Double) = setMaxPitch(maxPitch)
 
+  override suspend fun asyncSetCameraBoundingBox(boundingBox: BoundingBox?) = setCameraBoundingBox(boundingBox)
+
   override suspend fun asyncGetVisibleBoundingBox(): BoundingBox = getVisibleBoundingBox()
 
   override suspend fun asyncGetVisibleRegion(): VisibleRegion = getVisibleRegion()
@@ -134,6 +138,8 @@ internal interface StandardMaplibreMap : MaplibreMap {
   fun getCameraPosition(): CameraPosition
 
   fun setCameraPosition(cameraPosition: CameraPosition)
+
+  fun setCameraBoundingBox(boundingBox: BoundingBox?)
 
   fun setMaxZoom(maxZoom: Double)
 

--- a/lib/maplibre-compose/src/desktopMain/kotlin/dev/sargunv/maplibrecompose/core/WebviewMap.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/dev/sargunv/maplibrecompose/core/WebviewMap.kt
@@ -45,6 +45,15 @@ internal class WebviewMap(private val bridge: WebviewBridge) : MaplibreMap {
     bridge.callVoid("setMaxPitch", maxPitch)
   }
 
+  override suspend fun asyncSetCameraBoundingBox(boundingBox: BoundingBox?) {
+    bridge.callVoid("setMaxBounds", boundingBox?.let {
+      arrayOf(
+        it.southwest.coordinates,
+        it.northeast.coordinates
+      )
+    })
+  }
+
   override suspend fun asyncGetVisibleBoundingBox(): BoundingBox {
     return BoundingBox(Position(0.0, 0.0), Position(0.0, 0.0))
   }

--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/IosMap.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/IosMap.kt
@@ -270,6 +270,10 @@ internal class IosMap(
     mapView.maximumZoomLevel = maxZoom
   }
 
+  override fun setCameraBoundingBox(boundingBox: BoundingBox?) {
+    mapView.setMaximumScreenBounds(boundingBox?.toMLNCoordinateBounds())
+  }
+
   override fun getVisibleBoundingBox(): BoundingBox {
     return mapView.visibleCoordinateBounds.toBoundingBox()
   }

--- a/lib/maplibre-compose/src/jsMain/kotlin/dev/sargunv/maplibrecompose/core/JsMap.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/dev/sargunv/maplibrecompose/core/JsMap.kt
@@ -113,6 +113,17 @@ internal class JsMap(
     impl.setMaxZoom(maxZoom)
   }
 
+  override fun setCameraBoundingBox(boundingBox: BoundingBox?) {
+    impl.setMaxBounds(
+      boundingBox?.let {
+        arrayOf(
+          it.southwest.coordinates,
+          it.northeast.coordinates
+        )
+      }
+    )
+  }
+
   override fun getVisibleBoundingBox(): BoundingBox {
     return impl.getBounds().toBoundingBox()
   }


### PR DESCRIPTION
## Description
Adds the possibility to add a bounding box for the camera.

## Test plan

Tested on Android and iOS. I observed different behavior on these platforms and I added them to the documentation of the composable.

**Have you tested the changes? On which platforms?**

- Android: Samsung S21 Android 12, Pixel 8 Android 15
- iOS: iPhone 16 Pro iOS 18.3
