### PR TITLE
native core: pass through render stats

### DIFF
--- a/lib/maplibre-native-bindings-jni/src/main/cpp/jni_map_observer.cpp
+++ b/lib/maplibre-native-bindings-jni/src/main/cpp/jni_map_observer.cpp
@@ -75,9 +75,30 @@ void JniMapObserver::onDidFinishRenderingFrame(
   auto jMode = java_classes::get<RenderMode_class>().fromNativeValue(
     env, (int)status.mode
   );
+
+  const auto& stats = status.renderingStats;
+  auto jRenderingStats = java_classes::get<RenderingStats_class>().ctor(
+    env, stats.encodingTime, stats.renderingTime, stats.numFrames,
+    stats.numDrawCalls, stats.totalDrawCalls, stats.numCreatedTextures,
+    stats.numActiveTextures, stats.numTextureBindings, stats.numTextureUpdates,
+    static_cast<jlong>(stats.textureUpdateBytes),
+    static_cast<jlong>(stats.totalBuffers),
+    static_cast<jlong>(stats.totalBufferObjs),
+    static_cast<jlong>(stats.bufferUpdates),
+    static_cast<jlong>(stats.bufferObjUpdates),
+    static_cast<jlong>(stats.bufferUpdateBytes), stats.numBuffers,
+    stats.numFrameBuffers, stats.numIndexBuffers,
+    static_cast<jlong>(stats.indexUpdateBytes), stats.numVertexBuffers,
+    static_cast<jlong>(stats.vertexUpdateBytes), stats.numUniformBuffers,
+    stats.numUniformUpdates, static_cast<jlong>(stats.uniformUpdateBytes),
+    stats.memTextures, stats.memBuffers, stats.memIndexBuffers,
+    stats.memVertexBuffers, stats.memUniformBuffers, stats.stencilClears,
+    stats.stencilUpdates
+  );
+
   auto jStatus = java_classes::get<RenderFrameStatus_class>().ctor(
     env, jMode, static_cast<jboolean>(status.needsRepaint),
-    static_cast<jboolean>(status.placementChanged)
+    static_cast<jboolean>(status.placementChanged), jRenderingStats
   );
   java_classes::get<MapObserver_class>().onDidFinishRenderingFrame(
     env, observer, jStatus

--- a/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/map/RenderFrameStatus.kt
+++ b/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/map/RenderFrameStatus.kt
@@ -10,5 +10,5 @@ public constructor(
   val mode: RenderMode,
   val needsRepaint: Boolean,
   val placementChanged: Boolean,
-  // TODO: Add renderingStats when we wrap that type
+  val renderingStats: RenderingStats,
 )

--- a/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/map/RenderingStats.kt
+++ b/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/map/RenderingStats.kt
@@ -1,0 +1,41 @@
+package org.maplibre.kmp.native.map
+
+import smjni.jnigen.CalledByNative
+import smjni.jnigen.ExposeToNative
+
+@ExposeToNative
+public data class RenderingStats
+@CalledByNative
+public constructor(
+  val encodingTime: Double,
+  val renderingTime: Double,
+  val numFrames: Int,
+  val numDrawCalls: Int,
+  val totalDrawCalls: Int,
+  val numCreatedTextures: Int,
+  val numActiveTextures: Int,
+  val numTextureBindings: Int,
+  val numTextureUpdates: Int,
+  val textureUpdateBytes: Long,
+  val totalBuffers: Long,
+  val totalBufferObjs: Long,
+  val bufferUpdates: Long,
+  val bufferObjUpdates: Long,
+  val bufferUpdateBytes: Long,
+  val numBuffers: Int,
+  val numFrameBuffers: Int,
+  val numIndexBuffers: Int,
+  val indexUpdateBytes: Long,
+  val numVertexBuffers: Int,
+  val vertexUpdateBytes: Long,
+  val numUniformBuffers: Int,
+  val numUniformUpdates: Int,
+  val uniformUpdateBytes: Long,
+  val memTextures: Int,
+  val memBuffers: Int,
+  val memIndexBuffers: Int,
+  val memVertexBuffers: Int,
+  val memUniformBuffers: Int,
+  val stencilClears: Int,
+  val stencilUpdates: Int,
+)


### PR DESCRIPTION



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
