### PR TITLE
Exposed finished and failed map loading functions

### DIFF
--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/AndroidMap.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/AndroidMap.kt
@@ -105,6 +105,7 @@ internal class AndroidMap(
 
   init {
     mapView.addOnDidFinishLoadingMapListener { callbacks.onMapFinishedLoading(this) }
+    mapView.addOnDidFailLoadingMapListener { callbacks.onMapFailLoading(it) }
 
     map.addOnCameraMoveStartedListener { reason ->
       // MapLibre doesn't have docs on these reasons, and even though they're named like Google's:

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/MaplibreMap.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/MaplibreMap.kt
@@ -40,6 +40,8 @@ import kotlinx.coroutines.launch
  * @param onMapLongClick Invoked when the map is long-clicked. See [onMapClick].
  * @param onFrame Invoked on every rendered frame.
  * @param logger kermit logger to use.
+ * @param onMapLoadFailed Invoked when the map failed to load.
+ * @param onMapLoadFinished Invoked when the map finished loading.
  * @param content The map content additional to what is already part of the map as defined in the
  *   base map style linked in [baseStyle].
  *

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/MaplibreMap.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/MaplibreMap.kt
@@ -91,6 +91,8 @@ public fun MaplibreMap(
   onFrame: (framesPerSecond: Double) -> Unit = {},
   options: MapOptions = MapOptions(),
   logger: Logger? = remember { Logger.withTag("maplibre-compose") },
+  onMapFailLoading: (String?) -> Unit = {},
+  onMapFinishedLoading: () -> Unit = {},
   content: @Composable @MaplibreComposable () -> Unit = {},
 ) {
   var rememberedStyle by remember { mutableStateOf<SafeStyle?>(null) }
@@ -108,9 +110,14 @@ public fun MaplibreMap(
             map.metersPerDpAtLatitude(map.getCameraPosition().target.latitude)
         }
 
+        override fun onMapFailLoading(reason: String?) {
+          onMapFailLoading(reason)
+        }
+
         override fun onMapFinishedLoading(map: MaplibreMap) {
           map as StandardMaplibreMap
           styleState.reloadSources()
+          onMapFinishedLoading()
         }
 
         override fun onCameraMoveStarted(map: MaplibreMap, reason: CameraMoveReason) {

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/MaplibreMap.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/MaplibreMap.kt
@@ -91,8 +91,8 @@ public fun MaplibreMap(
   onFrame: (framesPerSecond: Double) -> Unit = {},
   options: MapOptions = MapOptions(),
   logger: Logger? = remember { Logger.withTag("maplibre-compose") },
-  onMapFailLoading: (String?) -> Unit = {},
-  onMapFinishedLoading: () -> Unit = {},
+  onMapLoadFailed: (reason: String?) -> Unit = {},
+  onMapLoadFinished: () -> Unit = {},
   content: @Composable @MaplibreComposable () -> Unit = {},
 ) {
   var rememberedStyle by remember { mutableStateOf<SafeStyle?>(null) }
@@ -111,13 +111,13 @@ public fun MaplibreMap(
         }
 
         override fun onMapFailLoading(reason: String?) {
-          onMapFailLoading(reason)
+          onMapLoadFailed(reason)
         }
 
         override fun onMapFinishedLoading(map: MaplibreMap) {
           map as StandardMaplibreMap
           styleState.reloadSources()
-          onMapFinishedLoading()
+          onMapLoadFinished()
         }
 
         override fun onCameraMoveStarted(map: MaplibreMap, reason: CameraMoveReason) {

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/MaplibreMap.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/MaplibreMap.kt
@@ -68,6 +68,8 @@ internal interface MaplibreMap {
 
     fun onMapFinishedLoading(map: MaplibreMap)
 
+    fun onMapFailLoading(reason: String?)
+
     fun onCameraMoveStarted(map: MaplibreMap, reason: CameraMoveReason)
 
     fun onCameraMoved(map: MaplibreMap)

--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/IosMap.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/IosMap.kt
@@ -147,6 +147,7 @@ internal class IosMap(
 
     override fun mapViewDidFailLoadingMap(mapView: MLNMapView, withError: NSError) {
       map.logger?.e { "Map failed to load: $withError" }
+      map.callbacks.onMapFailLoading(withError.localizedFailureReason)
     }
 
     override fun mapViewDidFinishLoadingMap(mapView: MLNMapView) {


### PR DESCRIPTION
## Description

I came accross [this issue here](https://github.com/maplibre/maplibre-compose/issues/416). Until such a map state is being created (which I assume will take a while), I would still already be happy to have some feedback on wether the map has loaded or not. This can be refined later on or expanded with different kind of callbacks or just simply added to a map state.

## Test plan

I simply extended the demos and looked if the callbacks are effectively propagated to the client.

## Checklist

**Have you tested the changes? On which platforms?**

- Android: Samsung S21 Android 12, Pixel 8 Android 15
- iOS: iPhone 16 Pro iOS 18.3
