### PR TITLE
desktop: implement camera options conversions

### DIFF
--- a/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/map/DesktopMapAdapter.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/map/DesktopMapAdapter.kt
@@ -3,6 +3,7 @@ package org.maplibre.compose.map
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.DpRect
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import io.github.dellisd.spatialk.geojson.BoundingBox
 import io.github.dellisd.spatialk.geojson.Feature
@@ -16,6 +17,8 @@ import org.maplibre.compose.expressions.value.BooleanValue
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.compose.style.DesktopStyle
 import org.maplibre.compose.util.VisibleRegion
+import org.maplibre.compose.util.toCameraPosition
+import org.maplibre.compose.util.toMlnCameraOptions
 import org.maplibre.kmp.native.camera.CameraChangeMode
 import org.maplibre.kmp.native.camera.CameraOptions
 import org.maplibre.kmp.native.map.MapLibreMap
@@ -64,8 +67,7 @@ internal class DesktopMapAdapter(internal var callbacks: MapAdapter.Callbacks) :
   }
 
   override fun getCameraPosition(): CameraPosition {
-    // TODO: get camera position
-    return CameraPosition()
+    return map.getCameraOptions().toCameraPosition()
   }
 
   override fun setCameraPosition(cameraPosition: CameraPosition) {
@@ -162,12 +164,7 @@ internal class DesktopMapAdapter(internal var callbacks: MapAdapter.Callbacks) :
 
   override suspend fun animateCameraPosition(finalPosition: CameraPosition, duration: Duration) {
     map.flyTo(
-      CameraOptions.centered(
-        center = LatLng(finalPosition.target.latitude, finalPosition.target.longitude),
-        zoom = finalPosition.zoom,
-        bearing = finalPosition.bearing,
-        pitch = finalPosition.tilt,
-      ),
+      finalPosition.toMlnCameraOptions(LayoutDirection.Ltr),
       duration.inWholeMilliseconds.toInt(),
     )
     // TODO: handle cancellation somehow?

--- a/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/util/conversions.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/util/conversions.kt
@@ -1,0 +1,45 @@
+package org.maplibre.compose.util
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import io.github.dellisd.spatialk.geojson.Position
+import org.maplibre.compose.camera.CameraPosition
+import org.maplibre.kmp.native.camera.CameraOptions as MLNCameraOptions
+import org.maplibre.kmp.native.util.EdgeInsets as MLNEdgeInsets
+import org.maplibre.kmp.native.util.LatLng as MLNLatLng
+
+internal fun MLNCameraOptions.toCameraPosition() =
+  CameraPosition(
+    target = center?.toPosition() ?: Position(0.0, 0.0),
+    bearing = bearing ?: 0.0,
+    tilt = pitch ?: 0.0,
+    zoom = zoom ?: 0.0,
+    padding = padding?.toPaddingValues() ?: PaddingValues(0.dp),
+  )
+
+internal fun CameraPosition.toMlnCameraOptions(layoutDirection: LayoutDirection) =
+  MLNCameraOptions.centered(
+    center = target.toMlnLatLng(),
+    bearing = bearing,
+    pitch = tilt,
+    zoom = zoom,
+    padding = padding.toMlnEdgeInsets(layoutDirection),
+  )
+
+internal fun MLNLatLng.toPosition() = Position(latitude = latitude, longitude = longitude)
+
+internal fun Position.toMlnLatLng() = MLNLatLng(latitude = latitude, longitude = longitude)
+
+internal fun MLNEdgeInsets.toPaddingValues() =
+  // TODO: should this be density scaled?
+  PaddingValues.Absolute(left = left.dp, top = top.dp, right = right.dp, bottom = bottom.dp)
+
+internal fun PaddingValues.toMlnEdgeInsets(layoutDirection: LayoutDirection) =
+  // TODO: should this be density scaled?
+  MLNEdgeInsets(
+    left = calculateLeftPadding(layoutDirection).value.toDouble(),
+    right = calculateRightPadding(layoutDirection).value.toDouble(),
+    top = calculateTopPadding().value.toDouble(),
+    bottom = calculateBottomPadding().value.toDouble(),
+  )


### PR DESCRIPTION


#570

Implement the conversions required for camera state to work.


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
