### PR TITLE
fix text size interpolation

### DIFF
--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/SymbolLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/SymbolLayer.kt
@@ -238,8 +238,8 @@ private fun rememberEmCompiler(textSize: Expression<TextUnitValue>): LayerProper
  *
  *   **Important:** If using zoom interpolation for text size, then all other properties defined in
  *   text units (like [textLetterSpacing], [textOffset], etc) MUST be defined in EM units, not SP
- *   units. If text size does not use zoom interpolation, then those other properties can be defined
- *   in either unit. This is a limitation of the MapLibre expression parser.
+ *   units. This is a limitation of the MapLibre expression parser. If text size does not use zoom
+ *   interpolation, then those other properties can be defined in either unit.
  *
  * @param textTransform Specifies how to capitalize text.
  * @param textLetterSpacing Text tracking amount.

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/SymbolLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/SymbolLayer.kt
@@ -236,6 +236,11 @@ private fun rememberEmCompiler(textSize: Expression<TextUnitValue>): LayerProper
  *
  *   Ignored if [textField] is not specified.
  *
+ *   **Important:** If using zoom interpolation for text size, then all other properties defined in
+ *   text units (like [textLetterSpacing], [textOffset], etc) MUST be defined in EM units, not SP
+ *   units. If text size does not use zoom interpolation, then those other properties can be defined
+ *   in either unit. This is a limitation of the MapLibre expression parser.
+ *
  * @param textTransform Specifies how to capitalize text.
  * @param textLetterSpacing Text tracking amount.
  *


### PR DESCRIPTION
<!-- Thanks for the PR! Please fill out the template below. -->

## Description

This PR fixes #555 (partially), and documents the remaining trigger case to avoid.

Background: We convert text unit expressions (those defined in Compose SP or EM) to float expressions in either DP or EM, depending on the unit MapLibre expects for that property. Previously, we were convert first to SP, and then to DP and EM based on that SP expression. This caused the bug because:
* Each conversion multiplies the text unit expression input to it
* The first conversion only multiplies the const values, so it keeps the interpolation at the top
* But the second conversion multiplies the previous expression, causing the top level to be a multiplication instead of interpolation

Now, for text size, we convert directly to DP. Separately, we still create an SP expression to help convert other properties that expect EM if they're defined in SP, and that transformation relies on the SP expression.

So, the crash is fixed in the common case (use zoom interpolation for text size) but still possible if two conditions are true:
* zoom interpolation is used for text size
* AND SPs are used in other properties like text offset

There's not really a general fix for that edge case; transforming SP to EM requires dividing by text size in SP, and that could be any arbitrary expression. But there's an easy workaround; just use EMs for properties like text offset if using zoom interpolation in text size.

## Test plan

```kt
textSize = interpolate(linear(), zoom(), Pair(3, const(0.3.em)), Pair(16, const(1.25.em)))
```

and 

```kt
textSize = interpolate(linear(), zoom(), Pair(3, const(5.sp)), Pair(16, const(20.sp)))
```

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
