### PR TITLE
Add workflow to label AI-generated PRs

### DIFF
--- a/.github/workflows/label-ai.yml
+++ b/.github/workflows/label-ai.yml
@@ -1,6 +1,8 @@
 name: Label AI-generated PRs
 
 on:
+  pull_request:
+    types: [opened, reopened, synchronize]
   pull_request_target:
     types: [opened, reopened, synchronize]
 

--- a/.github/workflows/label-ai.yml
+++ b/.github/workflows/label-ai.yml
@@ -1,0 +1,17 @@
+name: Label AI-generated PRs
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: sargunv/ai-pr-detector@64b95ea7b4b037eec2a4c7afb62e117fc006d77e # v0.1.0
+        with:
+          label: ai-generated

--- a/.github/workflows/label-ai.yml
+++ b/.github/workflows/label-ai.yml
@@ -1,8 +1,6 @@
 name: Label AI-generated PRs
 
 on:
-  pull_request:
-    types: [opened, reopened, synchronize]
   pull_request_target:
     types: [opened, reopened, synchronize]
 


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/label-ai.yml` that runs [`sargunv/ai-pr-detector`](https://github.com/sargunv/ai-pr-detector) on every PR and applies the `ai-generated` label when commit author/committer or `Co-authored-by:` trailers indicate AI authorship.
- Mirrors maplibre/spatial-k#318. API-only (no checkout, no compile) — runs in seconds.

## AI usage disclosure
Per the [MapLibre AI policy](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md): the workflow file was authored with Claude Code. This PR is also the test fixture — the commit on this branch carries a `Co-Authored-By: Claude` trailer, which the action should detect and use to apply the `ai-generated` label.

## Test plan
- [x] Workflow runs on this PR
- [x] Action detects the Claude co-author trailer on the commit
- [x] `ai-generated` label is applied automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)