### PR TITLE
Stabilize iOS CI

### DIFF
--- a/.github/actions/setup-gradle/action.yml
+++ b/.github/actions/setup-gradle/action.yml
@@ -7,8 +7,23 @@ runs:
       with:
         distribution: temurin
         java-version: 21
-    - uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+    - uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
       with:
         build-scan-publish: true
         build-scan-terms-of-use-url: https://gradle.com/terms-of-service
         build-scan-terms-of-use-agree: yes
+    - name: Prepare Gradle wrapper
+      shell: bash
+      run: |
+        for attempt in 1 2 3; do
+          if ./gradlew --version; then
+            exit 0
+          fi
+
+          echo "::warning::Gradle wrapper setup failed (attempt ${attempt}/3)"
+          rm -rf -- "${GRADLE_USER_HOME:?}/wrapper/dists"
+          if ((attempt < 3)); then
+            sleep $((attempt * 5))
+          fi
+        done
+        exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   format:
     runs-on: ubuntu-latest
@@ -65,6 +69,7 @@ jobs:
           script: ./gradlew connectedDebugAndroidTest
 
   test-ios:
+    timeout-minutes: 45
     strategy:
       matrix:
         include:
@@ -82,6 +87,7 @@ jobs:
         with:
           os: iOS
           os_version: ${{ matrix.os_version }}
+          wait_for_boot: true
       - run: |
           ./gradlew iosSimulatorArm64Test -- --device ${{ steps.setup-simulator.outputs.udid }}
 


### PR DESCRIPTION
## Description

Stabilize iOS CI by invalidating the poisoned Gradle wrapper cache, retrying wrapper setup, canceling superseded PR runs, and waiting for the simulator to boot.

## Test plan

Run `mise run check`; let the draft PR exercise `test-ios (^26)` on GitHub Actions.