### PR TITLE
fix(linux): enable vendored static deps for portable JNI builds

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "lib/maplibre-native-bindings-jni/maplibre-native"]
 	path = lib/maplibre-native-bindings-jni/vendor/maplibre-native
-	url = https://github.com/sargunv/maplibre-native.git
+	url = https://github.com/jamesarich/maplibre-native.git
 	ignore = dirty
 [submodule "lib/maplibre-native-bindings-jni/SimpleJNI"]
 	path = lib/maplibre-native-bindings-jni/vendor/SimpleJNI

--- a/lib/maplibre-native-bindings-jni/CMakePresets.json
+++ b/lib/maplibre-native-bindings-jni/CMakePresets.json
@@ -64,7 +64,8 @@
         "CMAKE_CXX_COMPILER": "clang++",
         "CMAKE_BUILD_WITH_INSTALL_RPATH": "ON",
         "MLN_WITH_X11": "ON",
-        "MLN_WITH_WAYLAND": "OFF"
+        "MLN_WITH_WAYLAND": "OFF",
+        "MLN_LINUX_STATIC_DEPS": "ON"
       }
     },
     {


### PR DESCRIPTION
## Description

Enable `MLN_LINUX_STATIC_DEPS` in the Linux CMake preset and point the maplibre-native submodule to a branch that supports vendoring system dependencies as static libraries.

This resolves #627 — Linux JNI artifacts will no longer crash with `UnsatisfiedLinkError` on distros whose system library versions differ from the build environment.

### Changes

- `lib/maplibre-native-bindings-jni/CMakePresets.json` — Added `"MLN_LINUX_STATIC_DEPS": "ON"` to the `linux-base` preset
- `.gitmodules` — Updated submodule URL to fork with vendoring support
- Submodule pointer updated to include the vendored deps implementation

### Upstream dependency

This PR depends on the maplibre-native changes in [sargunv/maplibre-native#2](https://github.com/sargunv/maplibre-native/pull/2). Once merged upstream, the submodule URL and pointer should be updated to point to the upstream repo.

### Test plan

**Desktop (Linux, Ubuntu 25.04):**
- [x] `./gradlew :lib:maplibre-native-bindings-jni:buildNative` succeeds
- [x] Built `.so` has no dynamic dependencies on vendored libraries
- [x] No vendored symbols leaked in `.so` exports
- [x] Map renders correctly in a Compose Desktop application

**Other platforms:**
- [x] Changes are Linux-only (preset gating) — no impact on macOS, Windows, Android, iOS, or JS builds

### Breaking changes

None. This only affects the Linux native build process, not the public API.