### PR TITLE
Implement GeoJsonSource for web

### DIFF
--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/sources/ComputedSource.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/sources/ComputedSource.kt
@@ -1,11 +1,19 @@
 package org.maplibre.compose.sources
 
+import org.maplibre.kmp.js.stylespec.sources.SourceSpecification
 import org.maplibre.spatialk.geojson.BoundingBox
 import org.maplibre.spatialk.geojson.FeatureCollection
 
 public actual class ComputedSource : Source {
 
   @Suppress("UNREACHABLE_CODE") override val impl: Nothing = TODO()
+
+  override val spec: SourceSpecification
+    get() = TODO("Not yet implemented")
+
+  override fun bind(source: org.maplibre.kmp.js.source.Source) {
+    TODO("Not yet implemented")
+  }
 
   public actual constructor(
     id: String,

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/sources/GeoJsonSource.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/sources/GeoJsonSource.kt
@@ -1,17 +1,36 @@
 package org.maplibre.compose.sources
 
 import kotlinx.serialization.json.JsonObject
+import org.maplibre.compose.util.jso
+import org.maplibre.kmp.js.stylespec.sources.GeoJSONSourceSpecification
+import org.maplibre.kmp.js.stylespec.sources.GeoJsonDataDefinition
 import org.maplibre.spatialk.geojson.Feature
 import org.maplibre.spatialk.geojson.FeatureCollection
+import org.maplibre.spatialk.geojson.toJson
+import org.maplibre.kmp.js.source.GeoJsonSource as JsGeoJsonSource
+import org.maplibre.kmp.js.source.Source as JsSource
 
-public actual class GeoJsonSource : Source {
+public actual class GeoJsonSource public actual constructor(id: String, data: GeoJsonData, options: GeoJsonOptions) : Source() {
 
-  @Suppress("UNREACHABLE_CODE") override val impl: Nothing = TODO()
+  override val spec: GeoJSONSourceSpecification = jso {
+    this.type = "geojson"
+    this.data = data.unwrap()
+  }
 
-  public actual constructor(id: String, data: GeoJsonData, options: GeoJsonOptions)
+  private var internalBinding: JsGeoJsonSource? = null
+  override val impl: JsGeoJsonSource
+    get() = requireNotNull(internalBinding)
+
+  override fun bind(source: JsSource) {
+    internalBinding = source.unsafeCast<JsGeoJsonSource>()
+  }
 
   public actual fun setData(data: GeoJsonData) {
-    TODO()
+    if (internalBinding != null) {
+      internalBinding?.setData(data.unwrap())
+    } else {
+      spec.data = data.unwrap()
+    }
   }
 
   public actual fun isCluster(feature: Feature<*, JsonObject?>): Boolean {
@@ -34,5 +53,13 @@ public actual class GeoJsonSource : Source {
     offset: Long,
   ): FeatureCollection<*, JsonObject?> {
     TODO()
+  }
+
+  private fun GeoJsonData.unwrap(): GeoJsonDataDefinition {
+    return when (this) {
+      is GeoJsonData.Features -> geoJson.toJson()
+      is GeoJsonData.JsonString -> json
+      is GeoJsonData.Uri -> uri
+    }.unsafeCast<GeoJsonDataDefinition>()
   }
 }

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/sources/ImageSource.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/sources/ImageSource.kt
@@ -2,9 +2,17 @@ package org.maplibre.compose.sources
 
 import androidx.compose.ui.graphics.ImageBitmap
 import org.maplibre.compose.util.PositionQuad
+import org.maplibre.kmp.js.stylespec.sources.SourceSpecification
 
 public actual class ImageSource : Source {
   override val impl: Nothing = TODO()
+
+  override val spec: SourceSpecification
+    get() = TODO("Not yet implemented")
+
+  override fun bind(source: org.maplibre.kmp.js.source.Source) {
+    TODO("Not yet implemented")
+  }
 
   public actual constructor(id: String, position: PositionQuad, image: ImageBitmap) {}
 

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/sources/RasterDemSource.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/sources/RasterDemSource.kt
@@ -1,8 +1,17 @@
 package org.maplibre.compose.sources
 
+import org.maplibre.kmp.js.stylespec.sources.SourceSpecification
+
 public actual class RasterDemSource : Source {
   public actual constructor(id: String, uri: String, tileSize: Int) : super() {
     this.impl = TODO()
+  }
+
+  override val spec: SourceSpecification
+    get() = TODO("Not yet implemented")
+
+  override fun bind(source: org.maplibre.kmp.js.source.Source) {
+    TODO("Not yet implemented")
   }
 
   public actual constructor(

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/sources/RasterSource.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/sources/RasterSource.kt
@@ -1,8 +1,17 @@
 package org.maplibre.compose.sources
 
+import org.maplibre.kmp.js.stylespec.sources.SourceSpecification
+
 public actual class RasterSource : Source {
   public actual constructor(id: String, uri: String, tileSize: Int) : super() {
     this.impl = TODO()
+  }
+
+  override val spec: SourceSpecification
+    get() = TODO("Not yet implemented")
+
+  override fun bind(source: org.maplibre.kmp.js.source.Source) {
+    TODO("Not yet implemented")
   }
 
   public actual constructor(

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/sources/Source.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/sources/Source.kt
@@ -1,13 +1,18 @@
 package org.maplibre.compose.sources
 
+import org.maplibre.kmp.js.stylespec.sources.SourceSpecification
+import org.maplibre.kmp.js.source.Source as JsSource
+
 public actual sealed class Source {
-  internal abstract val impl: Nothing
+  internal abstract val spec: SourceSpecification
 
-  internal actual val id: String
-    get() = TODO()
+  internal abstract val impl: JsSource
 
-  public actual val attributionHtml: String
-    get() = TODO()
+  internal abstract fun bind(source: JsSource)
+
+  internal actual val id: String by lazy { spec.id }
+
+  public actual val attributionHtml: String get() = impl.attribution.orEmpty()
 
   override fun toString(): String = "${this::class.simpleName}(id=\"$id\")"
 }

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/sources/UnknownSource.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/sources/UnknownSource.kt
@@ -1,3 +1,12 @@
 package org.maplibre.compose.sources
 
-public actual class UnknownSource(override val impl: Nothing) : Source()
+import org.maplibre.kmp.js.stylespec.sources.SourceSpecification
+
+public actual class UnknownSource(override val impl: Nothing) : Source() {
+  override val spec: SourceSpecification
+    get() = TODO("Not yet implemented")
+
+  override fun bind(source: org.maplibre.kmp.js.source.Source) {
+    TODO("Not yet implemented")
+  }
+}

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/sources/VectorSource.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/sources/VectorSource.kt
@@ -3,6 +3,7 @@ package org.maplibre.compose.sources
 import kotlinx.serialization.json.JsonObject
 import org.maplibre.compose.expressions.ast.Expression
 import org.maplibre.compose.expressions.value.BooleanValue
+import org.maplibre.kmp.js.stylespec.sources.SourceSpecification
 import org.maplibre.spatialk.geojson.Feature
 import org.maplibre.spatialk.geojson.Geometry
 
@@ -16,6 +17,13 @@ public actual class VectorSource : Source {
   }
 
   override val impl: Nothing
+
+  override val spec: SourceSpecification
+    get() = TODO("Not yet implemented")
+
+  override fun bind(source: org.maplibre.kmp.js.source.Source) {
+    TODO("Not yet implemented")
+  }
 
   public actual fun querySourceFeatures(
     sourceLayerIds: Set<String>,

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/style/JsStyle.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/style/JsStyle.kt
@@ -8,6 +8,8 @@ import org.maplibre.kmp.js.map.Map
 
 internal class JsStyle(internal val impl: Map) : Style {
 
+  private val sourceCache = mutableMapOf<String, Source>()
+
   override fun addImage(
     id: String,
     image: ImageBitmap,
@@ -18,16 +20,23 @@ internal class JsStyle(internal val impl: Map) : Style {
   override fun removeImage(id: String) {}
 
   override fun getSource(id: String): Source? {
-    return null
+    return sourceCache[id]
   }
 
   override fun getSources(): List<Source> {
-    return emptyList()
+    return sourceCache.values.toList()
   }
 
-  override fun addSource(source: Source) {}
+  override fun addSource(source: Source) {
+    impl.addSource(source.id, source.spec)
+    impl.getSource(source.id)?.let { source.bind(it) }
+    sourceCache[source.id] = source
+  }
 
-  override fun removeSource(source: Source) {}
+  override fun removeSource(source: Source) {
+    impl.removeSource(source.id)
+    sourceCache.remove(source.id)
+  }
 
   override fun getLayer(id: String): Layer? {
     return null

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/util/jso.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/util/jso.kt
@@ -1,0 +1,5 @@
+package org.maplibre.compose.util
+
+internal fun <T : Any> jso(): T = js("({})") as T
+
+internal inline fun <T : Any> jso(block: T.() -> Unit): T = jso<T>().apply(block)

--- a/lib/maplibre-js-bindings/src/commonMain/kotlin/org/maplibre/kmp/js/map/Map.kt
+++ b/lib/maplibre-js-bindings/src/commonMain/kotlin/org/maplibre/kmp/js/map/Map.kt
@@ -15,6 +15,8 @@ import org.maplibre.kmp.js.gestures.KeyboardHandler
 import org.maplibre.kmp.js.gestures.ScrollZoomHandler
 import org.maplibre.kmp.js.gestures.TwoFingersTouchPitchHandler
 import org.maplibre.kmp.js.gestures.TwoFingersTouchZoomRotateHandler
+import org.maplibre.kmp.js.source.Source
+import org.maplibre.kmp.js.stylespec.sources.SourceSpecification
 import org.w3c.dom.HTMLCanvasElement
 import org.w3c.dom.HTMLElement
 
@@ -34,6 +36,12 @@ public external class Map public constructor(options: MapOptions) {
   public val scrollZoom: ScrollZoomHandler
   public val touchPitch: TwoFingersTouchPitchHandler
   public val touchZoomRotate: TwoFingersTouchZoomRotateHandler
+
+  public fun addSource(id: String, source: SourceSpecification)
+
+  public fun removeSource(id: String)
+
+  public fun getSource(id: String): Source?
 
   public fun setStyle(style: dynamic)
 

--- a/lib/maplibre-js-bindings/src/commonMain/kotlin/org/maplibre/kmp/js/source/GeoJsonSource.kt
+++ b/lib/maplibre-js-bindings/src/commonMain/kotlin/org/maplibre/kmp/js/source/GeoJsonSource.kt
@@ -1,0 +1,15 @@
+package org.maplibre.kmp.js.source
+
+import org.maplibre.kmp.js.stylespec.sources.GeoJsonDataDefinition
+
+public abstract external class GeoJsonSource : Source {
+  override var id: String
+    get() = definedExternally
+    set(value) = definedExternally
+
+  override var attribution: String?
+    get() = definedExternally
+    set(value) = definedExternally
+
+  public fun setData(data: GeoJsonDataDefinition)
+}

--- a/lib/maplibre-js-bindings/src/commonMain/kotlin/org/maplibre/kmp/js/source/Source.kt
+++ b/lib/maplibre-js-bindings/src/commonMain/kotlin/org/maplibre/kmp/js/source/Source.kt
@@ -1,0 +1,10 @@
+package org.maplibre.kmp.js.source
+
+/**
+ * [Source](https://maplibre.org/maplibre-gl-js/docs/API/interfaces/Source)
+ */
+public external interface Source {
+  public var id: String
+
+  public var attribution: String?
+}

--- a/lib/maplibre-js-bindings/src/commonMain/kotlin/org/maplibre/kmp/js/stylespec/sources/GeoJSONSourceSpecification.kt
+++ b/lib/maplibre-js-bindings/src/commonMain/kotlin/org/maplibre/kmp/js/stylespec/sources/GeoJSONSourceSpecification.kt
@@ -23,7 +23,7 @@ public external interface GeoJSONSourceSpecification : SourceSpecification {
   public var maxzoom: Int?
 
   /** Contains an attribution to be displayed when map is shown to a user. */
-  public var attribution: String?
+  public override var attribution: String?
 
   /**
    * Size of the tile buffer on each side. A value of 0 produces no buffer. A value of 512 produces

--- a/lib/maplibre-js-bindings/src/commonMain/kotlin/org/maplibre/kmp/js/stylespec/sources/RasterDEMSourceSpecification.kt
+++ b/lib/maplibre-js-bindings/src/commonMain/kotlin/org/maplibre/kmp/js/stylespec/sources/RasterDEMSourceSpecification.kt
@@ -39,7 +39,7 @@ public external interface RasterDEMSourceSpecification : SourceSpecification {
   public var tileSize: Int?
 
   /** Contains an attribution to be displayed when map is shown to a user. */
-  public var attribution: String?
+  public override var attribution: String?
 
   /**
    * The encoding used by this source. Mapbox Terrain RGB is used by default. Defaults to "mapbox"

--- a/lib/maplibre-js-bindings/src/commonMain/kotlin/org/maplibre/kmp/js/stylespec/sources/RasterSourceSpecification.kt
+++ b/lib/maplibre-js-bindings/src/commonMain/kotlin/org/maplibre/kmp/js/stylespec/sources/RasterSourceSpecification.kt
@@ -41,7 +41,7 @@ public external interface RasterSourceSpecification : SourceSpecification {
   public var scheme: String?
 
   /** Contains an attribution to be displayed when map is shown to a user. */
-  public var attribution: String?
+  public override var attribution: String?
 
   /** A setting to determine whether a source's tiles are cached locally. */
   public var volatile: Boolean?

--- a/lib/maplibre-js-bindings/src/commonMain/kotlin/org/maplibre/kmp/js/stylespec/sources/SourceSpecification.kt
+++ b/lib/maplibre-js-bindings/src/commonMain/kotlin/org/maplibre/kmp/js/stylespec/sources/SourceSpecification.kt
@@ -10,4 +10,8 @@ package org.maplibre.kmp.js.stylespec.sources
 public sealed external interface SourceSpecification {
   /** The source type: "geojson", "vector", "raster", "raster-dem", "image", or "video". */
   public var type: String
+
+  public var id: String
+
+  public var attribution: String?
 }

--- a/lib/maplibre-js-bindings/src/commonMain/kotlin/org/maplibre/kmp/js/stylespec/sources/VectorSourceSpecification.kt
+++ b/lib/maplibre-js-bindings/src/commonMain/kotlin/org/maplibre/kmp/js/stylespec/sources/VectorSourceSpecification.kt
@@ -46,7 +46,7 @@ public external interface VectorSourceSpecification : SourceSpecification {
   public var maxzoom: Int?
 
   /** Contains an attribution to be displayed when map is shown to a user. */
-  public var attribution: String?
+  public override var attribution: String?
 
   /**
    * A property to use as a feature id (for feature state). Either a property name, or an object of


### PR DESCRIPTION
<!-- Thanks for the PR! Please fill out the template below. -->

## Description

This is a pass at implementing a source for the web version. The js bindings behave somewhat differently from the native/mobile bindings in the sense that the underlying source implementation objects can only _really_ be created using a reference to the `Map` object. (This will also apply to layers when those are implemented).

I've tried to get around this by "binding" the source implementations to the maplibre-compose object after the source has been added to the map, but this means that some method calls won't work _until_ the source has been added to a map which I fear will introduce some lifecycle headaches when trying to call these methods.

It's also possible this might not end up being an issue in practice, but I haven't been able to test those behaviours yet. 

Similarly, many maplibre-gl-js functions return `Promise`s while their native/mobile equivalents are synchronous calls. This effectively makes them impossible to implement under the current APIs.

I wanted to open this PR sooner than later to raise this potential issue in case there are other thoughts (or maybe this has already been raised before?)

## Test plan

TBD

<!-- Please describe how you tested the changes. -->

## Checklist

**To your knowledge, are you making any breaking changes?**

No

**Have you tested the changes? On which platforms?**
- Web: Chrome 143.0.7499.170
