### PR TITLE
Fix desktop map initialization at zero size

### DIFF
--- a/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/map/MapCanvas.kt
+++ b/lib/maplibre-native-bindings/src/desktopMain/kotlin/org/maplibre/kmp/native/map/MapCanvas.kt
@@ -26,6 +26,7 @@ public class MapCanvas(
   private var map: MapLibreMap? = null
 
   override fun paint(g: Graphics) {
+    if (width <= 0 || height <= 0) return
     renderer?.render()
   }
 
@@ -40,6 +41,12 @@ public class MapCanvas(
 
   override fun addNotify() {
     super.addNotify()
+
+    initializeMapIfReady()
+  }
+
+  private fun initializeMapIfReady() {
+    if (map != null || renderer != null || width <= 0 || height <= 0) return
 
     // Initialize a map
     val pixelRatio = this.graphicsConfiguration.defaultTransform.scaleX.toFloat()
@@ -99,6 +106,8 @@ public class MapCanvas(
 
     override fun componentResized(e: ComponentEvent) {
       val canvas = e.component as? MapCanvas ?: return
+      if (canvas.width <= 0 || canvas.height <= 0) return
+      canvas.initializeMapIfReady()
       val pixelRatio = canvas.graphicsConfiguration.defaultTransform.scaleX.toFloat()
       val size = Size(width = canvas.width, height = canvas.height)
       canvas.renderer?.setSize(size * pixelRatio)


### PR DESCRIPTION
Hotfix for #566 . Previously I only tested the Linux path. Now on Windows I noticed there's a crash if the surface is ever 0x0.

_Created using OpenCode with GPT-5.5_