### PR TITLE
fix mise postinstall

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -25,8 +25,7 @@ experimental = true
 postinstall = [
   "hk install",
   # Install and select XCode from .xcode-version
-  "xcodes install",
-  "xcodes select",
+  "if command -v xcodes; then xcodes install && xcodes select; fi",
 ]
 
 [tasks.check]


### PR DESCRIPTION
xcodes shouldn't run on non-mac platforms