### PR TITLE
fix: create CLLocationManager on main thread in IosLocationProvider

### DIFF
--- a/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/location/IosLocationProvider.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/location/IosLocationProvider.kt
@@ -7,12 +7,14 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.TimeSource
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.runningFold
 import kotlinx.coroutines.flow.sample
 import kotlinx.coroutines.flow.stateIn
@@ -57,13 +59,12 @@ public class IosLocationProvider(
   coroutineScope: CoroutineScope,
   sharingStarted: SharingStarted,
 ) : LocationProvider, OrientationProvider {
-  private val locationManager = CLLocationManager()
 
   init {
     if (
       enableLocation &&
-        locationManager.authorizationStatus != kCLAuthorizationStatusAuthorizedAlways &&
-        locationManager.authorizationStatus != kCLAuthorizationStatusAuthorizedWhenInUse
+        CLLocationManager.authorizationStatus() != kCLAuthorizationStatusAuthorizedAlways &&
+        CLLocationManager.authorizationStatus() != kCLAuthorizationStatusAuthorizedWhenInUse
     ) {
       throw PermissionException()
     }
@@ -71,6 +72,7 @@ public class IosLocationProvider(
 
   private val updates: StateFlow<ProviderUpdate?> =
     callbackFlow {
+        val locationManager = CLLocationManager()
         val delegate = Delegate(channel)
         locationManager.delegate = delegate
 
@@ -107,6 +109,7 @@ public class IosLocationProvider(
           locationManager.delegate = null
         }
       }
+      .flowOn(Dispatchers.Main)
       .stateIn(coroutineScope, sharingStarted, null)
 
   override val location: StateFlow<Location?> =


### PR DESCRIPTION
## Summary

Fixes #762

`CLLocationManager` must be created and used on a thread with an active RunLoop (i.e. the main thread). Previously, the instance was held as a class-level field and could be initialised on a Kotlin worker thread, causing iOS to silently stop delivering delegate callbacks after a handful of GPS fixes.

## Changes

**1. Move `CLLocationManager` instantiation inside the `callbackFlow` block and add `.flowOn(Dispatchers.Main)`**

This guarantees that the manager is always created, configured, started, and stopped on the main thread — regardless of which dispatcher the collector uses. The entire lifecycle of `CLLocationManager` (creation → `startUpdatingLocation` → `stopUpdatingLocation` → delegate teardown) is now confined to the `callbackFlow` execution context on `Dispatchers.Main`.

**2. Replace the instance-property `authorizationStatus` check in `init` with the class-level `CLLocationManager.authorizationStatus`**

This removes the need to hold a `CLLocationManager` reference on the class at all. The static property compiles correctly against the iOS 14+ SDK (verified by `compileIosMainKotlinMetadata` and `compileKotlinIosSimulatorArm64`).

## Testing

- Verified compilation with `./gradlew :lib:maplibre-compose:compileIosMainKotlinMetadata` ✅
- Verified compilation with `./gradlew compileKotlinIosSimulatorArm64` ✅

> **AI Disclosure:** This PR was created with AI assistance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved iOS location update handling to ensure updates are delivered on the main thread for more reliable UI behavior.
  * Optimized lifecycle and resource management of location delivery to reduce unnecessary background resource usage and improve stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->