### PR TITLE
Update Compose to resolve Linux segfault

### DIFF
--- a/demo-app/build.gradle.kts
+++ b/demo-app/build.gradle.kts
@@ -1,4 +1,3 @@
-import org.jetbrains.compose.ExperimentalComposeLibrary
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSetTree
@@ -42,7 +41,7 @@ kotlin {
     instrumentedTestVariant.sourceSetTree.set(KotlinSourceSetTree.test)
   }
 
-  listOf(iosArm64(), iosSimulatorArm64(), iosX64()).forEach {
+  listOf(iosArm64(), iosSimulatorArm64()).forEach {
     it.binaries.framework {
       baseName = "DemoApp"
       isStatic = true
@@ -71,12 +70,12 @@ kotlin {
     all { languageSettings { optIn("androidx.compose.material3.ExperimentalMaterial3Api") } }
 
     commonMain.dependencies {
-      implementation(compose.components.resources)
-      implementation(compose.foundation)
-      implementation(compose.material3)
-      implementation(compose.runtime)
-      implementation(compose.ui)
-      implementation(compose.materialIconsExtended)
+      implementation(libs.jetbrains.compose.components.resources)
+      implementation(libs.jetbrains.compose.foundation)
+      implementation(libs.jetbrains.compose.material3)
+      implementation(libs.jetbrains.compose.runtime)
+      implementation(libs.jetbrains.compose.ui)
+      implementation(libs.jetbrains.compose.material.iconsExtended)
       implementation(libs.androidx.navigation.compose)
       implementation(libs.ktor.client.core)
       implementation(libs.ktor.client.contentNegotiation)
@@ -102,7 +101,7 @@ kotlin {
     androidMain {
       dependsOn(androidIosShared)
       dependencies {
-        implementation(compose.uiTooling)
+        implementation(libs.jetbrains.compose.ui.tooling)
         implementation(libs.androidx.activity.compose)
         implementation(libs.kotlinx.coroutines.android)
         implementation(libs.ktor.client.okhttp)
@@ -153,7 +152,7 @@ kotlin {
       dependsOn(nonAndroidShared)
       dependsOn(desktopJsShared)
       dependencies {
-        implementation(compose.html.core)
+        implementation(libs.jetbrains.compose.html.core)
         implementation(libs.ktor.client.js)
       }
     }
@@ -163,13 +162,13 @@ kotlin {
       implementation(kotlin("test-common"))
       implementation(kotlin("test-annotations-common"))
 
-      @OptIn(ExperimentalComposeLibrary::class) implementation(compose.uiTest)
+      implementation(libs.jetbrains.compose.ui.test)
     }
 
     androidUnitTest.dependencies { implementation(compose.desktop.currentOs) }
 
     androidInstrumentedTest.dependencies {
-      implementation(compose.desktop.uiTestJUnit4)
+      implementation(libs.jetbrains.compose.ui.testJunit4)
       implementation(libs.androidx.composeUi.testManifest)
     }
   }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,6 +29,8 @@ simplejni = "3.14"
 # https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-compatibility-and-versioning.html#jetpack-compose-artifacts-used
 gradle-compose = "1.10.3"
 androidx-compose = "1.10.5"
+jetbrains-compose-material3 = "1.10.0-alpha05"
+jetbrains-compose-material-iconsExtended = "1.7.3"
 jetbrains-navigation = "2.9.2"
 
 # Android and Kotlin: Keep Kotlin up to date and set Android accordingly.
@@ -57,6 +59,16 @@ ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "kto
 ktor-client-contentNegotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
 ktor-serialization-kotlinxJson = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 lifecycle-runtime-compose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose", version.ref = "lifecycleRuntimeCompose" }
+jetbrains-compose-components-resources = { module = "org.jetbrains.compose.components:components-resources", version.ref = "gradle-compose" }
+jetbrains-compose-foundation = { module = "org.jetbrains.compose.foundation:foundation", version.ref = "gradle-compose" }
+jetbrains-compose-html-core = { module = "org.jetbrains.compose.html:html-core", version.ref = "gradle-compose" }
+jetbrains-compose-material-iconsExtended = { module = "org.jetbrains.compose.material:material-icons-extended", version.ref = "jetbrains-compose-material-iconsExtended" }
+jetbrains-compose-material3 = { module = "org.jetbrains.compose.material3:material3", version.ref = "jetbrains-compose-material3" }
+jetbrains-compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "gradle-compose" }
+jetbrains-compose-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "gradle-compose" }
+jetbrains-compose-ui-test = { module = "org.jetbrains.compose.ui:ui-test", version.ref = "gradle-compose" }
+jetbrains-compose-ui-testJunit4 = { module = "org.jetbrains.compose.ui:ui-test-junit4", version.ref = "gradle-compose" }
+jetbrains-compose-ui-tooling = { module = "org.jetbrains.compose.ui:ui-tooling", version.ref = "gradle-compose" }
 maplibre-android = { module = "org.maplibre.gl:android-sdk", version.ref = "maplibre-android-sdk" }
 maplibre-androidOpenGL = { module = "org.maplibre.gl:android-sdk-opengl", version.ref = "maplibre-android-sdk" }
 maplibre-androidVulkan = { module = "org.maplibre.gl:android-sdk-vulkan", version.ref = "maplibre-android-sdk" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,7 +27,7 @@ simplejni = "3.14"
 
 # Libraries coupled to Compose: keep Compose up to date and set others accordingly.
 # https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-compatibility-and-versioning.html#jetpack-compose-artifacts-used
-gradle-compose = "1.9.3"
+gradle-compose = "1.10.0"
 androidx-compose = "1.9.4"
 jetbrains-navigation = "2.9.1"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ kermit = "2.0.8"
 kotlin-wrappers = "2025.11.5"
 kotlinx-coroutines = "1.10.2"
 ktor = "3.3.2"
-lifecycleRuntimeCompose = "2.9.6"
+lifecycleRuntimeCompose = "2.10.0"
 maplibre-android-sdk = "12.3.1"
 maplibre-android-plugins = "3.0.2"
 maplibre-js = "5.12.0"
@@ -27,9 +27,9 @@ simplejni = "3.14"
 
 # Libraries coupled to Compose: keep Compose up to date and set others accordingly.
 # https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-compatibility-and-versioning.html#jetpack-compose-artifacts-used
-gradle-compose = "1.10.0"
-androidx-compose = "1.9.4"
-jetbrains-navigation = "2.9.1"
+gradle-compose = "1.10.3"
+androidx-compose = "1.10.5"
+jetbrains-navigation = "2.9.2"
 
 # Android and Kotlin: Keep Kotlin up to date and set Android accordingly.
 # Also note the Gradle and XCode versions in the matrix!

--- a/lib/maplibre-compose-gms/build.gradle.kts
+++ b/lib/maplibre-compose-gms/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.jetbrains.compose.ExperimentalComposeLibrary
-
 plugins {
   id("library-conventions")
   id("android-library-conventions")
@@ -26,8 +24,8 @@ kotlin {
   sourceSets {
     commonMain.dependencies {
       api(libs.alchemist)
-      implementation(compose.material3)
-      implementation(compose.components.resources)
+      implementation(libs.jetbrains.compose.material3)
+      implementation(libs.jetbrains.compose.components.resources)
       implementation(libs.bytesize)
       implementation(libs.htmlConverterCompose)
       api(project(":lib:maplibre-compose"))
@@ -42,13 +40,13 @@ kotlin {
       implementation(kotlin("test"))
       implementation(kotlin("test-common"))
       implementation(kotlin("test-annotations-common"))
-      @OptIn(ExperimentalComposeLibrary::class) implementation(compose.uiTest)
+      implementation(libs.jetbrains.compose.ui.test)
     }
 
     androidHostTest.dependencies { implementation(compose.desktop.currentOs) }
 
     androidDeviceTest.dependencies {
-      implementation(compose.desktop.uiTestJUnit4)
+      implementation(libs.jetbrains.compose.ui.testJunit4)
       implementation(libs.androidx.composeUi.testManifest)
     }
   }

--- a/lib/maplibre-compose-material3/build.gradle.kts
+++ b/lib/maplibre-compose-material3/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.jetbrains.compose.ExperimentalComposeLibrary
-
 plugins {
   id("library-conventions")
   id("android-library-conventions")
@@ -22,7 +20,7 @@ mavenPublishing {
 kotlin {
   androidLibrary { namespace = "org.maplibre.compose.material3" }
 
-  listOf(iosArm64(), iosSimulatorArm64(), iosX64()).forEach { it.configureSpmMaplibre(project) }
+  listOf(iosArm64(), iosSimulatorArm64()).forEach { it.configureSpmMaplibre(project) }
 
   jvm("desktop") { compilerOptions { jvmTarget = project.getJvmTarget() } }
 
@@ -33,8 +31,8 @@ kotlin {
   sourceSets {
     commonMain.dependencies {
       api(libs.alchemist)
-      implementation(compose.material3)
-      implementation(compose.components.resources)
+      implementation(libs.jetbrains.compose.material3)
+      implementation(libs.jetbrains.compose.components.resources)
       implementation(libs.bytesize)
       implementation(libs.htmlConverterCompose)
       api(project(":lib:maplibre-compose"))
@@ -52,13 +50,13 @@ kotlin {
       implementation(kotlin("test"))
       implementation(kotlin("test-common"))
       implementation(kotlin("test-annotations-common"))
-      @OptIn(ExperimentalComposeLibrary::class) implementation(compose.uiTest)
+      implementation(libs.jetbrains.compose.ui.test)
     }
 
     androidHostTest.dependencies { implementation(compose.desktop.currentOs) }
 
     androidDeviceTest.dependencies {
-      implementation(compose.desktop.uiTestJUnit4)
+      implementation(libs.jetbrains.compose.ui.testJunit4)
       implementation(libs.androidx.composeUi.testManifest)
     }
   }

--- a/lib/maplibre-compose/build.gradle.kts
+++ b/lib/maplibre-compose/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.jetbrains.compose.ExperimentalComposeLibrary
-
 plugins {
   id("library-conventions")
   id("android-library-conventions")
@@ -23,7 +21,7 @@ mavenPublishing {
 kotlin {
   androidLibrary { namespace = "org.maplibre.compose" }
 
-  listOf(iosArm64(), iosSimulatorArm64(), iosX64()).forEach {
+  listOf(iosArm64(), iosSimulatorArm64()).forEach {
     it.compilations.getByName("main") {
       cinterops {
         create("observer") {
@@ -44,13 +42,13 @@ kotlin {
   sourceSets {
     val desktopMain by getting
 
-    listOf(iosMain, iosArm64Main, iosSimulatorArm64Main, iosX64Main).forEach {
+    listOf(iosMain, iosArm64Main, iosSimulatorArm64Main).forEach {
       it { languageSettings { optIn("kotlinx.cinterop.ExperimentalForeignApi") } }
     }
 
     commonMain.dependencies {
-      implementation(compose.foundation)
-      implementation(compose.components.resources)
+      implementation(libs.jetbrains.compose.foundation)
+      implementation(libs.jetbrains.compose.components.resources)
       implementation(libs.lifecycle.runtime.compose)
       api(libs.kermit)
       api(libs.spatialk.geojson)
@@ -100,13 +98,13 @@ kotlin {
       implementation(kotlin("test-common"))
       implementation(kotlin("test-annotations-common"))
 
-      @OptIn(ExperimentalComposeLibrary::class) implementation(compose.uiTest)
+      implementation(libs.jetbrains.compose.ui.test)
     }
 
     androidHostTest.dependencies { implementation(compose.desktop.currentOs) }
 
     androidDeviceTest.dependencies {
-      implementation(compose.desktop.uiTestJUnit4)
+      implementation(libs.jetbrains.compose.ui.testJunit4)
       implementation(libs.androidx.composeUi.testManifest)
     }
   }

--- a/lib/maplibre-native-bindings-jni/CMakeLists.txt
+++ b/lib/maplibre-native-bindings-jni/CMakeLists.txt
@@ -4,6 +4,10 @@ include(cmake/vars.cmake)
 
 project(maplibre-jni)
 
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+    add_compile_definitions(NDEBUG)
+endif()
+
 include(cmake/target.cmake)
 
 include(cmake/dependencies/platform.cmake)

--- a/lib/maplibre-native-bindings-jni/CMakeLists.txt
+++ b/lib/maplibre-native-bindings-jni/CMakeLists.txt
@@ -4,10 +4,6 @@ include(cmake/vars.cmake)
 
 project(maplibre-jni)
 
-if(CMAKE_BUILD_TYPE STREQUAL "Release")
-    add_compile_definitions(NDEBUG)
-endif()
-
 include(cmake/target.cmake)
 
 include(cmake/dependencies/platform.cmake)


### PR DESCRIPTION
## Summary

Resolves #564. Compose v1.10 includes a version of skiko that uses the system's libstdc++ instead of statically linking it. This somehow resolves the segfault when combined with other libraries using libstdc++ like MapLibre.

Also removes apple x64 targets as they're being removed in Compose v1.11

_Created using OpenCode with GPT-5.5_