### PR TITLE
fix Linux segfault from stale JAWT drawable on OpenGL backend

### DIFF
--- a/lib/maplibre-native-bindings-jni/src/main/cpp/canvas_frontend.cpp
+++ b/lib/maplibre-native-bindings-jni/src/main/cpp/canvas_frontend.cpp
@@ -80,7 +80,6 @@ CanvasRenderer_class::render(JNIEnv* env, jCanvasRenderer renderer) {
     auto* frontend = reinterpret_cast<maplibre_jni::CanvasRenderer*>(
       java_classes::get<CanvasRenderer_class>().getNativePointer(env, renderer)
     );
-    // TODO: something in here is segfaulting on Linux
     frontend->render();
   } catch (const std::exception& e) {
     smjni::java_exception::translate(env, e);

--- a/lib/maplibre-native-bindings-jni/src/main/cpp/canvas_opengl_backend.cpp
+++ b/lib/maplibre-native-bindings-jni/src/main/cpp/canvas_opengl_backend.cpp
@@ -31,26 +31,34 @@ class OpenGLRenderableResource final : public mbgl::gl::RenderableResource {
       : backend(backend_), jawtContext(env, canvas_) {}
 
   ~OpenGLRenderableResource() {
-    check(glContext != nullptr, "glContext is nullptr");
+    // glContext is null if initGL() was never called (e.g. destroyed before first render).
+    if (glContext == nullptr) return;
 #if defined(__linux__)
-    glXMakeCurrent(
-      jawtContext.getDisplay(), jawtContext.getDrawable(), nullptr
-    );
-    glXDestroyContext(jawtContext.getDisplay(), glContext);
+    // Pass None as drawable: releasing a context doesn't need a valid window.
+    // display is the JVM's persistent X11 connection and remains valid here.
+    if (jawtContext.getDisplay() != nullptr) {
+      glXMakeCurrent(jawtContext.getDisplay(), None, nullptr);
+      glXDestroyContext(jawtContext.getDisplay(), glContext);
+    }
 #elif defined(_WIN32)
-    wglMakeCurrent(hdc, nullptr);
+    wglMakeCurrent(nullptr, nullptr);
     wglDeleteContext(glContext);
-    ReleaseDC(jawtContext.getHwnd(), hdc);
 #endif
   }
 
   void activate() {
-    jawtContext.lock();
+    jint lockResult = jawtContext.lock();
+    (void)lockResult;  // JAWT_LOCK_SURFACE_CHANGED: drawable was refreshed above;
+                       // existing GLX context remains valid for the new window as
+                       // long as the AWT peer uses the same X11 visual (typical).
     if (glContext == nullptr) initGL();
 #if defined(__linux__)
-    glXMakeCurrent(
-      jawtContext.getDisplay(), jawtContext.getDrawable(), glContext
-    );
+    if (glXMakeCurrent(
+          jawtContext.getDisplay(), jawtContext.getDrawable(), glContext
+        ) == False) {
+      jawtContext.unlock();
+      throw std::runtime_error("glXMakeCurrent failed");
+    }
 #elif defined(_WIN32)
     wglMakeCurrent(hdc, glContext);
 #endif
@@ -71,11 +79,11 @@ class OpenGLRenderableResource final : public mbgl::gl::RenderableResource {
 
   void deactivate() {
 #if defined(__linux__)
-    glXMakeCurrent(
-      jawtContext.getDisplay(), jawtContext.getDrawable(), nullptr
-    );
+    // Use None as drawable when releasing so that a stale drawable doesn't cause
+    // a crash if the surface was just recreated (JAWT_LOCK_SURFACE_CHANGED).
+    glXMakeCurrent(jawtContext.getDisplay(), None, nullptr);
 #elif defined(_WIN32)
-    wglMakeCurrent(hdc, nullptr);
+    wglMakeCurrent(nullptr, nullptr);
 #endif
     jawtContext.unlock();
   }

--- a/lib/maplibre-native-bindings-jni/src/main/cpp/jawt_context.hpp
+++ b/lib/maplibre-native-bindings-jni/src/main/cpp/jawt_context.hpp
@@ -40,43 +40,57 @@ class JawtContext {
     drawingSurface = awt.GetDrawingSurface(env, canvas);
     check(drawingSurface != nullptr, "awt.GetDrawingSurface failed");
 
+    // Do one lock/unlock to capture the X11 Display* (which is the JVM's
+    // persistent X11 connection and never changes). The Drawable is NOT cached
+    // here — it is refreshed on every subsequent lock() call.
     lock();
-
-    JAWT_DrawingSurfaceInfo* dsi =
-      drawingSurface->GetDrawingSurfaceInfo(drawingSurface);
-    check(dsi != nullptr, "drawingSurface->GetDrawingSurfaceInfo failed");
-
-#if defined(_WIN32)
-    JAWT_Win32DrawingSurfaceInfo* dsiWin =
-      (JAWT_Win32DrawingSurfaceInfo*)dsi->platformInfo;
-    hwnd = dsiWin->hwnd;
-    hdc = dsiWin->hdc;
-#elif defined(__APPLE__)
-    surfaceLayers = (SurfaceLayersRef)dsi->platformInfo;
-#elif defined(__linux__)
-    JAWT_X11DrawingSurfaceInfo* dsiX11 =
-      (JAWT_X11DrawingSurfaceInfo*)dsi->platformInfo;
-    display = dsiX11->display;
-    drawable = dsiX11->drawable;
-#endif
-
-    drawingSurface->FreeDrawingSurfaceInfo(dsi);
-
     unlock();
   }
 
   ~JawtContext() {
-    check(drawingSurface != nullptr, "drawingSurface is nullptr");
-    awt.FreeDrawingSurface(drawingSurface);
+    if (drawingSurface != nullptr) awt.FreeDrawingSurface(drawingSurface);
   }
 
+  // Locks the JAWT drawing surface and refreshes platform-specific surface
+  // info (display, drawable, etc.). The returned flags indicate surface changes
+  // (e.g. JAWT_LOCK_SURFACE_CHANGED). Must be paired with unlock().
   jint lock() {
+    check(currentDsi_ == nullptr, "JawtContext::lock() called while already locked");
     jint lockResult = drawingSurface->Lock(drawingSurface);
     check(lockResult != JAWT_LOCK_ERROR, "drawingSurface->Lock failed");
+
+    // Re-fetch surface info on every lock — the Drawable (X11 window ID)
+    // can change across lock cycles when the AWT peer is recreated (e.g.
+    // on first show, on resize with JAWT_LOCK_SURFACE_CHANGED). Using a
+    // stale Drawable in glXMakeCurrent/glXSwapBuffers causes a segfault.
+    currentDsi_ = drawingSurface->GetDrawingSurfaceInfo(drawingSurface);
+    check(currentDsi_ != nullptr, "drawingSurface->GetDrawingSurfaceInfo failed");
+
+#if defined(_WIN32)
+    auto* dsiWin =
+      static_cast<JAWT_Win32DrawingSurfaceInfo*>(currentDsi_->platformInfo);
+    hwnd = dsiWin->hwnd;
+    hdc = dsiWin->hdc;
+#elif defined(__APPLE__)
+    surfaceLayers = static_cast<SurfaceLayersRef>(currentDsi_->platformInfo);
+#elif defined(__linux__)
+    auto* dsiX11 =
+      static_cast<JAWT_X11DrawingSurfaceInfo*>(currentDsi_->platformInfo);
+    display = dsiX11->display;
+    drawable = dsiX11->drawable;
+#endif
+
     return lockResult;
   }
 
-  void unlock() { drawingSurface->Unlock(drawingSurface); }
+  // Releases JAWT surface info and unlocks the drawing surface.
+  void unlock() {
+    if (currentDsi_ != nullptr) {
+      drawingSurface->FreeDrawingSurfaceInfo(currentDsi_);
+      currentDsi_ = nullptr;
+    }
+    drawingSurface->Unlock(drawingSurface);
+  }
 
 #if defined(_WIN32)
   HWND getHwnd() const { return hwnd; }
@@ -89,8 +103,9 @@ class JawtContext {
 #endif
 
  private:
-  JAWT_DrawingSurface* drawingSurface;
+  JAWT_DrawingSurface* drawingSurface = nullptr;
   JAWT awt{};
+  JAWT_DrawingSurfaceInfo* currentDsi_ = nullptr;
 
 #if defined(_WIN32)
   HWND hwnd = nullptr;


### PR DESCRIPTION
Fixes #564

The segfault inside `render()` was caused by incorrect JAWT usage: `Display*` and `Drawable` were captured once in `JawtContext`'s constructor and cached forever. The JAWT spec requires re-fetching surface info after every `Lock()` call — the X11 `Drawable` (window ID) changes when the AWT peer is recreated on first show, on resize, or when `JAWT_LOCK_SURFACE_CHANGED` is returned. Passing a stale `Drawable` to `glXMakeCurrent`/`glXSwapBuffers` is what causes the crash.

Raised as one of the items in @sargunv's comment at https://github.com/sargunv/maplibre-native/pull/2#issuecomment-4262789003.

### Changes

- `jawt_context.hpp` — `lock()` now calls `GetDrawingSurfaceInfo()` after each `Lock()` and refreshes platform surface info (display, drawable, etc.); `unlock()` calls `FreeDrawingSurfaceInfo()` before `Unlock()`, following the required JAWT lifecycle. Constructor simplified to a single lock/unlock to initialise the `Display*` (which is the JVM's persistent X11 connection and never changes).
- `canvas_opengl_backend.cpp` — destructor: replace `check()` (throws from a destructor → UB during stack unwinding) with an early-return guard; use `glXMakeCurrent(display, None, nullptr)` to release the context without needing a valid window; `activate()` checks the `glXMakeCurrent` return value and throws a descriptive error on failure rather than silently proceeding with no current context; `deactivate()` also uses `None` as the drawable when releasing, for consistency.
- `canvas_frontend.cpp` — remove the TODO comment that flagged the segfault.

### Checklist

**To your knowledge, are you making any breaking changes?** No.

**Have you tested the changes? On which platforms?**
- macOS: builds and runs cleanly; cannot reproduce the Linux segfault on macOS but the fix is deterministic from the JAWT spec.