### PR TITLE
Correct iconPadding type: It is a DpPaddingValue

### DIFF
--- a/lib/maplibre-compose-expressions/src/commonMain/kotlin/dev/sargunv/maplibrecompose/expressions/Defaults.kt
+++ b/lib/maplibre-compose-expressions/src/commonMain/kotlin/dev/sargunv/maplibrecompose/expressions/Defaults.kt
@@ -12,7 +12,10 @@ import dev.sargunv.maplibrecompose.expressions.value.ColorValue
 import dev.sargunv.maplibrecompose.expressions.value.ListValue
 import dev.sargunv.maplibrecompose.expressions.value.StringValue
 
-public val ZeroPadding: PaddingValues.Absolute = PaddingValues.Absolute(0.dp)
+public val ZeroPadding: PaddingValues.Absolute = PaddingValues.Absolute(0.dp, 0.dp, 0.dp, 0.dp)
+
+public val DefaultIconPadding: PaddingValues.Absolute =
+  PaddingValues.Absolute(2.dp, 2.dp, 2.dp, 2.dp)
 
 public object Defaults {
   public val HeatmapColors: Expression<ColorValue> =

--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/layer/SymbolLayer.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/layer/SymbolLayer.kt
@@ -105,7 +105,7 @@ internal actual class SymbolLayer actual constructor(id: String, source: Source)
     impl.setProperties(PropertyFactory.iconRotate(rotate.toMLNExpression()))
   }
 
-  actual fun setIconPadding(padding: CompiledExpression<DpValue>) {
+  actual fun setIconPadding(padding: CompiledExpression<DpPaddingValue>) {
     impl.setProperties(PropertyFactory.iconPadding(padding.toMLNExpression()))
   }
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/SymbolLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/SymbolLayer.kt
@@ -11,6 +11,7 @@ import dev.sargunv.maplibrecompose.compose.FeaturesClickHandler
 import dev.sargunv.maplibrecompose.compose.MaplibreComposable
 import dev.sargunv.maplibrecompose.core.layer.SymbolLayer
 import dev.sargunv.maplibrecompose.core.source.Source
+import dev.sargunv.maplibrecompose.expressions.DefaultIconPadding
 import dev.sargunv.maplibrecompose.expressions.Defaults
 import dev.sargunv.maplibrecompose.expressions.ZeroPadding
 import dev.sargunv.maplibrecompose.expressions.ast.Expression
@@ -415,7 +416,7 @@ public fun SymbolLayer(
   iconOffset: Expression<DpOffsetValue> = const(DpOffset.Zero),
 
   // icon collision
-  iconPadding: Expression<DpValue> = const(2.dp),
+  iconPadding: Expression<DpPaddingValue> = const(DefaultIconPadding),
   iconAllowOverlap: Expression<BooleanValue> = const(false),
   iconOverlap: Expression<StringValue> = nil(),
   iconIgnorePlacement: Expression<BooleanValue> = const(false),

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/layer/SymbolLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/layer/SymbolLayer.kt
@@ -63,7 +63,7 @@ internal expect class SymbolLayer(id: String, source: Source) : FeatureLayer {
 
   fun setIconRotate(rotate: CompiledExpression<FloatValue>)
 
-  fun setIconPadding(padding: CompiledExpression<DpValue>)
+  fun setIconPadding(padding: CompiledExpression<DpPaddingValue>)
 
   fun setIconKeepUpright(keepUpright: CompiledExpression<BooleanValue>)
 

--- a/lib/maplibre-compose/src/desktopMain/kotlin/dev/sargunv/maplibrecompose/core/layer/SymbolLayer.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/dev/sargunv/maplibrecompose/core/layer/SymbolLayer.kt
@@ -100,7 +100,7 @@ internal actual class SymbolLayer actual constructor(id: String, source: Source)
     TODO()
   }
 
-  actual fun setIconPadding(padding: CompiledExpression<DpValue>) {
+  actual fun setIconPadding(padding: CompiledExpression<DpPaddingValue>) {
     TODO()
   }
 

--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/layer/SymbolLayer.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/layer/SymbolLayer.kt
@@ -111,7 +111,7 @@ internal actual class SymbolLayer actual constructor(id: String, source: Source)
     impl.iconRotation = rotate.toNSExpression()
   }
 
-  actual fun setIconPadding(padding: CompiledExpression<DpValue>) {
+  actual fun setIconPadding(padding: CompiledExpression<DpPaddingValue>) {
     impl.iconPadding = padding.toNSExpression()
   }
 

--- a/lib/maplibre-compose/src/jsMain/kotlin/dev/sargunv/maplibrecompose/core/layer/SymbolLayer.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/dev/sargunv/maplibrecompose/core/layer/SymbolLayer.kt
@@ -100,7 +100,7 @@ internal actual class SymbolLayer actual constructor(id: String, source: Source)
     TODO()
   }
 
-  actual fun setIconPadding(padding: CompiledExpression<DpValue>) {
+  actual fun setIconPadding(padding: CompiledExpression<DpPaddingValue>) {
     TODO()
   }
 


### PR DESCRIPTION
It looks like this was an oversight before:

[`icon-padding`](https://maplibre.org/maplibre-style-spec/layers/#icon-padding) is not of type `number` (like [`text-padding`](https://maplibre.org/maplibre-style-spec/layers/#text-padding)) but of type [`padding`](https://maplibre.org/maplibre-style-spec/types/#padding) (like [`icon-text-fit-padding`](https://maplibre.org/maplibre-style-spec/layers/#icon-text-fit-padding)).

It is a breaking change, as the interface changes.

I have not tested the changes. (But I can say from usage in my project that the linked documentation is correct, it is a padding, not a single value).

Also, `PaddingValues.Absolute(0.dp)` is wrong in the sense that `left` is set to `0.dp` and the rest is set to the default. (Which incidentally is also `0.dp`, so this doesn't result in a bug)