### PR TITLE
only apply bounding box when it changes, to prevent halting the camera animation without cause

### DIFF
--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/IosMap.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/IosMap.kt
@@ -266,7 +266,10 @@ internal class IosMap(
     mapView.maximumZoomLevel = maxZoom
   }
 
+  private var lastBoundingBox: BoundingBox? = null
+
   override fun setCameraBoundingBox(boundingBox: BoundingBox?) {
+    if (boundingBox == lastBoundingBox) return
     mapView.setMaximumScreenBounds(
       boundingBox?.toMLNCoordinateBounds()
         ?: MLNCoordinateBoundsMake(


### PR DESCRIPTION
<!-- Thanks for the PR! Please fill out the template below. -->

## Description

this is an attempt to resolve #508.

I added some logging and noticed the camera bounding box was being set whenever the animation stopped. We can't make that BoundingBox class as @Immutable or @Stable because it comes from a library, but we can remember the last set state ourselves and only update if it actually changes. 

## Test plan

Tested with the repro code from #508; animation no longer halts when keyboard collapses.


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
