### PR TITLE
Add desktop Vulkan canvas backend

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -35,9 +35,17 @@ jobs:
             renderer: opengl
             preset: linux-opengl
             runner: ubuntu-latest # amd64
+          - variant: linux-amd64-vulkan
+            renderer: vulkan
+            preset: linux-vulkan
+            runner: ubuntu-latest # amd64
           - variant: windows-amd64-opengl
             renderer: opengl
             preset: windows-opengl
+            runner: windows-latest # amd64
+          - variant: windows-amd64-vulkan
+            renderer: vulkan
+            preset: windows-vulkan
             runner: windows-latest # amd64
     runs-on: ${{ matrix.runner }}
     name: build-natives (${{ matrix.variant }})
@@ -80,8 +88,16 @@ jobs:
           path: ./lib/maplibre-native-bindings-jni/build/copiedResources/LinuxAmd64Opengl/linux/amd64/opengl/
       - uses: actions/download-artifact@v6
         with:
+          name: natives-linux-amd64-vulkan
+          path: ./lib/maplibre-native-bindings-jni/build/copiedResources/LinuxAmd64Vulkan/linux/amd64/vulkan/
+      - uses: actions/download-artifact@v6
+        with:
           name: natives-windows-amd64-opengl
           path: ./lib/maplibre-native-bindings-jni/build/copiedResources/WindowsAmd64Opengl/windows/amd64/opengl/
+      - uses: actions/download-artifact@v6
+        with:
+          name: natives-windows-amd64-vulkan
+          path: ./lib/maplibre-native-bindings-jni/build/copiedResources/WindowsAmd64Vulkan/windows/amd64/vulkan/
       - run: |
           ./gradlew publishAllPublicationsToGitHubPackagesRepository -PconfigureForPublishing=true
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,17 @@ jobs:
             renderer: opengl
             preset: linux-opengl
             runner: ubuntu-latest # amd64
+          - variant: linux-amd64-vulkan
+            renderer: vulkan
+            preset: linux-vulkan
+            runner: ubuntu-latest # amd64
           - variant: windows-amd64-opengl
             renderer: opengl
             preset: windows-opengl
+            runner: windows-latest # amd64
+          - variant: windows-amd64-vulkan
+            renderer: vulkan
+            preset: windows-vulkan
             runner: windows-latest # amd64
     runs-on: ${{ matrix.runner }}
     name: build-natives (${{ matrix.variant }})
@@ -64,8 +72,16 @@ jobs:
           path: ./lib/maplibre-native-bindings-jni/build/copiedResources/LinuxAmd64Opengl/linux/amd64/opengl/
       - uses: actions/download-artifact@v6
         with:
+          name: natives-linux-amd64-vulkan
+          path: ./lib/maplibre-native-bindings-jni/build/copiedResources/LinuxAmd64Vulkan/linux/amd64/vulkan/
+      - uses: actions/download-artifact@v6
+        with:
           name: natives-windows-amd64-opengl
           path: ./lib/maplibre-native-bindings-jni/build/copiedResources/WindowsAmd64Opengl/windows/amd64/opengl/
+      - uses: actions/download-artifact@v6
+        with:
+          name: natives-windows-amd64-vulkan
+          path: ./lib/maplibre-native-bindings-jni/build/copiedResources/WindowsAmd64Vulkan/windows/amd64/vulkan/
       - run: |
           ./gradlew publishAndReleaseToMavenCentral -PconfigureForPublishing=true --no-configuration-cache
         env:

--- a/buildSrc/src/main/kotlin/util.kt
+++ b/buildSrc/src/main/kotlin/util.kt
@@ -62,11 +62,11 @@ enum class DesktopVariant(
   MacosAarch64Vulkan("macos", "aarch64", "vulkan"),
   LinuxAmd64Opengl("linux", "amd64", "opengl", true),
   LinuxAarch64Opengl("linux", "aarch64", "opengl"),
-  LinuxAmd64Vulkan("linux", "amd64", "vulkan"),
+  LinuxAmd64Vulkan("linux", "amd64", "vulkan", true),
   LinuxAarch64Vulkan("linux", "aarch64", "vulkan"),
   WindowsAmd64Opengl("windows", "amd64", "opengl", true),
   WindowsAarch64Opengl("windows", "aarch64", "opengl"),
-  WindowsAmd64Vulkan("windows", "amd64", "vulkan"),
+  WindowsAmd64Vulkan("windows", "amd64", "vulkan", true),
   WindowsAarch64Vulkan("windows", "aarch64", "vulkan");
 
   companion object {

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -215,7 +215,9 @@ The following targets are available now:
 
 - `macos-aarch64-metal`
 - `linux-amd64-opengl`
+- `linux-amd64-vulkan`
 - `windows-amd64-opengl`
+- `windows-amd64-vulkan`
 
 Other architectures and renderers will be added later.
 

--- a/lib/maplibre-native-bindings-jni/cmake/backends/vulkan.cmake
+++ b/lib/maplibre-native-bindings-jni/cmake/backends/vulkan.cmake
@@ -16,6 +16,7 @@ endif()
 
 find_package(Vulkan REQUIRED)
 target_link_libraries(maplibre-jni PRIVATE Vulkan::Vulkan)
+target_include_directories(maplibre-jni SYSTEM PRIVATE ${maplibre-native_SOURCE_DIR}/src)
 
 # Don't use system Vulkan headers - use MapLibre's vendored headers for compatibility
 # The vendored headers are included via the Mapbox::Map target

--- a/lib/maplibre-native-bindings-jni/cmake/target.cmake
+++ b/lib/maplibre-native-bindings-jni/cmake/target.cmake
@@ -8,6 +8,7 @@ add_library(maplibre-jni SHARED
     src/main/cpp/canvas_frontend.cpp
     src/main/cpp/canvas_metal_backend.mm
     src/main/cpp/canvas_opengl_backend.cpp
+    src/main/cpp/canvas_vulkan_backend.cpp
     src/main/cpp/maplibre_util_projection.cpp
 )
 

--- a/lib/maplibre-native-bindings-jni/cmake/vars.cmake
+++ b/lib/maplibre-native-bindings-jni/cmake/vars.cmake
@@ -1,6 +1,7 @@
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+add_compile_definitions($<$<CONFIG:Release>:NDEBUG>)
 
 if(NOT DEFINED OUTPUT_DIR)
     message(FATAL_ERROR "OUTPUT_DIR is not defined")

--- a/lib/maplibre-native-bindings-jni/src/main/cpp/canvas_frontend.cpp
+++ b/lib/maplibre-native-bindings-jni/src/main/cpp/canvas_frontend.cpp
@@ -80,7 +80,6 @@ CanvasRenderer_class::render(JNIEnv* env, jCanvasRenderer renderer) {
     auto* frontend = reinterpret_cast<maplibre_jni::CanvasRenderer*>(
       java_classes::get<CanvasRenderer_class>().getNativePointer(env, renderer)
     );
-    // TODO: something in here is segfaulting on Linux
     frontend->render();
   } catch (const std::exception& e) {
     smjni::java_exception::translate(env, e);

--- a/lib/maplibre-native-bindings-jni/src/main/cpp/canvas_frontend.cpp
+++ b/lib/maplibre-native-bindings-jni/src/main/cpp/canvas_frontend.cpp
@@ -63,6 +63,13 @@ auto CanvasRenderer::getThreadPool() const -> const mbgl::TaggedScheduler& {
 
 void CanvasRenderer::render() {
   if (!renderer_ || !updateParameters_) return;
+#if defined(USE_VULKAN_BACKEND)
+  if (!backend_->lockSurfaceForRender()) return;
+  struct SurfaceUnlocker {
+    CanvasBackend& backend;
+    ~SurfaceUnlocker() { backend.unlockSurfaceAfterRender(); }
+  } surfaceUnlocker{*backend_};
+#endif
   mbgl::gfx::BackendScope scope(*backend_);
   renderer_->render(updateParameters_);
 }

--- a/lib/maplibre-native-bindings-jni/src/main/cpp/canvas_renderer.hpp
+++ b/lib/maplibre-native-bindings-jni/src/main/cpp/canvas_renderer.hpp
@@ -74,6 +74,8 @@ class CanvasBackend : public mbgl::vulkan::RendererBackend,
   explicit CanvasBackend(JNIEnv* env, jCanvas canvas);
   auto getDefaultRenderable() -> mbgl::gfx::Renderable& override;
   void setSize(mbgl::Size);
+  bool lockSurfaceForRender();
+  void unlockSurfaceAfterRender();
 
  protected:
   auto getInstanceExtensions() -> std::vector<const char*> override;

--- a/lib/maplibre-native-bindings-jni/src/main/cpp/canvas_renderer.hpp
+++ b/lib/maplibre-native-bindings-jni/src/main/cpp/canvas_renderer.hpp
@@ -21,7 +21,14 @@
 #include <mbgl/mtl/renderer_backend.hpp>
 #elif defined(USE_OPENGL_BACKEND)
 #include <mbgl/gl/renderer_backend.hpp>
+#elif defined(USE_VULKAN_BACKEND)
+#include <mbgl/vulkan/renderable_resource.hpp>
+#include <mbgl/vulkan/renderer_backend.hpp>
 #endif
+
+// clang-format off
+#include "fix_x11_pollution.h"
+// clang-format on
 
 namespace mbgl {
 class Renderer;
@@ -60,7 +67,19 @@ class CanvasBackend : public mbgl::gl::RendererBackend,
 };
 
 #elif defined(USE_VULKAN_BACKEND)
-#error "TODO: Implement Vulkan Backend"
+
+class CanvasBackend : public mbgl::vulkan::RendererBackend,
+                      public mbgl::vulkan::Renderable {
+ public:
+  explicit CanvasBackend(JNIEnv* env, jCanvas canvas);
+  auto getDefaultRenderable() -> mbgl::gfx::Renderable& override;
+  void setSize(mbgl::Size);
+
+ protected:
+  auto getInstanceExtensions() -> std::vector<const char*> override;
+  void activate() override {}
+  void deactivate() override {}
+};
 #endif
 
 class CanvasRenderer : public mbgl::RendererFrontend {

--- a/lib/maplibre-native-bindings-jni/src/main/cpp/canvas_vulkan_backend.cpp
+++ b/lib/maplibre-native-bindings-jni/src/main/cpp/canvas_vulkan_backend.cpp
@@ -104,6 +104,10 @@ class VulkanRenderableResource final
 
   void bind() override {}
 
+  bool lockForRender() { return jawtContext.tryLock(); }
+
+  void unlockAfterRender() { jawtContext.unlock(); }
+
  private:
   JawtContext jawtContext;
 };
@@ -122,6 +126,14 @@ CanvasBackend::CanvasBackend(JNIEnv* env, jCanvas canvas)
 
 auto CanvasBackend::getDefaultRenderable() -> mbgl::gfx::Renderable& {
   return *this;
+}
+
+bool CanvasBackend::lockSurfaceForRender() {
+  return getResource<VulkanRenderableResource>().lockForRender();
+}
+
+void CanvasBackend::unlockSurfaceAfterRender() {
+  getResource<VulkanRenderableResource>().unlockAfterRender();
 }
 
 void CanvasBackend::setSize(mbgl::Size newSize) {

--- a/lib/maplibre-native-bindings-jni/src/main/cpp/canvas_vulkan_backend.cpp
+++ b/lib/maplibre-native-bindings-jni/src/main/cpp/canvas_vulkan_backend.cpp
@@ -1,0 +1,150 @@
+#ifdef USE_VULKAN_BACKEND
+
+#include <stdexcept>
+
+#include <mbgl/vulkan/context.hpp>
+#include <mbgl/vulkan/renderable_resource.hpp>
+
+// clang-format off
+#include "fix_x11_pollution.h"
+// clang-format on
+
+#include "canvas_renderer.hpp"
+#include "java_classes.hpp"
+#include "jawt_context.hpp"
+#include "utils.hpp"
+
+#if defined(__linux__)
+#include <vulkan/vulkan_xlib.h>
+#elif defined(_WIN32)
+#include <vulkan/vulkan_win32.h>
+#endif
+
+namespace maplibre_jni {
+
+class VulkanRenderableResource final
+    : public mbgl::vulkan::SurfaceRenderableResource {
+ public:
+  VulkanRenderableResource(CanvasBackend& backend_, JNIEnv* env, jCanvas canvas)
+      : mbgl::vulkan::SurfaceRenderableResource(backend_),
+        jawtContext(env, canvas) {}
+
+  auto getDeviceExtensions() -> std::vector<const char*> override {
+    return {VK_KHR_SWAPCHAIN_EXTENSION_NAME};
+  }
+
+  void createPlatformSurface() override {
+    auto& backendImpl = static_cast<CanvasBackend&>(backend);
+
+#if defined(__linux__)
+    check(jawtContext.getDisplay() != nullptr, "X11 display is nullptr");
+    check(jawtContext.getDrawable() != 0, "X11 drawable is 0");
+
+    VkXlibSurfaceCreateInfoKHR createInfo{};
+    createInfo.sType = VK_STRUCTURE_TYPE_XLIB_SURFACE_CREATE_INFO_KHR;
+    createInfo.dpy = jawtContext.getDisplay();
+    createInfo.window = jawtContext.getDrawable();
+
+    auto createXlibSurface = reinterpret_cast<PFN_vkCreateXlibSurfaceKHR>(
+      backendImpl.getDispatcher().vkGetInstanceProcAddr(
+        backendImpl.getInstance().get(), "vkCreateXlibSurfaceKHR"
+      )
+    );
+    check(
+      createXlibSurface != nullptr, "vkCreateXlibSurfaceKHR is unavailable"
+    );
+
+    VkSurfaceKHR rawSurface = VK_NULL_HANDLE;
+    auto result = createXlibSurface(
+      backendImpl.getInstance().get(), &createInfo, nullptr, &rawSurface
+    );
+    check(result == VK_SUCCESS, "vkCreateXlibSurfaceKHR failed");
+
+    surface = vk::UniqueSurfaceKHR(
+      rawSurface,
+      vk::ObjectDestroy<vk::Instance, vk::DispatchLoaderDynamic>(
+        backendImpl.getInstance().get(), nullptr, backendImpl.getDispatcher()
+      )
+    );
+#elif defined(_WIN32)
+    check(jawtContext.getHwnd() != nullptr, "HWND is nullptr");
+
+    VkWin32SurfaceCreateInfoKHR createInfo{};
+    createInfo.sType = VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR;
+    createInfo.hinstance = GetModuleHandle(nullptr);
+    createInfo.hwnd = jawtContext.getHwnd();
+
+    auto createWin32Surface = reinterpret_cast<PFN_vkCreateWin32SurfaceKHR>(
+      backendImpl.getDispatcher().vkGetInstanceProcAddr(
+        backendImpl.getInstance().get(), "vkCreateWin32SurfaceKHR"
+      )
+    );
+    check(
+      createWin32Surface != nullptr, "vkCreateWin32SurfaceKHR is unavailable"
+    );
+
+    VkSurfaceKHR rawSurface = VK_NULL_HANDLE;
+    auto result = createWin32Surface(
+      backendImpl.getInstance().get(), &createInfo, nullptr, &rawSurface
+    );
+    check(result == VK_SUCCESS, "vkCreateWin32SurfaceKHR failed");
+
+    surface = vk::UniqueSurfaceKHR(
+      rawSurface,
+      vk::ObjectDestroy<vk::Instance, vk::DispatchLoaderDynamic>(
+        backendImpl.getInstance().get(), nullptr, backendImpl.getDispatcher()
+      )
+    );
+#else
+    throw std::runtime_error(
+      "Vulkan CanvasBackend is unsupported on this platform"
+    );
+#endif
+  }
+
+  void bind() override {}
+
+ private:
+  JawtContext jawtContext;
+};
+
+CanvasBackend::CanvasBackend(JNIEnv* env, jCanvas canvas)
+    : mbgl::vulkan::RendererBackend(mbgl::gfx::ContextMode::Unique),
+      mbgl::vulkan::Renderable(
+        mbgl::Size(
+          java_classes::get<Canvas_class>().getWidth(env, canvas),
+          java_classes::get<Canvas_class>().getHeight(env, canvas)
+        ),
+        std::make_unique<VulkanRenderableResource>(*this, env, canvas)
+      ) {
+  init();
+}
+
+auto CanvasBackend::getDefaultRenderable() -> mbgl::gfx::Renderable& {
+  return *this;
+}
+
+void CanvasBackend::setSize(mbgl::Size newSize) {
+  mbgl::vulkan::Renderable::setSize(newSize);
+
+  if (context) {
+    static_cast<mbgl::vulkan::Context&>(*context).requestSurfaceUpdate();
+  }
+}
+
+auto CanvasBackend::getInstanceExtensions() -> std::vector<const char*> {
+  auto extensions = mbgl::vulkan::RendererBackend::getInstanceExtensions();
+  extensions.push_back(VK_KHR_SURFACE_EXTENSION_NAME);
+
+#if defined(__linux__)
+  extensions.push_back(VK_KHR_XLIB_SURFACE_EXTENSION_NAME);
+#elif defined(_WIN32)
+  extensions.push_back(VK_KHR_WIN32_SURFACE_EXTENSION_NAME);
+#endif
+
+  return extensions;
+}
+
+}  // namespace maplibre_jni
+
+#endif

--- a/lib/maplibre-native-bindings-jni/src/main/cpp/jawt_context.hpp
+++ b/lib/maplibre-native-bindings-jni/src/main/cpp/jawt_context.hpp
@@ -72,8 +72,13 @@ class JawtContext {
 
   jint lock() {
     jint lockResult = drawingSurface->Lock(drawingSurface);
-    check(lockResult != JAWT_LOCK_ERROR, "drawingSurface->Lock failed");
+    check((lockResult & JAWT_LOCK_ERROR) == 0, "drawingSurface->Lock failed");
     return lockResult;
+  }
+
+  bool tryLock() {
+    jint lockResult = drawingSurface->Lock(drawingSurface);
+    return (lockResult & JAWT_LOCK_ERROR) == 0;
   }
 
   void unlock() { drawingSurface->Unlock(drawingSurface); }


### PR DESCRIPTION
Resolves #566. Based on my PoC linked in that issue.

Validated on Linux x64. Will validate Windows sometime later when I get the project building on windows again.

Not supporting Vulkan on macOS for now (though it's possible with MoltenVK) since we have a Metal implementation.

_Created using OpenCode with GPT-5.5_