### PR TITLE
Xcode: improve Java lookup and extract KMP framework embedding logic to a separate shell script and 

### DIFF
--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		7555FF7B242A565900829871 /* maplibre-compose-demo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "maplibre-compose-demo.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		7555FF8C242A565B00829871 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		AB3632DC29227652001CCB65 /* Config.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
+		4B5560EF2DFAB77B0056B885 /* embed-kmp-framework.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = "embed-kmp-framework.sh"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -44,6 +45,7 @@
 			isa = PBXGroup;
 			children = (
 				AB1DB47929225F7C00F7AF9C /* Configuration */,
+				4B5560F02DFAB77B0056B885 /* Scripts */,
 				7555FF7D242A565900829871 /* iosApp */,
 				7555FF7C242A565900829871 /* Products */,
 			);
@@ -74,6 +76,14 @@
 				AB3632DC29227652001CCB65 /* Config.xcconfig */,
 			);
 			path = Configuration;
+			sourceTree = "<group>";
+		};
+		4B5560F02DFAB77B0056B885 /* Scripts */ = {
+			isa = PBXGroup;
+			children = (
+				4B5560EF2DFAB77B0056B885 /* embed-kmp-framework.sh */,
+			);
+			path = scripts;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -160,7 +170,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [ \"YES\" = \"$OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED\" ]; then\n  echo \"Skipping Gradle build task invocation due to OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED environment variable set to \\\"YES\\\"\"\n  exit 0\nfi\ncd \"$SRCROOT/..\"\n./gradlew :demo-app:embedAndSignAppleFrameworkForXcode";
+			shellScript = "\"$SRCROOT/scripts/embed-kmp-framework.sh\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/iosApp/scripts/embed-kmp-framework.sh
+++ b/iosApp/scripts/embed-kmp-framework.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+set -eu
+
+if [ "YES" = "${OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED:-}" ]; then
+  echo "Skipping Gradle build task invocation due to OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED environment variable set to \"YES\""
+  exit 0
+fi
+
+if ! java -version >/dev/null 2>&1 && [ -z "${JAVA_HOME:-}" ]; then
+  if [ -x "$HOME/.sdkman/candidates/java/current/bin/java" ]; then
+    export JAVA_HOME="$HOME/.sdkman/candidates/java/current"
+  elif [ -x "/usr/libexec/java_home" ]; then
+    JAVA_HOME_CANDIDATE="$(/usr/libexec/java_home 2>/dev/null || true)"
+    if [ -n "$JAVA_HOME_CANDIDATE" ]; then
+      export JAVA_HOME="$JAVA_HOME_CANDIDATE"
+    fi
+  fi
+fi
+
+if [ -n "${JAVA_HOME:-}" ]; then
+  export PATH="$JAVA_HOME/bin:$PATH"
+fi
+
+if ! java -version >/dev/null 2>&1; then
+  echo "Java runtime not found. Set JAVA_HOME or install a JDK so Gradle can run from Xcode."
+  exit 1
+fi
+
+cd "$SRCROOT/.."
+exec ./gradlew :demo-app:embedAndSignAppleFrameworkForXcode

--- a/iosApp/scripts/embed-kmp-framework.sh
+++ b/iosApp/scripts/embed-kmp-framework.sh
@@ -8,9 +8,7 @@ if [ "YES" = "${OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED:-}" ]; then
 fi
 
 if ! java -version >/dev/null 2>&1 && [ -z "${JAVA_HOME:-}" ]; then
-  if [ -x "$HOME/.sdkman/candidates/java/current/bin/java" ]; then
-    export JAVA_HOME="$HOME/.sdkman/candidates/java/current"
-  elif [ -x "/usr/libexec/java_home" ]; then
+  if [ -x "/usr/libexec/java_home" ]; then
     JAVA_HOME_CANDIDATE="$(/usr/libexec/java_home 2>/dev/null || true)"
     if [ -n "$JAVA_HOME_CANDIDATE" ]; then
       export JAVA_HOME="$JAVA_HOME_CANDIDATE"


### PR DESCRIPTION
## Description

On my development machine the previous script couldn't find Java (I have it installed with [SDKMAN](https://sdkman.io/)) so I improved Java lookup and extracted the script into it's own file to make it more readable.

## Test plan

Built and ran the demo app on the iOS simulator from within Xcode.

## Checklist

**To your knowledge, are you making any breaking changes?**

no

**Have you tested the changes? On which platforms?**

- iOS: macOS Tahoe 26.3.1, Xcode 26.4.1


_Created using Codex with GPT-5_