### PR TITLE
fix ComputedSource on Android by forcing runtime serializer detection

### DIFF
--- a/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/sources/ComputedSource.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/sources/ComputedSource.kt
@@ -9,6 +9,7 @@ import org.maplibre.compose.util.toLatLngBounds
 import org.maplibre.geojson.FeatureCollection as MLNFeatureCollection
 import org.maplibre.spatialk.geojson.BoundingBox
 import org.maplibre.spatialk.geojson.FeatureCollection
+import org.maplibre.spatialk.geojson.GeoJsonObject
 import org.maplibre.spatialk.geojson.toJson
 
 public actual class ComputedSource : Source {
@@ -31,8 +32,12 @@ public actual class ComputedSource : Source {
           override fun getFeaturesForBounds(
             bounds: LatLngBounds,
             zoomLevel: Int,
-          ): MLNFeatureCollection =
-            MLNFeatureCollection.fromJson(getFeatures(bounds.toBoundingBox(), zoomLevel).toJson())
+          ): MLNFeatureCollection {
+            // HACK: we intentionally drop the FeatureCollection<*, *> type info in order to use the
+            // runtime serializer detection of GeoJsonObject.
+            val features: GeoJsonObject = getFeatures(bounds.toBoundingBox(), zoomLevel)
+            return MLNFeatureCollection.fromJson(features.toJson())
+          }
         },
     )
   )

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MaplibreMap.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MaplibreMap.kt
@@ -64,8 +64,12 @@ import org.maplibre.spatialk.geojson.Position
  *   [GeoJsonSource][org.maplibre.compose.sources.GeoJsonSource]),
  * - [rememberVectorSource][org.maplibre.compose.sources.rememberVectorSource] (see
  *   [VectorSource][org.maplibre.compose.sources.VectorSource]),
+ * - [rememberComputedSource][org.maplibre.compose.sources.rememberComputedSource] (see
+ *   [ComputedSource][org.maplibre.compose.sources.ComputedSource])
  * - [rememberRasterSource][org.maplibre.compose.sources.rememberRasterSource] (see
  *   [RasterSource][org.maplibre.compose.sources.RasterSource])
+ * - [rememberRasterDemSource][org.maplibre.compose.sources.rememberRasterDemSource] (see
+ *   [RasterDemSource][org.maplibre.compose.sources.RasterDemSource])
  *
  * A source that is already defined in the base map style can be referenced via
  * [getBaseSource][org.maplibre.compose.sources.getBaseSource].

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/sources/ComputedSource.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/sources/ComputedSource.kt
@@ -70,7 +70,7 @@ public data class ComputedSourceOptions(
  * Remember a new [ComputedSource] with the given [options] from the given [getFeatures] function.
  */
 @Composable
-public fun rememberGeoJsonSource(
+public fun rememberComputedSource(
   options: ComputedSourceOptions = ComputedSourceOptions(),
   getFeatures: (bounds: BoundingBox, zoomLevel: Int) -> FeatureCollection<*, *>,
 ): ComputedSource =


### PR DESCRIPTION
Spatial-K v0.4 made features generic, but maplibre-compose doesn't yet pass through the type information.

Spatial-K has support for falling back to runtime serializer detection in most cases, but we need to drop the "star projection" type info to make it work. We were already doing so on iOS, so this is a fix for Android. https://github.com/maplibre/spatial-k/pull/284 will make this unnecessary but it doesn't hurt

Also renamed a misnamed function (breaking) and corrected some docs.