### PR TITLE
Fix CI coverage for released native builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,34 @@ jobs:
           path:
             "demo-app/build/compose/binaries/main/${{ matrix.artifact_type }}/*"
 
+  build-natives:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # test-desktop and build-desktop-app already build the host default renderers:
+          # macOS metal, Linux OpenGL, and Windows OpenGL. Keep this matrix to the
+          # additional released native variants so CI covers releases without duplicate builds.
+          - variant: linux-amd64-vulkan
+            renderer: vulkan
+            runner: ubuntu-latest # amd64
+          - variant: windows-amd64-vulkan
+            renderer: vulkan
+            runner: windows-latest # amd64
+    runs-on: ${{ matrix.runner }}
+    name: build-natives (${{ matrix.variant }})
+    steps:
+      - if: ${{ matrix.runner == 'windows-latest' }}
+        run: git config --global core.longpaths true
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          submodules: recursive
+      - uses: ./.github/actions/setup-cmake
+      - uses: ./.github/actions/setup-gradle
+      - run: |
+          ./gradlew :lib:maplibre-native-bindings-jni:buildNative -PdesktopRenderer=${{ matrix.renderer }}
+
   all-good:
     needs:
       - format
@@ -187,6 +215,7 @@ jobs:
       - build-docs
       - build-android-app
       - build-desktop-app
+      - build-natives
     runs-on: ubuntu-latest
     steps:
       - run: echo 'All checks passed!'

--- a/lib/maplibre-native-bindings-jni/cmake/backends/vulkan.cmake
+++ b/lib/maplibre-native-bindings-jni/cmake/backends/vulkan.cmake
@@ -14,9 +14,12 @@ elseif(WIN32)
     target_compile_definitions(maplibre-jni PRIVATE VK_USE_PLATFORM_WIN32_KHR)
 endif()
 
-find_package(Vulkan REQUIRED)
-target_link_libraries(maplibre-jni PRIVATE Vulkan::Vulkan)
 target_include_directories(maplibre-jni SYSTEM PRIVATE ${maplibre-native_SOURCE_DIR}/src)
 
-# Don't use system Vulkan headers - use MapLibre's vendored headers for compatibility
-# The vendored headers are included via the Mapbox::Map target
+# Windows loads Vulkan dynamically through Vulkan-Hpp, and MapLibre provides the
+# compatible vendored headers via Mapbox::Map. Requiring a system Vulkan SDK on
+# Windows breaks CI because GitHub runners do not ship one.
+if(NOT WIN32)
+    find_package(Vulkan REQUIRED)
+    target_link_libraries(maplibre-jni PRIVATE Vulkan::Vulkan)
+endif()


### PR DESCRIPTION
Snapshot releases broke when we added Vulkan support on desktop in #566.

Here we ensure regular CI builds every native target that release workflows publish, and avoid requiring a system Vulkan SDK for Windows Vulkan configure.

_Created using OpenCode with GPT-5.5_