### PR TITLE
Fix style switcher demo on web and desktop

### DIFF
--- a/demo-app/src/desktopMain/kotlin/org/maplibre/compose/demoapp/DemoState.desktop.kt
+++ b/demo-app/src/desktopMain/kotlin/org/maplibre/compose/demoapp/DemoState.desktop.kt
@@ -2,11 +2,13 @@ package org.maplibre.compose.demoapp
 
 import androidx.compose.runtime.Composable
 
+private object FakeLocationPermissionState : LocationPermissionState {
+  override val hasPermission: Boolean = false
+
+  override fun requestPermission() {}
+}
+
 @Composable
 actual fun rememberLocationPermissionState(): LocationPermissionState {
-  return object : LocationPermissionState {
-    override val hasPermission: Boolean = false
-
-    override fun requestPermission() {}
-  }
+  return FakeLocationPermissionState
 }

--- a/demo-app/src/webMain/kotlin/org/maplibre/compose/demoapp/DemoState.web.kt
+++ b/demo-app/src/webMain/kotlin/org/maplibre/compose/demoapp/DemoState.web.kt
@@ -1,10 +1,14 @@
 package org.maplibre.compose.demoapp
 
-@androidx.compose.runtime.Composable
-actual fun rememberLocationPermissionState(): LocationPermissionState {
-  return object : LocationPermissionState {
-    override val hasPermission: Boolean = false
+import androidx.compose.runtime.Composable
 
-    override fun requestPermission() {}
-  }
+private object FakeLocationPermissionState : LocationPermissionState {
+  override val hasPermission: Boolean = false
+
+  override fun requestPermission() {}
+}
+
+@Composable
+actual fun rememberLocationPermissionState(): LocationPermissionState {
+  return FakeLocationPermissionState
 }


### PR DESCRIPTION
Resolves #669. The issue was that the fake location permission object was being recreated every call (wasn't actually `remember`ed).