### PR TITLE
fix location source geojson serialization

### DIFF
--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/location/LocationPuck.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/location/LocationPuck.kt
@@ -23,7 +23,8 @@ import kotlin.math.sin
 import kotlin.math.sqrt
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
-import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 import org.maplibre.compose.camera.CameraState
 import org.maplibre.compose.expressions.dsl.asNumber
 import org.maplibre.compose.expressions.dsl.condition
@@ -273,12 +274,12 @@ private fun rememberLocationSource(locationState: UserLocationState): GeoJsonSou
           Feature(
             geometry = Point(location.position),
             properties =
-              mapOf(
-                "accuracy" to JsonPrimitive(location.accuracy),
-                "bearing" to JsonPrimitive(location.bearing),
-                "bearingAccuracy" to JsonPrimitive(location.bearingAccuracy),
-                "age" to JsonPrimitive(location.timestamp.elapsedNow().inWholeNanoseconds),
-              ),
+              buildJsonObject {
+                put("accuracy", location.accuracy)
+                put("bearing", location.bearing)
+                put("bearingAccuracy", location.bearingAccuracy)
+                put("age", location.timestamp.elapsedNow().inWholeNanoseconds)
+              },
           )
         )
       }


### PR DESCRIPTION
<!-- Thanks for the PR! Please fill out the template below. -->

## Description

`mapOf()` createed a LinkedHashMap, which is generic and therefore not serializable with a default serializer.

The GeoJsonSource API was designed before Feature was generic, so it doesn't take this case into account. I updated it to `buildJsonObject` for now, but later we should improve the API to allow any serializeable properties type (reified properties or explicit serializer).
