### PR TITLE
fix: correct Android orientation bearing sign error

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -58,6 +58,7 @@ kotlin-wrappers-js = { group = "org.jetbrains.kotlin-wrappers", name = "kotlin-j
 kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-playServices = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-play-services", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-swing = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-swing", version.ref = "kotlinx-coroutines" }
+kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "ktor" }
 ktor-client-js = { module = "io.ktor:ktor-client-js", version.ref = "ktor" }

--- a/lib/maplibre-compose-gms/build.gradle.kts
+++ b/lib/maplibre-compose-gms/build.gradle.kts
@@ -43,7 +43,11 @@ kotlin {
       implementation(libs.jetbrains.compose.ui.test)
     }
 
-    androidHostTest.dependencies { implementation(compose.desktop.currentOs) }
+    androidHostTest.dependencies {
+      implementation(compose.desktop.currentOs)
+      implementation(libs.playServices.location)
+      implementation(libs.kotlinx.coroutines.test)
+    }
 
     androidDeviceTest.dependencies {
       implementation(libs.jetbrains.compose.ui.testJunit4)

--- a/lib/maplibre-compose-gms/src/androidHostTest/kotlin/org/maplibre/compose/gms/FusedOrientationProviderTest.kt
+++ b/lib/maplibre-compose-gms/src/androidHostTest/kotlin/org/maplibre/compose/gms/FusedOrientationProviderTest.kt
@@ -1,0 +1,66 @@
+package org.maplibre.compose.gms
+
+import com.google.android.gms.location.DeviceOrientation
+import com.google.android.gms.location.DeviceOrientationListener
+import com.google.android.gms.location.DeviceOrientationRequest
+import com.google.android.gms.location.FusedOrientationProviderClient
+import com.google.android.gms.tasks.Tasks
+import java.lang.reflect.InvocationHandler
+import java.lang.reflect.Method
+import java.lang.reflect.Proxy
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.maplibre.spatialk.units.Bearing
+import org.maplibre.spatialk.units.extensions.inDegrees
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class FusedOrientationProviderTest {
+
+  @Test
+  fun `input heading is preserved as clockwise bearing`() = runTest {
+    for (heading in listOf(0f, 45f, 90f, 123.45f, 180f, 270f, 359.99f)) {
+      val provider =
+        FusedOrientationProvider(
+          orientationClient = fakeClient(heading),
+          deviceOrientationRequest = DeviceOrientationRequest.Builder(1000L).build(),
+          coroutineScope = backgroundScope,
+          sharingStarted = SharingStarted.Eagerly,
+        )
+
+      runCurrent()
+      advanceTimeBy(2)
+      val result = provider.orientation.first { it != null }!!
+      val bearing = result.orientation!!.value
+
+      assertEquals(heading.toDouble(), Bearing.North.clockwiseRotationTo(bearing).inDegrees, 1e-10)
+    }
+  }
+
+  private fun fakeClient(heading: Float): FusedOrientationProviderClient {
+    val deviceOrientation =
+      DeviceOrientation.Builder(floatArrayOf(0f, 0f, 0f, 1f), heading, 5f, 0L).build()
+
+    return Proxy.newProxyInstance(
+      FusedOrientationProviderClient::class.java.classLoader,
+      arrayOf(FusedOrientationProviderClient::class.java),
+      object : InvocationHandler {
+        override fun invoke(proxy: Any, method: Method, args: Array<out Any>?): Any {
+          return when (method.name) {
+            "requestOrientationUpdates" -> {
+              (args!![2] as DeviceOrientationListener).onDeviceOrientationChanged(deviceOrientation)
+              Tasks.forResult(null)
+            }
+            "removeOrientationUpdates" -> Tasks.forResult(null)
+            else -> throw UnsupportedOperationException(method.name)
+          }
+        }
+      },
+    ) as FusedOrientationProviderClient
+  }
+}

--- a/lib/maplibre-compose-gms/src/androidMain/kotlin/org/maplibre/compose/gms/FusedOrientationProvider.kt
+++ b/lib/maplibre-compose-gms/src/androidMain/kotlin/org/maplibre/compose/gms/FusedOrientationProvider.kt
@@ -51,7 +51,7 @@ public class FusedOrientationProvider(
             Orientation(
               orientation =
                 BearingWithAccuracy(
-                  value = Bearing.North - orientation.headingDegrees.toDouble().degrees,
+                  value = Bearing.North + orientation.headingDegrees.toDouble().degrees,
                   accuracy = orientation.headingErrorDegrees.toDouble().degrees,
                 ),
               timestamp = TimeSource.Monotonic.markNow(),

--- a/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/location/AndroidOrientationProvider.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/location/AndroidOrientationProvider.kt
@@ -68,7 +68,7 @@ public class AndroidOrientationProvider(
                     Orientation(
                       orientation =
                         BearingWithAccuracy(
-                          value = Bearing.North - degrees,
+                          value = Bearing.North + degrees,
                           // we can not get accuracy in degrees
                           accuracy = null,
                         ),


### PR DESCRIPTION
Fix sign error in AndroidOrientationProvider and FusedOrientationProvider where heading/azimuth was subtracted instead of added to Bearing.North, making the bearing a mirror image across the North-South axis.

Test: End-to-end test for FusedOrientationProvider that verifies input headings are preserved as clockwise bearings.

_Created using OpenCode with Kimi K2.6_

