### PR TITLE
Fix IosLocationProvider locationManager and delegate garbage collection

### DIFF
--- a/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/location/IosLocationProvider.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/location/IosLocationProvider.kt
@@ -11,12 +11,14 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.runningFold
 import kotlinx.coroutines.flow.sample
+import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.flow.stateIn
 import org.maplibre.spatialk.units.Bearing
 import org.maplibre.spatialk.units.Length
@@ -60,21 +62,25 @@ public class IosLocationProvider(
   sharingStarted: SharingStarted,
 ) : LocationProvider, OrientationProvider {
 
+  private val locationManager by lazy { CLLocationManager() }
+  private var delegate: Delegate? = null
+
   init {
+    val authorizationStatus = CLLocationManager.authorizationStatus()
     if (
       enableLocation &&
-        CLLocationManager.authorizationStatus() != kCLAuthorizationStatusAuthorizedAlways &&
-        CLLocationManager.authorizationStatus() != kCLAuthorizationStatusAuthorizedWhenInUse
+        authorizationStatus != kCLAuthorizationStatusAuthorizedAlways &&
+        authorizationStatus != kCLAuthorizationStatusAuthorizedWhenInUse
     ) {
       throw PermissionException()
     }
   }
 
-  private val updates: StateFlow<ProviderUpdate?> =
+  private val updates: SharedFlow<ProviderUpdate> =
     callbackFlow {
-        val locationManager = CLLocationManager()
-        val delegate = Delegate(channel)
-        locationManager.delegate = delegate
+        val d = Delegate(channel)
+        delegate = d
+        locationManager.delegate = d
 
         if (enableLocation) {
           locationManager.desiredAccuracy =
@@ -107,10 +113,11 @@ public class IosLocationProvider(
             locationManager.stopUpdatingHeading()
           }
           locationManager.delegate = null
+          delegate = null
         }
       }
       .flowOn(Dispatchers.Main)
-      .stateIn(coroutineScope, sharingStarted, null)
+      .shareIn(coroutineScope, sharingStarted, replay = 1)
 
   override val location: StateFlow<Location?> =
     updates
@@ -133,11 +140,10 @@ public class IosLocationProvider(
       .sample(orientationUpdateInterval)
       .stateIn(coroutineScope, sharingStarted, null)
 
-  private inner class Delegate(private val channel: SendChannel<ProviderUpdate>) :
+  private class Delegate(private val channel: SendChannel<ProviderUpdate>) :
     NSObject(), CLLocationManagerDelegateProtocol {
     override fun locationManager(manager: CLLocationManager, didUpdateLocations: List<*>) {
       @Suppress("UNCHECKED_CAST") val locations = didUpdateLocations as? List<CLLocation>
-
       locations?.forEach { channel.trySend(ProviderUpdate.LocationUpdate(it.asMapLibreLocation())) }
     }
 


### PR DESCRIPTION
<!-- Thanks for the PR! Please fill out the template below. -->

## Description

This PR stabilizes the iOS location provider garbage collection.
- **iOS Location Stability:** Refactored `IosLocationProvider` to maintain a stable `CLLocationManager` and its delegate, preventing premature garbage collection and ensuring consistent updates.

<img width="933" height="301" alt="grafik" src="https://github.com/user-attachments/assets/cbd4d303-b36d-4b50-892e-eeec017bee9e" />
If you delete any of these 3 red lines then the bug is there. 

## Test plan

Verified that location updates are correctly received and displayed in the demo app on iOS and Android.

## Checklist

**To your knowledge, are you making any breaking changes?**

No

**Have you tested the changes? On which platforms?**

- Android: Tested on API 34 emulator.
- iOS: Tested on iPhone 15 simulator.

## AI assistance

- **Tools:** Android Studio Bot
- **Models:** Gemini 2.0 Flash
- **Context:** Fixes for location manager garbage collection and bearing inversion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Reduced iOS location provider resource use and improved sharing of location updates for more efficient background handling.

* **Refactor**
  * Simplified internal location/update handling by reusing manager and delegate instances; public APIs remain unchanged.

* **Bug Fixes**
  * Improved cleanup on stop to halt updates and clear internal delegates, reducing potential resource leaks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->