### PR TITLE
Add AI policy supplement and PR disclosure template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,15 +8,6 @@
 
 <!-- Please describe how you tested the changes. -->
 
-## AI assistance
-
-<!-- Remove this section if disclosure does not apply. -->
-
-- **Tools:**
-- **Models:**
-- **Scope:**
-- **Context:**
-
 ## Checklist
 
 **To your knowledge, are you making any breaking changes?**
@@ -31,3 +22,12 @@
 - iOS: <!-- describe the device and OS version -->
 - Desktop: <!-- describe the OS -->
 - Web: <!-- describe the browser and version -->
+
+## AI assistance
+
+<!-- Remove this section if disclosure does not apply. -->
+
+- **Tools:**
+- **Models:**
+- **Scope:**
+- **Context:**

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,15 @@
 
 <!-- Please describe how you tested the changes. -->
 
+## AI assistance
+
+<!-- Remove this section if disclosure does not apply. -->
+
+- **Tools:**
+- **Models:**
+- **Scope:**
+- **Context:**
+
 ## Checklist
 
 **To your knowledge, are you making any breaking changes?**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,17 +1,8 @@
-## AI Policy
+## Pull requests
 
-All contributions must comply with the
-[MapLibre AI policy](https://raw.githubusercontent.com/maplibre/maplibre/refs/heads/main/AI_POLICY.md).
-In summary: disclose AI usage, and issues and PR descriptions must be written by
-the human.
-
-Example PR disclosure format:
-
-```markdown
-_Created using [AGENT]_
-```
-
-Where `[AGENT]` is like "OpenCode with GPT-5.5" or "Claude Code with Opus 4.7".
+When you open a pull request, write **Description** and **Test plan** in at most
+one sentence of prose each. I will expand the PR description if more detail is
+needed. More context: [AI_POLICY.md](./AI_POLICY.md).
 
 ## Searching vendored MapLibre Native codebase
 

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,0 +1,65 @@
+# AI Policy
+
+Follow
+[MapLibre's AI Policy](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md)
+and the guidance below for this repository.
+
+## Stay in the loop
+
+Before you mark a pull request ready for review:
+
+- Read every line you are asking maintainers to merge.
+- Be able to explain the change, how it fits the codebase, and how you validated
+  it—without leaning on the tool to answer review questions.
+- Write the PR description yourself: motivation, approach, impact, and anything
+  you are unsure about. Spell-checking or translation help is fine; the ideas
+  and structure should be yours.
+
+Design the change. Use AI to draft, explore, or speed up typing—not to replace
+understanding the problem or the existing code.
+
+## Talk to maintainers in your own voice
+
+Issues, PR bodies, and review replies are a conversation between humans. Write
+them yourself.
+
+- State problems and proposals in your own words.
+- When a maintainer asks a question, answer from your understanding. Do not
+  paste model output as your reply.
+- Trim verbosity. Say what matters for the review.
+
+If you used AI to polish English, read the result once and adjust it so it
+sounds like you. For translation, writing in your native language and adding an
+English version in a quote block works well.
+
+## When AI context belongs in a thread
+
+Sometimes a snippet from an AI session helps reviewers (for example, a design
+option you rejected). Share it in a way that keeps the thread readable:
+
+- **A few lines:** Put them in a quote block (`>`), label them as AI-generated,
+  and add a short note in your own words on why they are relevant.
+- **More than a few lines:** Put the full text in a
+  [GitHub Gist](https://gist.github.com/) (or similar) and link it. In the
+  comment, summarize in your own words what the gist contains and what you want
+  reviewers to take from it.
+
+Do not post long, unedited AI output in issues or pull requests without
+maintainer approval.
+
+## Disclosure
+
+When disclosure applies under MapLibre's policy, fill in the **AI assistance**
+section of the pull request template. Disclosure is not penalized.
+
+When planning docs guided the work, commit them on your branch as you go.
+Removing them before merge is fine; reviewers can still follow the process in
+the commit history. Point to the relevant commits or paths in **Context** when
+that history matters for review.
+
+## Credits
+
+Practices in this document were informed by the AI policies of
+[uv](https://github.com/astral-sh/.github/blob/main/AI_POLICY.md),
+[ripgrep](https://github.com/BurntSushi/ripgrep/blob/master/AI_POLICY.md), and
+[Ghostty](https://github.com/ghostty-org/ghostty/blob/main/AI_POLICY.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ relevant, see the
 label. These are issues that need input or guidance from folks with deeper
 expertise on some topic.
 
-## Pull requests
+## Note on AI usage
 
 If you use AI assistance, follow the [AI policy](./AI_POLICY.md).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,13 +30,9 @@ relevant, see the
 label. These are issues that need input or guidance from folks with deeper
 expertise on some topic.
 
-## Note on AI usage
+## Pull requests
 
-If you are using any kind of AI assistance for your contributions, please take a
-moment to review
-[MapLibre's AI Policy](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md).
-tl;dr: do not let AI speak for you, verify all generated content before
-requesting a review and disclose AI usage in pull requests.
+If you use AI assistance, follow the [AI policy](./AI_POLICY.md).
 
 ## Set up your development environment
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Integrates the AI policy docs from [maplibre-native-ffi#199](https://github.com/maplibre/maplibre-native-ffi/pull/199).

## AI assistance

- **Tools:** Cursor Cloud
- **Models:** Composer 2.5
- **Scope:** Copy and adapt AI policy docs from maplibre-native-ffi
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-edc13757-50ae-42e4-a5d5-fe6768339628"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-edc13757-50ae-42e4-a5d5-fe6768339628"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

