### PR TITLE
make base style a data class to fix compose stability

### DIFF
--- a/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/BaseStyle.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/dev/sargunv/maplibrecompose/core/BaseStyle.kt
@@ -11,10 +11,10 @@ import kotlinx.serialization.json.putJsonObject
 @Immutable
 public sealed interface BaseStyle {
 
-  @Immutable public class Uri(public val uri: String) : BaseStyle
+  @Immutable public data class Uri(public val uri: String) : BaseStyle
 
   @Immutable
-  public class Json(public val json: String) : BaseStyle {
+  public data class Json(public val json: String) : BaseStyle {
 
     public constructor(json: JsonObject) : this(json.toString())
 


### PR DESCRIPTION
<!-- Thanks for the PR! Please fill out the template below. -->

## Description

Compose compares "stable" types based on their equality method. This type was previously missing an `equals` overload, so different instances were always treated as different values.

## Test plan

Modified the demo app to repro #506

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
