### PR TITLE
desktop - Fixed app crash issues on desktop when the map is removed from the UI

### DIFF
--- a/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/map/MapCanvas.kt
+++ b/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/map/MapCanvas.kt
@@ -65,11 +65,16 @@ public class MapCanvas(
   }
 
   override fun removeNotify() {
-    super.removeNotify()
-    map?.dispose()
-    map = null
-    renderer?.dispose()
-    renderer = null
+    // Fix for https://github.com/maplibre/maplibre-compose/issues/716 and https://github.com/maplibre/maplibre-compose/issues/695
+    // Calling super.removeNotify() before calling dispose crashes the app on jvm targets.
+    try {
+      map?.dispose()
+      map = null
+      renderer?.dispose()
+      renderer = null
+    } finally {
+      super.removeNotify()
+    }
 
     // HACK: Force a repaint by resizing the window slightly to avoid a ghost map on macoOS.
     val root = SwingUtilities.getWindowAncestor(this)

--- a/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/map/MapCanvas.kt
+++ b/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/map/MapCanvas.kt
@@ -65,7 +65,8 @@ public class MapCanvas(
   }
 
   override fun removeNotify() {
-    // Fix for https://github.com/maplibre/maplibre-compose/issues/716 and https://github.com/maplibre/maplibre-compose/issues/695
+    // Fix for https://github.com/maplibre/maplibre-compose/issues/716 and
+    // https://github.com/maplibre/maplibre-compose/issues/695
     // Calling super.removeNotify() before calling dispose crashes the app on jvm targets.
     try {
       map?.dispose()


### PR DESCRIPTION
<!-- Thanks for the PR! Please fill out the template below. -->

## Description

Issue found https://github.com/maplibre/maplibre-compose/issues/695 and https://github.com/maplibre/maplibre-compose/issues/716

Calling super.removeNotify() makes the native window to not be valid and crashes the GL driver when calling `dispose` on map and renderer resources. Fix is to call the `super.removeNotify()`  after the GL resources are disposed.

## Test plan

Tested the app on Windows by running the demo application > Map Manipulation and toggling the Show Map option.

## Checklist

**To your knowledge, are you making any breaking changes?**

I do not think so.

Tested on Windows 11

<!-- Delete any entries you haven't tested -->

- Desktop: Windows 11 64 bit
