### PR TITLE
Document iOS HarfBuzz link-order workaround and upgrade MapLibre iOS

### DIFF
--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -64,6 +64,21 @@ The easiest way is to select one of these two Gradle plugins:
 - JetBrains's [CocoaPods plugin][gradle-cocoapods]
 - Third party [Swift Package Manager plugin][gradle-spm4kmp]
 
+!!! warning
+
+    In Xcode, ensure your Kotlin/Compose framework is linked before
+    `MapLibre.framework`. Select your iOS app target, open **Build Settings**,
+    search for **Other Linker Flags**, and order the flags like this:
+
+    ```text
+    -framework ComposeApp
+    -framework MapLibre
+    ```
+
+    Replace `ComposeApp` with your Kotlin framework name. The opposite order can
+    cause broken Compose text rendering on iOS because both Compose and
+    MapLibre include HarfBuzz symbols.
+
 ### Cocoapods
 
 !!! info

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ androidTargetSdk=36
 iosDeploymentTarget=12.0
 jvmToolchain=21
 jvmTarget=11
-maplibreIosVersion=6.17.1
+maplibreIosVersion=6.25.1
 #
 # Dependency flags
 kotlin.code.style=official

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -320,9 +320,9 @@
 					"-ObjC",
 					"-l\"c++\"",
 					"-framework",
-					"\"MapLibre\"",
-					"-framework",
 					"\"DemoApp\"",
+					"-framework",
+					"\"MapLibre\"",
 					"-lsqlite3",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "${BUNDLE_ID}${TEAM_ID}";
@@ -357,9 +357,9 @@
 					"-ObjC",
 					"-l\"c++\"",
 					"-framework",
-					"\"MapLibre\"",
-					"-framework",
 					"\"DemoApp\"",
+					"-framework",
+					"\"MapLibre\"",
 					"-lsqlite3",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "${BUNDLE_ID}${TEAM_ID}";


### PR DESCRIPTION
_Created using OpenCode with GPT-5.5_

Resolves #551 by documenting a known workaround. It's not a real fix, and I'm concerned there may be other related bugs lurking, but it's good enough to unblock upgrading MapLibre iOS I think