### PR TITLE
android: only set bounding box when it changes

### DIFF
--- a/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/AndroidMap.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/dev/sargunv/maplibrecompose/core/AndroidMap.kt
@@ -210,7 +210,11 @@ internal class AndroidMap(
     map.setMaxZoomPreference(maxZoom)
   }
 
+  private var lastBoundingBox: BoundingBox? = null
+
   override fun setCameraBoundingBox(boundingBox: BoundingBox?) {
+    if (boundingBox == lastBoundingBox) return
+    lastBoundingBox = boundingBox
     map.setLatLngBoundsForCameraTarget(boundingBox?.toLatLngBounds())
   }
 


### PR DESCRIPTION
# 517 and #518 fixed this for ios, but it's an issue on android too.


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
