### PR TITLE
Fix desktop map removal teardown

### DIFF
--- a/lib/maplibre-native-bindings-jni/src/main/cpp/canvas_frontend.cpp
+++ b/lib/maplibre-native-bindings-jni/src/main/cpp/canvas_frontend.cpp
@@ -63,8 +63,11 @@ auto CanvasRenderer::getThreadPool() const -> const mbgl::TaggedScheduler& {
 
 void CanvasRenderer::render() {
   if (!renderer_ || !updateParameters_) return;
-#if defined(USE_VULKAN_BACKEND)
+#if defined(USE_OPENGL_BACKEND) || defined(USE_METAL_BACKEND) || \
+  defined(USE_VULKAN_BACKEND)
   if (!backend_->lockSurfaceForRender()) return;
+#endif
+#if defined(USE_VULKAN_BACKEND)
   struct SurfaceUnlocker {
     CanvasBackend& backend;
     ~SurfaceUnlocker() { backend.unlockSurfaceAfterRender(); }

--- a/lib/maplibre-native-bindings-jni/src/main/cpp/canvas_metal_backend.mm
+++ b/lib/maplibre-native-bindings-jni/src/main/cpp/canvas_metal_backend.mm
@@ -153,9 +153,25 @@ class MetalRenderableResource final : public mbgl::mtl::RenderableResource {
     }
   }
 
-  void activate() { jawtContext_.lock(); }
+  bool lockForRender() {
+    if (surfaceLocked) return true;
+    surfaceLocked = jawtContext_.tryLock();
+    return surfaceLocked;
+  }
 
-  void deactivate() { jawtContext_.unlock(); }
+  void activate() {
+    if (!surfaceLocked) {
+      jawtContext_.lock();
+      surfaceLocked = true;
+    }
+  }
+
+  void deactivate() {
+    if (surfaceLocked) {
+      jawtContext_.unlock();
+      surfaceLocked = false;
+    }
+  }
 
   [[nodiscard]] auto getBackend() const
     -> const mbgl::mtl::RendererBackend & override {
@@ -188,6 +204,7 @@ class MetalRenderableResource final : public mbgl::mtl::RenderableResource {
   mbgl::gfx::Texture2DPtr depthTexture;
   mbgl::gfx::Texture2DPtr stencilTexture;
   mbgl::Size size;
+  bool surfaceLocked = false;
 };
 
 CanvasBackend::CanvasBackend(JNIEnv *env, jCanvas canvas)
@@ -202,6 +219,10 @@ CanvasBackend::CanvasBackend(JNIEnv *env, jCanvas canvas)
 
 void CanvasBackend::setSize(mbgl::Size size) {
   getResource<MetalRenderableResource>().setSize(size);
+}
+
+bool CanvasBackend::lockSurfaceForRender() {
+  return getResource<MetalRenderableResource>().lockForRender();
 }
 
 auto CanvasBackend::getDefaultRenderable() -> mbgl::gfx::Renderable & {

--- a/lib/maplibre-native-bindings-jni/src/main/cpp/canvas_opengl_backend.cpp
+++ b/lib/maplibre-native-bindings-jni/src/main/cpp/canvas_opengl_backend.cpp
@@ -45,7 +45,10 @@ class OpenGLRenderableResource final : public mbgl::gl::RenderableResource {
   }
 
   void activate() {
-    jawtContext.lock();
+    if (!surfaceLocked) {
+      jawtContext.lock();
+      surfaceLocked = true;
+    }
     if (glContext == nullptr) initGL();
 #if defined(__linux__)
     glXMakeCurrent(
@@ -54,6 +57,12 @@ class OpenGLRenderableResource final : public mbgl::gl::RenderableResource {
 #elif defined(_WIN32)
     wglMakeCurrent(hdc, glContext);
 #endif
+  }
+
+  bool lockForRender() {
+    if (surfaceLocked) return true;
+    surfaceLocked = jawtContext.tryLock();
+    return surfaceLocked;
   }
 
   void bind() override {
@@ -77,7 +86,10 @@ class OpenGLRenderableResource final : public mbgl::gl::RenderableResource {
 #elif defined(_WIN32)
     wglMakeCurrent(hdc, nullptr);
 #endif
-    jawtContext.unlock();
+    if (surfaceLocked) {
+      jawtContext.unlock();
+      surfaceLocked = false;
+    }
   }
 
  private:
@@ -203,6 +215,7 @@ class OpenGLRenderableResource final : public mbgl::gl::RenderableResource {
 
   maplibre_jni::CanvasBackend& backend;
   JawtContext jawtContext;
+  bool surfaceLocked = false;
 #if defined(__linux__)
   GLXContext glContext = nullptr;
 #elif defined(_WIN32)
@@ -226,6 +239,10 @@ auto CanvasBackend::getDefaultRenderable() -> mbgl::gfx::Renderable& {
 }
 
 void CanvasBackend::setSize(mbgl::Size size) { this->size = size; }
+
+bool CanvasBackend::lockSurfaceForRender() {
+  return getResource<OpenGLRenderableResource>().lockForRender();
+}
 
 void CanvasBackend::activate() {
   auto& resource = getResource<OpenGLRenderableResource>();

--- a/lib/maplibre-native-bindings-jni/src/main/cpp/canvas_renderer.hpp
+++ b/lib/maplibre-native-bindings-jni/src/main/cpp/canvas_renderer.hpp
@@ -43,6 +43,7 @@ class CanvasBackend : public mbgl::mtl::RendererBackend,
   explicit CanvasBackend(JNIEnv* env, jCanvas canvas);
   auto getDefaultRenderable() -> mbgl::gfx::Renderable& override;
   void setSize(mbgl::Size);
+  bool lockSurfaceForRender();
 
  protected:
   void activate() override;
@@ -58,6 +59,7 @@ class CanvasBackend : public mbgl::gl::RendererBackend,
   explicit CanvasBackend(JNIEnv* env, jCanvas canvas);
   mbgl::gfx::Renderable& getDefaultRenderable() override;
   void setSize(mbgl::Size);
+  bool lockSurfaceForRender();
 
  protected:
   void activate() override;

--- a/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/map/MapCanvas.kt
+++ b/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/map/MapCanvas.kt
@@ -65,18 +65,20 @@ public class MapCanvas(
   }
 
   override fun removeNotify() {
-    super.removeNotify()
+    val root = SwingUtilities.getWindowAncestor(this)
     map?.dispose()
     map = null
     renderer?.dispose()
     renderer = null
+    super.removeNotify()
 
     // HACK: Force a repaint by resizing the window slightly to avoid a ghost map on macoOS.
-    val root = SwingUtilities.getWindowAncestor(this)
-    val oWidth = root.width
-    val oHeight = root.height
-    root.size = Dimension(oWidth + 1, oHeight + 1)
-    root.size = Dimension(oWidth, oHeight)
+    if (root != null) {
+      val oWidth = root.width
+      val oHeight = root.height
+      root.size = Dimension(oWidth + 1, oHeight + 1)
+      root.size = Dimension(oWidth, oHeight)
+    }
   }
 
   /**

--- a/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/map/MapCanvas.kt
+++ b/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/map/MapCanvas.kt
@@ -66,11 +66,17 @@ public class MapCanvas(
 
   override fun removeNotify() {
     val root = SwingUtilities.getWindowAncestor(this)
-    map?.dispose()
-    map = null
-    renderer?.dispose()
-    renderer = null
-    super.removeNotify()
+    // Fix for https://github.com/maplibre/maplibre-compose/issues/716 and
+    // https://github.com/maplibre/maplibre-compose/issues/695
+    // Calling super.removeNotify() before calling dispose crashes the app on jvm targets.
+    try {
+      map?.dispose()
+      map = null
+      renderer?.dispose()
+      renderer = null
+    } finally {
+      super.removeNotify()
+    }
 
     // HACK: Force a repaint by resizing the window slightly to avoid a ghost map on macoOS.
     if (root != null) {

--- a/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/map/MapCanvas.kt
+++ b/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/map/MapCanvas.kt
@@ -66,9 +66,6 @@ public class MapCanvas(
 
   override fun removeNotify() {
     val root = SwingUtilities.getWindowAncestor(this)
-    // Fix for https://github.com/maplibre/maplibre-compose/issues/716 and
-    // https://github.com/maplibre/maplibre-compose/issues/695
-    // Calling super.removeNotify() before calling dispose crashes the app on jvm targets.
     try {
       map?.dispose()
       map = null


### PR DESCRIPTION
## Summary

#770 plus extras

Should resolve #695 and perhaps #716 

- Dispose desktop map/native renderer resources before releasing the AWT peer.
- Skip stale desktop render frames when the JAWT drawing surface can no longer be locked.

## Testing

- `./gradlew -PdesktopRenderer=opengl :lib:maplibre-native-bindings-jni:buildNative`
- `./gradlew -PdesktopRenderer=vulkan :lib:maplibre-native-bindings-jni:buildNative`
- `./gradlew -PdesktopRenderer=opengl :lib:maplibre-native-bindings:compileKotlinDesktop`

_Created using OpenCode with GPT-5.5_