### PR TITLE
Add Linux Nix development shell

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,15 @@ All contributions must comply with the
 In summary: disclose AI usage, and issues and PR descriptions must be written by
 the human.
 
+Example PR disclosure format:
+
+```markdown
+## AI Disclosure
+
+AI assistance was used to help with implementation and verification. The PR
+description was written by the human author.
+```
+
 ## Searching vendored MapLibre Native codebase
 
 When searching the vendored maplibre-native codebase:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,8 +10,7 @@ Example PR disclosure format:
 ```markdown
 ## AI Disclosure
 
-AI assistance was used to help with implementation and verification. The PR
-description was written by the human author.
+Created with [AGENT].
 ```
 
 ## Searching vendored MapLibre Native codebase

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,10 +8,10 @@ the human.
 Example PR disclosure format:
 
 ```markdown
-## AI Disclosure
-
-Created with [AGENT].
+_Created using [AGENT]_
 ```
+
+Where `[AGENT]` is like "OpenCode with GPT-5.5" or "Claude Code with Opus 4.7".
 
 ## Searching vendored MapLibre Native codebase
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,22 +102,13 @@ You'll need to have your developer environment set up to build MapLibre Native.
   - If building the Vulkan backend, set the `VULKAN_SDK` environment variable to
     the MoltenVK prefix (`export VULKAN_SDK="$(brew --prefix molten-vk)"`).
 - [Linux requirements](https://maplibre.org/maplibre-native/docs/book/platforms/linux/index.html#requirements)
-  - On Fedora, install the following:
+  - On a Linux system with Nix, enter the Nix development shell before building:
     ```bash
-    sudo dnf group install c-development development-tools
-    sudo dnf install cmake ninja-build clang \
-      libcurl-devel libjpeg-turbo-devel libpng-devel libwebp-devel \
-      libX11-devel mesa-libGL-devel libuv-devel bzip2-devel libicu-devel \
-      vulkan-loader-devel
+    nix develop
     ```
-  - On Ubuntu, install the following:
-    ```bash
-    sudo apt update
-    sudo apt install build-essential cmake ninja-build clang \
-      libcurl4-openssl-dev libjpeg-turbo8-dev libpng-dev libwebp-dev \
-      libx11-dev libgl1-mesa-dev libuv1-dev libbz2-dev libicu-dev \
-      libvulkan-dev
-    ```
+    This provides the Linux native compiler and system libraries required to
+    build MapLibre Native. If you prefer not to use Nix, follow or adapt the
+    Ubuntu instructions in the page linked above.
 - [Windows requirements (MSVS2022)](https://maplibre.org/maplibre-native/docs/book/platforms/windows/build-msvc.html#prerequisites)
   - When cloning the repo, pass `--config core.longpaths=true` to Git to avoid
     issues with long file paths.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1776877367,
+        "narHash": "sha256-EHq1/OX139R1RvBzOJ0aMRT3xnWyqtHBRUBuO1gFzjI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0726a0ecb6d4e08f6adced58726b95db924cef57",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,58 @@
+{
+  description = "Development shell for MapLibre Compose";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs = { nixpkgs, ... }:
+    let
+      linuxSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+
+      forEachLinuxSystem = nixpkgs.lib.genAttrs linuxSystems;
+    in
+    {
+      devShells = forEachLinuxSystem (system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+          runtimeLibraries = with pkgs; [
+            fontconfig
+            freetype
+            libGL
+            stdenv.cc.cc.lib
+            libxkbcommon
+            wayland
+            libx11
+            libxcursor
+            libxext
+            libxi
+            libxrandr
+            libxrender
+            libxtst
+          ];
+        in
+        {
+          default = (pkgs.mkShell.override { stdenv = pkgs.clangStdenv; }) {
+            packages = with pkgs; [
+              bzip2
+              cmake
+              curl
+              icu
+              libGL
+              libjpeg_turbo
+              libpng
+              libuv
+              libwebp
+              ninja
+              pkg-config
+              vulkan-headers
+              vulkan-loader
+              libx11
+            ];
+
+            LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath runtimeLibraries;
+          };
+        });
+    };
+}


### PR DESCRIPTION
## Summary

On macOS, we use a toolchain from XCode. On Windows, from Visual Studio 2022.

On Linux, we previously relied on some platform-specific packages, with example lists for Ubuntu and Fedora.

Instead, here we'll commit an exact declarative environment using Nix, and make that the recommended default env on Linux. The old way still works for folks not using the Nix package manager.

Makes some progress on #684 for Linux.

I didn't use mise for the dependencies here because the native libraries would be hard / impossible to manage with mise.

If we can solve #568, then we can probably simplify this to just get a compiler from mise (and potentially drop VS2022 on Windows too)

## Verification

Tested on NixOS. _should_ work on any Linux distro with the Nix package manager installed, but I only have NixOS to validate on.

_Created with OpenCode with GPT-5.5_