### PR TITLE
desktop - support prebuilt JNI binaries via Maven Central to skip C++ build

### DIFF
--- a/demo-app/build.gradle.kts
+++ b/demo-app/build.gradle.kts
@@ -139,11 +139,21 @@ kotlin {
         implementation(libs.kotlinx.coroutines.swing)
         implementation(libs.ktor.client.okhttp)
 
-        runtimeOnly(project(":lib:maplibre-native-bindings-jni")) {
-          capabilities {
-            requireCapability(
-              "org.maplibre.compose:maplibre-native-bindings-jni-${Configuration(project).hostOsArchRendererTriplet}"
-            )
+        val prebuiltJniVersion =
+          (project.findProperty("prebuiltJniVersion") as? String)?.takeIf { it.isNotBlank() }
+        val jniCapability =
+          "org.maplibre.compose:maplibre-native-bindings-jni-${Configuration(project).hostOsArchRendererTriplet}"
+        if (prebuiltJniVersion != null) {
+          logger.warn(
+            "maplibre-compose: prebuiltJniVersion=$prebuiltJniVersion — using Maven Central " +
+              "JNI artifact. Only safe for changes outside lib/maplibre-native-bindings[-jni]."
+          )
+          runtimeOnly("org.maplibre.compose:maplibre-native-bindings-jni:$prebuiltJniVersion") {
+            capabilities { requireCapability(jniCapability) }
+          }
+        } else {
+          runtimeOnly(project(":lib:maplibre-native-bindings-jni")) {
+            capabilities { requireCapability(jniCapability) }
           }
         }
       }

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,6 +8,12 @@ jvmToolchain=21
 jvmTarget=11
 maplibreIosVersion=6.17.1
 #
+# Desktop JNI: set this in your personal ~/.gradle/gradle.properties to download the
+# pre-built native JNI library from Maven Central instead of compiling maplibre-native
+# from the C++ submodule (which requires cmake, ninja, and bazelisk and takes ~20 min).
+# Only safe for changes that don't touch lib/maplibre-native-bindings or
+# lib/maplibre-native-bindings-jni. Use the latest published release version.
+# prebuiltJniVersion=
 # Dependency flags
 kotlin.code.style=official
 kotlin.daemon.jvmargs=-Xmx2048M

--- a/lib/maplibre-native-bindings/build.gradle.kts
+++ b/lib/maplibre-native-bindings/build.gradle.kts
@@ -31,17 +31,24 @@ kotlin {
 
 dependencies { add("kspDesktop", libs.simplejni.kprocessor) }
 
+val prebuiltJniVersion = findProperty("prebuiltJniVersion") as? String
+
 ksp {
-  arg(
-    "smjni.jnigen.dest.path",
-    project(":lib:maplibre-native-bindings-jni")
-      .layout
-      .buildDirectory
-      .dir("generated/simplejni-headers")
-      .get()
-      .asFile
-      .absolutePath,
-  )
+  // When building the JNI layer from source, write generated C++ headers directly
+  // into the jni project's build dir so CMake can find them as inputs. When using
+  // prebuilt binaries, write to our own build dir (no C++ compilation happens).
+  val headersDest =
+    if (prebuiltJniVersion.isNullOrBlank()) {
+      project(":lib:maplibre-native-bindings-jni")
+        .layout.buildDirectory
+        .dir("generated/simplejni-headers")
+        .get()
+        .asFile
+        .absolutePath
+    } else {
+      layout.buildDirectory.dir("generated/simplejni-headers").get().asFile.absolutePath
+    }
+  arg("smjni.jnigen.dest.path", headersDest)
   arg("smjni.jnigen.own.dest.path", "true")
   arg("smjni.jnigen.output.list.name", "generated_headers.txt")
   arg("smjni.jnigen.expose.extra", listOf("java.lang.Double", "java.awt.Canvas").joinToString(";"))

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -34,6 +34,13 @@ dependencyResolutionManagement {
 // Versions: https://plugins.gradle.org/plugin/org.gradle.toolchains.foojay-resolver-convention
 plugins { id("org.gradle.toolchains.foojay-resolver-convention") version ("1.0.0") }
 
+// When set to a published version string (e.g. "0.7.0"), the native JNI library is
+// downloaded from Maven Central instead of being built from the C++ submodule.
+// Safe for Kotlin-only changes outside lib/maplibre-native-bindings[-jni].
+// Set in ~/.gradle/gradle.properties to avoid accidentally committing it.
+val prebuiltJniVersion: String? =
+  providers.gradleProperty("prebuiltJniVersion").orNull?.takeIf { it.isNotBlank() }
+
 include(
   ":",
   ":demo-app",
@@ -41,7 +48,10 @@ include(
   ":lib:maplibre-compose",
   ":lib:maplibre-compose-material3",
   ":lib:maplibre-native-bindings",
-  ":lib:maplibre-native-bindings-jni",
   ":lib:maplibre-js-bindings",
   ":lib:maplibre-compose-gms",
 )
+
+if (prebuiltJniVersion == null) {
+  include(":lib:maplibre-native-bindings-jni")
+}


### PR DESCRIPTION
Implements the "prebuilt binaries" suggestion from @sargunv in https://github.com/sargunv/maplibre-native/pull/2#issuecomment-4262789003 to improve the desktop contributor experience.

## Problem

Contributing to the desktop JVM target currently requires a full C++ build of maplibre-native (~20 min, needs cmake/ninja/bazelisk). This is a friction point for contributors making Kotlin-only changes.

## Solution

Add a `prebuiltJniVersion` Gradle property. When set, the build downloads the pre-built `maplibre-native-bindings-jni` artifact from Maven Central instead of compiling the C++ submodule.

**Usage** — add to your `~/.gradle/gradle.properties`:
```
prebuiltJniVersion=0.12.1
```

Then `./gradlew :demo-app:run` works without any C++ toolchain.

## Changes

- **`settings.gradle.kts`**: conditionally excludes `:lib:maplibre-native-bindings-jni` when `prebuiltJniVersion` is set
- **`lib/maplibre-native-bindings/build.gradle.kts`**: makes the KSP header output path conditional — writes to own build dir in prebuilt mode (no C++ compilation), or to the jni project build dir in source mode (current behavior)
- **`demo-app/build.gradle.kts`**: switches the `runtimeOnly` dependency between `project(...)` and Maven coordinates based on the property; emits a `logger.warn` in prebuilt mode as an ABI safety reminder
- **`gradle.properties`**: documents the option with a commented-out example

## Safety

Prebuilt mode is **only safe** when your changes are outside `lib/maplibre-native-bindings` and `lib/maplibre-native-bindings-jni` (i.e., no JNI interface changes). The build emits a warning to that effect. The property is intentionally documented as a personal `~/.gradle/gradle.properties` setting to avoid it being accidentally committed.