### PR TITLE
feat(desktop): implement style layer/source/expression support

### DIFF
--- a/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/layers/BackgroundLayer.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/layers/BackgroundLayer.kt
@@ -4,20 +4,22 @@ import org.maplibre.compose.expressions.ast.CompiledExpression
 import org.maplibre.compose.expressions.value.ColorValue
 import org.maplibre.compose.expressions.value.FloatValue
 import org.maplibre.compose.expressions.value.ImageValue
+import org.maplibre.compose.util.toJsonString
 
 internal actual class BackgroundLayer actual constructor(id: String) : Layer() {
-
-  override val impl: Nothing = TODO()
+  @Suppress("UNREACHABLE_CODE") override val impl: Nothing get() = TODO()
+  override val layerId: String = id
+  override fun layerType(): String = "background"
 
   actual fun setBackgroundColor(color: CompiledExpression<ColorValue>) {
-    TODO()
+    setPaintProp("background-color", color.toJsonString())
   }
 
   actual fun setBackgroundPattern(pattern: CompiledExpression<ImageValue>) {
-    TODO()
+    setPaintProp("background-pattern", pattern.toJsonString())
   }
 
   actual fun setBackgroundOpacity(opacity: CompiledExpression<FloatValue>) {
-    TODO()
+    setPaintProp("background-opacity", opacity.toJsonString())
   }
 }

--- a/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/layers/BackgroundLayer.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/layers/BackgroundLayer.kt
@@ -4,20 +4,22 @@ import org.maplibre.compose.expressions.ast.CompiledExpression
 import org.maplibre.compose.expressions.value.ColorValue
 import org.maplibre.compose.expressions.value.FloatValue
 import org.maplibre.compose.expressions.value.ImageValue
+import org.maplibre.compose.util.toJsonString
+import org.maplibre.kmp.native.style.layers.BackgroundLayer as MLNBackgroundLayer
 
 internal actual class BackgroundLayer actual constructor(id: String) : Layer() {
 
-  override val impl: Nothing = TODO()
+  override val impl = MLNBackgroundLayer(id)
 
   actual fun setBackgroundColor(color: CompiledExpression<ColorValue>) {
-    TODO()
+    color.toJsonString()?.let { impl.setProperty("background-color", it) }
   }
 
   actual fun setBackgroundPattern(pattern: CompiledExpression<ImageValue>) {
-    TODO()
+    pattern.toJsonString()?.let { impl.setProperty("background-pattern", it) }
   }
 
   actual fun setBackgroundOpacity(opacity: CompiledExpression<FloatValue>) {
-    TODO()
+    opacity.toJsonString()?.let { impl.setProperty("background-opacity", it) }
   }
 }

--- a/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/layers/CircleLayer.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/layers/CircleLayer.kt
@@ -10,62 +10,67 @@ import org.maplibre.compose.expressions.value.DpValue
 import org.maplibre.compose.expressions.value.FloatValue
 import org.maplibre.compose.expressions.value.TranslateAnchor
 import org.maplibre.compose.sources.Source
+import org.maplibre.compose.util.toJsonString
 
 internal actual class CircleLayer actual constructor(id: String, source: Source) :
   FeatureLayer(source) {
-  override val impl = TODO()
+  @Suppress("UNREACHABLE_CODE") override val impl: Nothing get() = TODO()
+  override val layerId: String = id
+  override fun layerType(): String = "circle"
 
-  actual override var sourceLayer: String = TODO()
+  actual override var sourceLayer: String
+    get() = sourceLayerString()
+    set(value) { updateSourceLayer(value) }
 
   actual override fun setFilter(filter: CompiledExpression<BooleanValue>) {
-    TODO()
+    updateFilter(filter)
   }
 
   actual fun setCircleSortKey(sortKey: CompiledExpression<FloatValue>) {
-    TODO()
+    setLayoutProp("circle-sort-key", sortKey.toJsonString())
   }
 
   actual fun setCircleRadius(radius: CompiledExpression<DpValue>) {
-    TODO()
+    setPaintProp("circle-radius", radius.toJsonString())
   }
 
   actual fun setCircleColor(color: CompiledExpression<ColorValue>) {
-    TODO()
+    setPaintProp("circle-color", color.toJsonString())
   }
 
   actual fun setCircleBlur(blur: CompiledExpression<FloatValue>) {
-    TODO()
+    setPaintProp("circle-blur", blur.toJsonString())
   }
 
   actual fun setCircleOpacity(opacity: CompiledExpression<FloatValue>) {
-    TODO()
+    setPaintProp("circle-opacity", opacity.toJsonString())
   }
 
   actual fun setCircleTranslate(translate: CompiledExpression<DpOffsetValue>) {
-    TODO()
+    setPaintProp("circle-translate", translate.toJsonString())
   }
 
   actual fun setCircleTranslateAnchor(translateAnchor: CompiledExpression<TranslateAnchor>) {
-    TODO()
+    setPaintProp("circle-translate-anchor", translateAnchor.toJsonString())
   }
 
   actual fun setCirclePitchScale(pitchScale: CompiledExpression<CirclePitchScale>) {
-    TODO()
+    setPaintProp("circle-pitch-scale", pitchScale.toJsonString())
   }
 
   actual fun setCirclePitchAlignment(pitchAlignment: CompiledExpression<CirclePitchAlignment>) {
-    TODO()
+    setPaintProp("circle-pitch-alignment", pitchAlignment.toJsonString())
   }
 
   actual fun setCircleStrokeWidth(strokeWidth: CompiledExpression<DpValue>) {
-    TODO()
+    setPaintProp("circle-stroke-width", strokeWidth.toJsonString())
   }
 
   actual fun setCircleStrokeColor(strokeColor: CompiledExpression<ColorValue>) {
-    TODO()
+    setPaintProp("circle-stroke-color", strokeColor.toJsonString())
   }
 
   actual fun setCircleStrokeOpacity(strokeOpacity: CompiledExpression<FloatValue>) {
-    TODO()
+    setPaintProp("circle-stroke-opacity", strokeOpacity.toJsonString())
   }
 }

--- a/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/layers/CircleLayer.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/layers/CircleLayer.kt
@@ -10,62 +10,68 @@ import org.maplibre.compose.expressions.value.DpValue
 import org.maplibre.compose.expressions.value.FloatValue
 import org.maplibre.compose.expressions.value.TranslateAnchor
 import org.maplibre.compose.sources.Source
+import org.maplibre.compose.util.toJsonString
+import org.maplibre.kmp.native.style.layers.CircleLayer as MLNCircleLayer
 
 internal actual class CircleLayer actual constructor(id: String, source: Source) :
   FeatureLayer(source) {
-  override val impl = TODO()
+  override val impl = MLNCircleLayer(id, source.id)
 
-  actual override var sourceLayer: String = TODO()
+  actual override var sourceLayer: String
+    get() = impl.sourceLayer
+    set(value) {
+      impl.sourceLayer = value
+    }
 
   actual override fun setFilter(filter: CompiledExpression<BooleanValue>) {
-    TODO()
+    filter.toJsonString()?.let { impl.setFilter(it) }
   }
 
   actual fun setCircleSortKey(sortKey: CompiledExpression<FloatValue>) {
-    TODO()
+    sortKey.toJsonString()?.let { impl.setProperty("circle-sort-key", it) }
   }
 
   actual fun setCircleRadius(radius: CompiledExpression<DpValue>) {
-    TODO()
+    radius.toJsonString()?.let { impl.setProperty("circle-radius", it) }
   }
 
   actual fun setCircleColor(color: CompiledExpression<ColorValue>) {
-    TODO()
+    color.toJsonString()?.let { impl.setProperty("circle-color", it) }
   }
 
   actual fun setCircleBlur(blur: CompiledExpression<FloatValue>) {
-    TODO()
+    blur.toJsonString()?.let { impl.setProperty("circle-blur", it) }
   }
 
   actual fun setCircleOpacity(opacity: CompiledExpression<FloatValue>) {
-    TODO()
+    opacity.toJsonString()?.let { impl.setProperty("circle-opacity", it) }
   }
 
   actual fun setCircleTranslate(translate: CompiledExpression<DpOffsetValue>) {
-    TODO()
+    translate.toJsonString()?.let { impl.setProperty("circle-translate", it) }
   }
 
   actual fun setCircleTranslateAnchor(translateAnchor: CompiledExpression<TranslateAnchor>) {
-    TODO()
+    translateAnchor.toJsonString()?.let { impl.setProperty("circle-translate-anchor", it) }
   }
 
   actual fun setCirclePitchScale(pitchScale: CompiledExpression<CirclePitchScale>) {
-    TODO()
+    pitchScale.toJsonString()?.let { impl.setProperty("circle-pitch-scale", it) }
   }
 
   actual fun setCirclePitchAlignment(pitchAlignment: CompiledExpression<CirclePitchAlignment>) {
-    TODO()
+    pitchAlignment.toJsonString()?.let { impl.setProperty("circle-pitch-alignment", it) }
   }
 
   actual fun setCircleStrokeWidth(strokeWidth: CompiledExpression<DpValue>) {
-    TODO()
+    strokeWidth.toJsonString()?.let { impl.setProperty("circle-stroke-width", it) }
   }
 
   actual fun setCircleStrokeColor(strokeColor: CompiledExpression<ColorValue>) {
-    TODO()
+    strokeColor.toJsonString()?.let { impl.setProperty("circle-stroke-color", it) }
   }
 
   actual fun setCircleStrokeOpacity(strokeOpacity: CompiledExpression<FloatValue>) {
-    TODO()
+    strokeOpacity.toJsonString()?.let { impl.setProperty("circle-stroke-opacity", it) }
   }
 }

--- a/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/layers/FeatureLayer.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/layers/FeatureLayer.kt
@@ -3,9 +3,30 @@ package org.maplibre.compose.layers
 import org.maplibre.compose.expressions.ast.CompiledExpression
 import org.maplibre.compose.expressions.value.BooleanValue
 import org.maplibre.compose.sources.Source
+import org.maplibre.compose.util.toJsonString
 
 internal actual sealed class FeatureLayer actual constructor(actual val source: Source) : Layer() {
+
+  private var _sourceLayer: String = ""
+  private var _filter: String? = null
+
   actual abstract var sourceLayer: String
 
   actual abstract fun setFilter(filter: CompiledExpression<BooleanValue>)
+
+  protected fun updateSourceLayer(value: String) {
+    _sourceLayer = value
+    style?.updateLayer(this)
+  }
+
+  protected fun updateFilter(filter: CompiledExpression<BooleanValue>) {
+    _filter = filter.toJsonString()
+    style?.updateLayer(this)
+  }
+
+  final override fun sourceId(): String = source.id
+
+  final override fun sourceLayerString(): String = _sourceLayer
+
+  final override fun filterJson(): String? = _filter
 }

--- a/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/layers/FeatureLayer.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/layers/FeatureLayer.kt
@@ -3,8 +3,11 @@ package org.maplibre.compose.layers
 import org.maplibre.compose.expressions.ast.CompiledExpression
 import org.maplibre.compose.expressions.value.BooleanValue
 import org.maplibre.compose.sources.Source
+import org.maplibre.kmp.native.style.layers.FeatureLayer as MLNFeatureLayer
 
 internal actual sealed class FeatureLayer actual constructor(actual val source: Source) : Layer() {
+  abstract override val impl: MLNFeatureLayer
+
   actual abstract var sourceLayer: String
 
   actual abstract fun setFilter(filter: CompiledExpression<BooleanValue>)

--- a/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/layers/FillExtrusionLayer.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/layers/FillExtrusionLayer.kt
@@ -8,46 +8,51 @@ import org.maplibre.compose.expressions.value.FloatValue
 import org.maplibre.compose.expressions.value.ImageValue
 import org.maplibre.compose.expressions.value.TranslateAnchor
 import org.maplibre.compose.sources.Source
+import org.maplibre.compose.util.toJsonString
 
 internal actual class FillExtrusionLayer actual constructor(id: String, source: Source) :
   FeatureLayer(source) {
-  override val impl = TODO()
+  @Suppress("UNREACHABLE_CODE") override val impl: Nothing get() = TODO()
+  override val layerId: String = id
+  override fun layerType(): String = "fill-extrusion"
 
-  actual override var sourceLayer: String = TODO()
+  actual override var sourceLayer: String
+    get() = sourceLayerString()
+    set(value) { updateSourceLayer(value) }
 
   actual override fun setFilter(filter: CompiledExpression<BooleanValue>) {
-    TODO()
+    updateFilter(filter)
   }
 
   actual fun setFillExtrusionOpacity(opacity: CompiledExpression<FloatValue>) {
-    TODO()
+    setPaintProp("fill-extrusion-opacity", opacity.toJsonString())
   }
 
   actual fun setFillExtrusionColor(color: CompiledExpression<ColorValue>) {
-    TODO()
+    setPaintProp("fill-extrusion-color", color.toJsonString())
   }
 
   actual fun setFillExtrusionTranslate(translate: CompiledExpression<DpOffsetValue>) {
-    TODO()
+    setPaintProp("fill-extrusion-translate", translate.toJsonString())
   }
 
   actual fun setFillExtrusionTranslateAnchor(anchor: CompiledExpression<TranslateAnchor>) {
-    TODO()
+    setPaintProp("fill-extrusion-translate-anchor", anchor.toJsonString())
   }
 
   actual fun setFillExtrusionPattern(pattern: CompiledExpression<ImageValue>) {
-    TODO()
+    setPaintProp("fill-extrusion-pattern", pattern.toJsonString())
   }
 
   actual fun setFillExtrusionHeight(height: CompiledExpression<FloatValue>) {
-    TODO()
+    setPaintProp("fill-extrusion-height", height.toJsonString())
   }
 
   actual fun setFillExtrusionBase(base: CompiledExpression<FloatValue>) {
-    TODO()
+    setPaintProp("fill-extrusion-base", base.toJsonString())
   }
 
   actual fun setFillExtrusionVerticalGradient(verticalGradient: CompiledExpression<BooleanValue>) {
-    TODO()
+    setPaintProp("fill-extrusion-vertical-gradient", verticalGradient.toJsonString())
   }
 }

--- a/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/layers/FillExtrusionLayer.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/layers/FillExtrusionLayer.kt
@@ -8,46 +8,54 @@ import org.maplibre.compose.expressions.value.FloatValue
 import org.maplibre.compose.expressions.value.ImageValue
 import org.maplibre.compose.expressions.value.TranslateAnchor
 import org.maplibre.compose.sources.Source
+import org.maplibre.compose.util.toJsonString
+import org.maplibre.kmp.native.style.layers.FillExtrusionLayer as MLNFillExtrusionLayer
 
 internal actual class FillExtrusionLayer actual constructor(id: String, source: Source) :
   FeatureLayer(source) {
-  override val impl = TODO()
+  override val impl = MLNFillExtrusionLayer(id, source.id)
 
-  actual override var sourceLayer: String = TODO()
+  actual override var sourceLayer: String
+    get() = impl.sourceLayer
+    set(value) {
+      impl.sourceLayer = value
+    }
 
   actual override fun setFilter(filter: CompiledExpression<BooleanValue>) {
-    TODO()
+    filter.toJsonString()?.let { impl.setFilter(it) }
   }
 
   actual fun setFillExtrusionOpacity(opacity: CompiledExpression<FloatValue>) {
-    TODO()
+    opacity.toJsonString()?.let { impl.setProperty("fill-extrusion-opacity", it) }
   }
 
   actual fun setFillExtrusionColor(color: CompiledExpression<ColorValue>) {
-    TODO()
+    color.toJsonString()?.let { impl.setProperty("fill-extrusion-color", it) }
   }
 
   actual fun setFillExtrusionTranslate(translate: CompiledExpression<DpOffsetValue>) {
-    TODO()
+    translate.toJsonString()?.let { impl.setProperty("fill-extrusion-translate", it) }
   }
 
   actual fun setFillExtrusionTranslateAnchor(anchor: CompiledExpression<TranslateAnchor>) {
-    TODO()
+    anchor.toJsonString()?.let { impl.setProperty("fill-extrusion-translate-anchor", it) }
   }
 
   actual fun setFillExtrusionPattern(pattern: CompiledExpression<ImageValue>) {
-    TODO()
+    pattern.toJsonString()?.let { impl.setProperty("fill-extrusion-pattern", it) }
   }
 
   actual fun setFillExtrusionHeight(height: CompiledExpression<FloatValue>) {
-    TODO()
+    height.toJsonString()?.let { impl.setProperty("fill-extrusion-height", it) }
   }
 
   actual fun setFillExtrusionBase(base: CompiledExpression<FloatValue>) {
-    TODO()
+    base.toJsonString()?.let { impl.setProperty("fill-extrusion-base", it) }
   }
 
   actual fun setFillExtrusionVerticalGradient(verticalGradient: CompiledExpression<BooleanValue>) {
-    TODO()
+    verticalGradient.toJsonString()?.let {
+      impl.setProperty("fill-extrusion-vertical-gradient", it)
+    }
   }
 }

--- a/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/layers/FillLayer.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/layers/FillLayer.kt
@@ -8,47 +8,51 @@ import org.maplibre.compose.expressions.value.FloatValue
 import org.maplibre.compose.expressions.value.ImageValue
 import org.maplibre.compose.expressions.value.TranslateAnchor
 import org.maplibre.compose.sources.Source
+import org.maplibre.compose.util.toJsonString
 
 internal actual class FillLayer actual constructor(id: String, source: Source) :
   FeatureLayer(source) {
+  @Suppress("UNREACHABLE_CODE") override val impl: Nothing get() = TODO()
+  override val layerId: String = id
+  override fun layerType(): String = "fill"
 
-  override val impl = TODO()
-
-  actual override var sourceLayer: String = TODO()
+  actual override var sourceLayer: String
+    get() = sourceLayerString()
+    set(value) { updateSourceLayer(value) }
 
   actual override fun setFilter(filter: CompiledExpression<BooleanValue>) {
-    TODO()
+    updateFilter(filter)
   }
 
   actual fun setFillSortKey(sortKey: CompiledExpression<FloatValue>) {
-    TODO()
+    setLayoutProp("fill-sort-key", sortKey.toJsonString())
   }
 
   actual fun setFillAntialias(antialias: CompiledExpression<BooleanValue>) {
-    TODO()
+    setPaintProp("fill-antialias", antialias.toJsonString())
   }
 
   actual fun setFillOpacity(opacity: CompiledExpression<FloatValue>) {
-    TODO()
+    setPaintProp("fill-opacity", opacity.toJsonString())
   }
 
   actual fun setFillColor(color: CompiledExpression<ColorValue>) {
-    TODO()
+    setPaintProp("fill-color", color.toJsonString())
   }
 
   actual fun setFillOutlineColor(outlineColor: CompiledExpression<ColorValue>) {
-    TODO()
+    setPaintProp("fill-outline-color", outlineColor.toJsonString())
   }
 
   actual fun setFillTranslate(translate: CompiledExpression<DpOffsetValue>) {
-    TODO()
+    setPaintProp("fill-translate", translate.toJsonString())
   }
 
   actual fun setFillTranslateAnchor(translateAnchor: CompiledExpression<TranslateAnchor>) {
-    TODO()
+    setPaintProp("fill-translate-anchor", translateAnchor.toJsonString())
   }
 
   actual fun setFillPattern(pattern: CompiledExpression<ImageValue>) {
-    TODO()
+    setPaintProp("fill-pattern", pattern.toJsonString())
   }
 }

--- a/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/layers/FillLayer.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/layers/FillLayer.kt
@@ -8,47 +8,53 @@ import org.maplibre.compose.expressions.value.FloatValue
 import org.maplibre.compose.expressions.value.ImageValue
 import org.maplibre.compose.expressions.value.TranslateAnchor
 import org.maplibre.compose.sources.Source
+import org.maplibre.compose.util.toJsonString
+import org.maplibre.kmp.native.style.layers.FillLayer as MLNFillLayer
 
 internal actual class FillLayer actual constructor(id: String, source: Source) :
   FeatureLayer(source) {
 
-  override val impl = TODO()
+  override val impl = MLNFillLayer(id, source.id)
 
-  actual override var sourceLayer: String = TODO()
+  actual override var sourceLayer: String
+    get() = impl.sourceLayer
+    set(value) {
+      impl.sourceLayer = value
+    }
 
   actual override fun setFilter(filter: CompiledExpression<BooleanValue>) {
-    TODO()
+    filter.toJsonString()?.let { impl.setFilter(it) }
   }
 
   actual fun setFillSortKey(sortKey: CompiledExpression<FloatValue>) {
-    TODO()
+    sortKey.toJsonString()?.let { impl.setProperty("fill-sort-key", it) }
   }
 
   actual fun setFillAntialias(antialias: CompiledExpression<BooleanValue>) {
-    TODO()
+    antialias.toJsonString()?.let { impl.setProperty("fill-antialias", it) }
   }
 
   actual fun setFillOpacity(opacity: CompiledExpression<FloatValue>) {
-    TODO()
+    opacity.toJsonString()?.let { impl.setProperty("fill-opacity", it) }
   }
 
   actual fun setFillColor(color: CompiledExpression<ColorValue>) {
-    TODO()
+    color.toJsonString()?.let { impl.setProperty("fill-color", it) }
   }
 
   actual fun setFillOutlineColor(outlineColor: CompiledExpression<ColorValue>) {
-    TODO()
+    outlineColor.toJsonString()?.let { impl.setProperty("fill-outline-color", it) }
   }
 
   actual fun setFillTranslate(translate: CompiledExpression<DpOffsetValue>) {
-    TODO()
+    translate.toJsonString()?.let { impl.setProperty("fill-translate", it) }
   }
 
   actual fun setFillTranslateAnchor(translateAnchor: CompiledExpression<TranslateAnchor>) {
-    TODO()
+    translateAnchor.toJsonString()?.let { impl.setProperty("fill-translate-anchor", it) }
   }
 
   actual fun setFillPattern(pattern: CompiledExpression<ImageValue>) {
-    TODO()
+    pattern.toJsonString()?.let { impl.setProperty("fill-pattern", it) }
   }
 }

--- a/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/layers/HeatmapLayer.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/layers/HeatmapLayer.kt
@@ -6,34 +6,39 @@ import org.maplibre.compose.expressions.value.ColorValue
 import org.maplibre.compose.expressions.value.DpValue
 import org.maplibre.compose.expressions.value.FloatValue
 import org.maplibre.compose.sources.Source
+import org.maplibre.compose.util.toJsonString
 
 internal actual class HeatmapLayer actual constructor(id: String, source: Source) :
   FeatureLayer(source) {
-  override val impl = TODO()
+  @Suppress("UNREACHABLE_CODE") override val impl: Nothing get() = TODO()
+  override val layerId: String = id
+  override fun layerType(): String = "heatmap"
 
-  actual override var sourceLayer: String = TODO()
+  actual override var sourceLayer: String
+    get() = sourceLayerString()
+    set(value) { updateSourceLayer(value) }
 
   actual override fun setFilter(filter: CompiledExpression<BooleanValue>) {
-    TODO()
+    updateFilter(filter)
   }
 
   actual fun setHeatmapRadius(radius: CompiledExpression<DpValue>) {
-    TODO()
+    setPaintProp("heatmap-radius", radius.toJsonString())
   }
 
   actual fun setHeatmapWeight(weight: CompiledExpression<FloatValue>) {
-    TODO()
+    setPaintProp("heatmap-weight", weight.toJsonString())
   }
 
   actual fun setHeatmapIntensity(intensity: CompiledExpression<FloatValue>) {
-    TODO()
+    setPaintProp("heatmap-intensity", intensity.toJsonString())
   }
 
   actual fun setHeatmapColor(color: CompiledExpression<ColorValue>) {
-    TODO()
+    setPaintProp("heatmap-color", color.toJsonString())
   }
 
   actual fun setHeatmapOpacity(opacity: CompiledExpression<FloatValue>) {
-    TODO()
+    setPaintProp("heatmap-opacity", opacity.toJsonString())
   }
 }

--- a/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/layers/HeatmapLayer.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/layers/HeatmapLayer.kt
@@ -6,34 +6,40 @@ import org.maplibre.compose.expressions.value.ColorValue
 import org.maplibre.compose.expressions.value.DpValue
 import org.maplibre.compose.expressions.value.FloatValue
 import org.maplibre.compose.sources.Source
+import org.maplibre.compose.util.toJsonString
+import org.maplibre.kmp.native.style.layers.HeatmapLayer as MLNHeatmapLayer
 
 internal actual class HeatmapLayer actual constructor(id: String, source: Source) :
   FeatureLayer(source) {
-  override val impl = TODO()
+  override val impl = MLNHeatmapLayer(id, source.id)
 
-  actual override var sourceLayer: String = TODO()
+  actual override var sourceLayer: String
+    get() = impl.sourceLayer
+    set(value) {
+      impl.sourceLayer = value
+    }
 
   actual override fun setFilter(filter: CompiledExpression<BooleanValue>) {
-    TODO()
+    filter.toJsonString()?.let { impl.setFilter(it) }
   }
 
   actual fun setHeatmapRadius(radius: CompiledExpression<DpValue>) {
-    TODO()
+    radius.toJsonString()?.let { impl.setProperty("heatmap-radius", it) }
   }
 
   actual fun setHeatmapWeight(weight: CompiledExpression<FloatValue>) {
-    TODO()
+    weight.toJsonString()?.let { impl.setProperty("heatmap-weight", it) }
   }
 
   actual fun setHeatmapIntensity(intensity: CompiledExpression<FloatValue>) {
-    TODO()
+    intensity.toJsonString()?.let { impl.setProperty("heatmap-intensity", it) }
   }
 
   actual fun setHeatmapColor(color: CompiledExpression<ColorValue>) {
-    TODO()
+    color.toJsonString()?.let { impl.setProperty("heatmap-color", it) }
   }
 
   actual fun setHeatmapOpacity(opacity: CompiledExpression<FloatValue>) {
-    TODO()
+    opacity.toJsonString()?.let { impl.setProperty("heatmap-opacity", it) }
   }
 }

--- a/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/layers/HillshadeLayer.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/layers/HillshadeLayer.kt
@@ -5,32 +5,36 @@ import org.maplibre.compose.expressions.value.ColorValue
 import org.maplibre.compose.expressions.value.FloatValue
 import org.maplibre.compose.expressions.value.IlluminationAnchor
 import org.maplibre.compose.sources.Source
+import org.maplibre.compose.util.toJsonString
 
 internal actual class HillshadeLayer actual constructor(id: String, actual val source: Source) :
   Layer() {
-  override val impl = TODO()
+  @Suppress("UNREACHABLE_CODE") override val impl: Nothing get() = TODO()
+  override val layerId: String = id
+  override fun layerType(): String = "hillshade"
+  override fun sourceId(): String = source.id
 
   actual fun setHillshadeIlluminationDirection(direction: CompiledExpression<FloatValue>) {
-    TODO()
+    setPaintProp("hillshade-illumination-direction", direction.toJsonString())
   }
 
   actual fun setHillshadeIlluminationAnchor(anchor: CompiledExpression<IlluminationAnchor>) {
-    TODO()
+    setPaintProp("hillshade-illumination-anchor", anchor.toJsonString())
   }
 
   actual fun setHillshadeExaggeration(exaggeration: CompiledExpression<FloatValue>) {
-    TODO()
+    setPaintProp("hillshade-exaggeration", exaggeration.toJsonString())
   }
 
   actual fun setHillshadeShadowColor(shadowColor: CompiledExpression<ColorValue>) {
-    TODO()
+    setPaintProp("hillshade-shadow-color", shadowColor.toJsonString())
   }
 
   actual fun setHillshadeHighlightColor(highlightColor: CompiledExpression<ColorValue>) {
-    TODO()
+    setPaintProp("hillshade-highlight-color", highlightColor.toJsonString())
   }
 
   actual fun setHillshadeAccentColor(accentColor: CompiledExpression<ColorValue>) {
-    TODO()
+    setPaintProp("hillshade-accent-color", accentColor.toJsonString())
   }
 }

--- a/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/layers/HillshadeLayer.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/layers/HillshadeLayer.kt
@@ -5,32 +5,34 @@ import org.maplibre.compose.expressions.value.ColorValue
 import org.maplibre.compose.expressions.value.FloatValue
 import org.maplibre.compose.expressions.value.IlluminationAnchor
 import org.maplibre.compose.sources.Source
+import org.maplibre.compose.util.toJsonString
+import org.maplibre.kmp.native.style.layers.HillshadeLayer as MLNHillshadeLayer
 
 internal actual class HillshadeLayer actual constructor(id: String, actual val source: Source) :
   Layer() {
-  override val impl = TODO()
+  override val impl = MLNHillshadeLayer(id, source.id)
 
   actual fun setHillshadeIlluminationDirection(direction: CompiledExpression<FloatValue>) {
-    TODO()
+    direction.toJsonString()?.let { impl.setProperty("hillshade-illumination-direction", it) }
   }
 
   actual fun setHillshadeIlluminationAnchor(anchor: CompiledExpression<IlluminationAnchor>) {
-    TODO()
+    anchor.toJsonString()?.let { impl.setProperty("hillshade-illumination-anchor", it) }
   }
 
   actual fun setHillshadeExaggeration(exaggeration: CompiledExpression<FloatValue>) {
-    TODO()
+    exaggeration.toJsonString()?.let { impl.setProperty("hillshade-exaggeration", it) }
   }
 
   actual fun setHillshadeShadowColor(shadowColor: CompiledExpression<ColorValue>) {
-    TODO()
+    shadowColor.toJsonString()?.let { impl.setProperty("hillshade-shadow-color", it) }
   }
 
   actual fun setHillshadeHighlightColor(highlightColor: CompiledExpression<ColorValue>) {
-    TODO()
+    highlightColor.toJsonString()?.let { impl.setProperty("hillshade-highlight-color", it) }
   }
 
   actual fun setHillshadeAccentColor(accentColor: CompiledExpression<ColorValue>) {
-    TODO()
+    accentColor.toJsonString()?.let { impl.setProperty("hillshade-accent-color", it) }
   }
 }

--- a/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/layers/Layer.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/layers/Layer.kt
@@ -1,28 +1,109 @@
 package org.maplibre.compose.layers
 
-internal actual sealed class Layer {
-  abstract val impl: Nothing
+import org.maplibre.compose.style.DesktopStyle
+import org.maplibre.compose.util.jsonEscape
 
-  actual val id: String
-    get() = TODO()
+internal actual sealed class Layer {
+  @Suppress("UNREACHABLE_CODE") abstract val impl: Nothing
+
+  internal abstract val layerId: String
+  actual val id: String get() = layerId
+
+  // Reference to the style this layer belongs to (null if not yet added to a style)
+  internal var style: DesktopStyle? = null
+
+  // The id of the layer this layer was inserted before (null = topmost)
+  internal var insertedBefore: String? = null
+
+  internal val layoutProps = mutableMapOf<String, String>()
+  internal val paintProps = mutableMapOf<String, String>()
+
+  private var _minZoom: Float = 0f
+  private var _maxZoom: Float = 22f
+  private var _visible: Boolean = true
 
   actual var minZoom: Float
-    get() = TODO()
+    get() = _minZoom
     set(value) {
-      TODO()
+      _minZoom = value
+      style?.updateLayer(this)
     }
 
   actual var maxZoom: Float
-    get() = TODO()
+    get() = _maxZoom
     set(value) {
-      TODO()
+      _maxZoom = value
+      style?.updateLayer(this)
     }
 
   actual var visible: Boolean
-    get() = TODO()
+    get() = _visible
     set(value) {
-      TODO()
+      _visible = value
+      layoutProps["visibility"] = if (value) "\"visible\"" else "\"none\""
+      style?.updateLayer(this)
     }
+
+  internal fun setLayoutProp(key: String, jsonValue: String) {
+    layoutProps[key] = jsonValue
+    style?.updateLayer(this)
+  }
+
+  internal fun setPaintProp(key: String, jsonValue: String) {
+    paintProps[key] = jsonValue
+    style?.updateLayer(this)
+  }
+
+  /** Returns the MapLibre style type string for this layer (e.g. "line", "fill"). */
+  internal abstract fun layerType(): String
+
+  /** Returns the source ID for this layer, or null if none. */
+  internal open fun sourceId(): String? = null
+
+  /** Returns the source-layer ID for this layer, or null if none. */
+  internal open fun sourceLayerString(): String? = null
+
+  /** Returns the filter expression JSON string for this layer, or null if none. */
+  internal open fun filterJson(): String? = null
+
+  /** Serializes the full layer spec to a MapLibre style JSON object string. */
+  internal open fun toJson(): String = buildString {
+    append("""{"id":""")
+    append(jsonEscape(id))
+    append(""","type":""")
+    append(jsonEscape(layerType()))
+    sourceId()?.let {
+      append(""","source":""")
+      append(jsonEscape(it))
+    }
+    sourceLayerString()?.takeIf { it.isNotEmpty() }?.let {
+      append(""","source-layer":""")
+      append(jsonEscape(it))
+    }
+    if (_minZoom != 0f) {
+      append(""","minzoom":""")
+      append(_minZoom)
+    }
+    if (_maxZoom != 22f) {
+      append(""","maxzoom":""")
+      append(_maxZoom)
+    }
+    filterJson()?.let {
+      append(""","filter":""")
+      append(it)
+    }
+    if (layoutProps.isNotEmpty()) {
+      append(""","layout":{""")
+      layoutProps.entries.joinTo(this, ",") { (k, v) -> "${jsonEscape(k)}:$v" }
+      append("}")
+    }
+    if (paintProps.isNotEmpty()) {
+      append(""","paint":{""")
+      paintProps.entries.joinTo(this, ",") { (k, v) -> "${jsonEscape(k)}:$v" }
+      append("}")
+    }
+    append("}")
+  }
 
   override fun toString() = "${this::class.simpleName}(id=\"$id\")"
 }

--- a/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/layers/Layer.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/layers/Layer.kt
@@ -1,27 +1,29 @@
 package org.maplibre.compose.layers
 
+import org.maplibre.kmp.native.style.layers.Layer as MLNLayer
+
 internal actual sealed class Layer {
-  abstract val impl: Nothing
+  abstract val impl: MLNLayer
 
   actual val id: String
-    get() = TODO()
+    get() = impl.id
 
   actual var minZoom: Float
-    get() = TODO()
+    get() = impl.minZoom
     set(value) {
-      TODO()
+      impl.minZoom = value
     }
 
   actual var maxZoom: Float
-    get() = TODO()
+    get() = impl.maxZoom
     set(value) {
-      TODO()
+      impl.maxZoom = value
     }
 
   actual var visible: Boolean
-    get() = TODO()
+    get() = impl.visible
     set(value) {
-      TODO()
+      impl.visible = value
     }
 
   override fun toString() = "${this::class.simpleName}(id=\"$id\")"

--- a/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/layers/LineLayer.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/layers/LineLayer.kt
@@ -12,79 +12,83 @@ import org.maplibre.compose.expressions.value.LineJoin
 import org.maplibre.compose.expressions.value.TranslateAnchor
 import org.maplibre.compose.expressions.value.VectorValue
 import org.maplibre.compose.sources.Source
+import org.maplibre.compose.util.toJsonString
 
 internal actual class LineLayer actual constructor(id: String, source: Source) :
   FeatureLayer(source) {
+  @Suppress("UNREACHABLE_CODE") override val impl: Nothing get() = TODO()
+  override val layerId: String = id
+  override fun layerType(): String = "line"
 
-  override val impl = TODO()
-
-  actual override var sourceLayer: String = TODO()
+  actual override var sourceLayer: String
+    get() = sourceLayerString()
+    set(value) { updateSourceLayer(value) }
 
   actual override fun setFilter(filter: CompiledExpression<BooleanValue>) {
-    TODO()
+    updateFilter(filter)
   }
 
   actual fun setLineCap(cap: CompiledExpression<LineCap>) {
-    TODO()
+    setLayoutProp("line-cap", cap.toJsonString())
   }
 
   actual fun setLineJoin(join: CompiledExpression<LineJoin>) {
-    TODO()
+    setLayoutProp("line-join", join.toJsonString())
   }
 
   actual fun setLineMiterLimit(miterLimit: CompiledExpression<FloatValue>) {
-    TODO()
+    setLayoutProp("line-miter-limit", miterLimit.toJsonString())
   }
 
   actual fun setLineRoundLimit(roundLimit: CompiledExpression<FloatValue>) {
-    TODO()
+    setLayoutProp("line-round-limit", roundLimit.toJsonString())
   }
 
   actual fun setLineSortKey(sortKey: CompiledExpression<FloatValue>) {
-    TODO()
+    setLayoutProp("line-sort-key", sortKey.toJsonString())
   }
 
   actual fun setLineOpacity(opacity: CompiledExpression<FloatValue>) {
-    TODO()
+    setPaintProp("line-opacity", opacity.toJsonString())
   }
 
   actual fun setLineColor(color: CompiledExpression<ColorValue>) {
-    TODO()
+    setPaintProp("line-color", color.toJsonString())
   }
 
   actual fun setLineTranslate(translate: CompiledExpression<DpOffsetValue>) {
-    TODO()
+    setPaintProp("line-translate", translate.toJsonString())
   }
 
   actual fun setLineTranslateAnchor(translateAnchor: CompiledExpression<TranslateAnchor>) {
-    TODO()
+    setPaintProp("line-translate-anchor", translateAnchor.toJsonString())
   }
 
   actual fun setLineWidth(width: CompiledExpression<DpValue>) {
-    TODO()
+    setPaintProp("line-width", width.toJsonString())
   }
 
   actual fun setLineGapWidth(gapWidth: CompiledExpression<DpValue>) {
-    TODO()
+    setPaintProp("line-gap-width", gapWidth.toJsonString())
   }
 
   actual fun setLineOffset(offset: CompiledExpression<DpValue>) {
-    TODO()
+    setPaintProp("line-offset", offset.toJsonString())
   }
 
   actual fun setLineBlur(blur: CompiledExpression<DpValue>) {
-    TODO()
+    setPaintProp("line-blur", blur.toJsonString())
   }
 
   actual fun setLineDasharray(dasharray: CompiledExpression<VectorValue<Number>>) {
-    TODO()
+    setPaintProp("line-dasharray", dasharray.toJsonString())
   }
 
   actual fun setLinePattern(pattern: CompiledExpression<ImageValue>) {
-    TODO()
+    setPaintProp("line-pattern", pattern.toJsonString())
   }
 
   actual fun setLineGradient(gradient: CompiledExpression<ColorValue>) {
-    TODO()
+    setPaintProp("line-gradient", gradient.toJsonString())
   }
 }

--- a/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/layers/LineLayer.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/layers/LineLayer.kt
@@ -12,79 +12,85 @@ import org.maplibre.compose.expressions.value.LineJoin
 import org.maplibre.compose.expressions.value.TranslateAnchor
 import org.maplibre.compose.expressions.value.VectorValue
 import org.maplibre.compose.sources.Source
+import org.maplibre.compose.util.toJsonString
+import org.maplibre.kmp.native.style.layers.LineLayer as MLNLineLayer
 
 internal actual class LineLayer actual constructor(id: String, source: Source) :
   FeatureLayer(source) {
 
-  override val impl = TODO()
+  override val impl = MLNLineLayer(id, source.id)
 
-  actual override var sourceLayer: String = TODO()
+  actual override var sourceLayer: String
+    get() = impl.sourceLayer
+    set(value) {
+      impl.sourceLayer = value
+    }
 
   actual override fun setFilter(filter: CompiledExpression<BooleanValue>) {
-    TODO()
+    filter.toJsonString()?.let { impl.setFilter(it) }
   }
 
   actual fun setLineCap(cap: CompiledExpression<LineCap>) {
-    TODO()
+    cap.toJsonString()?.let { impl.setProperty("line-cap", it) }
   }
 
   actual fun setLineJoin(join: CompiledExpression<LineJoin>) {
-    TODO()
+    join.toJsonString()?.let { impl.setProperty("line-join", it) }
   }
 
   actual fun setLineMiterLimit(miterLimit: CompiledExpression<FloatValue>) {
-    TODO()
+    miterLimit.toJsonString()?.let { impl.setProperty("line-miter-limit", it) }
   }
 
   actual fun setLineRoundLimit(roundLimit: CompiledExpression<FloatValue>) {
-    TODO()
+    roundLimit.toJsonString()?.let { impl.setProperty("line-round-limit", it) }
   }
 
   actual fun setLineSortKey(sortKey: CompiledExpression<FloatValue>) {
-    TODO()
+    sortKey.toJsonString()?.let { impl.setProperty("line-sort-key", it) }
   }
 
   actual fun setLineOpacity(opacity: CompiledExpression<FloatValue>) {
-    TODO()
+    opacity.toJsonString()?.let { impl.setProperty("line-opacity", it) }
   }
 
   actual fun setLineColor(color: CompiledExpression<ColorValue>) {
-    TODO()
+    color.toJsonString()?.let { impl.setProperty("line-color", it) }
   }
 
   actual fun setLineTranslate(translate: CompiledExpression<DpOffsetValue>) {
-    TODO()
+    translate.toJsonString()?.let { impl.setProperty("line-translate", it) }
   }
 
   actual fun setLineTranslateAnchor(translateAnchor: CompiledExpression<TranslateAnchor>) {
-    TODO()
+    translateAnchor.toJsonString()?.let { impl.setProperty("line-translate-anchor", it) }
   }
 
   actual fun setLineWidth(width: CompiledExpression<DpValue>) {
-    TODO()
+    width.toJsonString()?.let { impl.setProperty("line-width", it) }
   }
 
   actual fun setLineGapWidth(gapWidth: CompiledExpression<DpValue>) {
-    TODO()
+    gapWidth.toJsonString()?.let { impl.setProperty("line-gap-width", it) }
   }
 
   actual fun setLineOffset(offset: CompiledExpression<DpValue>) {
-    TODO()
+    offset.toJsonString()?.let { impl.setProperty("line-offset", it) }
   }
 
   actual fun setLineBlur(blur: CompiledExpression<DpValue>) {
-    TODO()
+    blur.toJsonString()?.let { impl.setProperty("line-blur", it) }
   }
 
   actual fun setLineDasharray(dasharray: CompiledExpression<VectorValue<Number>>) {
-    TODO()
+    dasharray.toJsonString()?.let { impl.setProperty("line-dasharray", it) }
   }
 
   actual fun setLinePattern(pattern: CompiledExpression<ImageValue>) {
-    TODO()
+    pattern.toJsonString()?.let { impl.setProperty("line-pattern", it) }
   }
 
   actual fun setLineGradient(gradient: CompiledExpression<ColorValue>) {
-    TODO()
+    gradient.toJsonString()?.let { impl.setProperty("line-gradient", it) }
   }
 }

--- a/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/layers/RasterLayer.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/layers/RasterLayer.kt
@@ -5,40 +5,44 @@ import org.maplibre.compose.expressions.value.FloatValue
 import org.maplibre.compose.expressions.value.MillisecondsValue
 import org.maplibre.compose.expressions.value.RasterResampling
 import org.maplibre.compose.sources.Source
+import org.maplibre.compose.util.toJsonString
 
 internal actual class RasterLayer actual constructor(id: String, actual val source: Source) :
   Layer() {
-  override val impl = TODO()
+  @Suppress("UNREACHABLE_CODE") override val impl: Nothing get() = TODO()
+  override val layerId: String = id
+  override fun layerType(): String = "raster"
+  override fun sourceId(): String = source.id
 
   actual fun setRasterOpacity(opacity: CompiledExpression<FloatValue>) {
-    TODO()
+    setPaintProp("raster-opacity", opacity.toJsonString())
   }
 
   actual fun setRasterHueRotate(hueRotate: CompiledExpression<FloatValue>) {
-    TODO()
+    setPaintProp("raster-hue-rotate", hueRotate.toJsonString())
   }
 
   actual fun setRasterBrightnessMin(brightnessMin: CompiledExpression<FloatValue>) {
-    TODO()
+    setPaintProp("raster-brightness-min", brightnessMin.toJsonString())
   }
 
   actual fun setRasterBrightnessMax(brightnessMax: CompiledExpression<FloatValue>) {
-    TODO()
+    setPaintProp("raster-brightness-max", brightnessMax.toJsonString())
   }
 
   actual fun setRasterSaturation(saturation: CompiledExpression<FloatValue>) {
-    TODO()
+    setPaintProp("raster-saturation", saturation.toJsonString())
   }
 
   actual fun setRasterContrast(contrast: CompiledExpression<FloatValue>) {
-    TODO()
+    setPaintProp("raster-contrast", contrast.toJsonString())
   }
 
   actual fun setRasterResampling(resampling: CompiledExpression<RasterResampling>) {
-    TODO()
+    setPaintProp("raster-resampling", resampling.toJsonString())
   }
 
   actual fun setRasterFadeDuration(fadeDuration: CompiledExpression<MillisecondsValue>) {
-    TODO()
+    setPaintProp("raster-fade-duration", fadeDuration.toJsonString())
   }
 }

--- a/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/layers/RasterLayer.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/layers/RasterLayer.kt
@@ -5,40 +5,42 @@ import org.maplibre.compose.expressions.value.FloatValue
 import org.maplibre.compose.expressions.value.MillisecondsValue
 import org.maplibre.compose.expressions.value.RasterResampling
 import org.maplibre.compose.sources.Source
+import org.maplibre.compose.util.toJsonString
+import org.maplibre.kmp.native.style.layers.RasterLayer as MLNRasterLayer
 
 internal actual class RasterLayer actual constructor(id: String, actual val source: Source) :
   Layer() {
-  override val impl = TODO()
+  override val impl = MLNRasterLayer(id, source.id)
 
   actual fun setRasterOpacity(opacity: CompiledExpression<FloatValue>) {
-    TODO()
+    opacity.toJsonString()?.let { impl.setProperty("raster-opacity", it) }
   }
 
   actual fun setRasterHueRotate(hueRotate: CompiledExpression<FloatValue>) {
-    TODO()
+    hueRotate.toJsonString()?.let { impl.setProperty("raster-hue-rotate", it) }
   }
 
   actual fun setRasterBrightnessMin(brightnessMin: CompiledExpression<FloatValue>) {
-    TODO()
+    brightnessMin.toJsonString()?.let { impl.setProperty("raster-brightness-min", it) }
   }
 
   actual fun setRasterBrightnessMax(brightnessMax: CompiledExpression<FloatValue>) {
-    TODO()
+    brightnessMax.toJsonString()?.let { impl.setProperty("raster-brightness-max", it) }
   }
 
   actual fun setRasterSaturation(saturation: CompiledExpression<FloatValue>) {
-    TODO()
+    saturation.toJsonString()?.let { impl.setProperty("raster-saturation", it) }
   }
 
   actual fun setRasterContrast(contrast: CompiledExpression<FloatValue>) {
-    TODO()
+    contrast.toJsonString()?.let { impl.setProperty("raster-contrast", it) }
   }
 
   actual fun setRasterResampling(resampling: CompiledExpression<RasterResampling>) {
-    TODO()
+    resampling.toJsonString()?.let { impl.setProperty("raster-resampling", it) }
   }
 
   actual fun setRasterFadeDuration(fadeDuration: CompiledExpression<MillisecondsValue>) {
-    TODO()
+    fadeDuration.toJsonString()?.let { impl.setProperty("raster-fade-duration", it) }
   }
 }

--- a/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/layers/SymbolLayer.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/layers/SymbolLayer.kt
@@ -27,252 +27,262 @@ import org.maplibre.compose.expressions.value.TextVariableAnchorOffsetValue
 import org.maplibre.compose.expressions.value.TextWritingMode
 import org.maplibre.compose.expressions.value.TranslateAnchor
 import org.maplibre.compose.sources.Source
+import org.maplibre.compose.util.toJsonString
 
 internal actual class SymbolLayer actual constructor(id: String, source: Source) :
   FeatureLayer(source) {
-  override val impl = TODO()
+  @Suppress("UNREACHABLE_CODE") override val impl: Nothing get() = TODO()
+  override val layerId: String = id
+  override fun layerType(): String = "symbol"
 
-  actual override var sourceLayer: String = TODO()
+  actual override var sourceLayer: String
+    get() = sourceLayerString()
+    set(value) { updateSourceLayer(value) }
 
   actual override fun setFilter(filter: CompiledExpression<BooleanValue>) {
-    TODO()
+    updateFilter(filter)
   }
 
+  // Layout — symbol-*
   actual fun setSymbolPlacement(placement: CompiledExpression<SymbolPlacement>) {
-    TODO()
+    setLayoutProp("symbol-placement", placement.toJsonString())
   }
 
   actual fun setSymbolSpacing(spacing: CompiledExpression<DpValue>) {
-    TODO()
+    setLayoutProp("symbol-spacing", spacing.toJsonString())
   }
 
   actual fun setSymbolAvoidEdges(avoidEdges: CompiledExpression<BooleanValue>) {
-    TODO()
+    setLayoutProp("symbol-avoid-edges", avoidEdges.toJsonString())
   }
 
   actual fun setSymbolSortKey(sortKey: CompiledExpression<FloatValue>) {
-    TODO()
+    setLayoutProp("symbol-sort-key", sortKey.toJsonString())
   }
 
   actual fun setSymbolZOrder(zOrder: CompiledExpression<SymbolZOrder>) {
-    TODO()
+    setLayoutProp("symbol-z-order", zOrder.toJsonString())
   }
 
+  // Layout — icon-*
   actual fun setIconAllowOverlap(allowOverlap: CompiledExpression<BooleanValue>) {
-    TODO()
+    setLayoutProp("icon-allow-overlap", allowOverlap.toJsonString())
   }
 
   actual fun setIconOverlap(overlap: CompiledExpression<StringValue>) {
-    TODO()
+    setLayoutProp("icon-overlap", overlap.toJsonString())
   }
 
   actual fun setIconIgnorePlacement(ignorePlacement: CompiledExpression<BooleanValue>) {
-    TODO()
+    setLayoutProp("icon-ignore-placement", ignorePlacement.toJsonString())
   }
 
   actual fun setIconOptional(optional: CompiledExpression<BooleanValue>) {
-    TODO()
+    setLayoutProp("icon-optional", optional.toJsonString())
   }
 
   actual fun setIconRotationAlignment(
     rotationAlignment: CompiledExpression<IconRotationAlignment>
   ) {
-    TODO()
+    setLayoutProp("icon-rotation-alignment", rotationAlignment.toJsonString())
   }
 
   actual fun setIconSize(size: CompiledExpression<FloatValue>) {
-    TODO()
+    setLayoutProp("icon-size", size.toJsonString())
   }
 
   actual fun setIconTextFit(textFit: CompiledExpression<IconTextFit>) {
-    TODO()
+    setLayoutProp("icon-text-fit", textFit.toJsonString())
   }
 
   actual fun setIconTextFitPadding(textFitPadding: CompiledExpression<DpPaddingValue>) {
-    TODO()
+    setLayoutProp("icon-text-fit-padding", textFitPadding.toJsonString())
   }
 
   actual fun setIconImage(image: CompiledExpression<ImageValue>) {
-    TODO()
+    setLayoutProp("icon-image", image.toJsonString())
   }
 
   actual fun setIconRotate(rotate: CompiledExpression<FloatValue>) {
-    TODO()
+    setLayoutProp("icon-rotate", rotate.toJsonString())
   }
 
   actual fun setIconPadding(padding: CompiledExpression<DpPaddingValue>) {
-    TODO()
+    setLayoutProp("icon-padding", padding.toJsonString())
   }
 
   actual fun setIconKeepUpright(keepUpright: CompiledExpression<BooleanValue>) {
-    TODO()
+    setLayoutProp("icon-keep-upright", keepUpright.toJsonString())
   }
 
   actual fun setIconOffset(offset: CompiledExpression<DpOffsetValue>) {
-    TODO()
+    setLayoutProp("icon-offset", offset.toJsonString())
   }
 
   actual fun setIconAnchor(anchor: CompiledExpression<SymbolAnchor>) {
-    TODO()
+    setLayoutProp("icon-anchor", anchor.toJsonString())
   }
 
   actual fun setIconPitchAlignment(pitchAlignment: CompiledExpression<IconPitchAlignment>) {
-    TODO()
+    setLayoutProp("icon-pitch-alignment", pitchAlignment.toJsonString())
   }
 
+  // Paint — icon-*
   actual fun setIconOpacity(opacity: CompiledExpression<FloatValue>) {
-    TODO()
+    setPaintProp("icon-opacity", opacity.toJsonString())
   }
 
   actual fun setIconColor(color: CompiledExpression<ColorValue>) {
-    TODO()
+    setPaintProp("icon-color", color.toJsonString())
   }
 
   actual fun setIconHaloColor(haloColor: CompiledExpression<ColorValue>) {
-    TODO()
+    setPaintProp("icon-halo-color", haloColor.toJsonString())
   }
 
   actual fun setIconHaloWidth(haloWidth: CompiledExpression<DpValue>) {
-    TODO()
+    setPaintProp("icon-halo-width", haloWidth.toJsonString())
   }
 
   actual fun setIconHaloBlur(haloBlur: CompiledExpression<DpValue>) {
-    TODO()
+    setPaintProp("icon-halo-blur", haloBlur.toJsonString())
   }
 
   actual fun setIconTranslate(translate: CompiledExpression<DpOffsetValue>) {
-    TODO()
+    setPaintProp("icon-translate", translate.toJsonString())
   }
 
   actual fun setIconTranslateAnchor(translateAnchor: CompiledExpression<TranslateAnchor>) {
-    TODO()
+    setPaintProp("icon-translate-anchor", translateAnchor.toJsonString())
   }
 
+  // Layout — text-*
   actual fun setTextPitchAlignment(pitchAlignment: CompiledExpression<TextPitchAlignment>) {
-    TODO()
+    setLayoutProp("text-pitch-alignment", pitchAlignment.toJsonString())
   }
 
   actual fun setTextRotationAlignment(
     rotationAlignment: CompiledExpression<TextRotationAlignment>
   ) {
-    TODO()
+    setLayoutProp("text-rotation-alignment", rotationAlignment.toJsonString())
   }
 
   actual fun setTextField(field: CompiledExpression<FormattedValue>) {
-    TODO()
+    setLayoutProp("text-field", field.toJsonString())
   }
 
   actual fun setTextFont(font: CompiledExpression<ListValue<StringValue>>) {
-    TODO()
+    setLayoutProp("text-font", font.toJsonString())
   }
 
   actual fun setTextSize(size: CompiledExpression<DpValue>) {
-    TODO()
+    setLayoutProp("text-size", size.toJsonString())
   }
 
   actual fun setTextMaxWidth(maxWidth: CompiledExpression<FloatValue>) {
-    TODO()
+    setLayoutProp("text-max-width", maxWidth.toJsonString())
   }
 
   actual fun setTextLineHeight(lineHeight: CompiledExpression<FloatValue>) {
-    TODO()
+    setLayoutProp("text-line-height", lineHeight.toJsonString())
   }
 
   actual fun setTextLetterSpacing(letterSpacing: CompiledExpression<FloatValue>) {
-    TODO()
+    setLayoutProp("text-letter-spacing", letterSpacing.toJsonString())
   }
 
   actual fun setTextJustify(justify: CompiledExpression<TextJustify>) {
-    TODO()
+    setLayoutProp("text-justify", justify.toJsonString())
   }
 
   actual fun setTextRadialOffset(radialOffset: CompiledExpression<FloatValue>) {
-    TODO()
+    setLayoutProp("text-radial-offset", radialOffset.toJsonString())
   }
 
   actual fun setTextVariableAnchor(variableAnchor: CompiledExpression<ListValue<SymbolAnchor>>) {
-    TODO()
+    setLayoutProp("text-variable-anchor", variableAnchor.toJsonString())
   }
 
   actual fun setTextVariableAnchorOffset(
     variableAnchorOffset: CompiledExpression<TextVariableAnchorOffsetValue>
   ) {
-    TODO()
+    setLayoutProp("text-variable-anchor-offset", variableAnchorOffset.toJsonString())
   }
 
   actual fun setTextAnchor(anchor: CompiledExpression<SymbolAnchor>) {
-    TODO()
+    setLayoutProp("text-anchor", anchor.toJsonString())
   }
 
   actual fun setTextMaxAngle(maxAngle: CompiledExpression<FloatValue>) {
-    TODO()
+    setLayoutProp("text-max-angle", maxAngle.toJsonString())
   }
 
   actual fun setTextWritingMode(writingMode: CompiledExpression<ListValue<TextWritingMode>>) {
-    TODO()
+    setLayoutProp("text-writing-mode", writingMode.toJsonString())
   }
 
   actual fun setTextRotate(rotate: CompiledExpression<FloatValue>) {
-    TODO()
+    setLayoutProp("text-rotate", rotate.toJsonString())
   }
 
   actual fun setTextPadding(padding: CompiledExpression<DpValue>) {
-    TODO()
+    setLayoutProp("text-padding", padding.toJsonString())
   }
 
   actual fun setTextKeepUpright(keepUpright: CompiledExpression<BooleanValue>) {
-    TODO()
+    setLayoutProp("text-keep-upright", keepUpright.toJsonString())
   }
 
   actual fun setTextTransform(transform: CompiledExpression<TextTransform>) {
-    TODO()
+    setLayoutProp("text-transform", transform.toJsonString())
   }
 
   actual fun setTextOffset(offset: CompiledExpression<FloatOffsetValue>) {
-    TODO()
+    setLayoutProp("text-offset", offset.toJsonString())
   }
 
   actual fun setTextAllowOverlap(allowOverlap: CompiledExpression<BooleanValue>) {
-    TODO()
+    setLayoutProp("text-allow-overlap", allowOverlap.toJsonString())
   }
 
   actual fun setTextOverlap(overlap: CompiledExpression<SymbolOverlap>) {
-    TODO()
+    setLayoutProp("text-overlap", overlap.toJsonString())
   }
 
   actual fun setTextIgnorePlacement(ignorePlacement: CompiledExpression<BooleanValue>) {
-    TODO()
+    setLayoutProp("text-ignore-placement", ignorePlacement.toJsonString())
   }
 
   actual fun setTextOptional(optional: CompiledExpression<BooleanValue>) {
-    TODO()
+    setLayoutProp("text-optional", optional.toJsonString())
   }
 
+  // Paint — text-*
   actual fun setTextOpacity(opacity: CompiledExpression<FloatValue>) {
-    TODO()
+    setPaintProp("text-opacity", opacity.toJsonString())
   }
 
   actual fun setTextColor(color: CompiledExpression<ColorValue>) {
-    TODO()
+    setPaintProp("text-color", color.toJsonString())
   }
 
   actual fun setTextHaloColor(haloColor: CompiledExpression<ColorValue>) {
-    TODO()
+    setPaintProp("text-halo-color", haloColor.toJsonString())
   }
 
   actual fun setTextHaloWidth(haloWidth: CompiledExpression<DpValue>) {
-    TODO()
+    setPaintProp("text-halo-width", haloWidth.toJsonString())
   }
 
   actual fun setTextHaloBlur(haloBlur: CompiledExpression<DpValue>) {
-    TODO()
+    setPaintProp("text-halo-blur", haloBlur.toJsonString())
   }
 
   actual fun setTextTranslate(translate: CompiledExpression<DpOffsetValue>) {
-    TODO()
+    setPaintProp("text-translate", translate.toJsonString())
   }
 
   actual fun setTextTranslateAnchor(translateAnchor: CompiledExpression<TranslateAnchor>) {
-    TODO()
+    setPaintProp("text-translate-anchor", translateAnchor.toJsonString())
   }
 }

--- a/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/layers/SymbolLayer.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/layers/SymbolLayer.kt
@@ -27,252 +27,258 @@ import org.maplibre.compose.expressions.value.TextVariableAnchorOffsetValue
 import org.maplibre.compose.expressions.value.TextWritingMode
 import org.maplibre.compose.expressions.value.TranslateAnchor
 import org.maplibre.compose.sources.Source
+import org.maplibre.compose.util.toJsonString
+import org.maplibre.kmp.native.style.layers.SymbolLayer as MLNSymbolLayer
 
 internal actual class SymbolLayer actual constructor(id: String, source: Source) :
   FeatureLayer(source) {
-  override val impl = TODO()
+  override val impl = MLNSymbolLayer(id, source.id)
 
-  actual override var sourceLayer: String = TODO()
+  actual override var sourceLayer: String
+    get() = impl.sourceLayer
+    set(value) {
+      impl.sourceLayer = value
+    }
 
   actual override fun setFilter(filter: CompiledExpression<BooleanValue>) {
-    TODO()
+    filter.toJsonString()?.let { impl.setFilter(it) }
   }
 
   actual fun setSymbolPlacement(placement: CompiledExpression<SymbolPlacement>) {
-    TODO()
+    placement.toJsonString()?.let { impl.setProperty("symbol-placement", it) }
   }
 
   actual fun setSymbolSpacing(spacing: CompiledExpression<DpValue>) {
-    TODO()
+    spacing.toJsonString()?.let { impl.setProperty("symbol-spacing", it) }
   }
 
   actual fun setSymbolAvoidEdges(avoidEdges: CompiledExpression<BooleanValue>) {
-    TODO()
+    avoidEdges.toJsonString()?.let { impl.setProperty("symbol-avoid-edges", it) }
   }
 
   actual fun setSymbolSortKey(sortKey: CompiledExpression<FloatValue>) {
-    TODO()
+    sortKey.toJsonString()?.let { impl.setProperty("symbol-sort-key", it) }
   }
 
   actual fun setSymbolZOrder(zOrder: CompiledExpression<SymbolZOrder>) {
-    TODO()
+    zOrder.toJsonString()?.let { impl.setProperty("symbol-z-order", it) }
   }
 
   actual fun setIconAllowOverlap(allowOverlap: CompiledExpression<BooleanValue>) {
-    TODO()
+    allowOverlap.toJsonString()?.let { impl.setProperty("icon-allow-overlap", it) }
   }
 
   actual fun setIconOverlap(overlap: CompiledExpression<StringValue>) {
-    TODO()
+    overlap.toJsonString()?.let { impl.setProperty("icon-overlap", it) }
   }
 
   actual fun setIconIgnorePlacement(ignorePlacement: CompiledExpression<BooleanValue>) {
-    TODO()
+    ignorePlacement.toJsonString()?.let { impl.setProperty("icon-ignore-placement", it) }
   }
 
   actual fun setIconOptional(optional: CompiledExpression<BooleanValue>) {
-    TODO()
+    optional.toJsonString()?.let { impl.setProperty("icon-optional", it) }
   }
 
   actual fun setIconRotationAlignment(
     rotationAlignment: CompiledExpression<IconRotationAlignment>
   ) {
-    TODO()
+    rotationAlignment.toJsonString()?.let { impl.setProperty("icon-rotation-alignment", it) }
   }
 
   actual fun setIconSize(size: CompiledExpression<FloatValue>) {
-    TODO()
+    size.toJsonString()?.let { impl.setProperty("icon-size", it) }
   }
 
   actual fun setIconTextFit(textFit: CompiledExpression<IconTextFit>) {
-    TODO()
+    textFit.toJsonString()?.let { impl.setProperty("icon-text-fit", it) }
   }
 
   actual fun setIconTextFitPadding(textFitPadding: CompiledExpression<DpPaddingValue>) {
-    TODO()
+    textFitPadding.toJsonString()?.let { impl.setProperty("icon-text-fit-padding", it) }
   }
 
   actual fun setIconImage(image: CompiledExpression<ImageValue>) {
-    TODO()
+    image.toJsonString()?.let { impl.setProperty("icon-image", it) }
   }
 
   actual fun setIconRotate(rotate: CompiledExpression<FloatValue>) {
-    TODO()
+    rotate.toJsonString()?.let { impl.setProperty("icon-rotate", it) }
   }
 
   actual fun setIconPadding(padding: CompiledExpression<DpPaddingValue>) {
-    TODO()
+    padding.toJsonString()?.let { impl.setProperty("icon-padding", it) }
   }
 
   actual fun setIconKeepUpright(keepUpright: CompiledExpression<BooleanValue>) {
-    TODO()
+    keepUpright.toJsonString()?.let { impl.setProperty("icon-keep-upright", it) }
   }
 
   actual fun setIconOffset(offset: CompiledExpression<DpOffsetValue>) {
-    TODO()
+    offset.toJsonString()?.let { impl.setProperty("icon-offset", it) }
   }
 
   actual fun setIconAnchor(anchor: CompiledExpression<SymbolAnchor>) {
-    TODO()
+    anchor.toJsonString()?.let { impl.setProperty("icon-anchor", it) }
   }
 
   actual fun setIconPitchAlignment(pitchAlignment: CompiledExpression<IconPitchAlignment>) {
-    TODO()
+    pitchAlignment.toJsonString()?.let { impl.setProperty("icon-pitch-alignment", it) }
   }
 
   actual fun setIconOpacity(opacity: CompiledExpression<FloatValue>) {
-    TODO()
+    opacity.toJsonString()?.let { impl.setProperty("icon-opacity", it) }
   }
 
   actual fun setIconColor(color: CompiledExpression<ColorValue>) {
-    TODO()
+    color.toJsonString()?.let { impl.setProperty("icon-color", it) }
   }
 
   actual fun setIconHaloColor(haloColor: CompiledExpression<ColorValue>) {
-    TODO()
+    haloColor.toJsonString()?.let { impl.setProperty("icon-halo-color", it) }
   }
 
   actual fun setIconHaloWidth(haloWidth: CompiledExpression<DpValue>) {
-    TODO()
+    haloWidth.toJsonString()?.let { impl.setProperty("icon-halo-width", it) }
   }
 
   actual fun setIconHaloBlur(haloBlur: CompiledExpression<DpValue>) {
-    TODO()
+    haloBlur.toJsonString()?.let { impl.setProperty("icon-halo-blur", it) }
   }
 
   actual fun setIconTranslate(translate: CompiledExpression<DpOffsetValue>) {
-    TODO()
+    translate.toJsonString()?.let { impl.setProperty("icon-translate", it) }
   }
 
   actual fun setIconTranslateAnchor(translateAnchor: CompiledExpression<TranslateAnchor>) {
-    TODO()
+    translateAnchor.toJsonString()?.let { impl.setProperty("icon-translate-anchor", it) }
   }
 
   actual fun setTextPitchAlignment(pitchAlignment: CompiledExpression<TextPitchAlignment>) {
-    TODO()
+    pitchAlignment.toJsonString()?.let { impl.setProperty("text-pitch-alignment", it) }
   }
 
   actual fun setTextRotationAlignment(
     rotationAlignment: CompiledExpression<TextRotationAlignment>
   ) {
-    TODO()
+    rotationAlignment.toJsonString()?.let { impl.setProperty("text-rotation-alignment", it) }
   }
 
   actual fun setTextField(field: CompiledExpression<FormattedValue>) {
-    TODO()
+    field.toJsonString()?.let { impl.setProperty("text-field", it) }
   }
 
   actual fun setTextFont(font: CompiledExpression<ListValue<StringValue>>) {
-    TODO()
+    font.toJsonString()?.let { impl.setProperty("text-font", it) }
   }
 
   actual fun setTextSize(size: CompiledExpression<DpValue>) {
-    TODO()
+    size.toJsonString()?.let { impl.setProperty("text-size", it) }
   }
 
   actual fun setTextMaxWidth(maxWidth: CompiledExpression<FloatValue>) {
-    TODO()
+    maxWidth.toJsonString()?.let { impl.setProperty("text-max-width", it) }
   }
 
   actual fun setTextLineHeight(lineHeight: CompiledExpression<FloatValue>) {
-    TODO()
+    lineHeight.toJsonString()?.let { impl.setProperty("text-line-height", it) }
   }
 
   actual fun setTextLetterSpacing(letterSpacing: CompiledExpression<FloatValue>) {
-    TODO()
+    letterSpacing.toJsonString()?.let { impl.setProperty("text-letter-spacing", it) }
   }
 
   actual fun setTextJustify(justify: CompiledExpression<TextJustify>) {
-    TODO()
+    justify.toJsonString()?.let { impl.setProperty("text-justify", it) }
   }
 
   actual fun setTextRadialOffset(radialOffset: CompiledExpression<FloatValue>) {
-    TODO()
+    radialOffset.toJsonString()?.let { impl.setProperty("text-radial-offset", it) }
   }
 
   actual fun setTextVariableAnchor(variableAnchor: CompiledExpression<ListValue<SymbolAnchor>>) {
-    TODO()
+    variableAnchor.toJsonString()?.let { impl.setProperty("text-variable-anchor", it) }
   }
 
   actual fun setTextVariableAnchorOffset(
     variableAnchorOffset: CompiledExpression<TextVariableAnchorOffsetValue>
   ) {
-    TODO()
+    variableAnchorOffset.toJsonString()?.let { impl.setProperty("text-variable-anchor-offset", it) }
   }
 
   actual fun setTextAnchor(anchor: CompiledExpression<SymbolAnchor>) {
-    TODO()
+    anchor.toJsonString()?.let { impl.setProperty("text-anchor", it) }
   }
 
   actual fun setTextMaxAngle(maxAngle: CompiledExpression<FloatValue>) {
-    TODO()
+    maxAngle.toJsonString()?.let { impl.setProperty("text-max-angle", it) }
   }
 
   actual fun setTextWritingMode(writingMode: CompiledExpression<ListValue<TextWritingMode>>) {
-    TODO()
+    writingMode.toJsonString()?.let { impl.setProperty("text-writing-mode", it) }
   }
 
   actual fun setTextRotate(rotate: CompiledExpression<FloatValue>) {
-    TODO()
+    rotate.toJsonString()?.let { impl.setProperty("text-rotate", it) }
   }
 
   actual fun setTextPadding(padding: CompiledExpression<DpValue>) {
-    TODO()
+    padding.toJsonString()?.let { impl.setProperty("text-padding", it) }
   }
 
   actual fun setTextKeepUpright(keepUpright: CompiledExpression<BooleanValue>) {
-    TODO()
+    keepUpright.toJsonString()?.let { impl.setProperty("text-keep-upright", it) }
   }
 
   actual fun setTextTransform(transform: CompiledExpression<TextTransform>) {
-    TODO()
+    transform.toJsonString()?.let { impl.setProperty("text-transform", it) }
   }
 
   actual fun setTextOffset(offset: CompiledExpression<FloatOffsetValue>) {
-    TODO()
+    offset.toJsonString()?.let { impl.setProperty("text-offset", it) }
   }
 
   actual fun setTextAllowOverlap(allowOverlap: CompiledExpression<BooleanValue>) {
-    TODO()
+    allowOverlap.toJsonString()?.let { impl.setProperty("text-allow-overlap", it) }
   }
 
   actual fun setTextOverlap(overlap: CompiledExpression<SymbolOverlap>) {
-    TODO()
+    overlap.toJsonString()?.let { impl.setProperty("text-overlap", it) }
   }
 
   actual fun setTextIgnorePlacement(ignorePlacement: CompiledExpression<BooleanValue>) {
-    TODO()
+    ignorePlacement.toJsonString()?.let { impl.setProperty("text-ignore-placement", it) }
   }
 
   actual fun setTextOptional(optional: CompiledExpression<BooleanValue>) {
-    TODO()
+    optional.toJsonString()?.let { impl.setProperty("text-optional", it) }
   }
 
   actual fun setTextOpacity(opacity: CompiledExpression<FloatValue>) {
-    TODO()
+    opacity.toJsonString()?.let { impl.setProperty("text-opacity", it) }
   }
 
   actual fun setTextColor(color: CompiledExpression<ColorValue>) {
-    TODO()
+    color.toJsonString()?.let { impl.setProperty("text-color", it) }
   }
 
   actual fun setTextHaloColor(haloColor: CompiledExpression<ColorValue>) {
-    TODO()
+    haloColor.toJsonString()?.let { impl.setProperty("text-halo-color", it) }
   }
 
   actual fun setTextHaloWidth(haloWidth: CompiledExpression<DpValue>) {
-    TODO()
+    haloWidth.toJsonString()?.let { impl.setProperty("text-halo-width", it) }
   }
 
   actual fun setTextHaloBlur(haloBlur: CompiledExpression<DpValue>) {
-    TODO()
+    haloBlur.toJsonString()?.let { impl.setProperty("text-halo-blur", it) }
   }
 
   actual fun setTextTranslate(translate: CompiledExpression<DpOffsetValue>) {
-    TODO()
+    translate.toJsonString()?.let { impl.setProperty("text-translate", it) }
   }
 
   actual fun setTextTranslateAnchor(translateAnchor: CompiledExpression<TranslateAnchor>) {
-    TODO()
+    translateAnchor.toJsonString()?.let { impl.setProperty("text-translate-anchor", it) }
   }
 }

--- a/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/layers/UnknownLayer.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/layers/UnknownLayer.kt
@@ -1,3 +1,29 @@
 package org.maplibre.compose.layers
 
-internal actual class UnknownLayer(override val impl: Nothing) : Layer()
+/**
+ * Represents a layer that exists in the base style but was not added by user Compose code. The
+ * full JSON spec is cached so the layer can be re-inserted after removal (e.g. for Anchor.Replace).
+ */
+internal actual class UnknownLayer(
+  private val _layerId: String,
+  internal val jsonSpec: String,
+) : Layer() {
+  @Suppress("UNREACHABLE_CODE") override val impl: Nothing get() = TODO()
+  override val layerId: String get() = _layerId
+  override fun layerType(): String = extractJsonStringField(jsonSpec, "type") ?: "unknown"
+
+  override fun toJson(): String = jsonSpec
+}
+
+private fun extractJsonStringField(json: String, field: String): String? {
+  val key = "\"$field\""
+  val keyIdx = json.indexOf(key)
+  if (keyIdx < 0) return null
+  val colon = json.indexOf(':', keyIdx + key.length)
+  if (colon < 0) return null
+  val quote1 = json.indexOf('"', colon + 1)
+  if (quote1 < 0) return null
+  val quote2 = json.indexOf('"', quote1 + 1)
+  if (quote2 < 0) return null
+  return json.substring(quote1 + 1, quote2)
+}

--- a/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/layers/UnknownLayer.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/layers/UnknownLayer.kt
@@ -1,3 +1,5 @@
 package org.maplibre.compose.layers
 
-internal actual class UnknownLayer(override val impl: Nothing) : Layer()
+import org.maplibre.kmp.native.style.layers.Layer as MLNLayer
+
+internal actual class UnknownLayer(override val impl: MLNLayer) : Layer()

--- a/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/map/DesktopMapAdapter.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/map/DesktopMapAdapter.kt
@@ -29,6 +29,7 @@ import org.maplibre.compose.util.toPosition
 import org.maplibre.compose.util.toScreenCoordinate
 import org.maplibre.kmp.native.camera.CameraChangeMode
 import org.maplibre.kmp.native.camera.CameraOptions
+import org.maplibre.kmp.native.map.MapCanvas
 import org.maplibre.kmp.native.map.MapControls
 import org.maplibre.kmp.native.map.MapLibreMap
 import org.maplibre.kmp.native.map.MapLoadError
@@ -39,6 +40,7 @@ import org.maplibre.kmp.native.util.Projection
 import org.maplibre.kmp.native.util.ScreenCoordinate
 import org.maplibre.spatialk.geojson.BoundingBox
 import org.maplibre.spatialk.geojson.Feature
+import org.maplibre.spatialk.geojson.FeatureCollection
 import org.maplibre.spatialk.geojson.Geometry
 import org.maplibre.spatialk.geojson.Position
 
@@ -48,6 +50,9 @@ internal class DesktopMapAdapter(internal var callbacks: MapAdapter.Callbacks) :
   internal lateinit var map: MapLibreMap
   internal lateinit var mapControls: MapControls
 
+  /** Reference to the AWT canvas; used to read canvas dimensions for visible-region computation. */
+  internal var canvas: MapCanvas? = null
+
   private var lastBaseStyle: BaseStyle? = null
 
   override fun onDidFinishLoadingMap() {
@@ -56,6 +61,10 @@ internal class DesktopMapAdapter(internal var callbacks: MapAdapter.Callbacks) :
 
   override fun onDidFailLoadingMap(error: MapLoadError, message: String) {
     callbacks.onMapFailLoading(message)
+  }
+
+  override fun onDidFinishLoadingStyle() {
+    callbacks.onStyleChanged(this, DesktopStyle(map))
   }
 
   override fun onCameraWillChange(mode: CameraChangeMode) {
@@ -101,7 +110,9 @@ internal class DesktopMapAdapter(internal var callbacks: MapAdapter.Callbacks) :
       is BaseStyle.Json -> map.loadStyleJSON(style.json)
     }
 
-    callbacks.onStyleChanged(this, DesktopStyle(map))
+    // Signal that a style change is in progress — the new style will be delivered via
+    // onDidFinishLoadingStyle() once it has loaded successfully.
+    callbacks.onStyleChanged(this, null)
   }
 
   override fun getCameraPosition(): CameraPosition {
@@ -161,12 +172,18 @@ internal class DesktopMapAdapter(internal var callbacks: MapAdapter.Callbacks) :
   }
 
   override fun getVisibleRegion(): VisibleRegion {
-    // TODO: get visible region
+    val c = canvas
+    val w = c?.width?.toDouble() ?: 0.0
+    val h = c?.height?.toDouble() ?: 0.0
+    val topLeft = map.latLngForPixel(ScreenCoordinate(0.0, 0.0)).toPosition()
+    val topRight = map.latLngForPixel(ScreenCoordinate(w, 0.0)).toPosition()
+    val bottomLeft = map.latLngForPixel(ScreenCoordinate(0.0, h)).toPosition()
+    val bottomRight = map.latLngForPixel(ScreenCoordinate(w, h)).toPosition()
     return VisibleRegion(
-      Position(0.0, 0.0),
-      Position(0.0, 0.0),
-      Position(0.0, 0.0),
-      Position(0.0, 0.0),
+      farLeft = topLeft,
+      farRight = topRight,
+      nearLeft = bottomLeft,
+      nearRight = bottomRight,
     )
   }
 
@@ -196,8 +213,9 @@ internal class DesktopMapAdapter(internal var callbacks: MapAdapter.Callbacks) :
     layerIds: Set<String>?,
     predicate: CompiledExpression<BooleanValue>?,
   ): List<Feature<Geometry, JsonObject?>> {
-    // TODO: query rendered features at offset
-    return emptyList()
+    val layerIdsJson = layerIds?.toJsonArrayString()
+    val resultJson = map.queryRenderedFeaturesAtPoint(offset.x.value, offset.y.value, layerIdsJson)
+    return parseFeatures(resultJson)
   }
 
   override fun queryRenderedFeatures(
@@ -205,8 +223,13 @@ internal class DesktopMapAdapter(internal var callbacks: MapAdapter.Callbacks) :
     layerIds: Set<String>?,
     predicate: CompiledExpression<BooleanValue>?,
   ): List<Feature<Geometry, JsonObject?>> {
-    // TODO: query rendered features in rectangle
-    return emptyList()
+    val layerIdsJson = layerIds?.toJsonArrayString()
+    val resultJson = map.queryRenderedFeaturesInBox(
+      rect.left.value, rect.top.value,
+      rect.right.value, rect.bottom.value,
+      layerIdsJson,
+    )
+    return parseFeatures(resultJson)
   }
 
   override fun metersPerDpAtLatitude(latitude: Double): Double {
@@ -264,5 +287,21 @@ internal class DesktopMapAdapter(internal var callbacks: MapAdapter.Callbacks) :
     val position = latLng.toPosition()
     val dpOffset = coordinate.toDpOffset()
     callbacks.onLongClick(this, position, dpOffset)
+  }
+
+  companion object {
+    private fun Set<String>.toJsonArrayString(): String =
+      joinToString(",", prefix = "[", postfix = "]") { "\"${it.replace("\"", "\\\"")}\"" }
+
+    @Suppress("TooGenericExceptionCaught")
+    private fun parseFeatures(json: String): List<Feature<Geometry, JsonObject?>> {
+      if (json.isBlank()) return emptyList()
+      return try {
+        val collection: FeatureCollection<Geometry, JsonObject?> = FeatureCollection.fromJson(json)
+        collection.features ?: emptyList()
+      } catch (e: Exception) {
+        emptyList()
+      }
+    }
   }
 }

--- a/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/map/DesktopMapView.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/map/DesktopMapView.kt
@@ -68,6 +68,7 @@ internal fun DesktopMapView(
             )
           controls.enable()
           adapter.map = map
+          adapter.canvas = canvas
           adapter.mapControls = controls
           adapter.setBaseStyle(style)
           @Suppress("AssignedValueIsNeverRead") // It is read

--- a/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/sources/ComputedSource.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/sources/ComputedSource.kt
@@ -3,14 +3,20 @@ package org.maplibre.compose.sources
 import org.maplibre.spatialk.geojson.BoundingBox
 import org.maplibre.spatialk.geojson.FeatureCollection
 
+/** ComputedSource (custom geometry source) is not yet supported on desktop. */
 public actual class ComputedSource : Source {
-  override val impl: Nothing = TODO("Not yet implemented")
+  @Suppress("UNREACHABLE_CODE") override val impl: Nothing get() = TODO()
+  override val _sourceId: String
 
   public actual constructor(
     id: String,
     options: ComputedSourceOptions,
     getFeatures: (bounds: BoundingBox, zoomLevel: Int) -> FeatureCollection<*, *>,
-  )
+  ) {
+    _sourceId = id
+  }
+
+  override fun toJson(): String = """{"type":"geojson","data":{"type":"FeatureCollection","features":[]}}"""
 
   public actual fun invalidateBounds(bounds: BoundingBox) {}
 

--- a/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/sources/ComputedSource.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/sources/ComputedSource.kt
@@ -1,16 +1,19 @@
 package org.maplibre.compose.sources
 
+import org.maplibre.kmp.native.style.sources.GeoJsonSource as MLNGeoJsonSource
 import org.maplibre.spatialk.geojson.BoundingBox
 import org.maplibre.spatialk.geojson.FeatureCollection
 
 public actual class ComputedSource : Source {
-  override val impl: Nothing = TODO("Not yet implemented")
+  override val impl: MLNGeoJsonSource
 
   public actual constructor(
     id: String,
     options: ComputedSourceOptions,
     getFeatures: (bounds: BoundingBox, zoomLevel: Int) -> FeatureCollection<*, *>,
-  )
+  ) : super() {
+    impl = MLNGeoJsonSource(id)
+  }
 
   public actual fun invalidateBounds(bounds: BoundingBox) {}
 

--- a/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/sources/GeoJsonSource.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/sources/GeoJsonSource.kt
@@ -1,38 +1,71 @@
 package org.maplibre.compose.sources
 
 import kotlinx.serialization.json.JsonObject
+import org.maplibre.compose.util.jsonEscape
 import org.maplibre.spatialk.geojson.Feature
 import org.maplibre.spatialk.geojson.FeatureCollection
+import org.maplibre.spatialk.geojson.Geometry
+import org.maplibre.spatialk.geojson.toJson
 
 public actual class GeoJsonSource : Source {
+  @Suppress("UNREACHABLE_CODE") override val impl: Nothing get() = TODO()
+  override val _sourceId: String
 
-  @Suppress("UNREACHABLE_CODE") override val impl: Nothing = TODO()
+  private val options: GeoJsonOptions
+  private var _data: GeoJsonData
 
-  public actual constructor(id: String, data: GeoJsonData, options: GeoJsonOptions)
+  // Set by DesktopStyle after adding to the map; used to push data updates
+  internal var style: org.maplibre.compose.style.DesktopStyle? = null
+
+  public actual constructor(id: String, data: GeoJsonData, options: GeoJsonOptions) {
+    _sourceId = id
+    _data = data
+    this.options = options
+  }
 
   public actual fun setData(data: GeoJsonData) {
-    TODO()
+    _data = data
+    // Use the direct GeoJSON update path to avoid a remove+add cycle, which would fail
+    // if any layer currently references this source.
+    style?.updateGeoJsonData(this, dataToJson(data))
   }
 
-  public actual fun isCluster(feature: Feature<*, JsonObject?>): Boolean {
-    TODO()
-  }
+  // Cluster operations are not supported on desktop
+  public actual fun isCluster(feature: Feature<*, JsonObject?>): Boolean = false
 
-  public actual fun getClusterExpansionZoom(feature: Feature<*, JsonObject?>): Double {
-    TODO()
-  }
+  public actual fun getClusterExpansionZoom(feature: Feature<*, JsonObject?>): Double = 0.0
 
   public actual fun getClusterChildren(
     feature: Feature<*, JsonObject?>
-  ): FeatureCollection<*, JsonObject?> {
-    TODO()
-  }
+  ): FeatureCollection<*, JsonObject?> = FeatureCollection<Geometry, JsonObject?>(emptyList())
 
   public actual fun getClusterLeaves(
     feature: Feature<*, JsonObject?>,
     limit: Long,
     offset: Long,
-  ): FeatureCollection<*, JsonObject?> {
-    TODO()
+  ): FeatureCollection<*, JsonObject?> = FeatureCollection<Geometry, JsonObject?>(emptyList())
+
+  override fun toJson(): String = buildString {
+    append("""{"type":"geojson"""")
+    append(""","data":""")
+    append(dataToJson(_data))
+    if (options.minZoom != SourceDefaults.MIN_ZOOM) append(""","minzoom":${options.minZoom}""")
+    if (options.maxZoom != SourceDefaults.MAX_ZOOM) append(""","maxzoom":${options.maxZoom}""")
+    if (options.buffer != 128) append(""","buffer":${options.buffer}""")
+    if (options.tolerance != 0.375f) append(""","tolerance":${options.tolerance}""")
+    if (options.cluster) {
+      append(""","cluster":true""")
+      append(""","clusterRadius":${options.clusterRadius}""")
+      append(""","clusterMaxZoom":${options.clusterMaxZoom}""")
+      append(""","clusterMinPoints":${options.clusterMinPoints}""")
+    }
+    if (options.lineMetrics) append(""","lineMetrics":true""")
+    append("}")
+  }
+
+  private fun dataToJson(data: GeoJsonData): String = when (data) {
+    is GeoJsonData.Uri -> jsonEscape(data.uri)
+    is GeoJsonData.JsonString -> data.json
+    is GeoJsonData.Features -> data.geoJson.toJson()
   }
 }

--- a/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/sources/GeoJsonSource.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/sources/GeoJsonSource.kt
@@ -1,31 +1,53 @@
 package org.maplibre.compose.sources
 
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.longOrNull
+import kotlinx.serialization.json.put
+import org.maplibre.kmp.native.style.sources.GeoJsonSource as MLNGeoJsonSource
 import org.maplibre.spatialk.geojson.Feature
 import org.maplibre.spatialk.geojson.FeatureCollection
+import org.maplibre.spatialk.geojson.Geometry
+import org.maplibre.spatialk.geojson.toJson
 
 public actual class GeoJsonSource : Source {
 
-  @Suppress("UNREACHABLE_CODE") override val impl: Nothing = TODO()
+  override val impl: MLNGeoJsonSource
 
-  public actual constructor(id: String, data: GeoJsonData, options: GeoJsonOptions)
+  public actual constructor(id: String, data: GeoJsonData, options: GeoJsonOptions) : super() {
+    impl = MLNGeoJsonSource(id, buildOptionsJson(options))
+    setData(data)
+  }
 
   public actual fun setData(data: GeoJsonData) {
-    TODO()
+    when (data) {
+      is GeoJsonData.Features -> impl.setGeoJson(data.geoJson.toJson())
+      is GeoJsonData.JsonString -> impl.setGeoJson(data.json)
+      is GeoJsonData.Uri -> impl.setUrl(data.uri)
+    }
   }
 
   public actual fun isCluster(feature: Feature<*, JsonObject?>): Boolean {
-    TODO()
+    return "cluster_id" in feature.properties.orEmpty()
   }
 
   public actual fun getClusterExpansionZoom(feature: Feature<*, JsonObject?>): Double {
-    TODO()
+    val clusterId = extractClusterId(feature) ?: return 0.0
+    return impl.getClusterExpansionZoom(clusterId).toDouble()
   }
 
   public actual fun getClusterChildren(
     feature: Feature<*, JsonObject?>
   ): FeatureCollection<*, JsonObject?> {
-    TODO()
+    val clusterId = extractClusterId(feature) ?: return FeatureCollection<Geometry?, JsonObject?>()
+    val json = impl.getClusterChildren(clusterId)
+    return try {
+      val fc: FeatureCollection<Geometry?, JsonObject?> = FeatureCollection.fromJson(json)
+      fc
+    } catch (_: Exception) {
+      FeatureCollection<Geometry?, JsonObject?>()
+    }
   }
 
   public actual fun getClusterLeaves(
@@ -33,6 +55,35 @@ public actual class GeoJsonSource : Source {
     limit: Long,
     offset: Long,
   ): FeatureCollection<*, JsonObject?> {
-    TODO()
+    val clusterId = extractClusterId(feature) ?: return FeatureCollection<Geometry?, JsonObject?>()
+    val json = impl.getClusterLeaves(clusterId, limit, offset)
+    return try {
+      val fc: FeatureCollection<Geometry?, JsonObject?> = FeatureCollection.fromJson(json)
+      fc
+    } catch (_: Exception) {
+      FeatureCollection<Geometry?, JsonObject?>()
+    }
+  }
+
+  private fun extractClusterId(feature: Feature<*, JsonObject?>): Long? {
+    return feature.properties?.get("cluster_id")?.jsonPrimitive?.longOrNull
+  }
+
+  private companion object {
+    fun buildOptionsJson(options: GeoJsonOptions): String? {
+      if (options == GeoJsonOptions()) return null
+      return buildJsonObject {
+          put("minzoom", options.minZoom)
+          put("maxzoom", options.maxZoom)
+          put("buffer", options.buffer)
+          put("tolerance", options.tolerance)
+          put("cluster", options.cluster)
+          put("clusterRadius", options.clusterRadius)
+          put("clusterMaxZoom", options.clusterMaxZoom)
+          put("clusterMinPoints", options.clusterMinPoints)
+          put("lineMetrics", options.lineMetrics)
+        }
+        .toString()
+    }
   }
 }

--- a/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/sources/ImageSource.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/sources/ImageSource.kt
@@ -2,17 +2,62 @@ package org.maplibre.compose.sources
 
 import androidx.compose.ui.graphics.ImageBitmap
 import org.maplibre.compose.util.PositionQuad
+import org.maplibre.compose.util.jsonEscape
 
 public actual class ImageSource : Source {
-  override val impl: Nothing = TODO()
+  @Suppress("UNREACHABLE_CODE") override val impl: Nothing get() = TODO()
+  override val _sourceId: String
 
-  public actual constructor(id: String, position: PositionQuad, image: ImageBitmap) {}
+  private val position: PositionQuad
+  // Either uri or bitmap data (uri takes precedence if set)
+  private var uri: String? = null
+  private var bitmap: ImageBitmap? = null
 
-  public actual constructor(id: String, position: PositionQuad, uri: String) {}
+  // Set by DesktopStyle to push updates after bounds/image/uri changes
+  internal var style: org.maplibre.compose.style.DesktopStyle? = null
 
-  public actual fun setBounds(bounds: PositionQuad) {}
+  public actual constructor(id: String, position: PositionQuad, image: ImageBitmap) {
+    _sourceId = id
+    this.position = position
+    this.bitmap = image
+  }
 
-  public actual fun setImage(image: ImageBitmap) {}
+  public actual constructor(id: String, position: PositionQuad, uri: String) {
+    _sourceId = id
+    this.position = position
+    this.uri = uri
+  }
 
-  public actual fun setUri(uri: String) {}
+  public actual fun setBounds(bounds: PositionQuad) {
+    // TODO: update via style once DesktopStyle supports source update
+  }
+
+  public actual fun setImage(image: ImageBitmap) {
+    bitmap = image
+    // ImageSource with bitmap data does not support live updates on desktop.
+    // The bitmap case is not serializable to JSON; use a URI-based ImageSource instead.
+  }
+
+  public actual fun setUri(uri: String) {
+    this.uri = uri
+    bitmap = null
+    style?.updateSource(this)
+  }
+
+  override fun toJson(): String {
+    val resolvedUri = uri ?: error(
+      "ImageSource '$_sourceId' was constructed with a bitmap but desktop requires a URI. " +
+        "Use ImageSource(id, position, uri) instead."
+    )
+    return buildString {
+      append("""{"type":"image"""")
+      append(""","url":${jsonEscape(resolvedUri)}""")
+      val tl = position.topLeft
+      val tr = position.topRight
+      val br = position.bottomRight
+      val bl = position.bottomLeft
+      append(""","coordinates":[[${tl.longitude},${tl.latitude}],[${tr.longitude},${tr.latitude}],[${br.longitude},${br.latitude}],[${bl.longitude},${bl.latitude}]]""")
+      append("}")
+    }
+  }
 }

--- a/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/sources/ImageSource.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/sources/ImageSource.kt
@@ -1,18 +1,59 @@
 package org.maplibre.compose.sources
 
 import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.toPixelMap
 import org.maplibre.compose.util.PositionQuad
+import org.maplibre.kmp.native.style.sources.ImageSource as MLNImageSource
 
 public actual class ImageSource : Source {
-  override val impl: Nothing = TODO()
+  override val impl: MLNImageSource
 
-  public actual constructor(id: String, position: PositionQuad, image: ImageBitmap) {}
+  public actual constructor(id: String, position: PositionQuad, image: ImageBitmap) : super() {
+    impl = MLNImageSource(id)
+    setBounds(position)
+    setImage(image)
+  }
 
-  public actual constructor(id: String, position: PositionQuad, uri: String) {}
+  public actual constructor(id: String, position: PositionQuad, uri: String) : super() {
+    impl = MLNImageSource(id)
+    setBounds(position)
+    setUri(uri)
+  }
 
-  public actual fun setBounds(bounds: PositionQuad) {}
+  public actual fun setBounds(bounds: PositionQuad) {
+    impl.setCoordinates(
+      tlLat = bounds.topLeft.latitude,
+      tlLng = bounds.topLeft.longitude,
+      trLat = bounds.topRight.latitude,
+      trLng = bounds.topRight.longitude,
+      brLat = bounds.bottomRight.latitude,
+      brLng = bounds.bottomRight.longitude,
+      blLat = bounds.bottomLeft.latitude,
+      blLng = bounds.bottomLeft.longitude,
+    )
+  }
 
-  public actual fun setImage(image: ImageBitmap) {}
+  public actual fun setImage(image: ImageBitmap) {
+    val width = image.width
+    val height = image.height
+    val pixelMap = image.toPixelMap()
+    val data = ByteArray(width * height * 4)
+    for (y in 0 until height) {
+      for (x in 0 until width) {
+        val color = pixelMap[x, y]
+        val i = (y * width + x) * 4
+        val a = (color.alpha * 255).toInt().toByte()
+        val alpha = color.alpha
+        data[i] = (color.red * alpha * 255).toInt().toByte()
+        data[i + 1] = (color.green * alpha * 255).toInt().toByte()
+        data[i + 2] = (color.blue * alpha * 255).toInt().toByte()
+        data[i + 3] = a
+      }
+    }
+    impl.setImage(width, height, data)
+  }
 
-  public actual fun setUri(uri: String) {}
+  public actual fun setUri(uri: String) {
+    impl.setUrl(uri)
+  }
 }

--- a/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/sources/RasterDemSource.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/sources/RasterDemSource.kt
@@ -1,8 +1,15 @@
 package org.maplibre.compose.sources
 
+import org.maplibre.compose.util.jsonEscape
+
 public actual class RasterDemSource : Source {
-  public actual constructor(id: String, uri: String, tileSize: Int) : super() {
-    this.impl = TODO()
+  @Suppress("UNREACHABLE_CODE") override val impl: Nothing get() = TODO()
+  override val _sourceId: String
+  private val json: String
+
+  public actual constructor(id: String, uri: String, tileSize: Int) {
+    _sourceId = id
+    json = """{"type":"raster-dem","url":${jsonEscape(uri)},"tileSize":$tileSize}"""
   }
 
   public actual constructor(
@@ -11,9 +18,24 @@ public actual class RasterDemSource : Source {
     options: TileSetOptions,
     tileSize: Int,
     demEncoding: RasterDemEncoding,
-  ) : super() {
-    this.impl = TODO()
+  ) {
+    _sourceId = id
+    json = buildString {
+      append("""{"type":"raster-dem","tiles":[""")
+      tiles.joinTo(this, ",") { jsonEscape(it) }
+      append("]")
+      append(""","tileSize":$tileSize""")
+      append(""","encoding":${jsonEscape(demEncoding.value)}""")
+      append(""","minzoom":${options.minZoom}""")
+      append(""","maxzoom":${options.maxZoom}""")
+      if (options.tileCoordinateSystem == TileCoordinateSystem.TMS) append(""","scheme":"tms"""")
+      options.boundingBox?.let { bb ->
+        append(""","bounds":[${bb.southwest.longitude},${bb.southwest.latitude},${bb.northeast.longitude},${bb.northeast.latitude}]""")
+      }
+      options.attributionHtml?.let { append(""","attribution":${jsonEscape(it)}""") }
+      append("}")
+    }
   }
 
-  override val impl: Nothing
+  override fun toJson(): String = json
 }

--- a/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/sources/RasterDemSource.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/sources/RasterDemSource.kt
@@ -1,8 +1,12 @@
 package org.maplibre.compose.sources
 
+import org.maplibre.kmp.native.style.sources.RasterDemSource as MLNRasterDemSource
+
 public actual class RasterDemSource : Source {
+  override val impl: MLNRasterDemSource
+
   public actual constructor(id: String, uri: String, tileSize: Int) : super() {
-    this.impl = TODO()
+    impl = MLNRasterDemSource(id, uri, tileSize)
   }
 
   public actual constructor(
@@ -12,8 +16,11 @@ public actual class RasterDemSource : Source {
     tileSize: Int,
     demEncoding: RasterDemEncoding,
   ) : super() {
-    this.impl = TODO()
+    impl =
+      MLNRasterDemSource(
+        id,
+        tiles,
+        buildTileSetJson(tiles, options, tileSize = tileSize, demEncoding = demEncoding.value),
+      )
   }
-
-  override val impl: Nothing
 }

--- a/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/sources/RasterSource.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/sources/RasterSource.kt
@@ -1,18 +1,34 @@
 package org.maplibre.compose.sources
 
+import org.maplibre.compose.util.jsonEscape
+
 public actual class RasterSource : Source {
-  public actual constructor(id: String, uri: String, tileSize: Int) : super() {
-    this.impl = TODO()
+  @Suppress("UNREACHABLE_CODE") override val impl: Nothing get() = TODO()
+  override val _sourceId: String
+  private val json: String
+
+  public actual constructor(id: String, uri: String, tileSize: Int) {
+    _sourceId = id
+    json = """{"type":"raster","url":${jsonEscape(uri)},"tileSize":$tileSize}"""
   }
 
-  public actual constructor(
-    id: String,
-    tiles: List<String>,
-    options: TileSetOptions,
-    tileSize: Int,
-  ) : super() {
-    this.impl = TODO()
+  public actual constructor(id: String, tiles: List<String>, options: TileSetOptions, tileSize: Int) {
+    _sourceId = id
+    json = buildString {
+      append("""{"type":"raster","tiles":[""")
+      tiles.joinTo(this, ",") { jsonEscape(it) }
+      append("]")
+      append(""","tileSize":$tileSize""")
+      append(""","minzoom":${options.minZoom}""")
+      append(""","maxzoom":${options.maxZoom}""")
+      if (options.tileCoordinateSystem == TileCoordinateSystem.TMS) append(""","scheme":"tms"""")
+      options.boundingBox?.let { bb ->
+        append(""","bounds":[${bb.southwest.longitude},${bb.southwest.latitude},${bb.northeast.longitude},${bb.northeast.latitude}]""")
+      }
+      options.attributionHtml?.let { append(""","attribution":${jsonEscape(it)}""") }
+      append("}")
+    }
   }
 
-  override val impl: Nothing
+  override fun toJson(): String = json
 }

--- a/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/sources/RasterSource.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/sources/RasterSource.kt
@@ -1,8 +1,12 @@
 package org.maplibre.compose.sources
 
+import org.maplibre.kmp.native.style.sources.RasterSource as MLNRasterSource
+
 public actual class RasterSource : Source {
+  override val impl: MLNRasterSource
+
   public actual constructor(id: String, uri: String, tileSize: Int) : super() {
-    this.impl = TODO()
+    impl = MLNRasterSource(id, uri, tileSize)
   }
 
   public actual constructor(
@@ -11,8 +15,6 @@ public actual class RasterSource : Source {
     options: TileSetOptions,
     tileSize: Int,
   ) : super() {
-    this.impl = TODO()
+    impl = MLNRasterSource(id, tiles, buildTileSetJson(tiles, options, tileSize = tileSize))
   }
-
-  override val impl: Nothing
 }

--- a/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/sources/Source.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/sources/Source.kt
@@ -1,13 +1,16 @@
 package org.maplibre.compose.sources
 
 public actual sealed class Source {
-  internal abstract val impl: Nothing
+  @Suppress("UNREACHABLE_CODE") internal abstract val impl: Nothing
 
-  internal actual val id: String
-    get() = TODO()
+  internal abstract val _sourceId: String
 
-  public actual val attributionHtml: String
-    get() = TODO()
+  internal actual val id: String get() = _sourceId
+
+  public actual val attributionHtml: String get() = ""
+
+  /** Returns a JSON string suitable for `map.addSourceJson()`. */
+  internal abstract fun toJson(): String
 
   override fun toString(): String = "${this::class.simpleName}(id=\"$id\")"
 }

--- a/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/sources/Source.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/sources/Source.kt
@@ -1,13 +1,15 @@
 package org.maplibre.compose.sources
 
+import org.maplibre.kmp.native.style.sources.Source as MLNSource
+
 public actual sealed class Source {
-  internal abstract val impl: Nothing
+  internal abstract val impl: MLNSource
 
   internal actual val id: String
-    get() = TODO()
+    get() = impl.id
 
   public actual val attributionHtml: String
-    get() = TODO()
+    get() = impl.attribution
 
   override fun toString(): String = "${this::class.simpleName}(id=\"$id\")"
 }

--- a/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/sources/TileSetJsonBuilder.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/sources/TileSetJsonBuilder.kt
@@ -1,0 +1,40 @@
+package org.maplibre.compose.sources
+
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+/**
+ * Builds a TileJSON config string for tile-based sources (vector, raster, raster-dem). The
+ * resulting JSON object can be parsed by the C++ side into a Tileset struct.
+ */
+internal fun buildTileSetJson(
+  tiles: List<String>,
+  options: TileSetOptions,
+  tileSize: Int? = null,
+  demEncoding: String? = null,
+): String =
+  buildJsonObject {
+      put("tiles", JsonArray(tiles.map { JsonPrimitive(it) }))
+      put("minzoom", options.minZoom)
+      put("maxzoom", options.maxZoom)
+      put("scheme", options.tileCoordinateSystem.name.lowercase())
+      options.attributionHtml?.let { put("attribution", it) }
+      options.boundingBox?.let { bbox ->
+        put(
+          "bounds",
+          JsonArray(
+            listOf(
+              JsonPrimitive(bbox.west),
+              JsonPrimitive(bbox.south),
+              JsonPrimitive(bbox.east),
+              JsonPrimitive(bbox.north),
+            )
+          ),
+        )
+      }
+      tileSize?.let { put("tileSize", it) }
+      demEncoding?.let { put("encoding", it) }
+    }
+    .toString()

--- a/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/sources/UnknownSource.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/sources/UnknownSource.kt
@@ -1,3 +1,11 @@
 package org.maplibre.compose.sources
 
-public actual class UnknownSource(override val impl: Nothing) : Source()
+/** Represents a layer that exists in the base style but was not added by user Compose code. */
+public actual class UnknownSource(
+  private val _id: String,
+  internal val jsonSpec: String,
+) : Source() {
+  @Suppress("UNREACHABLE_CODE") override val impl: Nothing get() = TODO()
+  override val _sourceId: String get() = _id
+  override fun toJson(): String = jsonSpec
+}

--- a/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/sources/UnknownSource.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/sources/UnknownSource.kt
@@ -1,3 +1,5 @@
 package org.maplibre.compose.sources
 
-public actual class UnknownSource(override val impl: Nothing) : Source()
+import org.maplibre.kmp.native.style.sources.Source as MLNSource
+
+public actual class UnknownSource(override val impl: MLNSource) : Source()

--- a/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/sources/VectorSource.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/sources/VectorSource.kt
@@ -1,26 +1,43 @@
 package org.maplibre.compose.sources
 
 import kotlinx.serialization.json.JsonObject
-import org.maplibre.compose.expressions.ast.Expression
-import org.maplibre.compose.expressions.value.BooleanValue
+import org.maplibre.compose.util.jsonEscape
 import org.maplibre.spatialk.geojson.Feature
 import org.maplibre.spatialk.geojson.Geometry
+import org.maplibre.compose.expressions.ast.Expression
+import org.maplibre.compose.expressions.value.BooleanValue
 
 public actual class VectorSource : Source {
-  public actual constructor(id: String, uri: String) : super() {
-    this.impl = TODO()
+  @Suppress("UNREACHABLE_CODE") override val impl: Nothing get() = TODO()
+  override val _sourceId: String
+  private val json: String
+
+  public actual constructor(id: String, uri: String) {
+    _sourceId = id
+    json = """{"type":"vector","url":${jsonEscape(uri)}}"""
   }
 
-  public actual constructor(id: String, tiles: List<String>, options: TileSetOptions) : super() {
-    this.impl = TODO()
+  public actual constructor(id: String, tiles: List<String>, options: TileSetOptions) {
+    _sourceId = id
+    json = buildString {
+      append("""{"type":"vector","tiles":[""")
+      tiles.joinTo(this, ",") { jsonEscape(it) }
+      append("]")
+      append(""","minzoom":${options.minZoom}""")
+      append(""","maxzoom":${options.maxZoom}""")
+      if (options.tileCoordinateSystem == TileCoordinateSystem.TMS) append(""","scheme":"tms"""")
+      options.boundingBox?.let { bb ->
+        append(""","bounds":[${bb.southwest.longitude},${bb.southwest.latitude},${bb.northeast.longitude},${bb.northeast.latitude}]""")
+      }
+      options.attributionHtml?.let { append(""","attribution":${jsonEscape(it)}""") }
+      append("}")
+    }
   }
 
-  override val impl: Nothing
+  override fun toJson(): String = json
 
   public actual fun querySourceFeatures(
     sourceLayerIds: Set<String>,
     predicate: Expression<BooleanValue>,
-  ): List<Feature<Geometry, JsonObject?>> {
-    TODO()
-  }
+  ): List<Feature<Geometry, JsonObject?>> = emptyList()
 }

--- a/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/sources/VectorSource.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/sources/VectorSource.kt
@@ -1,26 +1,50 @@
 package org.maplibre.compose.sources
 
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import org.maplibre.compose.expressions.ast.Expression
+import org.maplibre.compose.expressions.ast.ExpressionContext
+import org.maplibre.compose.expressions.dsl.const
 import org.maplibre.compose.expressions.value.BooleanValue
+import org.maplibre.compose.util.toJsonString
+import org.maplibre.kmp.native.style.sources.VectorSource as MLNVectorSource
 import org.maplibre.spatialk.geojson.Feature
+import org.maplibre.spatialk.geojson.FeatureCollection
 import org.maplibre.spatialk.geojson.Geometry
 
 public actual class VectorSource : Source {
+  override val impl: MLNVectorSource
+
   public actual constructor(id: String, uri: String) : super() {
-    this.impl = TODO()
+    impl = MLNVectorSource(id, uri)
   }
 
   public actual constructor(id: String, tiles: List<String>, options: TileSetOptions) : super() {
-    this.impl = TODO()
+    impl = MLNVectorSource(id, tiles, buildTileSetJson(tiles, options))
   }
-
-  override val impl: Nothing
 
   public actual fun querySourceFeatures(
     sourceLayerIds: Set<String>,
     predicate: Expression<BooleanValue>,
   ): List<Feature<Geometry, JsonObject?>> {
-    TODO()
+    val sourceLayersJson =
+      if (sourceLayerIds.isNotEmpty()) {
+        JsonArray(sourceLayerIds.map { JsonPrimitive(it) }).toString()
+      } else {
+        null
+      }
+
+    val filterJson =
+      predicate.takeUnless { it == const(true) }?.compile(ExpressionContext.None)?.toJsonString()
+
+    val resultJson = impl.querySourceFeatures(sourceLayersJson, filterJson)
+    return try {
+      val fc: FeatureCollection<Geometry?, JsonObject?> = FeatureCollection.fromJson(resultJson)
+      @Suppress("UNCHECKED_CAST")
+      fc.features as List<Feature<Geometry, JsonObject?>>
+    } catch (_: Exception) {
+      emptyList()
+    }
   }
 }

--- a/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/style/DesktopStyle.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/style/DesktopStyle.kt
@@ -1,49 +1,247 @@
 package org.maplibre.compose.style
 
 import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.toPixelMap
 import org.maplibre.compose.layers.Layer
+import org.maplibre.compose.layers.UnknownLayer
 import org.maplibre.compose.sources.Source
+import org.maplibre.compose.sources.UnknownSource
 import org.maplibre.compose.util.ImageResizeOptions
 import org.maplibre.kmp.native.map.MapLibreMap
 
 internal class DesktopStyle(internal val impl: MapLibreMap) : Style {
+
+  // Cache layer JSON specs from the base style so they can be re-inserted later (e.g. Anchor.Replace)
+  private val baseLayerSpecs: Map<String, String>
+
+  // Track user-added layers and sources by id
+  private val userLayers = mutableMapOf<String, Layer>()
+  private val userSources = mutableMapOf<String, Source>()
+
+  init {
+    val styleJson = impl.getStyleJson()
+    baseLayerSpecs = parseLayerSpecs(styleJson)
+  }
+
+  // region Images
 
   override fun addImage(
     id: String,
     image: ImageBitmap,
     sdf: Boolean,
     resizeOptions: ImageResizeOptions?,
-  ) {}
-
-  override fun removeImage(id: String) {}
-
-  override fun getSource(id: String): Source? {
-    return null
+  ) {
+    val w = image.width
+    val h = image.height
+    val pixelMap = image.toPixelMap()
+    // Convert ARGB (compose) to RGBA premultiplied (mbgl)
+    val bytes = ByteArray(w * h * 4)
+    var i = 0
+    for (y in 0 until h) {
+      for (x in 0 until w) {
+        val c = pixelMap[x, y]
+        val a = c.alpha
+        bytes[i++] = (c.red * a * 255 + 0.5f).toInt().coerceIn(0, 255).toByte()
+        bytes[i++] = (c.green * a * 255 + 0.5f).toInt().coerceIn(0, 255).toByte()
+        bytes[i++] = (c.blue * a * 255 + 0.5f).toInt().coerceIn(0, 255).toByte()
+        bytes[i++] = (a * 255 + 0.5f).toInt().coerceIn(0, 255).toByte()
+      }
+    }
+    val contentLeft = resizeOptions?.left?.value ?: 0f
+    val contentTop = resizeOptions?.top?.value ?: 0f
+    val contentRight = if (resizeOptions != null) w - resizeOptions.right.value else w.toFloat()
+    val contentBottom = if (resizeOptions != null) h - resizeOptions.bottom.value else h.toFloat()
+    impl.addStyleImage(id, w, h, bytes, 1f, sdf, contentLeft, contentTop, contentRight, contentBottom)
   }
 
-  override fun getSources(): List<Source> {
-    return emptyList()
+  override fun removeImage(id: String) {
+    impl.removeStyleImage(id)
   }
 
-  override fun addSource(source: Source) {}
+  // endregion
 
-  override fun removeSource(source: Source) {}
+  // region Sources
+
+  override fun getSource(id: String): Source? =
+    userSources[id] ?: run {
+      val ids = impl.getSourceIds()
+      if (id in ids) UnknownSource(id, "{}") else null
+    }
+
+  override fun getSources(): List<Source> =
+    impl.getSourceIds().map { userSources[it] ?: UnknownSource(it, "{}") }
+
+  override fun addSource(source: Source) {
+    impl.addSourceJson(source.id, source.toJson())
+    userSources[source.id] = source
+    if (source is org.maplibre.compose.sources.GeoJsonSource) source.style = this
+    if (source is org.maplibre.compose.sources.ImageSource) source.style = this
+  }
+
+  override fun removeSource(source: Source) {
+    impl.removeSource(source.id)
+    userSources.remove(source.id)
+    if (source is org.maplibre.compose.sources.GeoJsonSource) source.style = null
+    if (source is org.maplibre.compose.sources.ImageSource) source.style = null
+  }
+
+  /** Called by GeoJsonSource.setData() to update GeoJSON data in-place without removing the source. */
+  internal fun updateGeoJsonData(source: org.maplibre.compose.sources.GeoJsonSource, geoJson: String) {
+    impl.setGeoJsonData(source.id, geoJson)
+  }
+
+  /** Called by source setImage()/setUri() to re-add the source with updated data. Only safe when no layers reference the source. */
+  internal fun updateSource(source: Source) {
+    impl.removeSource(source.id)
+    impl.addSourceJson(source.id, source.toJson())
+  }
+
+  // endregion
+
+  // region Layers
 
   override fun getLayer(id: String): Layer? {
-    return null
+    userLayers[id]?.let { return it }
+    val spec = baseLayerSpecs[id] ?: return null
+    return UnknownLayer(id, spec)
   }
 
-  override fun getLayers(): List<Layer> {
-    return emptyList()
+  override fun getLayers(): List<Layer> =
+    impl.getLayerIds().map { userLayers[it] ?: UnknownLayer(it, baseLayerSpecs[it] ?: "{}") }
+
+  override fun addLayer(layer: Layer) {
+    impl.addLayerJson(layer.toJson(), null)
+    layer.style = this
+    layer.insertedBefore = null
+    userLayers[layer.id] = layer
   }
 
-  override fun addLayer(layer: Layer) {}
+  override fun addLayerAbove(id: String, layer: Layer) {
+    // In mbgl, addLayerJson(json, beforeId) inserts BELOW beforeId.
+    // "above id" means we need the layer that comes after id in the stack, and use it as beforeId.
+    val allIds = impl.getLayerIds()
+    val idx = allIds.indexOf(id)
+    val beforeId = if (idx < 0 || idx == allIds.size - 1) null else allIds[idx + 1]
+    impl.addLayerJson(layer.toJson(), beforeId)
+    layer.style = this
+    layer.insertedBefore = beforeId
+    userLayers[layer.id] = layer
+  }
 
-  override fun addLayerAbove(id: String, layer: Layer) {}
+  override fun addLayerBelow(id: String, layer: Layer) {
+    impl.addLayerJson(layer.toJson(), id)
+    layer.style = this
+    layer.insertedBefore = id
+    userLayers[layer.id] = layer
+  }
 
-  override fun addLayerBelow(id: String, layer: Layer) {}
+  override fun addLayerAt(index: Int, layer: Layer) {
+    val allIds = impl.getLayerIds()
+    // index 0 = bottom (below everything), index = allIds.size means top
+    val beforeId = if (index < allIds.size) allIds[index] else null
+    impl.addLayerJson(layer.toJson(), beforeId)
+    layer.style = this
+    layer.insertedBefore = beforeId
+    userLayers[layer.id] = layer
+  }
 
-  override fun addLayerAt(index: Int, layer: Layer) {}
+  override fun removeLayer(layer: Layer) {
+    impl.removeLayer(layer.id)
+    userLayers.remove(layer.id)
+    layer.style = null
+  }
 
-  override fun removeLayer(layer: Layer) {}
+  /** Called by Layer property setters to re-apply the full layer JSON after a property change. */
+  internal fun updateLayer(layer: Layer) {
+    impl.removeLayer(layer.id)
+    impl.addLayerJson(layer.toJson(), layer.insertedBefore)
+  }
+
+  // endregion
+
+  companion object {
+    /** Parses the top-level `layers` array from a MapLibre style JSON and returns a map of id → json. */
+    private fun parseLayerSpecs(styleJson: String): Map<String, String> {
+      if (styleJson.isBlank()) return emptyMap()
+      return try {
+        // Minimal JSON parser to extract layer objects from the "layers" array.
+        // We rely on the fact that each layer JSON is a valid JSON object at the top level.
+        val result = mutableMapOf<String, String>()
+        val layersKey = "\"layers\""
+        val layersStart = styleJson.indexOf(layersKey)
+        if (layersStart < 0) return emptyMap()
+        val bracketStart = styleJson.indexOf('[', layersStart + layersKey.length)
+        if (bracketStart < 0) return emptyMap()
+        var pos = bracketStart + 1
+        val end = styleJson.length
+        while (pos < end) {
+          // skip whitespace and commas
+          while (pos < end && styleJson[pos].isWhitespace()) pos++
+          if (pos >= end) break
+          if (styleJson[pos] == ']') break
+          if (styleJson[pos] == ',') { pos++; continue }
+          if (styleJson[pos] == '{') {
+            val objEnd = findMatchingBrace(styleJson, pos)
+            val objJson = styleJson.substring(pos, objEnd + 1)
+            val id = extractJsonStringField(objJson, "id")
+            if (id != null) result[id] = objJson
+            pos = objEnd + 1
+          } else {
+            pos++
+          }
+        }
+        result
+      } catch (e: Exception) {
+        emptyMap()
+      }
+    }
+
+    /** Finds the closing `}` matching the `{` at [start]. */
+    private fun findMatchingBrace(s: String, start: Int): Int {
+      var depth = 0
+      var inString = false
+      var escape = false
+      for (i in start until s.length) {
+        val c = s[i]
+        if (escape) { escape = false; continue }
+        if (c == '\\' && inString) { escape = true; continue }
+        if (c == '"') { inString = !inString; continue }
+        if (inString) continue
+        when (c) {
+          '{' -> depth++
+          '}' -> { depth--; if (depth == 0) return i }
+        }
+      }
+      return s.length - 1
+    }
+
+    /** Extracts the string value of a top-level field from a JSON object string. */
+    private fun extractJsonStringField(json: String, field: String): String? {
+      val key = "\"$field\""
+      var pos = json.indexOf(key)
+      while (pos >= 0) {
+        val colon = json.indexOf(':', pos + key.length)
+        if (colon < 0) return null
+        var valStart = colon + 1
+        while (valStart < json.length && json[valStart].isWhitespace()) valStart++
+        if (valStart >= json.length || json[valStart] != '"') {
+          pos = json.indexOf(key, pos + 1)
+          continue
+        }
+        val sb = StringBuilder()
+        var i = valStart + 1
+        var esc = false
+        while (i < json.length) {
+          val c = json[i]
+          if (esc) { sb.append(c); esc = false }
+          else if (c == '\\') esc = true
+          else if (c == '"') break
+          else sb.append(c)
+          i++
+        }
+        return sb.toString()
+      }
+      return null
+    }
+  }
 }

--- a/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/style/DesktopStyle.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/style/DesktopStyle.kt
@@ -1,49 +1,181 @@
 package org.maplibre.compose.style
 
 import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.toPixelMap
 import org.maplibre.compose.layers.Layer
+import org.maplibre.compose.layers.UnknownLayer
 import org.maplibre.compose.sources.Source
+import org.maplibre.compose.sources.UnknownSource
 import org.maplibre.compose.util.ImageResizeOptions
 import org.maplibre.kmp.native.map.MapLibreMap
 
 internal class DesktopStyle(internal val impl: MapLibreMap) : Style {
+
+  private val layerCache = mutableMapOf<String, Layer>()
+  private val layerOrder = mutableListOf<String>()
+  private val sourceCache = mutableMapOf<String, Source>()
 
   override fun addImage(
     id: String,
     image: ImageBitmap,
     sdf: Boolean,
     resizeOptions: ImageResizeOptions?,
-  ) {}
+  ) {
+    val width = image.width
+    val height = image.height
+    val pixelMap = image.toPixelMap()
+    val data = ByteArray(width * height * 4)
+    for (y in 0 until height) {
+      for (x in 0 until width) {
+        val color = pixelMap[x, y]
+        val a = color.alpha
+        val offset = (y * width + x) * 4
+        // Premultiply alpha for mbgl::PremultipliedImage
+        data[offset] = (color.red * a * 255f).toInt().toByte()
+        data[offset + 1] = (color.green * a * 255f).toInt().toByte()
+        data[offset + 2] = (color.blue * a * 255f).toInt().toByte()
+        data[offset + 3] = (a * 255f).toInt().toByte()
+      }
+    }
+    if (resizeOptions == null) {
+      impl.addStyleImage(id, width, height, 1.0f, sdf, data)
+    } else {
+      // Dp values treated as px at ratio 1.0 (desktop default density)
+      val left = resizeOptions.left.value
+      val top = resizeOptions.top.value
+      val right = width - resizeOptions.right.value
+      val bottom = height - resizeOptions.bottom.value
+      impl.addStyleImageStretched(
+        id,
+        width,
+        height,
+        1.0f,
+        sdf,
+        data,
+        stretchXFrom = left,
+        stretchXTo = right,
+        stretchYFrom = top,
+        stretchYTo = bottom,
+        contentLeft = left,
+        contentTop = top,
+        contentRight = right,
+        contentBottom = bottom,
+      )
+    }
+  }
 
-  override fun removeImage(id: String) {}
+  override fun removeImage(id: String) {
+    impl.removeStyleImage(id)
+  }
 
   override fun getSource(id: String): Source? {
+    sourceCache[id]?.let {
+      return it
+    }
+    // Check native style for base sources
+    if (impl.hasStyleSource(id)) {
+      val mlnSource = org.maplibre.kmp.native.style.sources.Source(id, "unknown")
+      mlnSource.bind(impl)
+      return UnknownSource(mlnSource)
+    }
     return null
   }
 
   override fun getSources(): List<Source> {
-    return emptyList()
+    val nativeIds = impl.getStyleSourceIds()
+    return nativeIds.map { id ->
+      sourceCache[id]
+        ?: run {
+          val mlnSource = org.maplibre.kmp.native.style.sources.Source(id, "unknown")
+          mlnSource.bind(impl)
+          UnknownSource(mlnSource)
+        }
+    }
   }
 
-  override fun addSource(source: Source) {}
+  override fun addSource(source: Source) {
+    impl.addStyleSource(source.impl.type, source.impl.id, source.impl.configJson())
+    source.impl.bind(impl)
+    sourceCache[source.id] = source
+  }
 
-  override fun removeSource(source: Source) {}
+  override fun removeSource(source: Source) {
+    impl.removeStyleSource(source.impl.id)
+    source.impl.unbind()
+    sourceCache.remove(source.id)
+  }
 
   override fun getLayer(id: String): Layer? {
+    layerCache[id]?.let {
+      return it
+    }
+    // Check native style for base layers
+    if (impl.hasStyleLayer(id)) {
+      val mlnLayer = org.maplibre.kmp.native.style.layers.Layer(id, "unknown", null)
+      mlnLayer.bind(impl)
+      val layer = UnknownLayer(mlnLayer)
+      layerCache[id] = layer
+      return layer
+    }
     return null
   }
 
   override fun getLayers(): List<Layer> {
-    return emptyList()
+    // Return base style layers (from native) + user layers, in native order
+    val nativeIds = impl.getStyleLayerIds()
+    return nativeIds.map { id ->
+      layerCache[id]
+        ?: run {
+          val mlnLayer = org.maplibre.kmp.native.style.layers.Layer(id, "unknown", null)
+          mlnLayer.bind(impl)
+          val layer = UnknownLayer(mlnLayer)
+          layerCache[id] = layer
+          layer
+        }
+    }
   }
 
-  override fun addLayer(layer: Layer) {}
+  private fun insertLayer(layer: Layer, beforeId: String?) {
+    if (layer.impl.type == "unknown") {
+      // Restore a previously-removed base style layer
+      impl.restoreStyleLayer(layer.impl.id, beforeId)
+    } else {
+      impl.addStyleLayer(layer.impl.type, layer.impl.id, layer.impl.sourceId, beforeId)
+    }
+    layer.impl.bind(impl)
+    layerCache[layer.id] = layer
+    if (beforeId != null) {
+      val idx = layerOrder.indexOf(beforeId)
+      if (idx >= 0) layerOrder.add(idx, layer.id) else layerOrder.add(layer.id)
+    } else {
+      layerOrder.add(layer.id)
+    }
+  }
 
-  override fun addLayerAbove(id: String, layer: Layer) {}
+  override fun addLayer(layer: Layer) = insertLayer(layer, beforeId = null)
 
-  override fun addLayerBelow(id: String, layer: Layer) {}
+  override fun addLayerAbove(id: String, layer: Layer) {
+    // Find the layer after 'id' in the native layer order
+    val nativeIds = impl.getStyleLayerIds()
+    val idx = nativeIds.indexOf(id)
+    if (idx < 0) error("Anchor layer '$id' not found in style")
+    val beforeId = if (idx + 1 < nativeIds.size) nativeIds[idx + 1] else null
+    insertLayer(layer, beforeId)
+  }
 
-  override fun addLayerAt(index: Int, layer: Layer) {}
+  override fun addLayerBelow(id: String, layer: Layer) = insertLayer(layer, beforeId = id)
 
-  override fun removeLayer(layer: Layer) {}
+  override fun addLayerAt(index: Int, layer: Layer) {
+    // Use native layer order to find the correct beforeId
+    val nativeIds = impl.getStyleLayerIds()
+    val beforeId = nativeIds.getOrNull(index)
+    insertLayer(layer, beforeId)
+  }
+
+  override fun removeLayer(layer: Layer) {
+    impl.removeStyleLayer(layer.impl.id)
+    layer.impl.unbind()
+    layerCache.remove(layer.id)
+    layerOrder.remove(layer.id)
+  }
 }

--- a/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/util/ExpressionEncoder.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/util/ExpressionEncoder.kt
@@ -1,0 +1,90 @@
+package org.maplibre.compose.util
+
+import androidx.compose.ui.unit.LayoutDirection
+import org.maplibre.compose.expressions.ast.BooleanLiteral
+import org.maplibre.compose.expressions.ast.ColorLiteral
+import org.maplibre.compose.expressions.ast.CompiledExpression
+import org.maplibre.compose.expressions.ast.CompiledFunctionCall
+import org.maplibre.compose.expressions.ast.CompiledListLiteral
+import org.maplibre.compose.expressions.ast.CompiledMapLiteral
+import org.maplibre.compose.expressions.ast.CompiledOptions
+import org.maplibre.compose.expressions.ast.DpPaddingLiteral
+import org.maplibre.compose.expressions.ast.FloatLiteral
+import org.maplibre.compose.expressions.ast.NullLiteral
+import org.maplibre.compose.expressions.ast.OffsetLiteral
+import org.maplibre.compose.expressions.ast.StringLiteral
+
+/**
+ * Serializes a [CompiledExpression] to a JSON string suitable for passing to the MapLibre style
+ * API. Mirrors the Android `normalizeJsonLike` logic but uses Kotlin's stdlib instead of Gson.
+ */
+internal fun CompiledExpression<*>.toJsonString(): String = encodeExpression(inLiteral = false)
+
+private fun CompiledExpression<*>.encodeExpression(inLiteral: Boolean): String =
+  when (this) {
+    NullLiteral -> "null"
+    is BooleanLiteral -> value.toString()
+    is FloatLiteral -> value.toJsonNumber()
+    is StringLiteral -> jsonEscape(value)
+    is ColorLiteral -> {
+      val r = (value.red * 255).toInt()
+      val g = (value.green * 255).toInt()
+      val b = (value.blue * 255).toInt()
+      val a = value.alpha
+      jsonEscape("rgba($r, $g, $b, $a)")
+    }
+    is OffsetLiteral ->
+      if (inLiteral) "[${value.x.toJsonNumber()},${value.y.toJsonNumber()}]"
+      else "[\"literal\",[${value.x.toJsonNumber()},${value.y.toJsonNumber()}]]"
+    is DpPaddingLiteral -> {
+      val top = value.calculateTopPadding().value.toJsonNumber()
+      val right = value.calculateRightPadding(LayoutDirection.Ltr).value.toJsonNumber()
+      val bottom = value.calculateBottomPadding().value.toJsonNumber()
+      val left = value.calculateLeftPadding(LayoutDirection.Ltr).value.toJsonNumber()
+      if (inLiteral) "[$top,$right,$bottom,$left]"
+      else "[\"literal\",[$top,$right,$bottom,$left]]"
+    }
+    is CompiledFunctionCall -> buildString {
+      append('[')
+      append(jsonEscape(name))
+      args.forEachIndexed { i, arg ->
+        append(',')
+        append(arg.encodeExpression(inLiteral || isLiteralArg(i)))
+      }
+      append(']')
+    }
+    is CompiledListLiteral<*> -> {
+      val items = value.joinToString(",") { it.encodeExpression(true) }
+      if (inLiteral) "[$items]" else "[\"literal\",[$items]]"
+    }
+    is CompiledMapLiteral<*> -> {
+      val entries = value.entries.joinToString(",") { (k, v) ->
+        "${jsonEscape(k)}:${v.encodeExpression(true)}"
+      }
+      if (inLiteral) "{$entries}" else "[\"literal\",{$entries}]"
+    }
+    is CompiledOptions<*> ->
+      value.entries.joinToString(",", prefix = "{", postfix = "}") { (k, v) ->
+        "${jsonEscape(k)}:${v.encodeExpression(inLiteral)}"
+      }
+  }
+
+private fun Float.toJsonNumber(): String =
+  if (isNaN() || isInfinite()) "null"
+  else if (this == toLong().toFloat()) toLong().toString()
+  else toString()
+
+internal fun jsonEscape(s: String): String = buildString {
+  append('"')
+  for (c in s) {
+    when (c) {
+      '"' -> append("\\\"")
+      '\\' -> append("\\\\")
+      '\n' -> append("\\n")
+      '\r' -> append("\\r")
+      '\t' -> append("\\t")
+      else -> append(c)
+    }
+  }
+  append('"')
+}

--- a/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/util/ExpressionEncoder.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/util/ExpressionEncoder.kt
@@ -1,0 +1,90 @@
+package org.maplibre.compose.util
+
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.unit.LayoutDirection
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import org.maplibre.compose.expressions.ast.BooleanLiteral
+import org.maplibre.compose.expressions.ast.ColorLiteral
+import org.maplibre.compose.expressions.ast.CompiledExpression
+import org.maplibre.compose.expressions.ast.CompiledFunctionCall
+import org.maplibre.compose.expressions.ast.CompiledListLiteral
+import org.maplibre.compose.expressions.ast.CompiledMapLiteral
+import org.maplibre.compose.expressions.ast.CompiledOptions
+import org.maplibre.compose.expressions.ast.DpPaddingLiteral
+import org.maplibre.compose.expressions.ast.FloatLiteral
+import org.maplibre.compose.expressions.ast.NullLiteral
+import org.maplibre.compose.expressions.ast.OffsetLiteral
+import org.maplibre.compose.expressions.ast.StringLiteral
+
+internal fun CompiledExpression<*>.toJsonString(): String = normalizeJsonLike(false).toString()
+
+private fun buildLiteralArray(
+  inLiteral: Boolean,
+  block: MutableList<JsonElement>.() -> Unit,
+): JsonElement {
+  val items = mutableListOf<JsonElement>().apply(block)
+  return if (inLiteral) {
+    JsonArray(items)
+  } else {
+    JsonArray(listOf(JsonPrimitive("literal"), JsonArray(items)))
+  }
+}
+
+private fun buildLiteralObject(
+  inLiteral: Boolean,
+  block: MutableMap<String, JsonElement>.() -> Unit,
+): JsonElement {
+  val map = mutableMapOf<String, JsonElement>().apply(block)
+  return if (inLiteral) {
+    JsonObject(map)
+  } else {
+    JsonArray(listOf(JsonPrimitive("literal"), JsonObject(map)))
+  }
+}
+
+private fun CompiledExpression<*>.normalizeJsonLike(inLiteral: Boolean): JsonElement =
+  when (this) {
+    NullLiteral -> JsonNull
+    is BooleanLiteral -> JsonPrimitive(value)
+    is FloatLiteral -> JsonPrimitive(value)
+    is StringLiteral -> JsonPrimitive(value)
+    is OffsetLiteral -> {
+      val offset = value
+      buildLiteralArray(inLiteral) {
+        add(JsonPrimitive(offset.x))
+        add(JsonPrimitive(offset.y))
+      }
+    }
+    is ColorLiteral ->
+      JsonPrimitive(
+        value.toArgb().let {
+          "rgba(${(it shr 16) and 0xFF}, ${(it shr 8) and 0xFF}, ${it and 0xFF}, ${value.alpha})"
+        }
+      )
+    is DpPaddingLiteral ->
+      buildLiteralArray(inLiteral) {
+        add(JsonPrimitive(value.calculateTopPadding().value))
+        add(JsonPrimitive(value.calculateRightPadding(LayoutDirection.Ltr).value))
+        add(JsonPrimitive(value.calculateBottomPadding().value))
+        add(JsonPrimitive(value.calculateLeftPadding(LayoutDirection.Ltr).value))
+      }
+    is CompiledFunctionCall ->
+      JsonArray(
+        buildList {
+          add(JsonPrimitive(name))
+          args.forEachIndexed { i, v -> add(v.normalizeJsonLike(inLiteral || isLiteralArg(i))) }
+        }
+      )
+    is CompiledListLiteral<*> ->
+      buildLiteralArray(inLiteral) { value.forEach { add(it.normalizeJsonLike(true)) } }
+    is CompiledMapLiteral<*> ->
+      buildLiteralObject(inLiteral) {
+        value.forEach { (k, v) -> put(k, v.normalizeJsonLike(true)) }
+      }
+    is CompiledOptions<*> ->
+      JsonObject(buildMap { value.forEach { (k, v) -> put(k, v.normalizeJsonLike(inLiteral)) } })
+  }

--- a/lib/maplibre-compose/src/desktopTest/kotlin/org/maplibre/compose/style/DesktopStyleNodeTest.kt
+++ b/lib/maplibre-compose/src/desktopTest/kotlin/org/maplibre/compose/style/DesktopStyleNodeTest.kt
@@ -1,0 +1,3 @@
+package org.maplibre.compose.style
+
+class DesktopStyleNodeTest : StyleNodeTest()

--- a/lib/maplibre-compose/src/desktopTest/kotlin/org/maplibre/compose/util/ExpressionEncoderTest.kt
+++ b/lib/maplibre-compose/src/desktopTest/kotlin/org/maplibre/compose/util/ExpressionEncoderTest.kt
@@ -1,0 +1,191 @@
+package org.maplibre.compose.util
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import org.maplibre.compose.expressions.ast.BooleanLiteral
+import org.maplibre.compose.expressions.ast.ColorLiteral
+import org.maplibre.compose.expressions.ast.CompiledExpression
+import org.maplibre.compose.expressions.ast.CompiledFunctionCall
+import org.maplibre.compose.expressions.ast.CompiledListLiteral
+import org.maplibre.compose.expressions.ast.CompiledMapLiteral
+import org.maplibre.compose.expressions.ast.CompiledOptions
+import org.maplibre.compose.expressions.ast.DpPaddingLiteral
+import org.maplibre.compose.expressions.ast.FloatLiteral
+import org.maplibre.compose.expressions.ast.NullLiteral
+import org.maplibre.compose.expressions.ast.OffsetLiteral
+import org.maplibre.compose.expressions.ast.StringLiteral
+
+class ExpressionEncoderTest {
+
+  @Test
+  fun nullLiteralReturnsJsonNull() {
+    assertEquals("null", NullLiteral.toJsonString())
+  }
+
+  @Test
+  fun floatLiteralEncodesToNumber() {
+    assertEquals("5.0", FloatLiteral.of(5f).toJsonString())
+    assertEquals("0.0", FloatLiteral.of(0f).toJsonString())
+    assertEquals("-3.5", FloatLiteral.of(-3.5f).toJsonString())
+  }
+
+  @Test
+  fun stringLiteralEncodesToJsonString() {
+    assertEquals("\"hello\"", StringLiteral.of("hello").toJsonString())
+    assertEquals("\"\"", StringLiteral.of("").toJsonString())
+    assertEquals("\"with spaces\"", StringLiteral.of("with spaces").toJsonString())
+  }
+
+  @Test
+  fun booleanLiteralEncodesToBoolean() {
+    assertEquals("true", BooleanLiteral.of(true).toJsonString())
+    assertEquals("false", BooleanLiteral.of(false).toJsonString())
+  }
+
+  @Test
+  fun offsetLiteralEncodesToLiteralArray() {
+    val result = OffsetLiteral.of(Offset(10f, 20f)).toJsonString()
+    assertEquals("[\"literal\",[10.0,20.0]]", result)
+  }
+
+  @Test
+  fun offsetZeroEncodesToLiteralArray() {
+    val result = OffsetLiteral.of(Offset.Zero).toJsonString()
+    assertEquals("[\"literal\",[0.0,0.0]]", result)
+  }
+
+  @Test
+  fun colorLiteralEncodesToRgba() {
+    val red = ColorLiteral.of(Color.Red)
+    assertEquals("\"rgba(255, 0, 0, 1.0)\"", red.toJsonString())
+  }
+
+  @Test
+  fun colorTransparentEncodesToRgba() {
+    val transparent = ColorLiteral.of(Color.Transparent)
+    assertEquals("\"rgba(0, 0, 0, 0.0)\"", transparent.toJsonString())
+  }
+
+  @Test
+  fun colorWithAlphaEncodesToRgba() {
+    val color = ColorLiteral.of(Color(0.5f, 0.5f, 0.5f, 0.5f))
+    val result = color.toJsonString()!!
+    // Should start with "rgba(" and end with ")"
+    assert(result.startsWith("\"rgba(")) { "Expected rgba format, got: $result" }
+    assert(result.endsWith(")\"")) { "Expected rgba format, got: $result" }
+    // RGB channels should be 128 (0.5 * 255 ≈ 128)
+    assert("128, 128, 128" in result) { "Expected rgb of 128, got: $result" }
+  }
+
+  @Test
+  fun dpPaddingLiteralEncodesToLiteralArray() {
+    // PaddingValues.Absolute(left, top, right, bottom)
+    // Encoder outputs [top, right, bottom, left] (CSS order)
+    val padding = DpPaddingLiteral.of(PaddingValues.Absolute(4.dp, 1.dp, 2.dp, 3.dp))
+    val result = padding.toJsonString()
+    assertEquals("[\"literal\",[1.0,2.0,3.0,4.0]]", result)
+  }
+
+  @Test
+  fun simpleFunctionCallEncodesToArray() {
+    // ["get", "name"]
+    val expr = CompiledFunctionCall.of("get", listOf(StringLiteral.of("name")))
+    assertEquals("[\"get\",\"name\"]", expr.toJsonString())
+  }
+
+  @Test
+  fun nestedFunctionCallEncodesToNestedArray() {
+    // ["==", ["get", "type"], "park"]
+    val getExpr = CompiledFunctionCall.of("get", listOf(StringLiteral.of("type")))
+    val eqExpr = CompiledFunctionCall.of("==", listOf(getExpr, StringLiteral.of("park")))
+    assertEquals("[\"==\",[\"get\",\"type\"],\"park\"]", eqExpr.toJsonString())
+  }
+
+  @Test
+  fun interpolateExpressionEncodesToArray() {
+    // ["interpolate", ["linear"], ["zoom"], 0, 1, 22, 20]
+    val linear = CompiledFunctionCall.of("linear", emptyList())
+    val zoom = CompiledFunctionCall.of("zoom", emptyList())
+    val expr =
+      CompiledFunctionCall.of(
+        "interpolate",
+        listOf(
+          linear,
+          zoom,
+          FloatLiteral.of(0f),
+          FloatLiteral.of(1f),
+          FloatLiteral.of(22f),
+          FloatLiteral.of(20f),
+        ),
+      )
+    assertEquals("[\"interpolate\",[\"linear\"],[\"zoom\"],0.0,1.0,22.0,20.0]", expr.toJsonString())
+  }
+
+  @Test
+  fun caseExpressionEncodesToArray() {
+    // ["case", ["==", ["get", "type"], "park"], "green", "gray"]
+    val getExpr = CompiledFunctionCall.of("get", listOf(StringLiteral.of("type")))
+    val condition = CompiledFunctionCall.of("==", listOf(getExpr, StringLiteral.of("park")))
+    val expr =
+      CompiledFunctionCall.of(
+        "case",
+        listOf(condition, StringLiteral.of("green"), StringLiteral.of("gray")),
+      )
+    assertEquals(
+      "[\"case\",[\"==\",[\"get\",\"type\"],\"park\"],\"green\",\"gray\"]",
+      expr.toJsonString(),
+    )
+  }
+
+  @Test
+  fun functionCallWithLiteralArgWrapsInLiteral() {
+    // When isLiteralArg returns true for index 0, the arg should be treated as literal context
+    val listArg =
+      CompiledFunctionCall.of(
+        "match",
+        listOf(
+          CompiledFunctionCall.of("get", listOf(StringLiteral.of("type"))),
+          StringLiteral.of("park"),
+          StringLiteral.of("green"),
+          StringLiteral.of("gray"),
+        ),
+      )
+    val result = listArg.toJsonString()
+    assertEquals("[\"match\",[\"get\",\"type\"],\"park\",\"green\",\"gray\"]", result)
+  }
+
+  @Test
+  fun compiledListLiteralEncodesToLiteralArray() {
+    val list =
+      CompiledListLiteral.of(
+        listOf(StringLiteral.of("a"), StringLiteral.of("b"), StringLiteral.of("c"))
+      )
+    assertEquals("[\"literal\",[\"a\",\"b\",\"c\"]]", list.toJsonString())
+  }
+
+  @Test
+  fun compiledMapLiteralEncodesToLiteralObject() {
+    val map =
+      CompiledMapLiteral.of(
+        mapOf("key" to StringLiteral.of("value"), "num" to FloatLiteral.of(42f))
+      )
+    assertEquals("[\"literal\",{\"key\":\"value\",\"num\":42.0}]", map.toJsonString())
+  }
+
+  @Test
+  fun compiledOptionsEncodesToPlainObject() {
+    @Suppress("UNCHECKED_CAST")
+    val opts =
+      CompiledOptions.of(
+        mapOf(
+          "font-scale" to FloatLiteral.of(1.2f) as CompiledExpression<Nothing>,
+          "text-font" to StringLiteral.of("Arial") as CompiledExpression<Nothing>,
+        )
+      )
+    assertEquals("{\"font-scale\":1.2,\"text-font\":\"Arial\"}", opts.toJsonString())
+  }
+}

--- a/lib/maplibre-native-bindings-jni/cmake/dependencies/maplibre-native.cmake
+++ b/lib/maplibre-native-bindings-jni/cmake/dependencies/maplibre-native.cmake
@@ -4,7 +4,10 @@
 # So we use git submodules instead and add_subdirectory() AFTER project()
 
 add_subdirectory(${maplibre-native_SOURCE_DIR} EXCLUDE_FROM_ALL SYSTEM)
-target_include_directories(maplibre-jni SYSTEM PRIVATE ${maplibre-native_SOURCE_DIR}/include)
+target_include_directories(maplibre-jni SYSTEM PRIVATE
+    ${maplibre-native_SOURCE_DIR}/include
+    ${maplibre-native_SOURCE_DIR}/src
+)
 target_link_libraries(maplibre-jni PRIVATE
     Mapbox::Map
     mbgl-compiler-options

--- a/lib/maplibre-native-bindings-jni/src/main/cpp/canvas_frontend.cpp
+++ b/lib/maplibre-native-bindings-jni/src/main/cpp/canvas_frontend.cpp
@@ -71,6 +71,22 @@ void CanvasRenderer::runOnce() { runLoop_->runOnce(); }
 
 void CanvasRenderer::setSize(mbgl::Size size) { backend_->setSize(size); }
 
+std::vector<mbgl::Feature> CanvasRenderer::queryRenderedFeaturesAtPoint(
+  mbgl::ScreenCoordinate point,
+  mbgl::RenderedQueryOptions options
+) {
+  if (!renderer_) return {};
+  return renderer_->queryRenderedFeatures(point, options);
+}
+
+std::vector<mbgl::Feature> CanvasRenderer::queryRenderedFeaturesInBox(
+  mbgl::ScreenBox box,
+  mbgl::RenderedQueryOptions options
+) {
+  if (!renderer_) return {};
+  return renderer_->queryRenderedFeatures(box, options);
+}
+
 }  // namespace maplibre_jni
 
 void JNICALL

--- a/lib/maplibre-native-bindings-jni/src/main/cpp/canvas_renderer.hpp
+++ b/lib/maplibre-native-bindings-jni/src/main/cpp/canvas_renderer.hpp
@@ -4,6 +4,8 @@
 #include <mbgl/gfx/backend_scope.hpp>
 #include <mbgl/gfx/renderable.hpp>
 #include <mbgl/gfx/renderer_backend.hpp>
+#include <mbgl/map/map.hpp>
+#include <mbgl/renderer/query.hpp>
 #include <mbgl/renderer/renderer_frontend.hpp>
 #include <mbgl/renderer/renderer_observer.hpp>
 #include <mbgl/util/run_loop.hpp>
@@ -74,6 +76,16 @@ class CanvasRenderer : public mbgl::RendererFrontend {
   const mbgl::TaggedScheduler& getThreadPool() const override;
   void setSize(mbgl::Size size);
   void runOnce();
+
+  std::vector<mbgl::Feature> queryRenderedFeaturesAtPoint(
+    mbgl::ScreenCoordinate point,
+    mbgl::RenderedQueryOptions options
+  );
+
+  std::vector<mbgl::Feature> queryRenderedFeaturesInBox(
+    mbgl::ScreenBox box,
+    mbgl::RenderedQueryOptions options
+  );
 
  private:
   std::unique_ptr<mbgl::util::RunLoop> runLoop_;

--- a/lib/maplibre-native-bindings-jni/src/main/cpp/canvas_renderer.hpp
+++ b/lib/maplibre-native-bindings-jni/src/main/cpp/canvas_renderer.hpp
@@ -108,6 +108,7 @@ class CanvasRenderer : public mbgl::RendererFrontend {
 
  public:
   void render();
+  mbgl::Renderer* getRenderer() const { return renderer_.get(); }
 };
 
 }  // namespace maplibre_jni

--- a/lib/maplibre-native-bindings-jni/src/main/cpp/maplibre_map.cpp
+++ b/lib/maplibre-native-bindings-jni/src/main/cpp/maplibre_map.cpp
@@ -5,12 +5,26 @@
 #include <mbgl/storage/resource_options.hpp>
 #include <mbgl/style/style.hpp>
 #include <mbgl/util/client_options.hpp>
+#include <mbgl/util/image.hpp>
+
+// Style manipulation via JSON conversion
+#include <mbgl/style/conversion/json.hpp>
+#include <mbgl/style/conversion/layer.hpp>
+#include <mbgl/style/conversion/source.hpp>
+#include <mbgl/style/image.hpp>
+#include <mbgl/style/layers/background_layer.hpp>
+#include <mbgl/style/source.hpp>
+#include <mbgl/style/sources/geojson_source.hpp>
+
+// GeoJSON / feature serialization
+#include <mapbox/geojson.hpp>
 
 #include <jni.h>
 #include <smjni/java_exception.h>
 
 #include <MapLibreMap_class.h>
 
+#include "canvas_renderer.hpp"
 #include "conversions.hpp"
 #include "java_classes.hpp"
 #include "jni_map_observer.hpp"
@@ -20,6 +34,7 @@
 struct MapWrapper {
   std::unique_ptr<mbgl::Map> map;
   std::unique_ptr<maplibre_jni::JniMapObserver> observer;
+  maplibre_jni::CanvasRenderer* renderer{nullptr};  // non-owning
 
   MapWrapper(mbgl::Map* map, maplibre_jni::JniMapObserver* observer)
       : map(map), observer(observer) {}
@@ -527,6 +542,246 @@ MapLibreMap_class::getTileLodZoomShiftNative(JNIEnv* env, jMapLibreMap map)
 // TODO: wrap ActionJournal
 // const std::unique_ptr<util::ActionJournal>& getActionJournal();
 
+#pragma mark - Style manipulation
+
+void JNICALL MapLibreMap_class::addLayerJson(
+  JNIEnv* env, jMapLibreMap map,
+  jstring layerJson, jstring beforeLayerIdOrNull
+) {
+  withMapWrapper(env, map, [env, layerJson, beforeLayerIdOrNull](auto wrapper) {
+    std::string json = smjni::java_string_to_cpp(env, layerJson);
+    mbgl::style::conversion::Error error;
+    auto layer = mbgl::style::conversion::convertJSON<
+      std::unique_ptr<mbgl::style::Layer>>(json, error);
+    if (!layer) {
+      throw std::runtime_error("Failed to parse layer JSON: " + error.message);
+    }
+    std::optional<std::string> beforeId;
+    if (beforeLayerIdOrNull) {
+      beforeId = smjni::java_string_to_cpp(env, beforeLayerIdOrNull);
+    }
+    wrapper->map->getStyle().addLayer(std::move(*layer), beforeId);
+  });
+}
+
+void JNICALL MapLibreMap_class::removeLayer(
+  JNIEnv* env, jMapLibreMap map, jstring layerId
+) {
+  withMapWrapper(env, map, [env, layerId](auto wrapper) {
+    wrapper->map->getStyle().removeLayer(
+      smjni::java_string_to_cpp(env, layerId)
+    );
+  });
+}
+
+auto JNICALL MapLibreMap_class::getLayerIds(JNIEnv* env, jMapLibreMap map)
+  -> jstringArray {
+  return reinterpret_cast<jstringArray>(
+    withMapWrapper(env, map, [env](auto wrapper) -> jobjectArray {
+      const auto& layers = wrapper->map->getStyle().getLayers();
+      auto arr = env->NewObjectArray(
+        static_cast<jsize>(layers.size()),
+        env->FindClass("java/lang/String"),
+        nullptr
+      );
+      for (jsize i = 0; i < static_cast<jsize>(layers.size()); i++) {
+        auto str = smjni::java_string_create(env, layers[i]->getID());
+        env->SetObjectArrayElement(arr, i, str.c_ptr());
+      }
+      return arr;
+    })
+  );
+}
+
+auto JNICALL MapLibreMap_class::getStyleJson(JNIEnv* env, jMapLibreMap map)
+  -> jstring {
+  return withMapWrapper(env, map, [env](auto wrapper) -> jstring {
+    return smjni::java_string_create(
+      env, wrapper->map->getStyle().getJSON()
+    ).release();
+  });
+}
+
+void JNICALL MapLibreMap_class::addSourceJson(
+  JNIEnv* env, jMapLibreMap map, jstring sourceId, jstring sourceJson
+) {
+  withMapWrapper(env, map, [env, sourceId, sourceJson](auto wrapper) {
+    std::string id = smjni::java_string_to_cpp(env, sourceId);
+    std::string json = smjni::java_string_to_cpp(env, sourceJson);
+    mbgl::style::conversion::Error error;
+    auto source = mbgl::style::conversion::convertJSON<
+      std::unique_ptr<mbgl::style::Source>>(json, error, id);
+    if (!source) {
+      throw std::runtime_error("Failed to parse source JSON: " + error.message);
+    }
+    wrapper->map->getStyle().addSource(std::move(*source));
+  });
+}
+
+void JNICALL MapLibreMap_class::removeSource(
+  JNIEnv* env, jMapLibreMap map, jstring sourceId
+) {
+  withMapWrapper(env, map, [env, sourceId](auto wrapper) {
+    wrapper->map->getStyle().removeSource(
+      smjni::java_string_to_cpp(env, sourceId)
+    );
+  });
+}
+
+void JNICALL MapLibreMap_class::setGeoJsonData(
+  JNIEnv* env, jMapLibreMap map, jstring sourceId, jstring geoJson
+) {
+  withMapWrapper(env, map, [env, sourceId, geoJson](auto wrapper) {
+    std::string id = smjni::java_string_to_cpp(env, sourceId);
+    auto* source = wrapper->map->getStyle().getSource(id);
+    if (!source) {
+      throw std::runtime_error("Source not found: " + id);
+    }
+    auto* geoJsonSource = source->template as<mbgl::style::GeoJSONSource>();
+    if (!geoJsonSource) {
+      throw std::runtime_error("Source is not a GeoJSON source: " + id);
+    }
+    std::string json = smjni::java_string_to_cpp(env, geoJson);
+    geoJsonSource->setGeoJSON(mapbox::geojson::parse(json));
+  });
+}
+
+auto JNICALL MapLibreMap_class::getSourceIds(JNIEnv* env, jMapLibreMap map)
+  -> jstringArray {
+  return reinterpret_cast<jstringArray>(
+    withMapWrapper(env, map, [env](auto wrapper) -> jobjectArray {
+      const auto& sources = wrapper->map->getStyle().getSources();
+      auto arr = env->NewObjectArray(
+        static_cast<jsize>(sources.size()),
+        env->FindClass("java/lang/String"),
+        nullptr
+      );
+      for (jsize i = 0; i < static_cast<jsize>(sources.size()); i++) {
+        auto str = smjni::java_string_create(env, sources[i]->getID());
+        env->SetObjectArrayElement(arr, i, str.c_ptr());
+      }
+      return arr;
+    })
+  );
+}
+
+void JNICALL MapLibreMap_class::addStyleImage(
+  JNIEnv* env, jMapLibreMap map,
+  jstring id, jint width, jint height, jbyteArray pixels,
+  jfloat scale, jboolean sdf,
+  jfloat contentLeft, jfloat contentTop,
+  jfloat contentRight, jfloat contentBottom
+) {
+  withMapWrapper(env, map, [&](auto wrapper) {
+    jsize len = env->GetArrayLength(pixels);
+    auto* raw = env->GetByteArrayElements(pixels, nullptr);
+
+    mbgl::PremultipliedImage image(
+      { static_cast<uint32_t>(width), static_cast<uint32_t>(height) }
+    );
+    std::memcpy(image.data.get(), raw, static_cast<size_t>(len));
+    env->ReleaseByteArrayElements(pixels, raw, JNI_ABORT);
+
+    std::optional<mbgl::style::ImageContent> content =
+      mbgl::style::ImageContent{contentLeft, contentTop, contentRight, contentBottom};
+    auto styleImage = std::make_unique<mbgl::style::Image>(
+      smjni::java_string_to_cpp(env, id),
+      std::move(image),
+      static_cast<float>(scale),
+      static_cast<bool>(sdf),
+      mbgl::style::ImageStretches{},
+      mbgl::style::ImageStretches{},
+      content
+    );
+    wrapper->map->getStyle().addImage(std::move(styleImage));
+  });
+}
+
+void JNICALL MapLibreMap_class::removeStyleImage(
+  JNIEnv* env, jMapLibreMap map, jstring id
+) {
+  withMapWrapper(env, map, [env, id](auto wrapper) {
+    wrapper->map->getStyle().removeImage(
+      smjni::java_string_to_cpp(env, id)
+    );
+  });
+}
+
+// Serializes a vector of mbgl::Feature to a GeoJSON FeatureCollection string.
+static std::string featuresToJson(const std::vector<mbgl::Feature>& features) {
+  mapbox::geojson::feature_collection fc;
+  fc.reserve(features.size());
+  for (const auto& f : features) {
+    fc.push_back(mapbox::geojson::feature{f.geometry, f.properties, f.id});
+  }
+  return mapbox::geojson::stringify(fc);
+}
+
+// Parses a JSON array of strings (e.g. ["a","b"]) into a vector.
+static std::vector<std::string> parseJsonStringArray(const std::string& json) {
+  std::vector<std::string> result;
+  size_t pos = 0;
+  while ((pos = json.find('"', pos)) != std::string::npos) {
+    size_t end = json.find('"', pos + 1);
+    if (end == std::string::npos) break;
+    result.push_back(json.substr(pos + 1, end - pos - 1));
+    pos = end + 1;
+  }
+  return result;
+}
+
+auto JNICALL MapLibreMap_class::queryRenderedFeaturesAtPoint(
+  JNIEnv* env, jMapLibreMap map,
+  jfloat x, jfloat y, jstring layerIdsJsonOrNull
+) -> jstring {
+  return withMapWrapper(env, map, [&](auto wrapper) -> jstring {
+    if (!wrapper->renderer) {
+      return smjni::java_string_create(
+        env, R"({"type":"FeatureCollection","features":[]})"
+      ).release();
+    }
+    mbgl::RenderedQueryOptions options;
+    if (layerIdsJsonOrNull) {
+      options.layerIDs = parseJsonStringArray(
+        smjni::java_string_to_cpp(env, layerIdsJsonOrNull)
+      );
+    }
+    auto features = wrapper->renderer->queryRenderedFeaturesAtPoint(
+      mbgl::ScreenCoordinate{static_cast<double>(x), static_cast<double>(y)},
+      options
+    );
+    return smjni::java_string_create(env, featuresToJson(features)).release();
+  });
+}
+
+auto JNICALL MapLibreMap_class::queryRenderedFeaturesInBox(
+  JNIEnv* env, jMapLibreMap map,
+  jfloat x1, jfloat y1, jfloat x2, jfloat y2,
+  jstring layerIdsJsonOrNull
+) -> jstring {
+  return withMapWrapper(env, map, [&](auto wrapper) -> jstring {
+    if (!wrapper->renderer) {
+      return smjni::java_string_create(
+        env, R"({"type":"FeatureCollection","features":[]})"
+      ).release();
+    }
+    mbgl::RenderedQueryOptions options;
+    if (layerIdsJsonOrNull) {
+      options.layerIDs = parseJsonStringArray(
+        smjni::java_string_to_cpp(env, layerIdsJsonOrNull)
+      );
+    }
+    auto features = wrapper->renderer->queryRenderedFeaturesInBox(
+      mbgl::ScreenBox{
+        {static_cast<double>(x1), static_cast<double>(y1)},
+        {static_cast<double>(x2), static_cast<double>(y2)}
+      },
+      options
+    );
+    return smjni::java_string_create(env, featuresToJson(features)).release();
+  });
+}
+
 #pragma mark - Allocation
 
 auto JNICALL MapLibreMap_class::nativeInit(
@@ -536,7 +791,7 @@ auto JNICALL MapLibreMap_class::nativeInit(
 ) -> jlong {
   try {
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-    auto* renderer = reinterpret_cast<mbgl::RendererFrontend*>(frontendPointer);
+    auto* frontend = reinterpret_cast<mbgl::RendererFrontend*>(frontendPointer);
     auto observer = std::make_unique<maplibre_jni::JniMapObserver>(observerObj);
     mbgl::MapOptions mapOptions =
       maplibre_jni::convertMapOptions(env, optionsObj);
@@ -545,7 +800,7 @@ auto JNICALL MapLibreMap_class::nativeInit(
     mbgl::ClientOptions clientOptions =
       maplibre_jni::convertClientOptions(env, clientOptionsObj);
     auto map = std::make_unique<mbgl::Map>(
-      *renderer, *observer, mapOptions, resourceOptions, clientOptions
+      *frontend, *observer, mapOptions, resourceOptions, clientOptions
     );
 
     // Get network file source for HTTP downloads
@@ -566,10 +821,15 @@ auto JNICALL MapLibreMap_class::nativeInit(
         mbgl::FileSourceType::Database, resourceOptions, clientOptions
       );
 
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-    return reinterpret_cast<jlong>(
+    // All fallible work is done; take ownership and store the renderer pointer.
+    auto wrapper = std::unique_ptr<MapWrapper>(
       new MapWrapper(map.release(), observer.release())
     );
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    wrapper->renderer = reinterpret_cast<maplibre_jni::CanvasRenderer*>(frontendPointer);
+
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    return reinterpret_cast<jlong>(wrapper.release());
   } catch (const std::exception& e) {
     smjni::java_exception::translate(env, e);
     return 0;

--- a/lib/maplibre-native-bindings-jni/src/main/cpp/maplibre_map.cpp
+++ b/lib/maplibre-native-bindings-jni/src/main/cpp/maplibre_map.cpp
@@ -1,16 +1,49 @@
+#include <unordered_map>
+
 #include <mbgl/map/map.hpp>
 #include <mbgl/map/map_options.hpp>
+#include <mbgl/renderer/query.hpp>
+#include <mbgl/renderer/renderer.hpp>
 #include <mbgl/storage/file_source.hpp>
 #include <mbgl/storage/file_source_manager.hpp>
 #include <mbgl/storage/resource_options.hpp>
+#include <mbgl/style/conversion/filter.hpp>
+#include <mbgl/style/conversion/geojson.hpp>
+#include <mbgl/style/conversion/json.hpp>
+#include <mbgl/style/conversion_impl.hpp>
+#include <mbgl/style/image.hpp>
+#include <mbgl/style/layers/background_layer.hpp>
+#include <mbgl/style/layers/circle_layer.hpp>
+#include <mbgl/style/layers/fill_extrusion_layer.hpp>
+#include <mbgl/style/layers/fill_layer.hpp>
+#include <mbgl/style/layers/heatmap_layer.hpp>
+#include <mbgl/style/layers/hillshade_layer.hpp>
+#include <mbgl/style/layers/line_layer.hpp>
+#include <mbgl/style/layers/raster_layer.hpp>
+#include <mbgl/style/layers/symbol_layer.hpp>
+#include <mbgl/style/sources/geojson_source.hpp>
+#include <mbgl/style/sources/image_source.hpp>
+#include <mbgl/style/sources/raster_dem_source.hpp>
+#include <mbgl/style/sources/raster_source.hpp>
+#include <mbgl/style/sources/vector_source.hpp>
 #include <mbgl/style/style.hpp>
 #include <mbgl/util/client_options.hpp>
+#include <mbgl/util/feature.hpp>
+#include <mbgl/util/geojson.hpp>
+#include <mbgl/util/immutable.hpp>
+#include <mbgl/util/premultiply.hpp>
+#include <mbgl/util/rapidjson.hpp>
+#include <mbgl/util/tileset.hpp>
 
 #include <jni.h>
+#include <mapbox/geojson.hpp>
+#include <mapbox/geojson_impl.hpp>
 #include <smjni/java_exception.h>
+#include <smjni/java_string.h>
 
 #include <MapLibreMap_class.h>
 
+#include "canvas_renderer.hpp"
 #include "conversions.hpp"
 #include "java_classes.hpp"
 #include "jni_map_observer.hpp"
@@ -20,9 +53,15 @@
 struct MapWrapper {
   std::unique_ptr<maplibre_jni::JniMapObserver> observer;
   std::unique_ptr<mbgl::Map> map;
+  maplibre_jni::CanvasRenderer* renderer;
+  std::unordered_map<std::string, std::unique_ptr<mbgl::style::Layer>>
+    preservedLayers;
 
-  MapWrapper(mbgl::Map* map, maplibre_jni::JniMapObserver* observer)
-      : observer(observer), map(map) {}
+  MapWrapper(
+    mbgl::Map* map, maplibre_jni::JniMapObserver* observer,
+    maplibre_jni::CanvasRenderer* renderer
+  )
+      : observer(observer), map(map), renderer(renderer) {}
 };
 
 template <typename Func>
@@ -39,6 +78,141 @@ auto withMapWrapper(JNIEnv* env, jMapLibreMap map, Func&& func)
     smjni::java_exception::translate(env, e);
     if constexpr (!std::is_void_v<ReturnType>) return ReturnType{};
   }
+}
+
+static mbgl::style::Layer* getLayerOrThrow(
+  MapWrapper* wrapper, const std::string& id
+) {
+  auto* layer = wrapper->map->getStyle().getLayer(id);
+  if (!layer) throw std::runtime_error("Layer not found: " + id);
+  return layer;
+}
+
+static double getJsonNumber(const mbgl::JSValue& v, double def = 0.0) {
+  if (v.IsDouble()) return v.GetDouble();
+  if (v.IsInt()) return static_cast<double>(v.GetInt());
+  if (v.IsUint()) return static_cast<double>(v.GetUint());
+  if (v.IsInt64()) return static_cast<double>(v.GetInt64());
+  if (v.IsUint64()) return static_cast<double>(v.GetUint64());
+  return def;
+}
+
+static mbgl::Tileset parseTileset(const mbgl::JSValue& config) {
+  mbgl::Tileset tileset;
+  if (!config.IsObject()) return tileset;
+
+  if (config.HasMember("tiles") && config["tiles"].IsArray()) {
+    for (const auto& t : config["tiles"].GetArray()) {
+      if (t.IsString())
+        tileset.tiles.emplace_back(t.GetString(), t.GetStringLength());
+    }
+  }
+
+  if (config.HasMember("minzoom"))
+    tileset.zoomRange.min =
+      static_cast<uint8_t>(getJsonNumber(config["minzoom"]));
+  if (config.HasMember("maxzoom"))
+    tileset.zoomRange.max =
+      static_cast<uint8_t>(getJsonNumber(config["maxzoom"]));
+
+  if (config.HasMember("scheme") && config["scheme"].IsString()) {
+    if (std::string(config["scheme"].GetString()) == "tms")
+      tileset.scheme = mbgl::Tileset::Scheme::TMS;
+  }
+
+  if (config.HasMember("attribution") && config["attribution"].IsString())
+    tileset.attribution = std::string(config["attribution"].GetString());
+
+  if (config.HasMember("encoding") && config["encoding"].IsString()) {
+    if (std::string(config["encoding"].GetString()) == "terrarium")
+      tileset.encoding = mbgl::Tileset::DEMEncoding::Terrarium;
+  }
+
+  if (config.HasMember("bounds") && config["bounds"].IsArray()) {
+    const auto& arr = config["bounds"].GetArray();
+    if (arr.Size() == 4) {
+      double w = getJsonNumber(arr[0]);
+      double s = getJsonNumber(arr[1]);
+      double e = getJsonNumber(arr[2]);
+      double n = getJsonNumber(arr[3]);
+      tileset.bounds =
+        mbgl::LatLngBounds::hull(mbgl::LatLng(s, w), mbgl::LatLng(n, e));
+    }
+  }
+
+  return tileset;
+}
+
+static uint16_t parseTileSize(const mbgl::JSValue& config) {
+  if (config.IsObject() && config.HasMember("tileSize"))
+    return static_cast<uint16_t>(getJsonNumber(config["tileSize"], 512));
+  return 512;
+}
+
+static std::unique_ptr<mbgl::style::Source> createTileSource(
+  const std::string& type, const std::string& id, const std::string& configJson
+) {
+  mbgl::JSDocument document;
+  document.Parse<0>(configJson.c_str());
+  if (document.HasParseError()) {
+    throw std::runtime_error("Failed to parse tile source config JSON");
+  }
+
+  // If config is a simple string, it's a URL
+  if (document.IsString()) {
+    std::string url(document.GetString(), document.GetStringLength());
+    if (type == "vector")
+      return std::make_unique<mbgl::style::VectorSource>(id, url);
+    if (type == "raster")
+      return std::make_unique<mbgl::style::RasterSource>(
+        id, url, uint16_t(512)
+      );
+    return std::make_unique<mbgl::style::RasterDEMSource>(
+      id, url, uint16_t(512)
+    );
+  }
+
+  // Otherwise parse as tileset config object
+  if (document.IsObject()) {
+    auto tileSize = parseTileSize(document);
+
+    // Object with "url" key = URL source with options (e.g. tileSize)
+    if (document.HasMember("url") && document["url"].IsString()) {
+      std::string url(
+        document["url"].GetString(), document["url"].GetStringLength()
+      );
+      if (type == "vector")
+        return std::make_unique<mbgl::style::VectorSource>(id, url);
+      if (type == "raster")
+        return std::make_unique<mbgl::style::RasterSource>(id, url, tileSize);
+      return std::make_unique<mbgl::style::RasterDEMSource>(id, url, tileSize);
+    }
+
+    // Object with "tiles" array = tileset config
+    auto tileset = parseTileset(document);
+    if (type == "vector")
+      return std::make_unique<mbgl::style::VectorSource>(
+        id, std::move(tileset)
+      );
+    if (type == "raster")
+      return std::make_unique<mbgl::style::RasterSource>(
+        id, std::move(tileset), tileSize
+      );
+    return std::make_unique<mbgl::style::RasterDEMSource>(
+      id, std::move(tileset), tileSize
+    );
+  }
+
+  // Fallback
+  if (type == "vector")
+    return std::make_unique<mbgl::style::VectorSource>(id, std::string());
+  if (type == "raster")
+    return std::make_unique<mbgl::style::RasterSource>(
+      id, std::string(), uint16_t(512)
+    );
+  return std::make_unique<mbgl::style::RasterDEMSource>(
+    id, std::string(), uint16_t(512)
+  );
 }
 
 #pragma mark - Rendering
@@ -73,6 +247,706 @@ MapLibreMap_class::loadStyleJSON(JNIEnv* env, jMapLibreMap map, jstring json) {
   withMapWrapper(env, map, [env, json](auto wrapper) {
     wrapper->map->getStyle().loadJSON(smjni::java_string_to_cpp(env, json));
   });
+}
+
+#pragma mark - Style Layers
+
+static std::unique_ptr<mbgl::style::Layer> createLayerByType(
+  const std::string& type, const std::string& id, const std::string& sourceId
+) {
+  if (type == "circle")
+    return std::make_unique<mbgl::style::CircleLayer>(id, sourceId);
+  if (type == "line")
+    return std::make_unique<mbgl::style::LineLayer>(id, sourceId);
+  if (type == "fill")
+    return std::make_unique<mbgl::style::FillLayer>(id, sourceId);
+  if (type == "symbol")
+    return std::make_unique<mbgl::style::SymbolLayer>(id, sourceId);
+  if (type == "raster")
+    return std::make_unique<mbgl::style::RasterLayer>(id, sourceId);
+  if (type == "hillshade")
+    return std::make_unique<mbgl::style::HillshadeLayer>(id, sourceId);
+  if (type == "heatmap")
+    return std::make_unique<mbgl::style::HeatmapLayer>(id, sourceId);
+  if (type == "fill-extrusion")
+    return std::make_unique<mbgl::style::FillExtrusionLayer>(id, sourceId);
+  if (type == "background")
+    return std::make_unique<mbgl::style::BackgroundLayer>(id);
+  throw std::runtime_error("Unknown layer type: " + type);
+}
+
+void JNICALL MapLibreMap_class::addStyleLayer(
+  JNIEnv* env, jMapLibreMap map, jstring type, jstring id, jstring sourceId,
+  jstring beforeId
+) {
+  withMapWrapper(env, map, [env, type, id, sourceId, beforeId](auto wrapper) {
+    auto cppType = smjni::java_string_to_cpp(env, type);
+    auto cppId = smjni::java_string_to_cpp(env, id);
+    auto cppSourceId = sourceId != nullptr
+                         ? smjni::java_string_to_cpp(env, sourceId)
+                         : std::string();
+
+    auto layer = createLayerByType(cppType, cppId, cppSourceId);
+
+    std::optional<std::string> before = std::nullopt;
+    if (beforeId != nullptr) {
+      before = smjni::java_string_to_cpp(env, beforeId);
+    }
+    wrapper->map->getStyle().addLayer(std::move(layer), before);
+    // Clean up any stale preserved copy with this ID
+    wrapper->preservedLayers.erase(cppId);
+  });
+}
+
+void JNICALL
+MapLibreMap_class::removeStyleLayer(JNIEnv* env, jMapLibreMap map, jstring id) {
+  withMapWrapper(env, map, [env, id](auto wrapper) {
+    auto cppId = smjni::java_string_to_cpp(env, id);
+    auto removed = wrapper->map->getStyle().removeLayer(cppId);
+    if (removed) {
+      wrapper->preservedLayers[cppId] = std::move(removed);
+    }
+  });
+}
+
+void JNICALL MapLibreMap_class::restoreStyleLayer(
+  JNIEnv* env, jMapLibreMap map, jstring id, jstring beforeId
+) {
+  withMapWrapper(env, map, [env, id, beforeId](auto wrapper) {
+    auto cppId = smjni::java_string_to_cpp(env, id);
+    auto it = wrapper->preservedLayers.find(cppId);
+    if (it == wrapper->preservedLayers.end()) {
+      throw std::runtime_error("No preserved layer: " + cppId);
+    }
+    auto layer = std::move(it->second);
+    wrapper->preservedLayers.erase(it);
+    std::optional<std::string> before = std::nullopt;
+    if (beforeId != nullptr) {
+      before = smjni::java_string_to_cpp(env, beforeId);
+    }
+    wrapper->map->getStyle().addLayer(std::move(layer), before);
+  });
+}
+
+void JNICALL MapLibreMap_class::setStyleLayerProperty(
+  JNIEnv* env, jMapLibreMap map, jstring layerId, jstring propertyName,
+  jstring valueJson
+) {
+  withMapWrapper(
+    env, map, [env, layerId, propertyName, valueJson](auto wrapper) {
+      auto cppLayerId = smjni::java_string_to_cpp(env, layerId);
+      auto cppName = smjni::java_string_to_cpp(env, propertyName);
+      auto cppJson = smjni::java_string_to_cpp(env, valueJson);
+
+      auto* layer = getLayerOrThrow(wrapper, cppLayerId);
+
+      mbgl::JSDocument document;
+      document.Parse<0>(cppJson.c_str());
+      if (document.HasParseError()) {
+        throw std::runtime_error(
+          "Failed to parse property JSON: " +
+          mbgl::formatJSONParseError(document)
+        );
+      }
+
+      const mbgl::JSValue* value = &document;
+      mbgl::style::conversion::Convertible convertible(value);
+      auto setError = layer->setProperty(cppName, convertible);
+      if (setError) {
+        throw std::runtime_error(
+          "Failed to set property '" + cppName + "': " + setError->message
+        );
+      }
+    }
+  );
+}
+
+void JNICALL MapLibreMap_class::setStyleLayerVisible(
+  JNIEnv* env, jMapLibreMap map, jstring layerId, jboolean visible
+) {
+  withMapWrapper(env, map, [env, layerId, visible](auto wrapper) {
+    auto cppLayerId = smjni::java_string_to_cpp(env, layerId);
+    auto* layer = getLayerOrThrow(wrapper, cppLayerId);
+    layer->setVisibility(
+      visible ? mbgl::style::VisibilityType::Visible
+              : mbgl::style::VisibilityType::None
+    );
+  });
+}
+
+void JNICALL MapLibreMap_class::setStyleLayerMinZoom(
+  JNIEnv* env, jMapLibreMap map, jstring layerId, jfloat minZoom
+) {
+  withMapWrapper(env, map, [env, layerId, minZoom](auto wrapper) {
+    auto cppLayerId = smjni::java_string_to_cpp(env, layerId);
+    getLayerOrThrow(wrapper, cppLayerId)->setMinZoom(minZoom);
+  });
+}
+
+void JNICALL MapLibreMap_class::setStyleLayerMaxZoom(
+  JNIEnv* env, jMapLibreMap map, jstring layerId, jfloat maxZoom
+) {
+  withMapWrapper(env, map, [env, layerId, maxZoom](auto wrapper) {
+    auto cppLayerId = smjni::java_string_to_cpp(env, layerId);
+    getLayerOrThrow(wrapper, cppLayerId)->setMaxZoom(maxZoom);
+  });
+}
+
+void JNICALL MapLibreMap_class::setStyleLayerSourceLayer(
+  JNIEnv* env, jMapLibreMap map, jstring layerId, jstring sourceLayer
+) {
+  withMapWrapper(env, map, [env, layerId, sourceLayer](auto wrapper) {
+    auto cppLayerId = smjni::java_string_to_cpp(env, layerId);
+    auto cppSourceLayer = smjni::java_string_to_cpp(env, sourceLayer);
+    getLayerOrThrow(wrapper, cppLayerId)->setSourceLayer(cppSourceLayer);
+  });
+}
+
+void JNICALL MapLibreMap_class::setStyleLayerFilter(
+  JNIEnv* env, jMapLibreMap map, jstring layerId, jstring filterJson
+) {
+  withMapWrapper(env, map, [env, layerId, filterJson](auto wrapper) {
+    auto cppLayerId = smjni::java_string_to_cpp(env, layerId);
+    auto cppJson = smjni::java_string_to_cpp(env, filterJson);
+    auto* layer = getLayerOrThrow(wrapper, cppLayerId);
+
+    mbgl::style::conversion::Error error;
+    auto filter =
+      mbgl::style::conversion::convertJSON<mbgl::style::Filter>(cppJson, error);
+    if (!filter) {
+      throw std::runtime_error("Failed to parse filter JSON: " + error.message);
+    }
+    layer->setFilter(*filter);
+  });
+}
+
+#pragma mark - Style Sources
+
+void JNICALL MapLibreMap_class::addStyleSource(
+  JNIEnv* env, jMapLibreMap map, jstring type, jstring id, jstring configJson
+) {
+  withMapWrapper(env, map, [env, type, id, configJson](auto wrapper) {
+    auto cppType = smjni::java_string_to_cpp(env, type);
+    auto cppId = smjni::java_string_to_cpp(env, id);
+    auto cppJson = configJson != nullptr
+                     ? smjni::java_string_to_cpp(env, configJson)
+                     : std::string("{}");
+
+    std::unique_ptr<mbgl::style::Source> source;
+
+    if (cppType == "geojson") {
+      // Parse GeoJSON options from configJson if provided
+      auto gjOptions = mbgl::style::GeoJSONOptions{};
+      if (cppJson != "{}") {
+        mbgl::JSDocument doc;
+        doc.Parse<0>(cppJson.c_str());
+        if (!doc.HasParseError() && doc.IsObject()) {
+          auto getInt = [&doc](const char* key, int def) -> int {
+            if (doc.HasMember(key))
+              return static_cast<int>(getJsonNumber(doc[key], def));
+            return def;
+          };
+          auto getBool = [&doc](const char* key, bool def) -> bool {
+            if (doc.HasMember(key) && doc[key].IsBool())
+              return doc[key].GetBool();
+            return def;
+          };
+          auto getFloat = [&doc](const char* key, double def) -> double {
+            if (doc.HasMember(key)) return getJsonNumber(doc[key], def);
+            return def;
+          };
+          gjOptions.minzoom = static_cast<uint8_t>(getInt("minzoom", 0));
+          gjOptions.maxzoom = static_cast<uint8_t>(getInt("maxzoom", 18));
+          gjOptions.buffer = static_cast<uint16_t>(getInt("buffer", 128));
+          gjOptions.tolerance = getFloat("tolerance", 0.375);
+          gjOptions.cluster = getBool("cluster", false);
+          gjOptions.clusterRadius =
+            static_cast<uint16_t>(getInt("clusterRadius", 50));
+          gjOptions.clusterMaxZoom =
+            static_cast<uint8_t>(getInt("clusterMaxZoom", 17));
+          gjOptions.clusterMinPoints =
+            static_cast<uint8_t>(getInt("clusterMinPoints", 2));
+          gjOptions.lineMetrics = getBool("lineMetrics", false);
+        }
+      }
+      source = std::make_unique<mbgl::style::GeoJSONSource>(
+        cppId,
+        mbgl::Immutable<mbgl::style::GeoJSONOptions>(
+          mbgl::makeMutable<mbgl::style::GeoJSONOptions>(std::move(gjOptions))
+        )
+      );
+    } else if (cppType == "vector" || cppType == "raster" ||
+               cppType == "raster-dem") {
+      source = createTileSource(cppType, cppId, cppJson);
+    } else if (cppType == "image") {
+      source = std::make_unique<mbgl::style::ImageSource>(
+        cppId, std::array<mbgl::LatLng, 4>()
+      );
+    } else {
+      throw std::runtime_error("Unknown source type: " + cppType);
+    }
+
+    wrapper->map->getStyle().addSource(std::move(source));
+  });
+}
+
+void JNICALL MapLibreMap_class::removeStyleSource(
+  JNIEnv* env, jMapLibreMap map, jstring id
+) {
+  withMapWrapper(env, map, [env, id](auto wrapper) {
+    auto cppId = smjni::java_string_to_cpp(env, id);
+    wrapper->map->getStyle().removeSource(cppId);
+  });
+}
+
+void JNICALL MapLibreMap_class::setStyleGeoJsonSourceData(
+  JNIEnv* env, jMapLibreMap map, jstring sourceId, jstring geoJson
+) {
+  withMapWrapper(env, map, [env, sourceId, geoJson](auto wrapper) {
+    auto cppSourceId = smjni::java_string_to_cpp(env, sourceId);
+    auto cppGeoJson = smjni::java_string_to_cpp(env, geoJson);
+
+    auto* source = wrapper->map->getStyle().getSource(cppSourceId);
+    if (!source) {
+      throw std::runtime_error("Source not found: " + cppSourceId);
+    }
+    auto* gjSource = source->template as<mbgl::style::GeoJSONSource>();
+    if (!gjSource) {
+      throw std::runtime_error(
+        "Source is not a GeoJSON source: " + cppSourceId
+      );
+    }
+
+    mbgl::style::conversion::Error error;
+    auto geojson =
+      mbgl::style::conversion::convertJSON<mbgl::GeoJSON>(cppGeoJson, error);
+    if (!geojson) {
+      throw std::runtime_error("Failed to parse GeoJSON: " + error.message);
+    }
+    gjSource->setGeoJSON(*geojson);
+  });
+}
+
+void JNICALL MapLibreMap_class::setStyleGeoJsonSourceUrl(
+  JNIEnv* env, jMapLibreMap map, jstring sourceId, jstring url
+) {
+  withMapWrapper(env, map, [env, sourceId, url](auto wrapper) {
+    auto cppSourceId = smjni::java_string_to_cpp(env, sourceId);
+    auto cppUrl = smjni::java_string_to_cpp(env, url);
+
+    auto* source = wrapper->map->getStyle().getSource(cppSourceId);
+    if (!source) {
+      throw std::runtime_error("Source not found: " + cppSourceId);
+    }
+    auto* gjSource = source->template as<mbgl::style::GeoJSONSource>();
+    if (!gjSource) {
+      throw std::runtime_error(
+        "Source is not a GeoJSON source: " + cppSourceId
+      );
+    }
+
+    gjSource->setURL(cppUrl);
+  });
+}
+
+auto JNICALL
+MapLibreMap_class::hasStyleLayer(JNIEnv* env, jMapLibreMap map, jstring layerId)
+  -> jboolean {
+  return withMapWrapper(env, map, [env, layerId](auto wrapper) -> jboolean {
+    auto cppId = smjni::java_string_to_cpp(env, layerId);
+    return wrapper->map->getStyle().getLayer(cppId) != nullptr ? JNI_TRUE
+                                                               : JNI_FALSE;
+  });
+}
+
+auto JNICALL MapLibreMap_class::hasStyleSource(
+  JNIEnv* env, jMapLibreMap map, jstring sourceId
+) -> jboolean {
+  return withMapWrapper(env, map, [env, sourceId](auto wrapper) -> jboolean {
+    auto cppId = smjni::java_string_to_cpp(env, sourceId);
+    return wrapper->map->getStyle().getSource(cppId) != nullptr ? JNI_TRUE
+                                                                : JNI_FALSE;
+  });
+}
+
+auto JNICALL MapLibreMap_class::getStyleLayerIds(JNIEnv* env, jMapLibreMap map)
+  -> jstringArray {
+  return withMapWrapper(env, map, [env](auto wrapper) -> jstringArray {
+    auto layers = wrapper->map->getStyle().getLayers();
+    auto result = env->NewObjectArray(
+      static_cast<jsize>(layers.size()), env->FindClass("java/lang/String"),
+      nullptr
+    );
+    for (size_t i = 0; i < layers.size(); ++i) {
+      auto jId = smjni::java_string_create(env, layers[i]->getID());
+      env->SetObjectArrayElement(result, static_cast<jsize>(i), jId.c_ptr());
+    }
+    return static_cast<jstringArray>(result);
+  });
+}
+
+auto JNICALL MapLibreMap_class::getStyleSourceIds(JNIEnv* env, jMapLibreMap map)
+  -> jstringArray {
+  return withMapWrapper(env, map, [env](auto wrapper) -> jstringArray {
+    auto sources = wrapper->map->getStyle().getSources();
+    auto result = env->NewObjectArray(
+      static_cast<jsize>(sources.size()), env->FindClass("java/lang/String"),
+      nullptr
+    );
+    for (size_t i = 0; i < sources.size(); ++i) {
+      auto jId = smjni::java_string_create(env, sources[i]->getID());
+      env->SetObjectArrayElement(result, static_cast<jsize>(i), jId.c_ptr());
+    }
+    return static_cast<jstringArray>(result);
+  });
+}
+
+#pragma mark - Style Images
+
+void JNICALL MapLibreMap_class::addStyleImage(
+  JNIEnv* env, jMapLibreMap map, jstring id, jint width, jint height,
+  jfloat pixelRatio, jboolean sdf, jbyteArray data
+) {
+  withMapWrapper(
+    env, map, [env, id, width, height, pixelRatio, sdf, data](auto wrapper) {
+      auto cppId = smjni::java_string_to_cpp(env, id);
+      auto len = env->GetArrayLength(data);
+      auto expectedLen = static_cast<jsize>(width) * height * 4;
+      if (len != expectedLen) {
+        throw std::runtime_error(
+          "Image data size mismatch: expected " + std::to_string(expectedLen) +
+          " got " + std::to_string(len)
+        );
+      }
+      auto* bytes = env->GetByteArrayElements(data, nullptr);
+      if (!bytes) throw std::runtime_error("Failed to access image byte array");
+
+      mbgl::PremultipliedImage image(
+        {static_cast<uint32_t>(width), static_cast<uint32_t>(height)}
+      );
+      std::memcpy(image.data.get(), bytes, len);
+      env->ReleaseByteArrayElements(data, bytes, JNI_ABORT);
+
+      wrapper->map->getStyle().addImage(
+        std::make_unique<mbgl::style::Image>(
+          cppId, std::move(image), pixelRatio, sdf != JNI_FALSE
+        )
+      );
+    }
+  );
+}
+
+void JNICALL
+MapLibreMap_class::removeStyleImage(JNIEnv* env, jMapLibreMap map, jstring id) {
+  withMapWrapper(env, map, [env, id](auto wrapper) {
+    auto cppId = smjni::java_string_to_cpp(env, id);
+    wrapper->map->getStyle().removeImage(cppId);
+  });
+}
+
+void JNICALL MapLibreMap_class::addStyleImageStretched(
+  JNIEnv* env, jMapLibreMap map, jstring id, jint width, jint height,
+  jfloat pixelRatio, jboolean sdf, jbyteArray data, jfloat stretchXFrom,
+  jfloat stretchXTo, jfloat stretchYFrom, jfloat stretchYTo, jfloat contentLeft,
+  jfloat contentTop, jfloat contentRight, jfloat contentBottom
+) {
+  withMapWrapper(
+    env, map,
+    [env, id, width, height, pixelRatio, sdf, data, stretchXFrom, stretchXTo,
+     stretchYFrom, stretchYTo, contentLeft, contentTop, contentRight,
+     contentBottom](auto wrapper) {
+      auto cppId = smjni::java_string_to_cpp(env, id);
+      auto len = env->GetArrayLength(data);
+      auto expectedLen = static_cast<jsize>(width) * height * 4;
+      if (len != expectedLen) {
+        throw std::runtime_error(
+          "Image data size mismatch: expected " + std::to_string(expectedLen) +
+          " got " + std::to_string(len)
+        );
+      }
+      auto* bytes = env->GetByteArrayElements(data, nullptr);
+      if (!bytes) throw std::runtime_error("Failed to access image byte array");
+
+      mbgl::PremultipliedImage image(
+        {static_cast<uint32_t>(width), static_cast<uint32_t>(height)}
+      );
+      std::memcpy(image.data.get(), bytes, len);
+      env->ReleaseByteArrayElements(data, bytes, JNI_ABORT);
+
+      mbgl::style::ImageStretches stretchX{{stretchXFrom, stretchXTo}};
+      mbgl::style::ImageStretches stretchY{{stretchYFrom, stretchYTo}};
+      mbgl::style::ImageContent content{
+        contentLeft, contentTop, contentRight, contentBottom
+      };
+
+      wrapper->map->getStyle().addImage(
+        std::make_unique<mbgl::style::Image>(
+          cppId, std::move(image), pixelRatio, sdf != JNI_FALSE,
+          std::move(stretchX), std::move(stretchY), content
+        )
+      );
+    }
+  );
+}
+
+#pragma mark - ImageSource
+
+void JNICALL MapLibreMap_class::setImageSourceCoordinates(
+  JNIEnv* env, jMapLibreMap map, jstring sourceId, jdouble tlLat, jdouble tlLng,
+  jdouble trLat, jdouble trLng, jdouble brLat, jdouble brLng, jdouble blLat,
+  jdouble blLng
+) {
+  withMapWrapper(
+    env, map,
+    [env, sourceId, tlLat, tlLng, trLat, trLng, brLat, brLng, blLat,
+     blLng](auto wrapper) {
+      auto cppId = smjni::java_string_to_cpp(env, sourceId);
+      auto* source = wrapper->map->getStyle().getSource(cppId);
+      if (!source) throw std::runtime_error("Source not found: " + cppId);
+      auto* imgSource = source->template as<mbgl::style::ImageSource>();
+      if (!imgSource)
+        throw std::runtime_error("Source is not an ImageSource: " + cppId);
+
+      std::array<mbgl::LatLng, 4> coords = {
+        {{tlLat, tlLng}, {trLat, trLng}, {brLat, brLng}, {blLat, blLng}}
+      };
+      imgSource->setCoordinates(coords);
+    }
+  );
+}
+
+void JNICALL MapLibreMap_class::setImageSourceImage(
+  JNIEnv* env, jMapLibreMap map, jstring sourceId, jint width, jint height,
+  jbyteArray data
+) {
+  withMapWrapper(env, map, [env, sourceId, width, height, data](auto wrapper) {
+    auto cppId = smjni::java_string_to_cpp(env, sourceId);
+    auto* source = wrapper->map->getStyle().getSource(cppId);
+    if (!source) throw std::runtime_error("Source not found: " + cppId);
+    auto* imgSource = source->template as<mbgl::style::ImageSource>();
+    if (!imgSource)
+      throw std::runtime_error("Source is not an ImageSource: " + cppId);
+
+    auto len = env->GetArrayLength(data);
+    auto expectedLen = static_cast<jsize>(width) * height * 4;
+    if (len != expectedLen) {
+      throw std::runtime_error(
+        "Image data size mismatch: expected " + std::to_string(expectedLen) +
+        " got " + std::to_string(len)
+      );
+    }
+    auto* bytes = env->GetByteArrayElements(data, nullptr);
+    if (!bytes) throw std::runtime_error("Failed to access image byte array");
+
+    mbgl::PremultipliedImage image(
+      {static_cast<uint32_t>(width), static_cast<uint32_t>(height)}
+    );
+    std::memcpy(image.data.get(), bytes, len);
+    env->ReleaseByteArrayElements(data, bytes, JNI_ABORT);
+
+    imgSource->setImage(std::move(image));
+  });
+}
+
+void JNICALL MapLibreMap_class::setImageSourceUrl(
+  JNIEnv* env, jMapLibreMap map, jstring sourceId, jstring url
+) {
+  withMapWrapper(env, map, [env, sourceId, url](auto wrapper) {
+    auto cppId = smjni::java_string_to_cpp(env, sourceId);
+    auto cppUrl = smjni::java_string_to_cpp(env, url);
+    auto* source = wrapper->map->getStyle().getSource(cppId);
+    if (!source) throw std::runtime_error("Source not found: " + cppId);
+    auto* imgSource = source->template as<mbgl::style::ImageSource>();
+    if (!imgSource)
+      throw std::runtime_error("Source is not an ImageSource: " + cppId);
+
+    imgSource->setURL(cppUrl);
+  });
+}
+
+#pragma mark - Query Features
+
+static std::string featuresToGeoJson(
+  const std::vector<mbgl::Feature>& features
+) {
+  mapbox::geojson::feature_collection fc;
+  fc.reserve(features.size());
+  for (const auto& f : features) {
+    fc.push_back(static_cast<const mbgl::GeoJSONFeature&>(f));
+  }
+  return mapbox::geojson::stringify(fc);
+}
+
+auto JNICALL MapLibreMap_class::querySourceFeatures(
+  JNIEnv* env, jMapLibreMap map, jstring sourceId, jstring sourceLayersJson,
+  jstring filterJson
+) -> jstring {
+  return withMapWrapper(
+    env, map,
+    [env, sourceId, sourceLayersJson, filterJson](auto wrapper) -> jstring {
+      auto cppSourceId = smjni::java_string_to_cpp(env, sourceId);
+
+      // Parse source layers
+      std::optional<std::vector<std::string>> sourceLayers;
+      if (sourceLayersJson) {
+        auto cppLayersJson = smjni::java_string_to_cpp(env, sourceLayersJson);
+        mbgl::JSDocument doc;
+        doc.Parse<0>(cppLayersJson.c_str());
+        if (!doc.HasParseError() && doc.IsArray()) {
+          std::vector<std::string> layers;
+          for (const auto& v : doc.GetArray()) {
+            if (v.IsString())
+              layers.emplace_back(v.GetString(), v.GetStringLength());
+          }
+          sourceLayers = std::move(layers);
+        }
+      }
+
+      // Parse filter (optional)
+      std::optional<mbgl::style::Filter> filter;
+      if (filterJson) {
+        auto cppFilterJson = smjni::java_string_to_cpp(env, filterJson);
+        mbgl::style::conversion::Error error;
+        auto parsed = mbgl::style::conversion::convertJSON<mbgl::style::Filter>(
+          cppFilterJson, error
+        );
+        if (parsed) {
+          filter = std::move(*parsed);
+        }
+      }
+
+      auto* renderer =
+        wrapper->renderer ? wrapper->renderer->getRenderer() : nullptr;
+      if (!renderer) {
+        return smjni::java_string_create(
+                 env, "{\"type\":\"FeatureCollection\",\"features\":[]}"
+        )
+          .release();
+      }
+
+      mbgl::SourceQueryOptions options(
+        std::move(sourceLayers), std::move(filter)
+      );
+      auto features = renderer->querySourceFeatures(cppSourceId, options);
+      auto json = featuresToGeoJson(features);
+      return smjni::java_string_create(env, json).release();
+    }
+  );
+}
+
+#pragma mark - Cluster Queries
+
+auto JNICALL MapLibreMap_class::getClusterChildren(
+  JNIEnv* env, jMapLibreMap map, jstring sourceId, jlong clusterId
+) -> jstring {
+  return withMapWrapper(
+    env, map, [env, sourceId, clusterId](auto wrapper) -> jstring {
+      auto cppSourceId = smjni::java_string_to_cpp(env, sourceId);
+
+      auto* renderer =
+        wrapper->renderer ? wrapper->renderer->getRenderer() : nullptr;
+      if (!renderer) {
+        return smjni::java_string_create(
+                 env, "{\"type\":\"FeatureCollection\",\"features\":[]}"
+        )
+          .release();
+      }
+
+      mbgl::Feature feature;
+      feature.properties["cluster_id"] = static_cast<uint64_t>(clusterId);
+
+      auto result = renderer->queryFeatureExtensions(
+        cppSourceId, feature, "supercluster", "children", {}
+      );
+
+      if (result.template is<mbgl::FeatureCollection>()) {
+        auto json = mapbox::geojson::stringify(
+          result.template get<mbgl::FeatureCollection>()
+        );
+        return smjni::java_string_create(env, json).release();
+      }
+      return smjni::java_string_create(
+               env, "{\"type\":\"FeatureCollection\",\"features\":[]}"
+      )
+        .release();
+    }
+  );
+}
+
+auto JNICALL MapLibreMap_class::getClusterLeaves(
+  JNIEnv* env, jMapLibreMap map, jstring sourceId, jlong clusterId, jlong limit,
+  jlong offset
+) -> jstring {
+  return withMapWrapper(
+    env, map,
+    [env, sourceId, clusterId, limit, offset](auto wrapper) -> jstring {
+      auto cppSourceId = smjni::java_string_to_cpp(env, sourceId);
+
+      auto* renderer =
+        wrapper->renderer ? wrapper->renderer->getRenderer() : nullptr;
+      if (!renderer) {
+        return smjni::java_string_create(
+                 env, "{\"type\":\"FeatureCollection\",\"features\":[]}"
+        )
+          .release();
+      }
+
+      mbgl::Feature feature;
+      feature.properties["cluster_id"] = static_cast<uint64_t>(clusterId);
+
+      std::map<std::string, mbgl::Value> args = {
+        {"limit", static_cast<uint64_t>(limit)},
+        {"offset", static_cast<uint64_t>(offset)}
+      };
+
+      auto result = renderer->queryFeatureExtensions(
+        cppSourceId, feature, "supercluster", "leaves", args
+      );
+
+      if (result.template is<mbgl::FeatureCollection>()) {
+        auto json = mapbox::geojson::stringify(
+          result.template get<mbgl::FeatureCollection>()
+        );
+        return smjni::java_string_create(env, json).release();
+      }
+      return smjni::java_string_create(
+               env, "{\"type\":\"FeatureCollection\",\"features\":[]}"
+      )
+        .release();
+    }
+  );
+}
+
+auto JNICALL MapLibreMap_class::getClusterExpansionZoom(
+  JNIEnv* env, jMapLibreMap map, jstring sourceId, jlong clusterId
+) -> jint {
+  return withMapWrapper(
+    env, map, [env, sourceId, clusterId](auto wrapper) -> jint {
+      auto cppSourceId = smjni::java_string_to_cpp(env, sourceId);
+
+      auto* renderer =
+        wrapper->renderer ? wrapper->renderer->getRenderer() : nullptr;
+      if (!renderer) return 0;
+
+      mbgl::Feature feature;
+      feature.properties["cluster_id"] = static_cast<uint64_t>(clusterId);
+
+      auto result = renderer->queryFeatureExtensions(
+        cppSourceId, feature, "supercluster", "expansion-zoom", {}
+      );
+
+      if (result.template is<mbgl::Value>()) {
+        auto& value = result.template get<mbgl::Value>();
+        if (value.template is<uint64_t>())
+          return static_cast<jint>(value.template get<uint64_t>());
+        if (value.template is<int64_t>())
+          return static_cast<jint>(value.template get<int64_t>());
+        if (value.template is<double>())
+          return static_cast<jint>(value.template get<double>());
+      }
+      return 0;
+    }
+  );
 }
 
 #pragma mark - Transitions
@@ -536,7 +1410,8 @@ auto JNICALL MapLibreMap_class::nativeInit(
 ) -> jlong {
   try {
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-    auto* renderer = reinterpret_cast<mbgl::RendererFrontend*>(frontendPointer);
+    auto* frontend =
+      reinterpret_cast<maplibre_jni::CanvasRenderer*>(frontendPointer);
     auto observer = std::make_unique<maplibre_jni::JniMapObserver>(observerObj);
     mbgl::MapOptions mapOptions =
       maplibre_jni::convertMapOptions(env, optionsObj);
@@ -545,7 +1420,7 @@ auto JNICALL MapLibreMap_class::nativeInit(
     mbgl::ClientOptions clientOptions =
       maplibre_jni::convertClientOptions(env, clientOptionsObj);
     auto map = std::make_unique<mbgl::Map>(
-      *renderer, *observer, mapOptions, resourceOptions, clientOptions
+      *frontend, *observer, mapOptions, resourceOptions, clientOptions
     );
 
     // Get network file source for HTTP downloads
@@ -568,7 +1443,7 @@ auto JNICALL MapLibreMap_class::nativeInit(
 
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     return reinterpret_cast<jlong>(
-      new MapWrapper(map.release(), observer.release())
+      new MapWrapper(map.release(), observer.release(), frontend)
     );
   } catch (const std::exception& e) {
     smjni::java_exception::translate(env, e);

--- a/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/map/MapLibreMap.kt
+++ b/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/map/MapLibreMap.kt
@@ -300,6 +300,56 @@ public class MapLibreMap(
 
   // endregion
 
+  // region Style manipulation
+
+  public external fun addLayerJson(layerJson: String, beforeLayerId: String?)
+
+  public external fun removeLayer(layerId: String)
+
+  public external fun getLayerIds(): Array<String>
+
+  public external fun getStyleJson(): String
+
+  public external fun addSourceJson(sourceId: String, sourceJson: String)
+
+  public external fun removeSource(sourceId: String)
+
+  public external fun getSourceIds(): Array<String>
+
+  /** Updates the GeoJSON data of an existing GeoJSON source without removing it. */
+  public external fun setGeoJsonData(sourceId: String, geoJson: String)
+
+  public external fun addStyleImage(
+    id: String,
+    width: Int,
+    height: Int,
+    pixels: ByteArray,
+    scale: Float,
+    sdf: Boolean,
+    contentLeft: Float,
+    contentTop: Float,
+    contentRight: Float,
+    contentBottom: Float,
+  )
+
+  public external fun removeStyleImage(id: String)
+
+  public external fun queryRenderedFeaturesAtPoint(
+    x: Float,
+    y: Float,
+    layerIdsJson: String?,
+  ): String
+
+  public external fun queryRenderedFeaturesInBox(
+    x1: Float,
+    y1: Float,
+    x2: Float,
+    y2: Float,
+    layerIdsJson: String?,
+  ): String
+
+  // endregion
+
   private companion object {
 
     @JvmStatic

--- a/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/map/MapLibreMap.kt
+++ b/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/map/MapLibreMap.kt
@@ -61,6 +61,134 @@ public class MapLibreMap(
 
   // endregion
 
+  // region Style Layers
+
+  public external fun addStyleLayer(type: String, id: String, sourceId: String?, beforeId: String?)
+
+  public external fun removeStyleLayer(id: String)
+
+  public external fun restoreStyleLayer(id: String, beforeId: String?)
+
+  public external fun setStyleLayerProperty(
+    layerId: String,
+    propertyName: String,
+    valueJson: String,
+  )
+
+  public external fun setStyleLayerVisible(layerId: String, visible: Boolean)
+
+  public external fun setStyleLayerMinZoom(layerId: String, minZoom: Float)
+
+  public external fun setStyleLayerMaxZoom(layerId: String, maxZoom: Float)
+
+  public external fun setStyleLayerSourceLayer(layerId: String, sourceLayer: String)
+
+  public external fun setStyleLayerFilter(layerId: String, filterJson: String)
+
+  // endregion
+
+  // region Style Sources
+
+  public external fun addStyleSource(type: String, id: String, configJson: String?)
+
+  public external fun removeStyleSource(id: String)
+
+  public external fun setStyleGeoJsonSourceData(sourceId: String, geoJson: String)
+
+  public external fun setStyleGeoJsonSourceUrl(sourceId: String, url: String)
+
+  public external fun hasStyleLayer(layerId: String): Boolean
+
+  public external fun hasStyleSource(sourceId: String): Boolean
+
+  public external fun getStyleLayerIds(): Array<String>
+
+  public external fun getStyleSourceIds(): Array<String>
+
+  // endregion
+
+  // region Style Images
+
+  public external fun addStyleImage(
+    id: String,
+    width: Int,
+    height: Int,
+    pixelRatio: Float,
+    sdf: Boolean,
+    data: ByteArray,
+  )
+
+  public external fun addStyleImageStretched(
+    id: String,
+    width: Int,
+    height: Int,
+    pixelRatio: Float,
+    sdf: Boolean,
+    data: ByteArray,
+    stretchXFrom: Float,
+    stretchXTo: Float,
+    stretchYFrom: Float,
+    stretchYTo: Float,
+    contentLeft: Float,
+    contentTop: Float,
+    contentRight: Float,
+    contentBottom: Float,
+  )
+
+  public external fun removeStyleImage(id: String)
+
+  // endregion
+
+  // region ImageSource
+
+  public external fun setImageSourceCoordinates(
+    sourceId: String,
+    tlLat: Double,
+    tlLng: Double,
+    trLat: Double,
+    trLng: Double,
+    brLat: Double,
+    brLng: Double,
+    blLat: Double,
+    blLng: Double,
+  )
+
+  public external fun setImageSourceImage(
+    sourceId: String,
+    width: Int,
+    height: Int,
+    data: ByteArray,
+  )
+
+  public external fun setImageSourceUrl(sourceId: String, url: String)
+
+  // endregion
+
+  // region Query Features
+
+  public external fun querySourceFeatures(
+    sourceId: String,
+    sourceLayersJson: String?,
+    filterJson: String?,
+  ): String
+
+  // endregion
+
+  // region Cluster Queries
+
+  public external fun getClusterChildren(sourceId: String, clusterId: Long): String
+
+  public external fun getClusterLeaves(
+    sourceId: String,
+    clusterId: Long,
+    limit: Long,
+    offset: Long,
+  ): String
+
+  public external fun getClusterExpansionZoom(sourceId: String, clusterId: Long): Int
+
+  // endregion
+
   // region Transitions
 
   public external fun cancelTransitions()

--- a/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/style/layers/BackgroundLayer.kt
+++ b/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/style/layers/BackgroundLayer.kt
@@ -1,0 +1,3 @@
+package org.maplibre.kmp.native.style.layers
+
+public class BackgroundLayer(id: String) : Layer(id, "background", null)

--- a/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/style/layers/CircleLayer.kt
+++ b/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/style/layers/CircleLayer.kt
@@ -1,0 +1,3 @@
+package org.maplibre.kmp.native.style.layers
+
+public class CircleLayer(id: String, sourceId: String) : FeatureLayer(id, "circle", sourceId)

--- a/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/style/layers/FeatureLayer.kt
+++ b/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/style/layers/FeatureLayer.kt
@@ -1,0 +1,40 @@
+package org.maplibre.kmp.native.style.layers
+
+public abstract class FeatureLayer(id: String, type: String, sourceId: String) :
+  Layer(id, type, sourceId) {
+
+  private var pendingSourceLayer: String? = null
+  private var pendingFilter: String? = null
+
+  public var sourceLayer: String = ""
+    set(value) {
+      field = value
+      val m = map
+      if (m != null) {
+        m.setStyleLayerSourceLayer(id, value)
+      } else {
+        pendingSourceLayer = value
+      }
+    }
+
+  public fun setFilter(filterJson: String) {
+    val m = map
+    if (m != null) {
+      m.setStyleLayerFilter(id, filterJson)
+    } else {
+      pendingFilter = filterJson
+    }
+  }
+
+  override fun bind(map: org.maplibre.kmp.native.map.MapLibreMap) {
+    super.bind(map)
+    pendingSourceLayer?.let {
+      map.setStyleLayerSourceLayer(id, it)
+      pendingSourceLayer = null
+    }
+    pendingFilter?.let {
+      map.setStyleLayerFilter(id, it)
+      pendingFilter = null
+    }
+  }
+}

--- a/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/style/layers/FillExtrusionLayer.kt
+++ b/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/style/layers/FillExtrusionLayer.kt
@@ -1,0 +1,4 @@
+package org.maplibre.kmp.native.style.layers
+
+public class FillExtrusionLayer(id: String, sourceId: String) :
+  FeatureLayer(id, "fill-extrusion", sourceId)

--- a/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/style/layers/FillLayer.kt
+++ b/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/style/layers/FillLayer.kt
@@ -1,0 +1,3 @@
+package org.maplibre.kmp.native.style.layers
+
+public class FillLayer(id: String, sourceId: String) : FeatureLayer(id, "fill", sourceId)

--- a/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/style/layers/HeatmapLayer.kt
+++ b/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/style/layers/HeatmapLayer.kt
@@ -1,0 +1,3 @@
+package org.maplibre.kmp.native.style.layers
+
+public class HeatmapLayer(id: String, sourceId: String) : FeatureLayer(id, "heatmap", sourceId)

--- a/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/style/layers/HillshadeLayer.kt
+++ b/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/style/layers/HillshadeLayer.kt
@@ -1,0 +1,3 @@
+package org.maplibre.kmp.native.style.layers
+
+public class HillshadeLayer(id: String, sourceId: String) : Layer(id, "hillshade", sourceId)

--- a/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/style/layers/Layer.kt
+++ b/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/style/layers/Layer.kt
@@ -1,0 +1,53 @@
+package org.maplibre.kmp.native.style.layers
+
+import org.maplibre.kmp.native.map.MapLibreMap
+
+public open class Layer(
+  public val id: String,
+  public val type: String,
+  public val sourceId: String?,
+) {
+  internal var map: MapLibreMap? = null
+  private val pendingProperties = mutableMapOf<String, String>()
+
+  public var minZoom: Float = 0f
+    set(value) {
+      field = value
+      map?.setStyleLayerMinZoom(id, value)
+    }
+
+  public var maxZoom: Float = 24f
+    set(value) {
+      field = value
+      map?.setStyleLayerMaxZoom(id, value)
+    }
+
+  public var visible: Boolean = true
+    set(value) {
+      field = value
+      map?.setStyleLayerVisible(id, value)
+    }
+
+  public fun setProperty(name: String, valueJson: String) {
+    val m = map
+    if (m != null) {
+      m.setStyleLayerProperty(id, name, valueJson)
+    } else {
+      pendingProperties[name] = valueJson
+    }
+  }
+
+  public open fun bind(map: MapLibreMap) {
+    this.map = map
+    // Flush buffered state
+    if (minZoom != 0f) map.setStyleLayerMinZoom(id, minZoom)
+    if (maxZoom != 24f) map.setStyleLayerMaxZoom(id, maxZoom)
+    if (!visible) map.setStyleLayerVisible(id, false)
+    pendingProperties.forEach { (name, value) -> map.setStyleLayerProperty(id, name, value) }
+    pendingProperties.clear()
+  }
+
+  public open fun unbind() {
+    map = null
+  }
+}

--- a/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/style/layers/LineLayer.kt
+++ b/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/style/layers/LineLayer.kt
@@ -1,0 +1,3 @@
+package org.maplibre.kmp.native.style.layers
+
+public class LineLayer(id: String, sourceId: String) : FeatureLayer(id, "line", sourceId)

--- a/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/style/layers/RasterLayer.kt
+++ b/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/style/layers/RasterLayer.kt
@@ -1,0 +1,3 @@
+package org.maplibre.kmp.native.style.layers
+
+public class RasterLayer(id: String, sourceId: String) : Layer(id, "raster", sourceId)

--- a/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/style/layers/SymbolLayer.kt
+++ b/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/style/layers/SymbolLayer.kt
@@ -1,0 +1,3 @@
+package org.maplibre.kmp.native.style.layers
+
+public class SymbolLayer(id: String, sourceId: String) : FeatureLayer(id, "symbol", sourceId)

--- a/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/style/sources/GeoJsonSource.kt
+++ b/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/style/sources/GeoJsonSource.kt
@@ -1,0 +1,63 @@
+package org.maplibre.kmp.native.style.sources
+
+import org.maplibre.kmp.native.map.MapLibreMap
+
+public class GeoJsonSource(id: String, public val optionsJson: String? = null) :
+  Source(id, "geojson") {
+
+  private var pendingGeoJson: String? = null
+  private var pendingUrl: String? = null
+
+  override fun configJson(): String? = optionsJson
+
+  public fun setGeoJson(geoJson: String) {
+    val m = map
+    if (m != null) {
+      m.setStyleGeoJsonSourceData(id, geoJson)
+    } else {
+      pendingGeoJson = geoJson
+      pendingUrl = null
+    }
+  }
+
+  public fun setUrl(url: String) {
+    val m = map
+    if (m != null) {
+      m.setStyleGeoJsonSourceUrl(id, url)
+    } else {
+      pendingUrl = url
+      pendingGeoJson = null
+    }
+  }
+
+  public fun getClusterChildren(clusterId: Long): String {
+    val m = map ?: return EMPTY_FEATURE_COLLECTION
+    return m.getClusterChildren(id, clusterId)
+  }
+
+  public fun getClusterLeaves(clusterId: Long, limit: Long, offset: Long): String {
+    val m = map ?: return EMPTY_FEATURE_COLLECTION
+    return m.getClusterLeaves(id, clusterId, limit, offset)
+  }
+
+  public fun getClusterExpansionZoom(clusterId: Long): Int {
+    val m = map ?: return 0
+    return m.getClusterExpansionZoom(id, clusterId)
+  }
+
+  override fun bind(map: MapLibreMap) {
+    super.bind(map)
+    pendingGeoJson?.let {
+      map.setStyleGeoJsonSourceData(id, it)
+      pendingGeoJson = null
+    }
+    pendingUrl?.let {
+      map.setStyleGeoJsonSourceUrl(id, it)
+      pendingUrl = null
+    }
+  }
+
+  private companion object {
+    const val EMPTY_FEATURE_COLLECTION = """{"type":"FeatureCollection","features":[]}"""
+  }
+}

--- a/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/style/sources/ImageSource.kt
+++ b/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/style/sources/ImageSource.kt
@@ -1,0 +1,64 @@
+package org.maplibre.kmp.native.style.sources
+
+import org.maplibre.kmp.native.map.MapLibreMap
+
+public class ImageSource(id: String) : Source(id, "image") {
+
+  private var pendingCoordinates: DoubleArray? = null
+  private var pendingImage: ImageData? = null
+  private var pendingUrl: String? = null
+
+  private class ImageData(val width: Int, val height: Int, val data: ByteArray)
+
+  public fun setCoordinates(
+    tlLat: Double,
+    tlLng: Double,
+    trLat: Double,
+    trLng: Double,
+    brLat: Double,
+    brLng: Double,
+    blLat: Double,
+    blLng: Double,
+  ) {
+    val m = map
+    if (m != null) {
+      m.setImageSourceCoordinates(id, tlLat, tlLng, trLat, trLng, brLat, brLng, blLat, blLng)
+    } else {
+      pendingCoordinates = doubleArrayOf(tlLat, tlLng, trLat, trLng, brLat, brLng, blLat, blLng)
+    }
+  }
+
+  public fun setImage(width: Int, height: Int, data: ByteArray) {
+    val m = map
+    if (m != null) {
+      m.setImageSourceImage(id, width, height, data)
+    } else {
+      pendingImage = ImageData(width, height, data)
+    }
+  }
+
+  public fun setUrl(url: String) {
+    val m = map
+    if (m != null) {
+      m.setImageSourceUrl(id, url)
+    } else {
+      pendingUrl = url
+    }
+  }
+
+  override fun bind(map: MapLibreMap) {
+    super.bind(map)
+    pendingCoordinates?.let { c ->
+      map.setImageSourceCoordinates(id, c[0], c[1], c[2], c[3], c[4], c[5], c[6], c[7])
+      pendingCoordinates = null
+    }
+    pendingImage?.let { img ->
+      map.setImageSourceImage(id, img.width, img.height, img.data)
+      pendingImage = null
+    }
+    pendingUrl?.let { url ->
+      map.setImageSourceUrl(id, url)
+      pendingUrl = null
+    }
+  }
+}

--- a/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/style/sources/RasterDemSource.kt
+++ b/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/style/sources/RasterDemSource.kt
@@ -1,0 +1,31 @@
+package org.maplibre.kmp.native.style.sources
+
+public class RasterDemSource : Source {
+  private val uri: String?
+  private val tileSize: Int
+  private val tileSetJson: String?
+
+  public constructor(id: String, uri: String, tileSize: Int = 512) : super(id, "raster-dem") {
+    this.uri = uri
+    this.tileSize = tileSize
+    this.tileSetJson = null
+  }
+
+  public constructor(
+    id: String,
+    tiles: List<String>,
+    tileSetJson: String?,
+  ) : super(id, "raster-dem") {
+    this.uri = null
+    this.tileSize = 512
+    this.tileSetJson = tileSetJson
+  }
+
+  override fun configJson(): String? {
+    if (uri != null) {
+      if (tileSize != 512) return """{"url":${jsonString(uri)},"tileSize":$tileSize}"""
+      return jsonString(uri)
+    }
+    return tileSetJson
+  }
+}

--- a/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/style/sources/RasterSource.kt
+++ b/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/style/sources/RasterSource.kt
@@ -1,0 +1,27 @@
+package org.maplibre.kmp.native.style.sources
+
+public class RasterSource : Source {
+  private val uri: String?
+  private val tileSize: Int
+  private val tileSetJson: String?
+
+  public constructor(id: String, uri: String, tileSize: Int = 512) : super(id, "raster") {
+    this.uri = uri
+    this.tileSize = tileSize
+    this.tileSetJson = null
+  }
+
+  public constructor(id: String, tiles: List<String>, tileSetJson: String?) : super(id, "raster") {
+    this.uri = null
+    this.tileSize = 512
+    this.tileSetJson = tileSetJson
+  }
+
+  override fun configJson(): String? {
+    if (uri != null) {
+      if (tileSize != 512) return """{"url":${jsonString(uri)},"tileSize":$tileSize}"""
+      return jsonString(uri)
+    }
+    return tileSetJson
+  }
+}

--- a/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/style/sources/Source.kt
+++ b/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/style/sources/Source.kt
@@ -1,0 +1,40 @@
+package org.maplibre.kmp.native.style.sources
+
+import org.maplibre.kmp.native.map.MapLibreMap
+
+public open class Source(public val id: String, public val type: String) {
+  internal var map: MapLibreMap? = null
+
+  public val attribution: String = ""
+
+  public open fun configJson(): String? = null
+
+  public open fun bind(map: MapLibreMap) {
+    this.map = map
+  }
+
+  public open fun unbind() {
+    map = null
+  }
+}
+
+/** Encodes a string as a JSON string literal with proper escaping. */
+internal fun jsonString(value: String): String = buildString {
+  append('"')
+  for (ch in value) {
+    when (ch) {
+      '"' -> append("\\\"")
+      '\\' -> append("\\\\")
+      '\n' -> append("\\n")
+      '\r' -> append("\\r")
+      '\t' -> append("\\t")
+      else ->
+        if (ch.code < 0x20) {
+          append("\\u${ch.code.toString(16).padStart(4, '0')}")
+        } else {
+          append(ch)
+        }
+    }
+  }
+  append('"')
+}

--- a/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/style/sources/VectorSource.kt
+++ b/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/style/sources/VectorSource.kt
@@ -1,0 +1,30 @@
+package org.maplibre.kmp.native.style.sources
+
+public class VectorSource : Source {
+  private val uri: String?
+  private val tiles: List<String>?
+  private val tileSetJson: String?
+
+  public constructor(id: String, uri: String) : super(id, "vector") {
+    this.uri = uri
+    this.tiles = null
+    this.tileSetJson = null
+  }
+
+  public constructor(id: String, tiles: List<String>, tileSetJson: String?) : super(id, "vector") {
+    this.uri = null
+    this.tiles = tiles
+    this.tileSetJson = tileSetJson
+  }
+
+  override fun configJson(): String? {
+    if (uri != null) return jsonString(uri)
+    if (tiles != null) return tileSetJson
+    return null
+  }
+
+  public fun querySourceFeatures(sourceLayersJson: String?, filterJson: String?): String {
+    val m = map ?: return """{"type":"FeatureCollection","features":[]}"""
+    return m.querySourceFeatures(id, sourceLayersJson, filterJson)
+  }
+}


### PR DESCRIPTION
## Summary

Implements full desktop style parity for layers, sources, and expressions — the desktop JVM target can now render styled maps with the same layer/source APIs as Android and iOS.

This is a complete rewrite addressing all review feedback from @sargunv on the previous iteration:
- ✅ **Backing object pattern** — layers/sources are persistent objects mutated in-place (not removed+re-added)
- ✅ **Per-property mutation** — uses `mbgl::style::Layer::setProperty(name, Convertible)` 
- ✅ **No full JSON interchange** — JSON only used for expression values, not whole-layer specs

## Architecture

```
Compose Layer (desktopMain)
  CircleLayer.setCircleRadius(expr) →
    expr.toJsonString() → impl.setProperty("circle-radius", json)

Native Bindings (maplibre-native-bindings)
  Layer.setProperty(name, json) →
    if bound: map.setStyleLayerProperty(id, name, json)
    else: buffer in pendingProperties (flushed on bind)

C++ JNI (maplibre_map.cpp)
  setStyleLayerProperty(id, name, json) →
    rapidjson::Parse → Convertible → layer->setProperty(name, convertible)
```

## What's implemented

### C++ JNI (`maplibre_map.cpp`)
- Layer management: `addStyleLayer`, `removeStyleLayer`, `restoreStyleLayer`
- Layer properties: `setStyleLayerProperty`, `setStyleLayerVisible`, `setStyleLayerMinZoom/MaxZoom`, `setStyleLayerSourceLayer`, `setStyleLayerFilter`
- Source management: `addStyleSource`, `removeStyleSource`, `setStyleGeoJsonSourceData`, `setStyleGeoJsonSourceUrl`
- Style images: `addStyleImage`, `addStyleImageStretched`, `removeStyleImage`
- Image source: `setImageSourceCoordinates`, `setImageSourceImage`, `setImageSourceUrl`
- Queries: `querySourceFeatures`, `getClusterChildren`, `getClusterLeaves`, `getClusterExpansionZoom`
- Introspection: `hasStyleLayer`, `hasStyleSource`, `getStyleLayerIds`, `getStyleSourceIds`

### Kotlin native bindings
- Base `Layer` class with pending-state buffering (properties set before `bind()` are queued and flushed on bind)
- `FeatureLayer` with source-layer and filter buffering
- `bind()`/`unbind()` lifecycle on both Layer and Source
- All 9 layer types: Circle, Line, Fill, Symbol, Raster, Hillshade, Heatmap, FillExtrusion, Background
- All source types: GeoJson (with cluster queries), Vector, Raster, RasterDem, Image
- `preservedLayers` map for remove/restore of base style layers

### Compose integration
- `DesktopStyle` with full layer ordering (above/below/at) using native ID queries
- Layer cache for base-style UnknownLayer wrappers (avoids duplicates)
- All layer composables wired to JNI via per-property setters
- All source composables with proper lifecycle management
- `ExpressionEncoder` — `CompiledExpression<*>` → JSON string (matches mbgl style spec array form)
- tileSize passthrough for URI-based raster/raster-dem sources

### Tests (31 passing)
- `ExpressionEncoderTest` — 17 tests covering all literal types and function calls
- `DesktopStyleNodeTest` — 14 inherited layer ordering and source management tests

## Key design decisions

1. **JSON strings over JNI** — Expressions and filters are serialized as JSON strings (e.g. `["interpolate",["linear"],["zoom"],0,1,22,20]`). This avoids building a full JNI type system like Android's `jni.hpp`-based `Value` wrapper while still being type-safe at the Kotlin layer.

2. **Direct rapidjson parsing** — Instead of `convertJSON<mbgl::Value>` (which has no Converter), we parse JSON directly with `mbgl::JSDocument` and pass `const JSValue*` as `Convertible` to mbgl's conversion system.

3. **Layer preserve/restore** — Removed layers are held in a `preservedLayers` map so base-style layers can be hidden and restored without losing their state. Stale entries are cleaned up on re-add.

4. **Literal object encoding** — Desktop emits `["literal", {...}]` (array form per style spec) rather than Android's `{"literal": {...}}` which only works with the Android SDK's internal converter.

## Remaining stubs (out of scope)
- `ComputedSource` — requires reverse JNI callbacks (Java→C++ data push)
- `DesktopOrientationProvider` — unrelated to style

## How to verify
```bash
./gradlew :lib:maplibre-compose:desktopMainClasses   # Kotlin compilation
./gradlew :lib:maplibre-compose:desktopTest           # 31 tests pass
./gradlew :lib:maplibre-native-bindings-jni:buildNative  # C++ compilation (requires toolchain)
```

_Created using Copilot (Claude Opus 4.6)_