### PR TITLE
auto assign source IDs

### DIFF
--- a/demo-app/src/androidIosShared/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/OfflineManagerDemo.kt
+++ b/demo-app/src/androidIosShared/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/OfflineManagerDemo.kt
@@ -57,7 +57,7 @@ object OfflineManagerDemo : Demo {
     val offlineManager = rememberOfflineManager()
     FillLayer(
       id = "offline-packs",
-      source = rememberOfflinePacksSource("offline-packs", offlineManager.packs),
+      source = rememberOfflinePacksSource(offlineManager.packs),
       opacity = const(0.5f),
       color =
         switch(

--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/AnimatedLayerDemo.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/AnimatedLayerDemo.kt
@@ -36,7 +36,6 @@ object AnimatedLayerDemo : Demo {
   override fun MapContent(state: DemoState, isOpen: Boolean) {
     val routeSource =
       rememberGeoJsonSource(
-        id = "amtrak-routes",
         data =
           GeoJsonData.Uri(
             "https://raw.githubusercontent.com/datanews/amtrak-geojson/refs/heads/master/amtrak-combined.geojson"

--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/MarkersDemo.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/demoapp/demos/MarkersDemo.kt
@@ -45,11 +45,10 @@ object MarkersDemo : Demo {
 
     val amtrakStations =
       rememberGeoJsonSource(
-        id = "amtrak-stations",
         data =
           GeoJsonData.Uri(
             "https://raw.githubusercontent.com/datanews/amtrak-geojson/refs/heads/master/amtrak-stations.geojson"
-          ),
+          )
       )
 
     SymbolLayer(

--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/docsnippets/Layers.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/docsnippets/Layers.kt
@@ -35,17 +35,11 @@ fun Layers() {
 
   MaplibreMap {
     val amtrakStations =
-      rememberGeoJsonSource(
-        id = "amtrak-stations",
-        data = GeoJsonData.Uri(Res.getUri("files/data/amtrak_stations.geojson")),
-      )
+      rememberGeoJsonSource(GeoJsonData.Uri(Res.getUri("files/data/amtrak_stations.geojson")))
 
     // -8<- [start:amtrak-1]
     val amtrakRoutes =
-      rememberGeoJsonSource(
-        id = "amtrak-routes",
-        data = GeoJsonData.Uri(Res.getUri("files/data/amtrak_routes.geojson")),
-      )
+      rememberGeoJsonSource(GeoJsonData.Uri(Res.getUri("files/data/amtrak_routes.geojson")))
     LineLayer(
       id = "amtrak-routes-casing",
       source = amtrakRoutes,

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/engine/IncrementingId.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/engine/IncrementingId.kt
@@ -1,0 +1,7 @@
+package dev.sargunv.maplibrecompose.compose.engine
+
+internal class IncrementingId(private val name: String) {
+  private var nextId = 0
+
+  fun next(): String = "__MAPLIBRE_COMPOSE_${name}_${nextId++}"
+}

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/engine/IncrementingIdMap.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/engine/IncrementingIdMap.kt
@@ -1,11 +1,11 @@
 package dev.sargunv.maplibrecompose.compose.engine
 
 internal class IncrementingIdMap<in T>(private val name: String) {
-  private var nextId = 0
+  private val ids = IncrementingId(name)
   private val map = mutableMapOf<T, String>()
 
   fun addId(value: T): String {
-    return map.getOrPut(value) { "__MAPLIBRE_COMPOSE_${name}_${nextId++}" }
+    return map.getOrPut(value) { ids.next() }
   }
 
   fun getId(value: T): String {

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/engine/SourceManager.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/engine/SourceManager.kt
@@ -6,8 +6,8 @@ import dev.sargunv.maplibrecompose.core.source.Source
 internal class SourceManager(private val node: StyleNode) {
 
   private val baseSources = node.style.getSources().associateBy { it.id }
-  private val sourcesToAdd = mutableListOf<Source>()
   private val counter = ReferenceCounter<Source>()
+  private val sourceIds = IncrementingId("source")
 
   /** Receives updates on changes to the style */
   internal var state: StyleState? = null
@@ -16,11 +16,13 @@ internal class SourceManager(private val node: StyleNode) {
     return baseSources[id] ?: error("Source ID '$id' not found in base style")
   }
 
+  internal fun nextId(): String = sourceIds.next()
+
   internal fun addReference(source: Source) {
     require(source.id !in baseSources) { "Source ID '${source.id}' already exists in base style" }
     counter.increment(source) {
-      node.logger?.i { "Queuing source ${source.id} for addition" }
-      sourcesToAdd.add(source)
+      node.logger?.i { "Adding source ${source.id}" }
+      node.style.addSource(source)
     }
   }
 
@@ -36,12 +38,6 @@ internal class SourceManager(private val node: StyleNode) {
   }
 
   internal fun applyChanges() {
-    sourcesToAdd
-      .onEach {
-        node.logger?.i { "Adding source ${it.id}" }
-        node.style.addSource(it)
-        state?.reloadSources()
-      }
-      .clear()
+    state?.reloadSources()
   }
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/CircleLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/CircleLayer.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import dev.sargunv.maplibrecompose.compose.FeaturesClickHandler
 import dev.sargunv.maplibrecompose.compose.MaplibreComposable
+import dev.sargunv.maplibrecompose.compose.source.SourceReferenceEffect
 import dev.sargunv.maplibrecompose.core.layer.CircleLayer
 import dev.sargunv.maplibrecompose.core.source.Source
 import dev.sargunv.maplibrecompose.expressions.ast.Expression
@@ -98,6 +99,7 @@ public fun CircleLayer(
   val compiledPitchScale = compile(pitchScale)
   val compiledPitchAlignment = compile(pitchAlignment)
 
+  SourceReferenceEffect(source)
   LayerNode(
     factory = { CircleLayer(id = id, source = source) },
     update = {

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/FillExtrusionLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/FillExtrusionLayer.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.DpOffset
 import dev.sargunv.maplibrecompose.compose.FeaturesClickHandler
 import dev.sargunv.maplibrecompose.compose.MaplibreComposable
+import dev.sargunv.maplibrecompose.compose.source.SourceReferenceEffect
 import dev.sargunv.maplibrecompose.core.layer.FillExtrusionLayer
 import dev.sargunv.maplibrecompose.core.source.Source
 import dev.sargunv.maplibrecompose.expressions.ast.Expression
@@ -91,6 +92,7 @@ public fun FillExtrusionLayer(
   val compiledBase = compile(base)
   val compiledVerticalGradient = compile(verticalGradient)
 
+  SourceReferenceEffect(source)
   LayerNode(
     factory = { FillExtrusionLayer(id = id, source = source) },
     update = {

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/FillLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/FillLayer.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.DpOffset
 import dev.sargunv.maplibrecompose.compose.FeaturesClickHandler
 import dev.sargunv.maplibrecompose.compose.MaplibreComposable
+import dev.sargunv.maplibrecompose.compose.source.SourceReferenceEffect
 import dev.sargunv.maplibrecompose.core.layer.FillLayer
 import dev.sargunv.maplibrecompose.core.source.Source
 import dev.sargunv.maplibrecompose.expressions.ast.Expression
@@ -90,6 +91,7 @@ public fun FillLayer(
   val compiledTranslateAnchor = compile(translateAnchor)
   val compiledOutlineColor = compile(outlineColor)
 
+  SourceReferenceEffect(source)
   LayerNode(
     factory = { FillLayer(id = id, source = source) },
     update = {

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/HeatmapLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/HeatmapLayer.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.unit.dp
 import dev.sargunv.maplibrecompose.compose.FeaturesClickHandler
 import dev.sargunv.maplibrecompose.compose.MaplibreComposable
+import dev.sargunv.maplibrecompose.compose.source.SourceReferenceEffect
 import dev.sargunv.maplibrecompose.core.layer.HeatmapLayer
 import dev.sargunv.maplibrecompose.core.source.Source
 import dev.sargunv.maplibrecompose.expressions.Defaults
@@ -71,6 +72,7 @@ public fun HeatmapLayer(
   val compiledWeight = compile(weight)
   val compiledIntensity = compile(intensity)
 
+  SourceReferenceEffect(source)
   LayerNode(
     factory = { HeatmapLayer(id = id, source = source) },
     update = {

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/HillshadeLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/HillshadeLayer.kt
@@ -3,6 +3,7 @@ package dev.sargunv.maplibrecompose.compose.layer
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import dev.sargunv.maplibrecompose.compose.MaplibreComposable
+import dev.sargunv.maplibrecompose.compose.source.SourceReferenceEffect
 import dev.sargunv.maplibrecompose.core.layer.HillshadeLayer
 import dev.sargunv.maplibrecompose.core.source.Source
 import dev.sargunv.maplibrecompose.expressions.ast.Expression
@@ -57,6 +58,7 @@ public fun HillshadeLayer(
   val compiledIlluminationAnchor = compile(illuminationAnchor)
   val compiledExaggeration = compile(exaggeration)
 
+  SourceReferenceEffect(source)
   LayerNode(
     factory = { HillshadeLayer(id = id, source = source) },
     update = {

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/LineLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/LineLayer.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import dev.sargunv.maplibrecompose.compose.FeaturesClickHandler
 import dev.sargunv.maplibrecompose.compose.MaplibreComposable
+import dev.sargunv.maplibrecompose.compose.source.SourceReferenceEffect
 import dev.sargunv.maplibrecompose.core.layer.LineLayer
 import dev.sargunv.maplibrecompose.core.source.Source
 import dev.sargunv.maplibrecompose.expressions.ast.Expression
@@ -130,6 +131,7 @@ public fun LineLayer(
   val compiledMiterLimit = compile(miterLimit)
   val compiledRoundLimit = compile(roundLimit)
 
+  SourceReferenceEffect(source)
   LayerNode(
     factory = { LineLayer(id = id, source = source) },
     update = {

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/RasterLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/RasterLayer.kt
@@ -2,6 +2,7 @@ package dev.sargunv.maplibrecompose.compose.layer
 
 import androidx.compose.runtime.Composable
 import dev.sargunv.maplibrecompose.compose.MaplibreComposable
+import dev.sargunv.maplibrecompose.compose.source.SourceReferenceEffect
 import dev.sargunv.maplibrecompose.core.layer.RasterLayer
 import dev.sargunv.maplibrecompose.core.source.Source
 import dev.sargunv.maplibrecompose.expressions.ast.Expression
@@ -63,6 +64,7 @@ public fun RasterLayer(
   val compiledResampling = compile(resampling)
   val compiledFadeDuration = compile(fadeDuration)
 
+  SourceReferenceEffect(source)
   LayerNode(
     factory = { RasterLayer(id = id, source = source) },
     update = {

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/SymbolLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/layer/SymbolLayer.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import dev.sargunv.maplibrecompose.compose.FeaturesClickHandler
 import dev.sargunv.maplibrecompose.compose.MaplibreComposable
+import dev.sargunv.maplibrecompose.compose.source.SourceReferenceEffect
 import dev.sargunv.maplibrecompose.core.layer.SymbolLayer
 import dev.sargunv.maplibrecompose.core.source.Source
 import dev.sargunv.maplibrecompose.expressions.DefaultIconPadding
@@ -546,6 +547,7 @@ public fun SymbolLayer(
   val compiledTextTranslate = compile(textTranslate)
   val compiledTextTranslateAnchor = compile(textTranslateAnchor)
 
+  SourceReferenceEffect(source)
   LayerNode(
     factory = { SymbolLayer(id = id, source = source) },
     update = {

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/source/SourceReferenceEffect.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/source/SourceReferenceEffect.kt
@@ -1,0 +1,15 @@
+package dev.sargunv.maplibrecompose.compose.source
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import dev.sargunv.maplibrecompose.compose.engine.LocalStyleNode
+import dev.sargunv.maplibrecompose.core.source.Source
+
+@Composable
+internal fun SourceReferenceEffect(source: Source) {
+  val node = LocalStyleNode.current
+  DisposableEffect(source) {
+    node.sourceManager.addReference(source)
+    onDispose { node.sourceManager.removeReference(source) }
+  }
+}

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/source/rememberComputedSource.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/source/rememberComputedSource.kt
@@ -1,6 +1,7 @@
 package dev.sargunv.maplibrecompose.compose.source
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.key
 import dev.sargunv.maplibrecompose.core.source.ComputedSource
 import dev.sargunv.maplibrecompose.core.source.ComputedSourceOptions
 import io.github.dellisd.spatialk.geojson.BoundingBox
@@ -14,7 +15,9 @@ public fun rememberGeoJsonSource(
   options: ComputedSourceOptions = ComputedSourceOptions(),
   getFeatures: (bounds: BoundingBox, zoomLevel: Int) -> FeatureCollection,
 ): ComputedSource =
-  rememberUserSource(
-    factory = { ComputedSource(id = it, options = options, getFeatures = getFeatures) },
-    update = {},
-  )
+  key(options, getFeatures) {
+    rememberUserSource(
+      factory = { ComputedSource(id = it, options = options, getFeatures = getFeatures) },
+      update = {},
+    )
+  }

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/source/rememberComputedSource.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/source/rememberComputedSource.kt
@@ -1,25 +1,20 @@
 package dev.sargunv.maplibrecompose.compose.source
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.key
 import dev.sargunv.maplibrecompose.core.source.ComputedSource
 import dev.sargunv.maplibrecompose.core.source.ComputedSourceOptions
 import io.github.dellisd.spatialk.geojson.BoundingBox
 import io.github.dellisd.spatialk.geojson.FeatureCollection
 
 /**
- * Remember a new [ComputedSource] with the given [id] and [options] from the given [getFeatures]
- * function.
+ * Remember a new [ComputedSource] with the given [options] from the given [getFeatures] function.
  */
 @Composable
 public fun rememberGeoJsonSource(
-  id: String,
   options: ComputedSourceOptions = ComputedSourceOptions(),
   getFeatures: (bounds: BoundingBox, zoomLevel: Int) -> FeatureCollection,
 ): ComputedSource =
-  key(id, options, getFeatures) {
-    rememberUserSource(
-      factory = { ComputedSource(id = id, options = options, getFeatures = getFeatures) },
-      update = {},
-    )
-  }
+  rememberUserSource(
+    factory = { ComputedSource(id = it, options = options, getFeatures = getFeatures) },
+    update = {},
+  )

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/source/rememberGeoJsonSource.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/source/rememberGeoJsonSource.kt
@@ -6,20 +6,15 @@ import dev.sargunv.maplibrecompose.core.source.GeoJsonData
 import dev.sargunv.maplibrecompose.core.source.GeoJsonOptions
 import dev.sargunv.maplibrecompose.core.source.GeoJsonSource
 
-/**
- * Remember a new [GeoJsonSource] with the given [id] and [options] from the given [GeoJsonData].
- *
- * @throws IllegalArgumentException if a source with the given [id] already exists.
- */
+/** Remember a new [GeoJsonSource] with the given [options] from the given [GeoJsonData]. */
 @Composable
 public fun rememberGeoJsonSource(
-  id: String,
   data: GeoJsonData,
   options: GeoJsonOptions = GeoJsonOptions(),
 ): GeoJsonSource =
-  key(id, options) {
+  key(options) {
     rememberUserSource(
-      factory = { GeoJsonSource(id = id, data = data, options = options) },
+      factory = { GeoJsonSource(id = it, data = data, options = options) },
       update = { setData(data) },
     )
   }

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/source/rememberImageSource.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/source/rememberImageSource.kt
@@ -1,45 +1,28 @@
 package dev.sargunv.maplibrecompose.compose.source
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.key
 import androidx.compose.ui.graphics.ImageBitmap
 import dev.sargunv.maplibrecompose.core.source.ImageSource
 import dev.sargunv.maplibrecompose.core.util.PositionQuad
 
-/**
- * Remember a new [ImageSource] with the given [id] from the given [uri].
- *
- * @throws IllegalArgumentException if a source with the given [id] already exists.
- */
+/** Remember a new [ImageSource] from the given [uri]. */
 @Composable
-public fun rememberImageSource(id: String, position: PositionQuad, uri: String): ImageSource =
-  key(id, uri) {
-    rememberUserSource(
-      factory = { ImageSource(id = id, position = position, uri = uri) },
-      update = {
-        setBounds(position)
-        setUri(uri)
-      },
-    )
-  }
+public fun rememberImageSource(position: PositionQuad, uri: String): ImageSource =
+  rememberUserSource(
+    factory = { ImageSource(id = it, position = position, uri = uri) },
+    update = {
+      setBounds(position)
+      setUri(uri)
+    },
+  )
 
-/**
- * Remember a new [ImageSource] with the given [id] from the given [bitmap].
- *
- * @throws IllegalArgumentException if a source with the given [id] already exists.
- */
+/** Remember a new [ImageSource] from the given [bitmap]. */
 @Composable
-public fun rememberImageSource(
-  id: String,
-  position: PositionQuad,
-  bitmap: ImageBitmap,
-): ImageSource =
-  key(id, bitmap) {
-    rememberUserSource(
-      factory = { ImageSource(id = id, position = position, image = bitmap) },
-      update = {
-        setBounds(position)
-        setImage(bitmap)
-      },
-    )
-  }
+public fun rememberImageSource(position: PositionQuad, bitmap: ImageBitmap): ImageSource =
+  rememberUserSource(
+    factory = { ImageSource(id = it, position = position, image = bitmap) },
+    update = {
+      setBounds(position)
+      setImage(bitmap)
+    },
+  )

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/source/rememberRasterSource.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/source/rememberRasterSource.kt
@@ -1,6 +1,7 @@
 package dev.sargunv.maplibrecompose.compose.source
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.key
 import dev.sargunv.maplibrecompose.core.source.Defaults
 import dev.sargunv.maplibrecompose.core.source.RasterSource
 import dev.sargunv.maplibrecompose.core.source.TileSetOptions
@@ -11,10 +12,12 @@ public fun rememberRasterSource(
   uri: String,
   tileSize: Int = Defaults.RASTER_TILE_SIZE,
 ): RasterSource =
-  rememberUserSource(
-    factory = { RasterSource(id = it, uri = uri, tileSize = tileSize) },
-    update = {},
-  )
+  key(uri, tileSize) {
+    rememberUserSource(
+      factory = { RasterSource(id = it, uri = uri, tileSize = tileSize) },
+      update = {},
+    )
+  }
 
 @Composable
 public fun rememberRasterSource(
@@ -22,7 +25,9 @@ public fun rememberRasterSource(
   options: TileSetOptions = TileSetOptions(),
   tileSize: Int = Defaults.RASTER_TILE_SIZE,
 ): RasterSource =
-  rememberUserSource(
-    factory = { RasterSource(id = it, tiles = tiles, options = options, tileSize = tileSize) },
-    update = {},
-  )
+  key(tiles, options, tileSize) {
+    rememberUserSource(
+      factory = { RasterSource(id = it, tiles = tiles, options = options, tileSize = tileSize) },
+      update = {},
+    )
+  }

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/source/rememberRasterSource.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/source/rememberRasterSource.kt
@@ -1,39 +1,28 @@
 package dev.sargunv.maplibrecompose.compose.source
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.key as composeKey
 import dev.sargunv.maplibrecompose.core.source.Defaults
 import dev.sargunv.maplibrecompose.core.source.RasterSource
 import dev.sargunv.maplibrecompose.core.source.TileSetOptions
 
-/**
- * Remember a new [RasterSource] with the given [id] and [tileSize] from the given [uri].
- *
- * @throws IllegalArgumentException if a layer with the given [id] already exists.
- */
+/** Remember a new [RasterSource] with the given [tileSize] from the given [uri]. */
 @Composable
 public fun rememberRasterSource(
-  id: String,
   uri: String,
   tileSize: Int = Defaults.RASTER_TILE_SIZE,
 ): RasterSource =
-  composeKey(id, uri, tileSize) {
-    rememberUserSource(
-      factory = { RasterSource(id = id, uri = uri, tileSize = tileSize) },
-      update = {},
-    )
-  }
+  rememberUserSource(
+    factory = { RasterSource(id = it, uri = uri, tileSize = tileSize) },
+    update = {},
+  )
 
 @Composable
 public fun rememberRasterSource(
-  id: String,
   tiles: List<String>,
   options: TileSetOptions = TileSetOptions(),
   tileSize: Int = Defaults.RASTER_TILE_SIZE,
 ): RasterSource =
-  composeKey(id, tiles, options, tileSize) {
-    rememberUserSource(
-      factory = { RasterSource(id = id, tiles = tiles, options = options, tileSize = tileSize) },
-      update = {},
-    )
-  }
+  rememberUserSource(
+    factory = { RasterSource(id = it, tiles = tiles, options = options, tileSize = tileSize) },
+    update = {},
+  )

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/source/rememberUserSource.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/source/rememberUserSource.kt
@@ -8,12 +8,20 @@ import dev.sargunv.maplibrecompose.compose.engine.LocalStyleNode
 import dev.sargunv.maplibrecompose.core.source.Source
 
 @Composable
-internal fun <T : Source> rememberUserSource(factory: () -> T, update: T.() -> Unit): T {
+internal fun <T : Source> rememberUserSource(factory: (String) -> T, update: T.() -> Unit): T {
   val node = LocalStyleNode.current
-  val source = remember(node) { factory().also { node.sourceManager.addReference(it) } }
+  val source = remember(factory, node) { factory(node.sourceManager.nextId()) }
   LaunchedEffect(source, update, node.style.isUnloaded) {
     if (!node.style.isUnloaded) source.update()
   }
-  DisposableEffect(node, source) { onDispose { node.sourceManager.removeReference(source) } }
   return source
+}
+
+@Composable
+internal fun SourceReferenceEffect(source: Source) {
+  val node = LocalStyleNode.current
+  DisposableEffect(source) {
+    node.sourceManager.addReference(source)
+    onDispose { node.sourceManager.removeReference(source) }
+  }
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/source/rememberUserSource.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/source/rememberUserSource.kt
@@ -1,7 +1,6 @@
 package dev.sargunv.maplibrecompose.compose.source
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import dev.sargunv.maplibrecompose.compose.engine.LocalStyleNode
@@ -10,18 +9,9 @@ import dev.sargunv.maplibrecompose.core.source.Source
 @Composable
 internal fun <T : Source> rememberUserSource(factory: (String) -> T, update: T.() -> Unit): T {
   val node = LocalStyleNode.current
-  val source = remember(factory, node) { factory(node.sourceManager.nextId()) }
+  val source = remember(node) { factory(node.sourceManager.nextId()) }
   LaunchedEffect(source, update, node.style.isUnloaded) {
     if (!node.style.isUnloaded) source.update()
   }
   return source
-}
-
-@Composable
-internal fun SourceReferenceEffect(source: Source) {
-  val node = LocalStyleNode.current
-  DisposableEffect(source) {
-    node.sourceManager.addReference(source)
-    onDispose { node.sourceManager.removeReference(source) }
-  }
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/source/rememberVectorSource.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/source/rememberVectorSource.kt
@@ -1,30 +1,20 @@
 package dev.sargunv.maplibrecompose.compose.source
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.key as composeKey
 import dev.sargunv.maplibrecompose.core.source.TileSetOptions
 import dev.sargunv.maplibrecompose.core.source.VectorSource
 
-/**
- * Remember a new [VectorSource] with the given [id] from the given [uri].
- *
- * @throws IllegalArgumentException if a layer with the given [id] already exists.
- */
+/** Remember a new [VectorSource] from the given [uri]. */
 @Composable
-public fun rememberVectorSource(id: String, uri: String): VectorSource =
-  composeKey(id, uri) {
-    rememberUserSource(factory = { VectorSource(id = id, uri = uri) }, update = {})
-  }
+public fun rememberVectorSource(uri: String): VectorSource =
+  rememberUserSource(factory = { VectorSource(id = it, uri = uri) }, update = {})
 
 @Composable
 public fun rememberVectorSource(
-  id: String,
   tiles: List<String>,
   options: TileSetOptions = TileSetOptions(),
 ): VectorSource =
-  composeKey(id, tiles, options) {
-    rememberUserSource(
-      factory = { VectorSource(id = id, tiles = tiles, options = options) },
-      update = {},
-    )
-  }
+  rememberUserSource(
+    factory = { VectorSource(id = it, tiles = tiles, options = options) },
+    update = {},
+  )

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/source/rememberVectorSource.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/source/rememberVectorSource.kt
@@ -1,20 +1,23 @@
 package dev.sargunv.maplibrecompose.compose.source
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.key
 import dev.sargunv.maplibrecompose.core.source.TileSetOptions
 import dev.sargunv.maplibrecompose.core.source.VectorSource
 
 /** Remember a new [VectorSource] from the given [uri]. */
 @Composable
 public fun rememberVectorSource(uri: String): VectorSource =
-  rememberUserSource(factory = { VectorSource(id = it, uri = uri) }, update = {})
+  key(uri) { rememberUserSource(factory = { VectorSource(id = it, uri = uri) }, update = {}) }
 
 @Composable
 public fun rememberVectorSource(
   tiles: List<String>,
   options: TileSetOptions = TileSetOptions(),
 ): VectorSource =
-  rememberUserSource(
-    factory = { VectorSource(id = it, tiles = tiles, options = options) },
-    update = {},
-  )
+  key(tiles, options) {
+    rememberUserSource(
+      factory = { VectorSource(id = it, tiles = tiles, options = options) },
+      update = {},
+    )
+  }

--- a/lib/maplibre-compose/src/commonTest/kotlin/dev/sargunv/maplibrecompose/compose/StyleNodeTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/dev/sargunv/maplibrecompose/compose/StyleNodeTest.kt
@@ -100,26 +100,6 @@ abstract class StyleNodeTest {
   }
 
   @Test
-  fun shouldAllowAddSourceBeforeRemove() = runComposeUiTest {
-    runOnUiThread {
-      val s = makeStyleNode()
-      val s1 = GeoJsonSource("new", GeoJsonData.Features(FeatureCollection()), GeoJsonOptions())
-      val s2 = GeoJsonSource("new", GeoJsonData.Features(FeatureCollection()), GeoJsonOptions())
-
-      s.sourceManager.addReference(s1)
-      s.onEndChanges()
-
-      assertEquals(s1, s.style.getSource("new"))
-
-      s.sourceManager.addReference(s2)
-      s.sourceManager.removeReference(s1)
-      s.onEndChanges()
-
-      assertEquals(s2, s.style.getSource("new"))
-    }
-  }
-
-  @Test
   fun shouldAnchorTop() = runComposeUiTest {
     runOnUiThread {
       val s = makeStyleNode()

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/dev/sargunv/maplibrecompose/compose/offline/rememberOfflinePacksSource.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/dev/sargunv/maplibrecompose/compose/offline/rememberOfflinePacksSource.kt
@@ -24,13 +24,11 @@ import io.github.dellisd.spatialk.geojson.dsl.featureCollection
  */
 @Composable
 public fun rememberOfflinePacksSource(
-  id: String,
   offlinePacks: Set<OfflinePack>,
   options: GeoJsonOptions = GeoJsonOptions(),
   putExtraProperties: PropertiesBuilder.(OfflinePack) -> Unit = {},
 ): Source {
   return rememberGeoJsonSource(
-    id = id,
     options = options,
     data =
       GeoJsonData.Features(


### PR DESCRIPTION
<!-- Thanks for the PR! Please fill out the template below. -->

## Description

Fixes #236 and similar crashes when recreating sources by auto generating source IDs, which ensures we never have an ID conflict and we can remove sources after adding their replacements.

## Test plan

Re-enabled the cluster property demo, and also testing toggling demo visibility (which used to crash)

## Checklist

**To your knowledge, are you making any breaking changes?**

Yes, the `id` param is no longer provided to the `remember*Source` functions.


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
