### PR TITLE
ios: set last bounding box

### DIFF
--- a/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/IosMap.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/dev/sargunv/maplibrecompose/core/IosMap.kt
@@ -270,6 +270,7 @@ internal class IosMap(
 
   override fun setCameraBoundingBox(boundingBox: BoundingBox?) {
     if (boundingBox == lastBoundingBox) return
+    lastBoundingBox = boundingBox
     mapView.setMaximumScreenBounds(
       boundingBox?.toMLNCoordinateBounds()
         ?: MLNCoordinateBoundsMake(


### PR DESCRIPTION
Forgot this in #517


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
