### PR TITLE
desktop: implement some camera methods by wrapping LatLngBounds

### DIFF
--- a/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/map/DesktopMapAdapter.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/map/DesktopMapAdapter.kt
@@ -18,8 +18,11 @@ import org.maplibre.compose.expressions.value.BooleanValue
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.compose.style.DesktopStyle
 import org.maplibre.compose.util.VisibleRegion
+import org.maplibre.compose.util.toBoundingBox
 import org.maplibre.compose.util.toCameraPosition
 import org.maplibre.compose.util.toMlnCameraOptions
+import org.maplibre.compose.util.toMlnEdgeInsets
+import org.maplibre.compose.util.toMlnLatLngBounds
 import org.maplibre.kmp.native.camera.CameraChangeMode
 import org.maplibre.kmp.native.camera.CameraOptions
 import org.maplibre.kmp.native.map.MapLibreMap
@@ -103,8 +106,7 @@ internal class DesktopMapAdapter(internal var callbacks: MapAdapter.Callbacks) :
   }
 
   override fun getVisibleBoundingBox(): BoundingBox {
-    // TODO: get visible bounding box
-    return BoundingBox(Position(0.0, 0.0), Position(0.0, 0.0))
+    return map.latLngBoundsForCamera(map.getCameraOptions()).toBoundingBox()
   }
 
   override fun getVisibleRegion(): VisibleRegion {
@@ -183,6 +185,21 @@ internal class DesktopMapAdapter(internal var callbacks: MapAdapter.Callbacks) :
     padding: PaddingValues,
     duration: Duration,
   ) {
-    // TODO: flyTo bounding box
+    val cameraOptions =
+      map.cameraForLatLngBounds(
+        bounds = boundingBox.toMlnLatLngBounds(),
+        padding = padding.toMlnEdgeInsets(LayoutDirection.Ltr),
+        bearing = bearing,
+        pitch = tilt,
+      )
+
+    map.flyTo(cameraOptions, duration.inWholeMilliseconds.toInt())
+
+    try {
+      delay(duration)
+    } catch (e: CancellationException) {
+      map.cancelTransitions()
+      throw e
+    }
   }
 }

--- a/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/util/conversions.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/util/conversions.kt
@@ -3,11 +3,13 @@ package org.maplibre.compose.util
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
+import io.github.dellisd.spatialk.geojson.BoundingBox
 import io.github.dellisd.spatialk.geojson.Position
 import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.kmp.native.camera.CameraOptions as MLNCameraOptions
 import org.maplibre.kmp.native.util.EdgeInsets as MLNEdgeInsets
 import org.maplibre.kmp.native.util.LatLng as MLNLatLng
+import org.maplibre.kmp.native.util.LatLngBounds as MLNLatLngBounds
 
 internal fun MLNCameraOptions.toCameraPosition() =
   CameraPosition(
@@ -43,3 +45,9 @@ internal fun PaddingValues.toMlnEdgeInsets(layoutDirection: LayoutDirection) =
     top = calculateTopPadding().value.toDouble(),
     bottom = calculateBottomPadding().value.toDouble(),
   )
+
+internal fun MLNLatLngBounds.toBoundingBox() =
+  BoundingBox(south = south, west = west, north = north, east = east)
+
+internal fun BoundingBox.toMlnLatLngBounds() =
+  MLNLatLngBounds.hull(southwest.toMlnLatLng(), northeast.toMlnLatLng())

--- a/lib/maplibre-native-bindings-jni/src/main/cpp/conversions.cpp
+++ b/lib/maplibre-native-bindings-jni/src/main/cpp/conversions.cpp
@@ -28,6 +28,28 @@ auto convertLatLng(JNIEnv* env, mbgl::LatLng latLng) -> jLatLng {
   return latLngObj.release();
 }
 
+auto convertLatLngBounds(JNIEnv* env, jLatLngBounds latLngBoundsObj)
+  -> mbgl::LatLngBounds {
+  auto north =
+    java_classes::get<LatLngBounds_class>().getNorth(env, latLngBoundsObj);
+  auto east =
+    java_classes::get<LatLngBounds_class>().getEast(env, latLngBoundsObj);
+  auto south =
+    java_classes::get<LatLngBounds_class>().getSouth(env, latLngBoundsObj);
+  auto west =
+    java_classes::get<LatLngBounds_class>().getWest(env, latLngBoundsObj);
+  return mbgl::LatLngBounds::hull({south, west}, {north, east});
+}
+
+auto convertLatLngBounds(JNIEnv* env, const mbgl::LatLngBounds& latLngBounds)
+  -> jLatLngBounds {
+  auto latLngBoundsObj = java_classes::get<LatLngBounds_class>().ctor(
+    env, latLngBounds.north(), latLngBounds.east(), latLngBounds.south(),
+    latLngBounds.west()
+  );
+  return latLngBoundsObj.release();
+}
+
 auto convertScreenCoordinate(JNIEnv* env, jScreenCoordinate screenCoordinateObj)
   -> mbgl::ScreenCoordinate {
   auto x =

--- a/lib/maplibre-native-bindings-jni/src/main/cpp/conversions.hpp
+++ b/lib/maplibre-native-bindings-jni/src/main/cpp/conversions.hpp
@@ -14,6 +14,12 @@ auto convertLatLng(JNIEnv* env, jLatLng latLngObj) -> mbgl::LatLng;
 
 auto convertLatLng(JNIEnv* env, mbgl::LatLng latLng) -> jLatLng;
 
+auto convertLatLngBounds(JNIEnv* env, jLatLngBounds latLngBoundsObj)
+  -> mbgl::LatLngBounds;
+
+auto convertLatLngBounds(JNIEnv* env, const mbgl::LatLngBounds& latLngBounds)
+  -> jLatLngBounds;
+
 auto convertEdgeInsets(JNIEnv* env, jEdgeInsets edgeInsetsObj)
   -> mbgl::EdgeInsets;
 

--- a/lib/maplibre-native-bindings-jni/src/main/cpp/maplibre_map.cpp
+++ b/lib/maplibre-native-bindings-jni/src/main/cpp/maplibre_map.cpp
@@ -202,11 +202,55 @@ void JNICALL MapLibreMap_class::rotateBy(
   });
 }
 
-// TODO: wrap latlng bounds camera methods
-// CameraOptions cameraForLatLngBounds(const LatLngBounds&,
-//   const EdgeInsets&,
-//   const std::optional<double>& bearing = std::nullopt,
-//   const std::optional<double>& pitch = std::nullopt) const;
+auto JNICALL MapLibreMap_class::cameraForLatLngBounds(
+  JNIEnv* env, jMapLibreMap map, jLatLngBounds bounds, jEdgeInsets padding,
+  jDouble bearing, jDouble pitch
+) -> jCameraOptions {
+  return withMapWrapper(
+    env, map, [env, bounds, padding, bearing, pitch](auto wrapper) {
+      auto cppBounds = maplibre_jni::convertLatLngBounds(env, bounds);
+      auto cppPadding = maplibre_jni::convertEdgeInsets(env, padding);
+
+      std::optional<double> cppBearing = std::nullopt;
+      if (bearing != nullptr) {
+        cppBearing =
+          java_classes::get<Double_class>().doubleValue(env, bearing);
+      }
+
+      std::optional<double> cppPitch = std::nullopt;
+      if (pitch != nullptr) {
+        cppPitch = java_classes::get<Double_class>().doubleValue(env, pitch);
+      }
+
+      auto opts = wrapper->map->cameraForLatLngBounds(
+        cppBounds, cppPadding, cppBearing, cppPitch
+      );
+      return maplibre_jni::convertCameraOptions(env, opts);
+    }
+  );
+}
+
+auto JNICALL MapLibreMap_class::latLngBoundsForCamera(
+  JNIEnv* env, jMapLibreMap map, jCameraOptions camera
+) -> jLatLngBounds {
+  return withMapWrapper(env, map, [env, camera](auto wrapper) {
+    auto cppCamera = maplibre_jni::convertCameraOptions(env, camera);
+    auto bounds = wrapper->map->latLngBoundsForCamera(cppCamera);
+    return maplibre_jni::convertLatLngBounds(env, bounds);
+  });
+}
+
+auto JNICALL MapLibreMap_class::latLngBoundsForCameraUnwrapped(
+  JNIEnv* env, jMapLibreMap map, jCameraOptions camera
+) -> jLatLngBounds {
+  return withMapWrapper(env, map, [env, camera](auto wrapper) {
+    auto cppCamera = maplibre_jni::convertCameraOptions(env, camera);
+    auto bounds = wrapper->map->latLngBoundsForCameraUnwrapped(cppCamera);
+    return maplibre_jni::convertLatLngBounds(env, bounds);
+  });
+}
+
+// TODO: wrap remaining camera methods
 // CameraOptions cameraForLatLngs(const std::vector<LatLng>&,
 // const EdgeInsets&,
 // const std::optional<double>& bearing = std::nullopt,
@@ -215,8 +259,6 @@ void JNICALL MapLibreMap_class::rotateBy(
 // const EdgeInsets&,
 // const std::optional<double>& bearing = std::nullopt,
 // const std::optional<double>& pitch = std::nullopt) const;
-// LatLngBounds latLngBoundsForCamera(const CameraOptions&) const;
-// LatLngBounds latLngBoundsForCameraUnwrapped(const CameraOptions&) const;
 
 #pragma mark - Bounds
 

--- a/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/map/MapLibreMap.kt
+++ b/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/map/MapLibreMap.kt
@@ -98,11 +98,23 @@ public class MapLibreMap(
 
   public external fun rotateBy(first: ScreenCoordinate, second: ScreenCoordinate)
 
-  // TODO: cameraForLatLngBounds(bounds, edgeInsets, bearing?, pitch?)
+  public external fun cameraForLatLngBounds(
+    bounds: org.maplibre.kmp.native.util.LatLngBounds,
+    padding: org.maplibre.kmp.native.util.EdgeInsets,
+    bearing: Double? = null,
+    pitch: Double? = null,
+  ): CameraOptions
+
+  public external fun latLngBoundsForCamera(
+    camera: CameraOptions
+  ): org.maplibre.kmp.native.util.LatLngBounds
+
+  public external fun latLngBoundsForCameraUnwrapped(
+    camera: CameraOptions
+  ): org.maplibre.kmp.native.util.LatLngBounds
+
   // TODO: cameraForLatLngs(points, edgeInsets, bearing?, pitch?)
   // TODO: cameraForGeometry(geometry, edgeInsets, bearing?, pitch?)
-  // TODO: latLngBoundsForCamera(cameraOptions)
-  // TODO: latLngBoundsForCameraUnwrapped(cameraOptions)
   // endregion
 
   // region Bounds

--- a/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/util/EdgeInsets.kt
+++ b/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/util/EdgeInsets.kt
@@ -30,6 +30,4 @@ public constructor(
     val centerY = (height - top - bottom) / 2.0 + top
     return ScreenCoordinate(centerX, centerY)
   }
-
-  override fun toString(): String = "EdgeInsets(top=$top, left=$left, bottom=$bottom, right=$right)"
 }

--- a/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/util/LatLngBounds.kt
+++ b/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/util/LatLngBounds.kt
@@ -1,0 +1,124 @@
+package org.maplibre.kmp.native.util
+
+import smjni.jnigen.CalledByNative
+import smjni.jnigen.ExposeToNative
+
+@ExposeToNative
+public data class LatLngBounds
+@CalledByNative
+public constructor(
+  @get:CalledByNative val north: Double,
+  @get:CalledByNative val east: Double,
+  @get:CalledByNative val south: Double,
+  @get:CalledByNative val west: Double,
+) {
+  init {
+    require(north.isFinite()) { "north latitude must be finite" }
+    require(east.isFinite()) { "east longitude must be finite" }
+    require(south.isFinite()) { "south latitude must be finite" }
+    require(west.isFinite()) { "west longitude must be finite" }
+  }
+
+  /** Get the northeast corner of this bounds. */
+  public val northeast: LatLng
+    get() = LatLng(north, east)
+
+  /** Get the southwest corner of this bounds. */
+  public val southwest: LatLng
+    get() = LatLng(south, west)
+
+  /** Get the northwest corner of this bounds. */
+  public val northwest: LatLng
+    get() = LatLng(north, west)
+
+  /** Get the southeast corner of this bounds. */
+  public val southeast: LatLng
+    get() = LatLng(south, east)
+
+  /** Get the center point of this bounds. */
+  public val center: LatLng
+    get() = LatLng((south + north) / 2.0, (west + east) / 2.0)
+
+  /** Returns true if these bounds are valid. */
+  public fun isValid(): Boolean = south <= north && west <= east
+
+  /** Returns true if these bounds are empty (have zero area). */
+  public fun isEmpty(): Boolean = south > north || west > east
+
+  /** Returns true if the bounds span the antimeridian. */
+  public fun crossesAntimeridian(): Boolean {
+    // For unwrapped bounds, this checks if west > east after wrapping
+    val wrappedWest = if (west < -180.0) west + 360.0 else if (west > 180.0) west - 360.0 else west
+    val wrappedEast = if (east < -180.0) east + 360.0 else if (east > 180.0) east - 360.0 else east
+    return wrappedWest > wrappedEast
+  }
+
+  /** Returns true if this bounds contains the given point. */
+  public fun contains(latLng: LatLng): Boolean {
+    val lat = latLng.latitude
+    val lng = latLng.longitude
+
+    return lat in south..north && lng >= west && lng <= east
+  }
+
+  /** Returns true if this bounds contains the given bounds. */
+  public fun contains(bounds: LatLngBounds): Boolean {
+    return bounds.south >= south &&
+      bounds.north <= north &&
+      bounds.west >= west &&
+      bounds.east <= east
+  }
+
+  /** Returns true if this bounds intersects with the given bounds. */
+  public fun intersects(bounds: LatLngBounds): Boolean {
+    return !(bounds.south > north ||
+      bounds.north < south ||
+      bounds.west > east ||
+      bounds.east < west)
+  }
+
+  /** Returns a new bounds extended to include the given point. */
+  public fun extend(latLng: LatLng): LatLngBounds {
+    return LatLngBounds(
+      north = maxOf(north, latLng.latitude),
+      east = maxOf(east, latLng.longitude),
+      south = minOf(south, latLng.latitude),
+      west = minOf(west, latLng.longitude),
+    )
+  }
+
+  /** Returns a new bounds extended to include the given bounds. */
+  public fun extend(bounds: LatLngBounds): LatLngBounds {
+    return LatLngBounds(
+      north = maxOf(north, bounds.north),
+      east = maxOf(east, bounds.east),
+      south = minOf(south, bounds.south),
+      west = minOf(west, bounds.west),
+    )
+  }
+
+  public companion object {
+    /** Return bounds covering the entire (unwrapped) world. */
+    public fun world(): LatLngBounds = LatLngBounds(90.0, 180.0, -90.0, -180.0)
+
+    /** Return bounds consisting of a single point. */
+    public fun singleton(latLng: LatLng): LatLngBounds =
+      LatLngBounds(latLng.latitude, latLng.longitude, latLng.latitude, latLng.longitude)
+
+    /** Return the convex hull of two points; the smallest bounds that contains both. */
+    public fun hull(a: LatLng, b: LatLng): LatLngBounds =
+      LatLngBounds(
+        north = maxOf(a.latitude, b.latitude),
+        east = maxOf(a.longitude, b.longitude),
+        south = minOf(a.latitude, b.latitude),
+        west = minOf(a.longitude, b.longitude),
+      )
+
+    /**
+     * Return bounds that may serve as the identity element for the extend operation. This
+     * represents empty bounds where south > north and west > east.
+     */
+    public fun empty(): LatLngBounds =
+      LatLngBounds(north = -90.0, east = -180.0, south = 90.0, west = 180.0)
+  }
+}

--- a/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/util/ScreenCoordinate.kt
+++ b/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/util/ScreenCoordinate.kt
@@ -6,6 +6,4 @@ import smjni.jnigen.ExposeToNative
 @ExposeToNative
 public data class ScreenCoordinate
 @CalledByNative
-public constructor(@get:CalledByNative val x: Double, @get:CalledByNative val y: Double) {
-  override fun toString(): String = "ScreenCoordinate($x, $y)"
-}
+public constructor(@get:CalledByNative val x: Double, @get:CalledByNative val y: Double)

--- a/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/util/Size.kt
+++ b/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/util/Size.kt
@@ -16,8 +16,6 @@ public constructor(@get:CalledByNative val width: Int, @get:CalledByNative val h
   val isEmpty: Boolean
     get() = width == 0 || height == 0
 
-  override fun toString(): String = "Size($width, $height)"
-
   public operator fun plus(other: Size): Size {
     return Size(width + other.width, height + other.height)
   }


### PR DESCRIPTION
<!-- Thanks for the PR! Please fill out the template below. -->

Implement `animateCameraPosition` and `getVisibleBoundingBox` by wrapping LatLngBounds in the native core.

#570 

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
