### PR TITLE
Docs: Sources & Layers: Show where to put rememberGeoJsonSource

### DIFF
--- a/demo-app/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Layers.kt
+++ b/demo-app/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Layers.kt
@@ -37,10 +37,10 @@ fun Layers() {
   // -8<- [end:simple]
 
   MaplibreMap {
+    // -8<- [start:amtrak-1]
     val amtrakStations =
       rememberGeoJsonSource(GeoJsonData.Uri(Res.getUri("files/data/amtrak_stations.geojson")))
 
-    // -8<- [start:amtrak-1]
     val amtrakRoutes =
       rememberGeoJsonSource(GeoJsonData.Uri(Res.getUri("files/data/amtrak_routes.geojson")))
     LineLayer(

--- a/docs/docs/layers.md
+++ b/docs/docs/layers.md
@@ -19,7 +19,9 @@ The above example shows how to add a layer referring to a source from the base
 style, but you can also declare new sources:
 
 ```kotlin
--8<- "demo-app/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Layers.kt:amtrak-1"
+MaplibreMap {
+  -8<- "demo-app/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Layers.kt:amtrak-1"
+}
 ```
 
 For small, frequently updated in-memory GeoJSON sources, you can opt into
@@ -28,7 +30,9 @@ platforms ignore the option for now. Under the hood, this maps to MapLibre
 Native Android's [GeoJsonOptions.withSynchronousUpdate()][android-sync-update]:
 
 ```kotlin
--8<- "demo-app/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Layers.kt:synchronous-geojson-updates"
+MaplibreMap {
+  -8<- "demo-app/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Layers.kt:synchronous-geojson-updates"
+}
 ```
 
 The full breadth of layer styling options available is out of scope for this


### PR DESCRIPTION
Putting `rememberGeoJsonSource` outside of `MaplibreMap` will result in the following very cryptic error in Logcat:

```
Error was captured in composition.
java.lang.IllegalStateException
	at org.maplibre.compose.style.RememberStyleCompositionKt.LocalStyleNode$lambda$0(rememberStyleComposition.kt:47)
	at org.maplibre.compose.style.RememberStyleCompositionKt$$ExternalSyntheticLambda0.invoke(D8$$SyntheticClass:0)
	at kotlin.SynchronizedLazyImpl.getValue(LazyJVM.kt:86)
	at androidx.compose.runtime.LazyValueHolder.getCurrent(ValueHolders.kt:46)
	at androidx.compose.runtime.LazyValueHolder.readValue(ValueHolders.kt:48)
	at androidx.compose.runtime.CompositionLocalMapKt.read(CompositionLocalMap.kt:88)
	at androidx.compose.runtime.GapComposer.consume(GapComposer.kt:1235)
	at org.maplibre.compose.sources.SourceKt.rememberUserSource(Source.kt:49)
	at org.maplibre.compose.sources.GeoJsonSourceKt.rememberGeoJsonSource(GeoJsonSource.kt:105)
	at com.example.myapplication, MainActivityKt.MainApp(MainActivity.kt:67)
	...
```

And it takes a bit of scrolling down to see `at com.example.myapplication, MainActivityKt.MainApp(MainActivity.kt:67)`, and learn there's something wrong with `rememberGeoJsonSource`.

But even then, it's not clear what's wrong nor how to fix it.

My hope is that, by having a "honorable mention" of `MaplibreMap`, future readers will know that they need to put `rememberGeoJsonSource` inside `MaplibreMap`