### PR TITLE
fix get base source

### DIFF
--- a/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/docsnippets/Layers.kt
+++ b/demo-app/src/commonMain/kotlin/dev/sargunv/maplibrecompose/docsnippets/Layers.kt
@@ -28,8 +28,9 @@ import org.jetbrains.compose.resources.ExperimentalResourceApi
 fun Layers() {
   // -8<- [start:simple]
   MaplibreMap(baseStyle = BaseStyle.Uri("https://tiles.openfreemap.org/styles/liberty")) {
-    val tiles = getBaseSource(id = "openmaptiles")
-    CircleLayer(id = "example", source = tiles, sourceLayer = "poi")
+    getBaseSource(id = "openmaptiles")?.let { tiles ->
+      CircleLayer(id = "example", source = tiles, sourceLayer = "poi")
+    }
   }
   // -8<- [end:simple]
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/engine/SourceManager.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/engine/SourceManager.kt
@@ -12,8 +12,8 @@ internal class SourceManager(private val node: StyleNode) {
   /** Receives updates on changes to the style */
   internal var state: StyleState? = null
 
-  internal fun getBaseSource(id: String): Source {
-    return baseSources[id] ?: error("Source ID '$id' not found in base style")
+  internal fun getBaseSource(id: String): Source? {
+    return baseSources[id]
   }
 
   internal fun nextId(): String = sourceIds.next()

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/source/SourceReferenceEffect.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/source/SourceReferenceEffect.kt
@@ -9,7 +9,20 @@ import dev.sargunv.maplibrecompose.core.source.Source
 internal fun SourceReferenceEffect(source: Source) {
   val node = LocalStyleNode.current
   DisposableEffect(source) {
-    node.sourceManager.addReference(source)
-    onDispose { node.sourceManager.removeReference(source) }
+    when (node.sourceManager.getBaseSource(source.id)) {
+      null -> {
+        // free to reference a new source
+        node.sourceManager.addReference(source)
+        onDispose { node.sourceManager.removeReference(source) }
+      }
+      source -> {
+        // a base source was referenced; no-op
+        onDispose {}
+      }
+      else -> {
+        // not the base source, but conflicting id with a base source
+        error("Source id '${source.id}' conflicts with a base source")
+      }
+    }
   }
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/source/getBaseSource.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/compose/source/getBaseSource.kt
@@ -12,7 +12,7 @@ import dev.sargunv.maplibrecompose.core.source.Source
  * @throws IllegalStateException if the source does not exist
  */
 @Composable
-public fun getBaseSource(id: String): Source {
+public fun getBaseSource(id: String): Source? {
   val node = LocalStyleNode.current
   return remember(node, id) { node.sourceManager.getBaseSource(id) }
 }

--- a/lib/maplibre-compose/src/commonTest/kotlin/dev/sargunv/maplibrecompose/compose/StyleNodeTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/dev/sargunv/maplibrecompose/compose/StyleNodeTest.kt
@@ -48,7 +48,7 @@ abstract class StyleNodeTest {
     runOnUiThread {
       val s = makeStyleNode()
       assertEquals(testSources[1], s.sourceManager.getBaseSource("bar"))
-      assertFails { s.sourceManager.getBaseSource("BAR") }
+      assertEquals(null, s.sourceManager.getBaseSource("BAR"))
     }
   }
 


### PR DESCRIPTION
<!-- Thanks for the PR! Please fill out the template below. -->

## Description

since v0.10.0, `getBaseSource` would crash when passed to a layer because we tried to add it to the style (as if it's a user source).

separately, it seems to crash if it's called before the style is fully loaded. 

fixed both by making it nullable, and only adding a reference if it's null (and therefore a user source)

## Test plan

```kt
getBaseSource(id = "openmaptiles")?.let { tiles ->
  CircleLayer(id = "example", source = tiles, sourceLayer = "poi")
}
```

## Checklist

**To your knowledge, are you making any breaking changes?**

yes, `getBaseSource` now returns a nullable `Source`

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
