### PR TITLE
Update gradle-spm4kmp link to new URL

### DIFF
--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -250,7 +250,7 @@ to get a detailed map with all the features you'd expect, proceed to
 [gh-packages]: https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-gradle-registry
 [gh-packages-guide]: https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-gradle-registry#using-a-published-package
 [gradle-cocoapods]: https://kotlinlang.org/docs/native-cocoapods.html
-[gradle-spm4kmp]: https://frankois944.github.io/spm4Kmp/
+[gradle-spm4kmp]: https://spmforkmp.eu/
 [cocoapods-support]: https://blog.cocoapods.org/CocoaPods-Support-Plans/
 [repo]: https://github.com/maplibre/maplibre-compose
 [demotiles]: https://demotiles.maplibre.org/


### PR DESCRIPTION
Changes the https spm4kmp url in getting-stared to the new url: https://spmforkmp.eu/
Old github.io page is no longer available.
