### PR TITLE
make coderabbit chill out a bit

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+# Config reference: https://docs.coderabbit.ai/reference/configuration
+
+reviews:
+    # don't post in user's own PR summary, make a separate comment
+    high_level_summary_in_walkthrough: true
+
+    # reduce noisy defaults
+    collapse_walkthrough: true
+    review_status: false
+    in_progress_fortune: false
+    poem: false
+    finishing_touches:
+        docstrings:
+            enabled: false
+        unit_tests:
+            enabled: false
+        simplify:
+            enabled: false
+
+chat:
+    # free OSS plan, should be fine
+    allow_non_org_members: true
+
+    # reduce noisy defaults
+    art: false
+    auto_reply: false

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -2,26 +2,26 @@
 # Config reference: https://docs.coderabbit.ai/reference/configuration
 
 reviews:
-    # don't post in user's own PR summary, make a separate comment
-    high_level_summary_in_walkthrough: true
+  # don't post in user's own PR summary, make a separate comment
+  high_level_summary_in_walkthrough: true
 
-    # reduce noisy defaults
-    collapse_walkthrough: true
-    review_status: false
-    in_progress_fortune: false
-    poem: false
-    finishing_touches:
-        docstrings:
-            enabled: false
-        unit_tests:
-            enabled: false
-        simplify:
-            enabled: false
+  # reduce noisy defaults
+  collapse_walkthrough: true
+  review_status: false
+  in_progress_fortune: false
+  poem: false
+  finishing_touches:
+    docstrings:
+      enabled: false
+    unit_tests:
+      enabled: false
+    simplify:
+      enabled: false
 
 chat:
-    # free OSS plan, should be fine
-    allow_non_org_members: true
+  # free OSS plan, should be fine
+  allow_non_org_members: true
 
-    # reduce noisy defaults
-    art: false
-    auto_reply: false
+  # reduce noisy defaults
+  art: false
+  auto_reply: false


### PR DESCRIPTION
of the three ai review tools I've enabled recently, coderabbit seems to be the noisiest and the least accurate

I'll probably end up turning it off, but for now just quieting it down a bit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code review configuration settings to optimize development workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->