### PR TITLE
fix: make LocationTrackingEffect react to location updates

### DIFF
--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/location/LocationTrackingEffect.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/location/LocationTrackingEffect.kt
@@ -38,10 +38,13 @@ public fun LocationTrackingEffect(
   LaunchedEffect(enabled, trackBearing, changeCollector) {
     if (!enabled) return@LaunchedEffect
 
-    snapshotFlow { locationState }
+    // Observe UserLocationState.location and UserLocationState.orientation instead of
+    // UserLocationState. Compose only tracks State reads, so snapshotFlow { UserLocationState }
+    // will not emit when UserLocationState.location or UserLocationState.orientation changes.
+    snapshotFlow { locationState.location to locationState.orientation }
       .distinctUntilChanged equal@{ old, new ->
-        val oldLocation = old.location
-        val newLocation = new.location
+        val oldLocation = old.first
+        val newLocation = new.first
 
         if (oldLocation != null && newLocation != null) {
           if (trackBearing && (oldLocation.course != null || newLocation.course != null)) {
@@ -67,8 +70,8 @@ public fun LocationTrackingEffect(
             return@equal false
         }
 
-        val oldOrientation = old.orientation?.orientation
-        val newOrientation = new.orientation?.orientation
+        val oldOrientation = old.second?.orientation
+        val newOrientation = new.second?.orientation
 
         if (trackBearing && oldOrientation != null && newOrientation != null) {
           if (oldOrientation.value.smallestRotationTo(newOrientation.value).inDegrees >= precision)
@@ -77,7 +80,7 @@ public fun LocationTrackingEffect(
 
         true
       }
-      .collect(changeCollector)
+      .collect { changeCollector.emit(locationState) }
   }
 }
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/location/LocationTrackingEffect.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/location/LocationTrackingEffect.kt
@@ -46,7 +46,9 @@ public fun LocationTrackingEffect(
         val oldLocation = old.first
         val newLocation = new.first
 
-        if (oldLocation != null && newLocation != null) {
+        if (oldLocation == null || newLocation == null) {
+          if (oldLocation != newLocation) return@equal false
+        } else {
           if (trackBearing && (oldLocation.course != null || newLocation.course != null)) {
             if (oldLocation.course == null) return@equal false
             if (newLocation.course == null) return@equal false
@@ -73,8 +75,13 @@ public fun LocationTrackingEffect(
         val oldOrientation = old.second?.orientation
         val newOrientation = new.second?.orientation
 
-        if (trackBearing && oldOrientation != null && newOrientation != null) {
-          if (oldOrientation.value.smallestRotationTo(newOrientation.value).inDegrees >= precision)
+        if (trackBearing) {
+          if (oldOrientation == null || newOrientation == null) {
+            if (oldOrientation != newOrientation) return@equal false
+          } else if (
+            abs(oldOrientation.value.smallestRotationTo(newOrientation.value).inDegrees) >=
+              precision
+          )
             return@equal false
         }
 


### PR DESCRIPTION
Fixes: #808

Re: ChatGPT / Codex "Emit a stable location snapshot" / "Preserve previous location snapshots" review: I believe this is out of the scope of this PR.

Let me know if you want me to add a snapshot type to this PR or in another PR