### PR TITLE
feat(linux): enable vendored deps amalgamation in Linux preset

### DIFF
--- a/lib/maplibre-native-bindings-jni/CMakePresets.json
+++ b/lib/maplibre-native-bindings-jni/CMakePresets.json
@@ -64,7 +64,9 @@
         "CMAKE_CXX_COMPILER": "clang++",
         "CMAKE_BUILD_WITH_INSTALL_RPATH": "ON",
         "MLN_WITH_X11": "ON",
-        "MLN_WITH_WAYLAND": "OFF"
+        "MLN_WITH_WAYLAND": "OFF",
+        "MLN_CREATE_AMALGAMATION": "ON",
+        "MLN_VENDORED_DEPS": "ON"
       }
     },
     {


### PR DESCRIPTION
## Description

Enable `MLN_CREATE_AMALGAMATION` and `MLN_VENDORED_DEPS` in the `linux-base` CMake preset so Linux JNI builds produce portable shared libraries without runtime dependency on distro-specific library versions.

This resolves #627 — Linux JNI artifacts will no longer crash with `UnsatisfiedLinkError` on distros whose system library versions differ from the build environment.

### Changes

- `lib/maplibre-native-bindings-jni/CMakePresets.json` — Added `"MLN_CREATE_AMALGAMATION": "ON"` and `"MLN_VENDORED_DEPS": "ON"` to the `linux-base` preset

**No `.gitmodules` or submodule changes.** This is a preset-only change.

### Upstream dependency

This PR depends on [maplibre/maplibre-native#4229](https://github.com/maplibre/maplibre-native/pull/4229) (`MLN_VENDORED_DEPS` option) being merged upstream and picked up into the maplibre-native submodule. Until then, the preset variables will be silently ignored by CMake (unknown cache variables are not errors).

### Test plan

**Desktop (Linux, Ubuntu 25.04):**
- [x] Full native build succeeds with vendored deps
- [x] Built `.so` has no dynamic dependencies on vendored libraries
- [x] No vendored symbols leaked in `.so` exports
- [x] Map renders correctly in a Compose Desktop application

**Other platforms:**
- [x] Changes are Linux-only (preset gating) — no impact on macOS, Windows, Android, iOS, or JS

### Breaking changes

None.