### PR TITLE
Support style URIs in Compose Resources on Desktop

### DIFF
--- a/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/map/DesktopMapAdapter.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/map/DesktopMapAdapter.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.unit.LayoutDirection
 import io.github.dellisd.spatialk.geojson.BoundingBox
 import io.github.dellisd.spatialk.geojson.Feature
 import io.github.dellisd.spatialk.geojson.Position
+import java.net.URI
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.time.Duration
 import kotlin.time.DurationUnit
@@ -38,7 +39,6 @@ import org.maplibre.kmp.native.map.RenderFrameStatus
 import org.maplibre.kmp.native.util.LatLng
 import org.maplibre.kmp.native.util.Projection
 import org.maplibre.kmp.native.util.ScreenCoordinate
-import java.net.URI
 
 internal class DesktopMapAdapter(internal var callbacks: MapAdapter.Callbacks) :
   MapAdapter, MapObserver, MapControls.Observer {
@@ -90,11 +90,12 @@ internal class DesktopMapAdapter(internal var callbacks: MapAdapter.Callbacks) :
     lastBaseStyle = style
 
     when (style) {
-      is BaseStyle.Uri -> if (style.uri.startsWith("jar:file:")) {
+      is BaseStyle.Uri ->
+        if (style.uri.startsWith("jar:file:")) {
           map.loadStyleJSON(URI(style.uri).toURL().readText())
-      } else {
+        } else {
           map.loadStyleURL(style.uri)
-      }
+        }
       is BaseStyle.Json -> map.loadStyleJSON(style.json)
     }
 


### PR DESCRIPTION
<!-- Thanks for the PR! Please fill out the template below. -->

## Description

<!-- Please include a summary of the change. -->
This is a simple fix to support style URIs in Compose Resources on the desktop target.
I am not sure if this is the perfect solution, but it works.

## Test plan

<!-- Please describe how you tested the changes. -->
Tested by running the demo app on macOS.
The OSM carto style did not load previously. After this fix, it loads successfully.

## Checklist

**To your knowledge, are you making any breaking changes?**

<!-- If yes, please describe -->
There are no breaking changes. It should be sufficient to verify that it runs on all desktop platforms.

**Have you tested the changes? On which platforms?**

<!-- Delete any entries you haven't tested -->

- Desktop: macOS 15.6
