### PR TITLE
Fix desktop map removal teardown

### DIFF
--- a/lib/maplibre-native-bindings-jni/src/main/cpp/canvas_frontend.cpp
+++ b/lib/maplibre-native-bindings-jni/src/main/cpp/canvas_frontend.cpp
@@ -38,6 +38,9 @@ CanvasRenderer::CanvasRenderer(
 }
 
 void CanvasRenderer::reset() {
+  if (renderer_) {
+    renderer_->setObserver(nullptr);
+  }
   renderer_.reset();
   observer_.reset();
   updateParameters_.reset();

--- a/lib/maplibre-native-bindings-jni/src/main/cpp/maplibre_map.cpp
+++ b/lib/maplibre-native-bindings-jni/src/main/cpp/maplibre_map.cpp
@@ -18,11 +18,11 @@
 #pragma mark - Helpers
 
 struct MapWrapper {
-  std::unique_ptr<mbgl::Map> map;
   std::unique_ptr<maplibre_jni::JniMapObserver> observer;
+  std::unique_ptr<mbgl::Map> map;
 
   MapWrapper(mbgl::Map* map, maplibre_jni::JniMapObserver* observer)
-      : map(map), observer(observer) {}
+      : observer(observer), map(map) {}
 };
 
 template <typename Func>

--- a/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/map/CanvasRenderer.kt
+++ b/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/map/CanvasRenderer.kt
@@ -12,6 +12,8 @@ public class CanvasRenderer(
   @get:CalledByNative @get:JvmName("getCanvas") internal val canvas: Canvas,
   pixelRatio: Float,
 ) : RendererFrontend {
+  private var isDisposed = false
+
   internal val nativePeer =
     AutoCleanPointer(
       new = { alloc(canvas = this, pixelRatio = pixelRatio) },
@@ -23,7 +25,10 @@ public class CanvasRenderer(
   override val nativePointer: Long
     get() = nativePeer.rawPtr
 
-  public fun dispose(): Unit = nativePeer.clean()
+  public fun dispose() {
+    isDisposed = true
+    nativePeer.clean()
+  }
 
   public external fun render()
 
@@ -41,7 +46,7 @@ public class CanvasRenderer(
   @Suppress("unused")
   @CalledByNative
   private fun requestRunOnce() {
-    EventQueue.invokeLater { runOnce() }
+    EventQueue.invokeLater { if (!isDisposed) runOnce() }
   }
 
   private companion object Companion {


### PR DESCRIPTION
Fix #716 by changing native map teardown to detach renderer observers before destruction and adding a disposed guard for queued renderer callbacks.

_Created using OpenCode with GPT-5.5_