### PR TITLE
wip: try using prebuilt maplibre native

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,3 @@
-[submodule "lib/maplibre-native-bindings-jni/maplibre-native"]
-	path = lib/maplibre-native-bindings-jni/vendor/maplibre-native
-	url = https://github.com/sargunv/maplibre-native.git
-	ignore = dirty
 [submodule "lib/maplibre-native-bindings-jni/SimpleJNI"]
 	path = lib/maplibre-native-bindings-jni/vendor/SimpleJNI
 	url = https://github.com/gershnik/SimpleJNI.git

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,23 +3,12 @@
 This file provides guidance to OpenCode and other agents when working with code
 in this repository.
 
-## SEARCHING VENDORED MAPLIBRE-NATIVE CODEBASE:
+## Searching MapLibre Native headers
 
-When searching the vendored maplibre-native codebase:
+When searching the MapLibre Native headers, look in
+`lib/maplibre-native-bindings-jni/build/cmake/windows-opengl/maplibre-native-headers-src/include/`
 
-- Location: Look in `lib/maplibre-native-bindings-jni/vendor/maplibre-native/`
-- Key Directories:
-  - `platform/linux/` `- Linux-specific code (includes linux.cmake)
-  - `platform/windows/` - Windows-specific code (includes windows.cmake)
-  - `platform/darwin/` - macOS/iOS-specific code (includes darwin.cmake)
-  - `platform/default/` - Cross-platform code
-  - `include/mbgl/` - Public headers
-  - `src/mbgl/` - Implementation files
-- Common Search Patterns:
-  - Platform-specific cmake: `platform/*/platform/*.cmake`
-  - MLN options: `option(MLN*WITH*\*`
-  - Compiler flags: `target_compile_options`, `target_link_options`
-  - Feature detection: `MLN_WITH_OPENGL`, `MLN_WITH_VULKAN`
+This directory is gitignored, so search tools may not find it by default.
 
 ## Development Commands
 

--- a/justfile
+++ b/justfile
@@ -12,10 +12,6 @@ pre-commit-uninstall:
 format:
     pre-commit run --all-files
 
-# Reset the vcpkg submodule to a clean state
-clean-vcpkg:
-    cd lib/maplibre-native-bindings-jni/vendor/maplibre-native/platform/windows/vendor/vcpkg; git reset --hard; git clean -fdx
-
 run-desktop:
     ./gradlew :demo-app:run
 

--- a/lib/maplibre-native-bindings-jni/CMakeLists.txt
+++ b/lib/maplibre-native-bindings-jni/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.21)
 
+include(FetchContent)
 include(cmake/vars.cmake)
 
 project(maplibre-jni)

--- a/lib/maplibre-native-bindings-jni/build.gradle.kts
+++ b/lib/maplibre-native-bindings-jni/build.gradle.kts
@@ -112,7 +112,6 @@ if (config.shouldConfigureForPublishing) {
     inputs.file(layout.projectDirectory.file("CMakeLists.txt"))
     inputs.dir(layout.projectDirectory.dir("cmake"))
     inputs.file(layout.projectDirectory.file("vendor/SimpleJNI/CMakeLists.txt"))
-    inputs.file(layout.projectDirectory.file("vendor/maplibre-native/CMakeLists.txt"))
     inputs.file(layout.projectDirectory.file("CMakePresets.json"))
     inputs.dir(layout.projectDirectory.dir("src/main/cpp"))
     inputs.dir(layout.buildDirectory.dir("generated/simplejni-headers"))

--- a/lib/maplibre-native-bindings-jni/cmake/backends/metal.cmake
+++ b/lib/maplibre-native-bindings-jni/cmake/backends/metal.cmake
@@ -8,9 +8,5 @@ if(NOT APPLE)
     message(FATAL_ERROR "Metal backend is only supported on macOS")
 endif()
 
-target_include_directories(maplibre-jni SYSTEM PRIVATE
-    ${maplibre-native_SOURCE_DIR}/vendor/metal-cpp
-)
-
 target_compile_definitions(maplibre-jni PRIVATE USE_METAL_BACKEND)
 target_link_libraries(maplibre-jni PRIVATE "-framework Metal")

--- a/lib/maplibre-native-bindings-jni/cmake/dependencies/maplibre-native.cmake
+++ b/lib/maplibre-native-bindings-jni/cmake/dependencies/maplibre-native.cmake
@@ -4,26 +4,30 @@ include(FetchContent)
 
 set(MAPLIBRE_NATIVE_VERSION core-9b6325a14e2cf1cc29ab28c1855ad376f1ba4903)
 set(MAPLIBRE_NATIVE_BASE_URL https://github.com/maplibre/maplibre-native/releases/download/${MAPLIBRE_NATIVE_VERSION})
+set(MAPLIBRE_NATIVE_HEADERS_SHA256 56354473ff88653046f62c4ffe2ee879e97eee0cb7f8385210e8b650322a78b7)
 
 # TODO: detect set arch and renderer properly
 if(WIN32)
     # TODO: need amalgam version or libraries
     set(MAPLIBRE_NATIVE_LIBRARY_NAME maplibre-native-core-windows-x64-opengl.lib)
+    set(MAPLIBRE_NATIVE_LIBRARY_SHA256 543cd81afc4ed32fd3ed8c813de557a9730e51ba5943d7f4cab20adef5a114fa)
 elseif(APPLE)
     set(MAPLIBRE_NATIVE_LIBRARY_NAME libmaplibre-native-core-amalgam-macos-arm64-metal.a)
+    set(MAPLIBRE_NATIVE_LIBRARY_SHA256 127707ffa405f3cbc78741f7f21d44b35c3b618a30c16cd0a3881331b9d4c765)
 elseif(LINUX)
     set(MAPLIBRE_NATIVE_LIBRARY_NAME libmaplibre-native-core-amalgam-linux-x64-opengl.a)
+    set(MAPLIBRE_NATIVE_LIBRARY_SHA256 25ec73c7ba7b198dd0dc0ce7959ee4096e8b3dac68fd55bb4fb94be91ceb3421)
 endif()
 
 FetchContent_Populate(maplibre-native-lib
     URL ${MAPLIBRE_NATIVE_BASE_URL}/${MAPLIBRE_NATIVE_LIBRARY_NAME}
-    URL_HASH SHA256=543cd81afc4ed32fd3ed8c813de557a9730e51ba5943d7f4cab20adef5a114fa
+    URL_HASH SHA256=${MAPLIBRE_NATIVE_LIBRARY_SHA256}
     DOWNLOAD_NO_EXTRACT TRUE
 )
 
 FetchContent_Populate(maplibre-native-headers
     URL ${MAPLIBRE_NATIVE_BASE_URL}/maplibre-native-headers.tar.gz
-    URL_HASH SHA256=56354473ff88653046f62c4ffe2ee879e97eee0cb7f8385210e8b650322a78b7
+    URL_HASH SHA256=${MAPLIBRE_NATIVE_HEADERS_SHA256}
 )
 
 target_include_directories(maplibre-jni SYSTEM PRIVATE

--- a/lib/maplibre-native-bindings-jni/cmake/dependencies/maplibre-native.cmake
+++ b/lib/maplibre-native-bindings-jni/cmake/dependencies/maplibre-native.cmake
@@ -1,12 +1,45 @@
 # MapLibre Native dependency configuration
 
-# FetchContent causes problems with the vcpkg toolchain
-# So we use git submodules instead and add_subdirectory() AFTER project()
+include(FetchContent)
 
-add_subdirectory(${maplibre-native_SOURCE_DIR} EXCLUDE_FROM_ALL SYSTEM)
-target_include_directories(maplibre-jni SYSTEM PRIVATE ${maplibre-native_SOURCE_DIR}/include)
+set(MAPLIBRE_NATIVE_VERSION core-9b6325a14e2cf1cc29ab28c1855ad376f1ba4903)
+set(MAPLIBRE_NATIVE_BASE_URL https://github.com/maplibre/maplibre-native/releases/download/${MAPLIBRE_NATIVE_VERSION})
+
+# TODO: detect set arch and renderer properly
+if(WIN32)
+    # TODO: need amalgam version or libraries
+    set(MAPLIBRE_NATIVE_LIBRARY_NAME maplibre-native-core-windows-x64-opengl.lib)
+elseif(APPLE)
+    set(MAPLIBRE_NATIVE_LIBRARY_NAME libmaplibre-native-core-amalgam-macos-arm64-metal.a)
+elseif(LINUX)
+    set(MAPLIBRE_NATIVE_LIBRARY_NAME libmaplibre-native-core-amalgam-linux-x64-opengl.a)
+endif()
+
+FetchContent_Populate(maplibre-native-lib
+    URL ${MAPLIBRE_NATIVE_BASE_URL}/${MAPLIBRE_NATIVE_LIBRARY_NAME}
+    URL_HASH SHA256=543cd81afc4ed32fd3ed8c813de557a9730e51ba5943d7f4cab20adef5a114fa
+    DOWNLOAD_NO_EXTRACT TRUE
+)
+
+FetchContent_Populate(maplibre-native-headers
+    URL ${MAPLIBRE_NATIVE_BASE_URL}/maplibre-native-headers.tar.gz
+    URL_HASH SHA256=56354473ff88653046f62c4ffe2ee879e97eee0cb7f8385210e8b650322a78b7
+)
+
+target_include_directories(maplibre-jni SYSTEM PRIVATE
+    ${maplibre-native-headers_SOURCE_DIR}/include
+    ${maplibre-native-headers_SOURCE_DIR}/vendor/metal-cpp
+    ${maplibre-native-headers_SOURCE_DIR}/vendor/maplibre-native-base/include
+    ${maplibre-native-headers_SOURCE_DIR}/vendor/maplibre-native-base/extras/expected-lite/include
+    ${maplibre-native-headers_SOURCE_DIR}/vendor/maplibre-native-base/deps/geojson.hpp/include
+    ${maplibre-native-headers_SOURCE_DIR}/vendor/maplibre-native-base/deps/geometry.hpp/include
+    ${maplibre-native-headers_SOURCE_DIR}/vendor/maplibre-native-base/deps/variant/include
+)
+
 target_link_libraries(maplibre-jni PRIVATE
-    Mapbox::Map
-    mbgl-compiler-options
-    mbgl-vendor-unique_resource
+    ${maplibre-native-lib_SOURCE_DIR}/${MAPLIBRE_NATIVE_LIBRARY_NAME}
+)
+
+target_compile_definitions(maplibre-jni PRIVATE
+    M_PI=3.14159265358979323846
 )

--- a/lib/maplibre-native-bindings-jni/cmake/dependencies/simplejni.cmake
+++ b/lib/maplibre-native-bindings-jni/cmake/dependencies/simplejni.cmake
@@ -1,8 +1,5 @@
 # SimpleJNI dependency configuration
 
-# FetchContent causes problems with the vcpkg toolchain
-# So we use git submodules instead and add_subdirectory() AFTER project()
-
-add_subdirectory(${SimpleJNI_SOURCE_DIR} EXCLUDE_FROM_ALL SYSTEM)
+add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/vendor/SimpleJNI" EXCLUDE_FROM_ALL SYSTEM)
 target_include_directories(maplibre-jni SYSTEM PRIVATE ${SIMPLEJNI_HEADERS_DIR})
 target_link_libraries(maplibre-jni PRIVATE smjni::smjni)

--- a/lib/maplibre-native-bindings-jni/cmake/vars.cmake
+++ b/lib/maplibre-native-bindings-jni/cmake/vars.cmake
@@ -16,10 +16,3 @@ endif()
 if(APPLE)
     enable_language(OBJCXX)
 endif()
-
-set(SimpleJNI_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/vendor/SimpleJNI")
-set(maplibre-native_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/vendor/maplibre-native")
-
-if(WIN32)
-    set(CMAKE_TOOLCHAIN_FILE ${maplibre-native_SOURCE_DIR}/platform/windows/custom-toolchain.cmake)
-endif()


### PR DESCRIPTION
<!-- Thanks for the PR! Please fill out the template below. -->

## Description

#568, #575, #627

Blockers:
- Windows: need amalgam or libraries: https://github.com/maplibre/maplibre-native/issues/3686
- macOS: need missing  headers: https://github.com/maplibre/maplibre-native/pull/3791
- Linux: linker errors due to text relocations. is the static lib not built with -fPIC?

also before merging, need to configure presets to set the library name appropriately (with arch somehow)
