### PR TITLE
dry up native build ci configs and cache cmake _deps

### DIFF
--- a/.github/actions/setup-cmake/action.yml
+++ b/.github/actions/setup-cmake/action.yml
@@ -1,0 +1,22 @@
+name: Setup CMake
+description: Set up caching for native builds
+runs:
+  using: composite
+  steps:
+    - name: Cache CMake deps
+      uses: actions/cache@v4
+      with:
+        path: lib/maplibre-native-bindings-jni/build/cmake/_deps
+        key: |
+          cmake-deps-${{hashFiles('lib/maplibre-native-bindings-jni/CMakeLists.txt') }}
+    - if: runner.os == 'Windows'
+      name: Setup MSVC environment
+      uses: ilammy/msvc-dev-cmd@v1
+    - if: runner.os == 'Linux'
+      name: Install Linux maplibre-native dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          libcurl4-openssl-dev libjpeg-turbo8-dev libpng-dev libwebp-dev \
+          libx11-dev libgl1-mesa-dev libuv1-dev libbz2-dev libicu-dev \
+          libvulkan-dev

--- a/.github/actions/setup-cmake/action.yml
+++ b/.github/actions/setup-cmake/action.yml
@@ -14,6 +14,7 @@ runs:
       uses: ilammy/msvc-dev-cmd@v1
     - if: runner.os == 'Linux'
       name: Install Linux maplibre-native dependencies
+      shell: bash
       run: |
         sudo apt-get update
         sudo apt-get install -y \

--- a/.github/actions/setup-gradle/action.yml
+++ b/.github/actions/setup-gradle/action.yml
@@ -1,5 +1,5 @@
-name: Setup
-description: Set up the build environment, used by most jobs
+name: Setup Gradle
+description: Set up the Java and Gradle environment
 runs:
   using: composite
   steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: ./.github/actions/setup
+      - uses: ./.github/actions/setup-gradle
       - run: ./gradlew lint
 
   test-android:
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: ./.github/actions/setup
+      - uses: ./.github/actions/setup-gradle
       - run: ./gradlew testDebugUnitTest
       - name: Run with AVD ./gradlew connectedDebugAndroidTest
         uses: ./.github/actions/run-with-avd
@@ -70,7 +70,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: ./.github/actions/setup
+      - uses: ./.github/actions/setup-gradle
       - uses: futureware-tech/simulator-action@v4
         id: setup-simulator
         with:
@@ -86,7 +86,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: ./.github/actions/setup
+      - uses: ./.github/actions/setup-gradle
       - run: ./gradlew jsBrowserTest
 
   test-desktop:
@@ -100,23 +100,12 @@ jobs:
           - runner: windows-latest # amd64
     runs-on: ${{ matrix.runner }}
     steps:
-      - if: ${{ matrix.runner == 'windows-latest' }}
-        run: git config --global core.longpaths true
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           submodules: recursive
-      - if: ${{ matrix.runner == 'windows-latest' }}
-        uses: ilammy/msvc-dev-cmd@v1
-      - if: ${{ matrix.runner == 'ubuntu-latest' }}
-        name: Install Linux maplibre-native dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libcurl4-openssl-dev libjpeg-turbo8-dev libpng-dev libwebp-dev \
-            libx11-dev libgl1-mesa-dev libuv1-dev libbz2-dev libicu-dev \
-            libvulkan-dev
-      - uses: ./.github/actions/setup
+      - uses: ./.github/actions/setup-gradle
+      - uses: ./.github/actions/setup-cmake
       - run: ./gradlew desktopTest
 
   build-docs:
@@ -125,7 +114,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: ./.github/actions/setup
+      - uses: ./.github/actions/setup-gradle
       - run: ./gradlew generateDocs
       - uses: actions/upload-pages-artifact@v3
         with:
@@ -137,7 +126,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: ./.github/actions/setup
+      - uses: ./.github/actions/setup-gradle
       - run: ./gradlew packageDebug
       - uses: actions/upload-artifact@v4
         with:
@@ -163,23 +152,12 @@ jobs:
     runs-on: ${{ matrix.runner }}
     name: build-desktop-app (${{ matrix.runner }})
     steps:
-      - if: ${{ matrix.runner == 'windows-latest' }}
-        run: git config --global core.longpaths true
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           submodules: recursive
-      - if: ${{ matrix.runner == 'windows-latest' }}
-        uses: ilammy/msvc-dev-cmd@v1
-      - if: ${{ matrix.runner == 'ubuntu-latest' }}
-        name: Install Linux maplibre-native dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libcurl4-openssl-dev libjpeg-turbo8-dev libpng-dev libwebp-dev \
-            libx11-dev libgl1-mesa-dev libuv1-dev libbz2-dev libicu-dev \
-            libvulkan-dev
-      - uses: ./.github/actions/setup
+      - uses: ./.github/actions/setup-gradle
+      - uses: ./.github/actions/setup-cmake
       - run: ./gradlew :demo-app:packageDistributionForCurrentOS
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -42,23 +42,12 @@ jobs:
     runs-on: ${{ matrix.runner }}
     name: build-natives (${{ matrix.variant }})
     steps:
-      - if: ${{ matrix.runner == 'windows-latest' }}
-        run: git config --global core.longpaths true
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           submodules: recursive
-      - if: ${{ matrix.runner == 'windows-latest' }}
-        uses: ilammy/msvc-dev-cmd@v1
-      - if: ${{ matrix.runner == 'ubuntu-latest' }}
-        name: Install Linux maplibre-native dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libcurl4-openssl-dev libjpeg-turbo8-dev libpng-dev libwebp-dev \
-            libx11-dev libgl1-mesa-dev libuv1-dev libbz2-dev libicu-dev \
-            libvulkan-dev
-      - uses: ./.github/actions/setup
+      - uses: ./.github/actions/setup-gradle
+      - uses: ./.github/actions/setup-cmake
       - run: |
           ./gradlew :lib:maplibre-native-bindings-jni:buildNative -PdesktopRenderer=${{ matrix.renderer }}
       - uses: actions/upload-artifact@v4
@@ -78,7 +67,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: ./.github/actions/setup
+      - uses: ./.github/actions/setup-gradle
       - uses: actions/download-artifact@v4
         with:
           name: natives-macos-aarch64-metal

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,23 +25,12 @@ jobs:
     runs-on: ${{ matrix.runner }}
     name: build-natives (${{ matrix.variant }})
     steps:
-      - if: ${{ matrix.runner == 'windows-latest' }}
-        run: git config --global core.longpaths true
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           submodules: recursive
-      - if: ${{ matrix.runner == 'windows-latest' }}
-        uses: ilammy/msvc-dev-cmd@v1
-      - if: ${{ matrix.runner == 'ubuntu-latest' }}
-        name: Install Linux maplibre-native dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libcurl4-openssl-dev libjpeg-turbo8-dev libpng-dev libwebp-dev \
-            libx11-dev libgl1-mesa-dev libuv1-dev libbz2-dev libicu-dev \
-            libvulkan-dev
-      - uses: ./.github/actions/setup
+      - uses: ./.github/actions/setup-gradle
+      - uses: ./.github/actions/setup-cmake
       - run: |
           ./gradlew :lib:maplibre-native-bindings-jni:buildNative -PdesktopRenderer=${{ matrix.renderer }}
       - uses: actions/upload-artifact@v4
@@ -62,7 +51,7 @@ jobs:
         with:
           fetch-depth: 0
       - run: git fetch --tags --force # https://github.com/actions/checkout/issues/290
-      - uses: ./.github/actions/setup
+      - uses: ./.github/actions/setup-gradle
       - uses: actions/download-artifact@v4
         with:
           name: natives-macos-aarch64-metal
@@ -103,7 +92,7 @@ jobs:
         with:
           fetch-depth: 0
       - run: git fetch --tags --force # https://github.com/actions/checkout/issues/290
-      - uses: ./.github/actions/setup
+      - uses: ./.github/actions/setup-gradle
       - run: ./gradlew generateDocs
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "lib/maplibre-native-bindings-jni/vendor/vcpkg"]
 	path = lib/maplibre-native-bindings-jni/vendor/vcpkg
 	url = https://github.com/microsoft/vcpkg
+  ignore = dirty

--- a/justfile
+++ b/justfile
@@ -12,6 +12,17 @@ pre-commit-uninstall:
 format:
     pre-commit run --all-files
 
+clean-vcpkg:
+    cd lib/maplibre-native-bindings-jni/vendor/vcpkg; git reset --hard; git clean -fdx
+
+clean-gradle:
+    ./gradlew clean
+
+clean-cmake:
+    rm -rf lib/maplibre-native-bindings-jni/build/cmake
+
+clean: clean-gradle clean-vcpkg clean-cmake
+
 run-desktop:
     ./gradlew :demo-app:run
 

--- a/lib/maplibre-native-bindings-jni/CMakeLists.txt
+++ b/lib/maplibre-native-bindings-jni/CMakeLists.txt
@@ -33,6 +33,7 @@ FetchContent_Declare(
   GIT_REPOSITORY https://github.com/maplibre/maplibre-native.git
   GIT_TAG core-9b6325a14e2cf1cc29ab28c1855ad376f1ba4903
   GIT_SHALLOW 1
+  GIT_CONFIG core.longpaths=true
   SYSTEM
   EXCLUDE_FROM_ALL
 )


### PR DESCRIPTION
<!-- Thanks for the PR! Please fill out the template below. -->

Should somewhat improve #568 


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"fetchcontent","parentHead":"fe1db397b3e85ad167ab39bf7c81ddb068a2836c","parentPull":575,"trunk":"main"}
```
-->
