### PR TITLE
try removing nonpublic includes

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -8,6 +8,8 @@ Checks:
   - bugprone-*
   - cert-*
   - cppcoreguidelines-*
+  - -cppcoreguidelines-avoid-magic-numbers
+  - -readability-magic-numbers
 CheckOptions:
   - key: readability-braces-around-statements.ShortStatementLines
     value: 2

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "lib/maplibre-native-bindings-jni/maplibre-native"]
 	path = lib/maplibre-native-bindings-jni/vendor/maplibre-native
-	url = https://github.com/maplibre/maplibre-native.git
+	url = https://github.com/sargunv/maplibre-native.git
 	ignore = dirty
 [submodule "lib/maplibre-native-bindings-jni/SimpleJNI"]
 	path = lib/maplibre-native-bindings-jni/vendor/SimpleJNI

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -35,7 +35,7 @@
       "languages": ["kotlin", "gradle-kotlin-dsl"]
     },
     {
-      "command": "clang-format",
+      "command": "clang-format --assume-filename=${file}",
       "languages": ["c", "cpp", "objective-c", "objective-cpp"]
     }
   ],

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -44,5 +44,17 @@
   "java.configuration.updateBuildConfiguration": "disabled",
   "java.import.gradle.enabled": false,
   "java.server.launchMode": "LightWeight",
-  "kotlin.languageServer.enabled": false
+  "kotlin.languageServer.enabled": false,
+  "terminal.integrated.defaultProfile.windows": "Native Tools",
+  "terminal.integrated.profiles.windows": {
+    "Native Tools": {
+      "overrideName": true,
+      "path": "C:\\WINDOWS\\System32\\cmd.exe",
+      "args": [
+        "/k",
+        "C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC\\Auxiliary\\Build\\vcvarsall.bat",
+        "${env:PROCESSOR_ARCHITECTURE}"
+      ]
+    }
+  }
 }

--- a/lib/maplibre-native-bindings-jni/CMakeLists.txt
+++ b/lib/maplibre-native-bindings-jni/CMakeLists.txt
@@ -59,15 +59,6 @@ target_include_directories(maplibre-jni
         ${maplibre-native_SOURCE_DIR}/include
 )
 
-# Add Windows-specific includes
-if(WIN32)
-    target_include_directories(maplibre-jni SYSTEM PRIVATE
-        ${maplibre-native_SOURCE_DIR}/platform/windows/vendor/vcpkg/installed/arm64-windows/include
-        ${maplibre-native_SOURCE_DIR}/platform/windows/vendor/vcpkg/installed/x64-windows/include
-        ${maplibre-native_SOURCE_DIR}/platform/windows/vendor/vcpkg/installed/x86-windows/include
-    )
-endif()
-
 # Add Metal-cpp headers for macOS
 if(APPLE)
     target_include_directories(maplibre-jni SYSTEM PRIVATE

--- a/lib/maplibre-native-bindings-jni/CMakeLists.txt
+++ b/lib/maplibre-native-bindings-jni/CMakeLists.txt
@@ -57,14 +57,11 @@ target_include_directories(maplibre-jni
         ${SIMPLEJNI_HEADERS_DIR}
         ${JNI_INCLUDE_DIRS}
         ${maplibre-native_SOURCE_DIR}/include
-        ${maplibre-native_SOURCE_DIR}/platform/default/include
-        ${maplibre-native_SOURCE_DIR}/src
 )
 
 # Add Windows-specific includes
 if(WIN32)
     target_include_directories(maplibre-jni SYSTEM PRIVATE
-        ${maplibre-native_SOURCE_DIR}/platform/windows/include
         ${maplibre-native_SOURCE_DIR}/platform/windows/vendor/vcpkg/installed/arm64-windows/include
         ${maplibre-native_SOURCE_DIR}/platform/windows/vendor/vcpkg/installed/x64-windows/include
         ${maplibre-native_SOURCE_DIR}/platform/windows/vendor/vcpkg/installed/x86-windows/include

--- a/lib/maplibre-native-bindings-jni/src/main/cpp/canvas_frontend.cpp
+++ b/lib/maplibre-native-bindings-jni/src/main/cpp/canvas_frontend.cpp
@@ -2,7 +2,6 @@
 
 #include <mbgl/gfx/renderer_backend.hpp>
 #include <mbgl/renderer/renderer.hpp>
-#include <mbgl/renderer/update_parameters.hpp>
 
 #include <jni_md.h>
 #include <smjni/java_ref.h>
@@ -52,7 +51,7 @@ void CanvasRenderer::setObserver(mbgl::RendererObserver& observer) {
 }
 
 void CanvasRenderer::update(std::shared_ptr<mbgl::UpdateParameters> params) {
-  updateParameters_ = std::make_unique<mbgl::UpdateParameters>(*params);
+  updateParameters_ = std::move(params);
   if (canvasRenderer_.c_ptr() == nullptr) return;
   java_classes::get<CanvasRenderer_class>().requestCanvasRepaint(
     smjni::jni_provider::get_jni(), canvasRenderer_.c_ptr()
@@ -66,8 +65,7 @@ auto CanvasRenderer::getThreadPool() const -> const mbgl::TaggedScheduler& {
 void CanvasRenderer::render() {
   if (!renderer_ || !updateParameters_) return;
   mbgl::gfx::BackendScope scope(*backend_);
-  auto copy = std::make_shared<mbgl::UpdateParameters>(*updateParameters_);
-  renderer_->render(copy);
+  renderer_->render(updateParameters_);
 }
 
 void CanvasRenderer::runOnce() { runLoop_->runOnce(); }

--- a/lib/maplibre-native-bindings-jni/src/main/cpp/canvas_frontend.cpp
+++ b/lib/maplibre-native-bindings-jni/src/main/cpp/canvas_frontend.cpp
@@ -3,7 +3,6 @@
 #include <mbgl/gfx/renderer_backend.hpp>
 #include <mbgl/renderer/renderer.hpp>
 
-#include <jni_md.h>
 #include <smjni/java_ref.h>
 #include <smjni/jni_provider.h>
 #include <type_mapping.h>

--- a/lib/maplibre-native-bindings-jni/src/main/cpp/canvas_metal_backend.mm
+++ b/lib/maplibre-native-bindings-jni/src/main/cpp/canvas_metal_backend.mm
@@ -1,6 +1,6 @@
+#ifdef USE_METAL_BACKEND
 #include <iostream>
 #include <memory>
-#ifdef USE_METAL_BACKEND
 
 #include <mbgl/mtl/context.hpp>
 #include <mbgl/mtl/renderable_resource.hpp>

--- a/lib/maplibre-native-bindings-jni/src/main/cpp/canvas_metal_backend.mm
+++ b/lib/maplibre-native-bindings-jni/src/main/cpp/canvas_metal_backend.mm
@@ -197,10 +197,6 @@ void CanvasBackend::setSize(mbgl::Size size) {
   getResource<MetalRenderableResource>().setSize(size);
 }
 
-auto CanvasBackend::createContext() -> std::unique_ptr<mbgl::gfx::Context> {
-  return std::make_unique<mbgl::mtl::Context>(*this);
-}
-
 auto CanvasBackend::getDefaultRenderable() -> mbgl::gfx::Renderable & {
   return *this;
 }

--- a/lib/maplibre-native-bindings-jni/src/main/cpp/canvas_opengl_backend.cpp
+++ b/lib/maplibre-native-bindings-jni/src/main/cpp/canvas_opengl_backend.cpp
@@ -82,7 +82,7 @@ class OpenGLRenderableResource final : public mbgl::gl::RenderableResource {
     GLXFBConfig* configs = glXChooseFBConfig(
       jawtContext.getDisplay(), DefaultScreen(jawtContext.getDisplay()),
       (int[]){GLX_X_RENDERABLE,
-              True,
+              1,
               GLX_DRAWABLE_TYPE,
               GLX_WINDOW_BIT,
               GLX_RENDER_TYPE,
@@ -102,8 +102,8 @@ class OpenGLRenderableResource final : public mbgl::gl::RenderableResource {
               GLX_STENCIL_SIZE,
               8,
               GLX_DOUBLEBUFFER,
-              True,
-              None},
+              1,
+              0},
       &fbCount
     );
     check(
@@ -123,10 +123,10 @@ class OpenGLRenderableResource final : public mbgl::gl::RenderableResource {
     );
 
     glContext = glXCreateContextAttribsARB(
-      jawtContext.getDisplay(), config, nullptr, True,
+      jawtContext.getDisplay(), config, nullptr, 1,
       (int[]){GLX_CONTEXT_MAJOR_VERSION_ARB, 3, GLX_CONTEXT_MINOR_VERSION_ARB,
               0, GLX_CONTEXT_PROFILE_MASK_ARB, GLX_CONTEXT_CORE_PROFILE_BIT_ARB,
-              None}
+              0}
     );
     check(glContext != nullptr, "glContext is nullptr");
   }

--- a/lib/maplibre-native-bindings-jni/src/main/cpp/canvas_opengl_backend.cpp
+++ b/lib/maplibre-native-bindings-jni/src/main/cpp/canvas_opengl_backend.cpp
@@ -11,7 +11,6 @@
 #include <GL/glx.h>
 #include <GL/glxext.h>
 #elif defined(_WIN32)
-#include <gl_functions_wgl.h>
 #include <windows.h>
 #endif
 
@@ -19,6 +18,13 @@ namespace maplibre_jni {
 
 class OpenGLRenderableResource final : public mbgl::gl::RenderableResource {
  public:
+  OpenGLRenderableResource(const OpenGLRenderableResource&) = delete;
+  OpenGLRenderableResource(OpenGLRenderableResource&&) = delete;
+  auto operator=(const OpenGLRenderableResource&)
+    -> OpenGLRenderableResource& = delete;
+  auto operator=(OpenGLRenderableResource&&)
+    -> OpenGLRenderableResource& = delete;
+
   explicit OpenGLRenderableResource(
     maplibre_jni::CanvasBackend& backend_, JNIEnv* env, jCanvas canvas_
   )
@@ -157,32 +163,35 @@ class OpenGLRenderableResource final : public mbgl::gl::RenderableResource {
       );
     }
     check(pixelFormat != 0, "ChoosePixelFormat failed");
-    check(SetPixelFormat(hdc, pixelFormat, &pfd), "SetPixelFormat failed");
+    check(SetPixelFormat(hdc, pixelFormat, &pfd) != 0, "SetPixelFormat failed");
 
     // Create temporary context
-    auto tempContext = wglCreateContext(hdc);
+    auto* tempContext = wglCreateContext(hdc);
     check(tempContext != nullptr, "wglCreateContext failed");
-    check(wglMakeCurrent(hdc, tempContext), "wglMakeCurrent failed");
+    check(wglMakeCurrent(hdc, tempContext) != 0, "wglMakeCurrent failed");
 
     // Get function pointer for wglCreateContextAttribsARB
-    auto wglCreateContextAttribsARB = (PFNWGLCREATECONTEXTATTRIBSARBPROC)
-      wglGetProcAddress("wglCreateContextAttribsARB");
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    auto wglCreateContextAttribsARB = reinterpret_cast<
+      HGLRC(WINAPI*)(HDC hDC, HGLRC hShareContext, const int* attribList)>(
+      wglGetProcAddress("wglCreateContextAttribsARB")
+    );
     check(
       wglCreateContextAttribsARB != nullptr,
       "wglCreateContextAttribsARB not available"
     );
 
     // Create modern OpenGL context
-    int attribs[] = {
-      WGL_CONTEXT_MAJOR_VERSION_ARB,
+    std::array<int, 7> attribs = {
+      0x2091,  // WGL_CONTEXT_MAJOR_VERSION_ARB
       3,
-      WGL_CONTEXT_MINOR_VERSION_ARB,
+      0x2092,  // WGL_CONTEXT_MINOR_VERSION_ARB
       0,
-      WGL_CONTEXT_PROFILE_MASK_ARB,
-      WGL_CONTEXT_CORE_PROFILE_BIT_ARB,
+      0x9126,  // WGL_CONTEXT_PROFILE_MASK_ARB
+      1,       // WGL_CONTEXT_CORE_PROFILE_BIT_ARB,
       0,
     };
-    glContext = wglCreateContextAttribsARB(hdc, nullptr, attribs);
+    glContext = wglCreateContextAttribsARB(hdc, nullptr, attribs.data());
     check(glContext != nullptr, "failed to create WGL context");
 
     // Clean up temporary context
@@ -212,7 +221,9 @@ CanvasBackend::CanvasBackend(JNIEnv* env, jCanvas canvas)
         std::make_unique<OpenGLRenderableResource>(*this, env, canvas)
       ) {}
 
-mbgl::gfx::Renderable& CanvasBackend::getDefaultRenderable() { return *this; }
+auto CanvasBackend::getDefaultRenderable() -> mbgl::gfx::Renderable& {
+  return *this;
+}
 
 void CanvasBackend::setSize(mbgl::Size size) { this->size = size; }
 
@@ -232,7 +243,10 @@ mbgl::gl::ProcAddress CanvasBackend::getExtensionFunctionPointer(
 #if defined(__linux__)
   return glXGetProcAddressARB((const GLubyte*)name);
 #elif defined(_WIN32)
-  return reinterpret_cast<mbgl::gl::ProcAddress>(wgl_GetProcAddress(name));
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+  return reinterpret_cast<mbgl::gl::ProcAddress>(
+    GetProcAddress(LoadLibraryA("opengl32.dll"), name)
+  );
 #endif
 }
 

--- a/lib/maplibre-native-bindings-jni/src/main/cpp/canvas_renderer.hpp
+++ b/lib/maplibre-native-bindings-jni/src/main/cpp/canvas_renderer.hpp
@@ -13,6 +13,10 @@
 #include <smjni/java_ref.h>
 #include <type_mapping.h>
 
+// clang-format off
+#include "fix_x11_pollution.h"
+// clang-format on
+
 #if defined(USE_METAL_BACKEND)
 #include <mbgl/mtl/renderer_backend.hpp>
 #elif defined(USE_OPENGL_BACKEND)

--- a/lib/maplibre-native-bindings-jni/src/main/cpp/canvas_renderer.hpp
+++ b/lib/maplibre-native-bindings-jni/src/main/cpp/canvas_renderer.hpp
@@ -6,7 +6,6 @@
 #include <mbgl/gfx/renderer_backend.hpp>
 #include <mbgl/renderer/renderer_frontend.hpp>
 #include <mbgl/renderer/renderer_observer.hpp>
-#include <mbgl/renderer/update_parameters.hpp>
 #include <mbgl/util/run_loop.hpp>
 
 #include <jawt.h>
@@ -80,7 +79,7 @@ class CanvasRenderer : public mbgl::RendererFrontend {
   std::unique_ptr<CanvasBackend> backend_;
   std::unique_ptr<mbgl::Renderer> renderer_;
   std::unique_ptr<mbgl::RendererObserver> observer_;
-  std::unique_ptr<mbgl::UpdateParameters> updateParameters_;
+  std::shared_ptr<mbgl::UpdateParameters> updateParameters_;
 
  public:
   void render();

--- a/lib/maplibre-native-bindings-jni/src/main/cpp/canvas_renderer.hpp
+++ b/lib/maplibre-native-bindings-jni/src/main/cpp/canvas_renderer.hpp
@@ -30,14 +30,12 @@ class CanvasBackend : public mbgl::mtl::RendererBackend,
                       public mbgl::gfx::Renderable {
  public:
   explicit CanvasBackend(JNIEnv* env, jCanvas canvas);
-  mbgl::gfx::Renderable& getDefaultRenderable() override;
-  void wait() override {}
+  auto getDefaultRenderable() -> mbgl::gfx::Renderable& override;
   void setSize(mbgl::Size);
 
  protected:
   void activate() override;
   void deactivate() override;
-  std::unique_ptr<mbgl::gfx::Context> createContext() override;
   void updateAssumedState() override {}
 };
 

--- a/lib/maplibre-native-bindings-jni/src/main/cpp/fix_x11_pollution.h
+++ b/lib/maplibre-native-bindings-jni/src/main/cpp/fix_x11_pollution.h
@@ -1,0 +1,7 @@
+#ifdef Always
+#undef Always
+#endif
+
+#ifdef None
+#undef None
+#endif

--- a/lib/maplibre-native-bindings-jni/src/main/cpp/jawt_context.hpp
+++ b/lib/maplibre-native-bindings-jni/src/main/cpp/jawt_context.hpp
@@ -12,6 +12,10 @@
 #include <X11/Xlib.h>
 #endif
 
+// clang-format off
+#include "fix_x11_pollution.h"
+// clang-format on
+
 namespace maplibre_jni {
 
 #ifdef __APPLE__

--- a/lib/maplibre-native-bindings-jni/src/main/cpp/jni_map_observer.cpp
+++ b/lib/maplibre-native-bindings-jni/src/main/cpp/jni_map_observer.cpp
@@ -1,5 +1,3 @@
-#pragma once
-
 #include <mbgl/map/map_observer.hpp>
 
 #include "jni_map_observer.hpp"

--- a/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/util/SharedLibraryLoader.kt
+++ b/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/util/SharedLibraryLoader.kt
@@ -39,7 +39,7 @@ internal object SharedLibraryLoader {
           "libcurl.dll", // libcurl (depends on zlib)
           "maplibre-jni.dll", // main JNI library (depends on all above)
         )
-      os == "windows" -> listOf("libmaplibre-jni.dll")
+      os == "windows" -> listOf("maplibre-jni.dll")
       os == "macos" -> listOf("libmaplibre-jni.dylib")
       else -> listOf("libmaplibre-jni.so")
     }


### PR DESCRIPTION
<!-- Thanks for the PR! Please fill out the template below. -->

## Description

To use the prebuilt core (#568) we'll need to eliminate use of nonpublic includes.

I'm using this branch to test that build in CI.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
