### PR TITLE
Link to MapLibre org AI policy, symlink CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,15 +1,15 @@
 # AGENTS.md
 
-This file provides guidance to OpenCode and other agents when working with code
-in this repository.
+All contributions must comply with the
+[MapLibre AI policy](https://raw.githubusercontent.com/maplibre/maplibre/refs/heads/main/AI_POLICY.md).
 
-## SEARCHING VENDORED MAPLIBRE-NATIVE CODEBASE:
+## Searching vendored MapLibre Native codebase
 
 When searching the vendored maplibre-native codebase:
 
 - Location: Look in `lib/maplibre-native-bindings-jni/vendor/maplibre-native/`
 - Key Directories:
-  - `platform/linux/` `- Linux-specific code (includes linux.cmake)
+  - `platform/linux/` - Linux-specific code (includes linux.cmake)
   - `platform/windows/` - Windows-specific code (includes windows.cmake)
   - `platform/darwin/` - macOS/iOS-specific code (includes darwin.cmake)
   - `platform/default/` - Cross-platform code
@@ -86,10 +86,3 @@ The library uses platform-specific implementations:
 - **Android/iOS**: MapLibre Native SDKs (MapLibre Android SDK, MapLibre iOS)
 - **Web**: MapLibre GL JS via `maplibre-js-bindings`
 - **Desktop**: MapLibre Native Core via `maplibre-native-bindings`
-
-### Build Configuration
-
-- Kotlin version: Check `gradle/libs.versions.toml`
-- Android SDK: min 23, compile/target 35
-- iOS deployment target: 12.0
-- JVM toolchain: 21, target: 11

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,3 +142,9 @@ If not using the pre-commit hook, you can manually format the code using:
 ```bash
 hk fix --all
 ```
+
+## AI policy
+
+This project follows the MapLibre organization's
+[AI policy](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md). Review
+it before submitting AI-generated contributions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,14 @@ relevant, see the
 label. These are issues that need input or guidance from folks with deeper
 expertise on some topic.
 
+## Note on AI usage
+
+If you are using any kind of AI assistance for your contributions, please take a
+moment to review
+[MapLibre's AI Policy](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).
+tl;dr: do not let AI speak for you, verify all generated content before
+requesting a review and disclose AI usage in pull requests.
+
 ## Set up your development environment
 
 ### Mise
@@ -142,9 +150,3 @@ If not using the pre-commit hook, you can manually format the code using:
 ```bash
 hk fix --all
 ```
-
-## AI policy
-
-This project follows the MapLibre organization's
-[AI policy](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md). Review
-it before submitting AI-generated contributions.


### PR DESCRIPTION
## Summary

- Symlink `CLAUDE.md` to `AGENTS.md` so both Claude Code and other agents share the same guidance file.
- Add a reference to the [MapLibre AI policy](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md) in `CONTRIBUTING.md` and `AGENTS.md`.
- Clean up `AGENTS.md`: fix stray backtick, normalize heading casing, remove stale build configuration section.

## Test plan

- [x] Verify `CLAUDE.md` symlink resolves correctly
- [x] Verify AI policy links are valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)