### PR TITLE
desktop: implement camera bounds

### DIFF
--- a/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/map/DesktopMapAdapter.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/map/DesktopMapAdapter.kt
@@ -86,33 +86,23 @@ internal class DesktopMapAdapter(internal var callbacks: MapAdapter.Callbacks) :
   }
 
   override fun setCameraBoundingBox(boundingBox: BoundingBox?) {
-    val currentBounds = map.getBounds()
-    val newBounds = currentBounds.copy(bounds = boundingBox?.toMlnLatLngBounds())
-    map.setBounds(newBounds)
+    map.bounds = map.bounds.copy(bounds = boundingBox?.toMlnLatLngBounds())
   }
 
   override fun setMaxZoom(maxZoom: Double) {
-    val currentBounds = map.getBounds()
-    val newBounds = currentBounds.copy(maxZoom = maxZoom)
-    map.setBounds(newBounds)
+    map.bounds = map.bounds.copy(maxZoom = maxZoom)
   }
 
   override fun setMinZoom(minZoom: Double) {
-    val currentBounds = map.getBounds()
-    val newBounds = currentBounds.copy(minZoom = minZoom)
-    map.setBounds(newBounds)
+    map.bounds = map.bounds.copy(minZoom = minZoom)
   }
 
   override fun setMinPitch(minPitch: Double) {
-    val currentBounds = map.getBounds()
-    val newBounds = currentBounds.copy(minPitch = minPitch)
-    map.setBounds(newBounds)
+    map.bounds = map.bounds.copy(minPitch = minPitch)
   }
 
   override fun setMaxPitch(maxPitch: Double) {
-    val currentBounds = map.getBounds()
-    val newBounds = currentBounds.copy(maxPitch = maxPitch)
-    map.setBounds(newBounds)
+    map.bounds = map.bounds.copy(maxPitch = maxPitch)
   }
 
   override fun getVisibleBoundingBox(): BoundingBox {

--- a/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/map/DesktopMapAdapter.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/map/DesktopMapAdapter.kt
@@ -86,23 +86,33 @@ internal class DesktopMapAdapter(internal var callbacks: MapAdapter.Callbacks) :
   }
 
   override fun setCameraBoundingBox(boundingBox: BoundingBox?) {
-    // TODO: bounds
+    val currentBounds = map.getBounds()
+    val newBounds = currentBounds.copy(bounds = boundingBox?.toMlnLatLngBounds())
+    map.setBounds(newBounds)
   }
 
   override fun setMaxZoom(maxZoom: Double) {
-    // TODO: bounds
+    val currentBounds = map.getBounds()
+    val newBounds = currentBounds.copy(maxZoom = maxZoom)
+    map.setBounds(newBounds)
   }
 
   override fun setMinZoom(minZoom: Double) {
-    // TODO: bounds
+    val currentBounds = map.getBounds()
+    val newBounds = currentBounds.copy(minZoom = minZoom)
+    map.setBounds(newBounds)
   }
 
   override fun setMinPitch(minPitch: Double) {
-    // TODO: bounds
+    val currentBounds = map.getBounds()
+    val newBounds = currentBounds.copy(minPitch = minPitch)
+    map.setBounds(newBounds)
   }
 
   override fun setMaxPitch(maxPitch: Double) {
-    // TODO: bounds
+    val currentBounds = map.getBounds()
+    val newBounds = currentBounds.copy(maxPitch = maxPitch)
+    map.setBounds(newBounds)
   }
 
   override fun getVisibleBoundingBox(): BoundingBox {

--- a/lib/maplibre-native-bindings-jni/src/main/cpp/conversions.cpp
+++ b/lib/maplibre-native-bindings-jni/src/main/cpp/conversions.cpp
@@ -6,6 +6,7 @@
 #include <smjni/java_ref.h>
 #include <smjni/java_string.h>
 
+#include <BoundOptions_class.h>
 #include <CameraOptions_class.h>
 #include <MapOptions_class.h>
 
@@ -84,6 +85,82 @@ auto convertEdgeInsets(JNIEnv* env, const mbgl::EdgeInsets& edgeInsets)
   auto obj = java_classes::get<EdgeInsets_class>().ctor(
     env, edgeInsets.top(), edgeInsets.left(), edgeInsets.bottom(),
     edgeInsets.right()
+  );
+  return obj.release();
+}
+
+auto convertBoundOptions(JNIEnv* env, jBoundOptions boundOptionsObj)
+  -> mbgl::BoundOptions {
+  auto bounds =
+    java_classes::get<BoundOptions_class>().getBounds(env, boundOptionsObj);
+  auto minZoom =
+    java_classes::get<BoundOptions_class>().getMinZoom(env, boundOptionsObj);
+  auto maxZoom =
+    java_classes::get<BoundOptions_class>().getMaxZoom(env, boundOptionsObj);
+  auto minPitch =
+    java_classes::get<BoundOptions_class>().getMinPitch(env, boundOptionsObj);
+  auto maxPitch =
+    java_classes::get<BoundOptions_class>().getMaxPitch(env, boundOptionsObj);
+
+  mbgl::BoundOptions options;
+  if (bounds)
+    options.withLatLngBounds(convertLatLngBounds(env, bounds.c_ptr()));
+  if (minZoom)
+    options.withMinZoom(
+      java_classes::get<Double_class>().doubleValue(env, minZoom.c_ptr())
+    );
+  if (maxZoom)
+    options.withMaxZoom(
+      java_classes::get<Double_class>().doubleValue(env, maxZoom.c_ptr())
+    );
+  if (minPitch)
+    options.withMinPitch(
+      java_classes::get<Double_class>().doubleValue(env, minPitch.c_ptr())
+    );
+  if (maxPitch)
+    options.withMaxPitch(
+      java_classes::get<Double_class>().doubleValue(env, maxPitch.c_ptr())
+    );
+
+  return options;
+}
+
+auto convertBoundOptions(JNIEnv* env, const mbgl::BoundOptions& boundOptions)
+  -> jBoundOptions {
+  smjni::local_java_ref<jLatLngBounds> jBounds;
+  if (boundOptions.bounds) {
+    jBounds = java_classes::get<LatLngBounds_class>().ctor(
+      env, boundOptions.bounds->north(), boundOptions.bounds->east(),
+      boundOptions.bounds->south(), boundOptions.bounds->west()
+    );
+  }
+
+  smjni::local_java_ref<jDouble> jMinZoom;
+  if (boundOptions.minZoom) {
+    jMinZoom =
+      java_classes::get<Double_class>().valueOf(env, *boundOptions.minZoom);
+  }
+
+  smjni::local_java_ref<jDouble> jMaxZoom;
+  if (boundOptions.maxZoom) {
+    jMaxZoom =
+      java_classes::get<Double_class>().valueOf(env, *boundOptions.maxZoom);
+  }
+
+  smjni::local_java_ref<jDouble> jMinPitch;
+  if (boundOptions.minPitch) {
+    jMinPitch =
+      java_classes::get<Double_class>().valueOf(env, *boundOptions.minPitch);
+  }
+
+  smjni::local_java_ref<jDouble> jMaxPitch;
+  if (boundOptions.maxPitch) {
+    jMaxPitch =
+      java_classes::get<Double_class>().valueOf(env, *boundOptions.maxPitch);
+  }
+
+  auto obj = java_classes::get<BoundOptions_class>().ctor(
+    env, jBounds, jMinZoom, jMaxZoom, jMinPitch, jMaxPitch
   );
   return obj.release();
 }

--- a/lib/maplibre-native-bindings-jni/src/main/cpp/conversions.hpp
+++ b/lib/maplibre-native-bindings-jni/src/main/cpp/conversions.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <mbgl/map/bound_options.hpp>
 #include <mbgl/map/camera.hpp>
 #include <mbgl/map/map_options.hpp>
 #include <mbgl/storage/resource_options.hpp>
@@ -32,6 +33,12 @@ auto convertScreenCoordinate(JNIEnv* env, jScreenCoordinate screenCoordinateObj)
 auto convertScreenCoordinate(
   JNIEnv* env, mbgl::ScreenCoordinate screenCoordinate
 ) -> jScreenCoordinate;
+
+auto convertBoundOptions(JNIEnv* env, jBoundOptions boundOptionsObj)
+  -> mbgl::BoundOptions;
+
+auto convertBoundOptions(JNIEnv* env, const mbgl::BoundOptions& boundOptions)
+  -> jBoundOptions;
 
 auto convertCameraOptions(JNIEnv* env, jCameraOptions cameraOptionsObj)
   -> mbgl::CameraOptions;

--- a/lib/maplibre-native-bindings-jni/src/main/cpp/maplibre_map.cpp
+++ b/lib/maplibre-native-bindings-jni/src/main/cpp/maplibre_map.cpp
@@ -264,9 +264,22 @@ auto JNICALL MapLibreMap_class::latLngBoundsForCameraUnwrapped(
 
 #pragma mark - Bounds
 
-// TODO: wrap BoundOptions
-// void setBounds(const BoundOptions& options);
-// BoundOptions getBounds() const;
+void JNICALL MapLibreMap_class::setBoundsNative(
+  JNIEnv* env, jMapLibreMap map, jBoundOptions boundOptions
+) {
+  withMapWrapper(env, map, [env, boundOptions](auto wrapper) {
+    auto opts = maplibre_jni::convertBoundOptions(env, boundOptions);
+    wrapper->map->setBounds(opts);
+  });
+}
+
+auto JNICALL MapLibreMap_class::getBoundsNative(JNIEnv* env, jMapLibreMap map)
+  -> jBoundOptions {
+  return withMapWrapper(env, map, [env](auto wrapper) {
+    auto opts = wrapper->map->getBounds();
+    return maplibre_jni::convertBoundOptions(env, opts);
+  });
+}
 
 #pragma mark - Map Options
 

--- a/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/map/BoundOptions.kt
+++ b/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/map/BoundOptions.kt
@@ -1,0 +1,22 @@
+package org.maplibre.kmp.native.map
+
+import org.maplibre.kmp.native.util.LatLngBounds
+import smjni.jnigen.CalledByNative
+import smjni.jnigen.ExposeToNative
+
+/** Options to limit what parts of a map are visible. All fields are optional. */
+@ExposeToNative
+public data class BoundOptions
+@CalledByNative
+public constructor(
+  /** Sets the latitude and longitude bounds to which the camera center are constrained */
+  @get:CalledByNative val bounds: LatLngBounds? = null,
+  /** Minimum zoom level allowed */
+  @get:CalledByNative val minZoom: Double? = null,
+  /** Maximum zoom level allowed */
+  @get:CalledByNative val maxZoom: Double? = null,
+  /** Minimum pitch allowed in degrees */
+  @get:CalledByNative val minPitch: Double? = null,
+  /** Maximum pitch allowed in degrees */
+  @get:CalledByNative val maxPitch: Double? = null,
+)

--- a/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/map/MapLibreMap.kt
+++ b/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/map/MapLibreMap.kt
@@ -129,9 +129,13 @@ public class MapLibreMap(
 
   // region Bounds
 
-  // TODO: setBounds(options)
+  public fun setBounds(options: BoundOptions): Unit = setBoundsNative(options)
 
-  // TODO: getBounds()
+  public fun getBounds(): BoundOptions = getBoundsNative()
+
+  private external fun setBoundsNative(options: BoundOptions)
+
+  private external fun getBoundsNative(): BoundOptions
 
   // endregion
 

--- a/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/map/MapLibreMap.kt
+++ b/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/map/MapLibreMap.kt
@@ -129,9 +129,9 @@ public class MapLibreMap(
 
   // region Bounds
 
-  public fun setBounds(options: BoundOptions): Unit = setBoundsNative(options)
-
-  public fun getBounds(): BoundOptions = getBoundsNative()
+  public var bounds: BoundOptions
+    get() = getBoundsNative()
+    set(value) = setBoundsNative(value)
 
   private external fun setBoundsNative(options: BoundOptions)
 


### PR DESCRIPTION
#570

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
