### PR TITLE
docs: link Compose iOS HarfBuzz issue

### DIFF
--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -79,6 +79,8 @@ The easiest way is to select one of these two Gradle plugins:
     cause broken Compose text rendering on iOS because both Compose and
     MapLibre include HarfBuzz symbols.
 
+    See [CMP-8882](https://youtrack.jetbrains.com/issue/CMP-8882/)
+
 ### Cocoapods
 
 !!! info


### PR DESCRIPTION
Follows up #781 by accepting the review suggestion to link CMP-8882 from the iOS linker warning.

_Created using OpenCode with GPT-5.5_