### PR TITLE
Add platform seams for FFI resource work

### DIFF
--- a/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/desktop/DesktopRuntimeOptions.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/desktop/DesktopRuntimeOptions.kt
@@ -58,6 +58,6 @@ internal fun absoluteEnvironmentPath(value: String?): Path? =
   value?.takeIf { it.isNotBlank() }?.let(Paths::get)?.takeIf(Path::isAbsolute)
 
 internal fun DesktopRuntimeOptions.toMlnFfiRuntimeOptions(): MlnFfiRuntimeOptions =
-  MlnFfiRuntimeOptions(cachePath, maximumCacheSizeBytes)
+  MlnFfiRuntimeOptions(cachePath.toFile(), maximumCacheSizeBytes)
 
 private val APPLICATION_ID = Regex("[A-Za-z0-9_-]+(?:\\.[A-Za-z0-9_-]+)*")

--- a/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/resource/MlnFfiBlockingWork.desktop.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/resource/MlnFfiBlockingWork.desktop.kt
@@ -1,0 +1,5 @@
+package org.maplibre.compose.resource
+
+internal actual fun startMlnFfiBlockingWork(name: String, work: () -> Unit) {
+  Thread.ofVirtual().name(name).start(work)
+}

--- a/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/resource/PlatformResourceReader.desktop.kt
+++ b/lib/maplibre-compose/src/desktopMain/kotlin/org/maplibre/compose/resource/PlatformResourceReader.desktop.kt
@@ -1,0 +1,6 @@
+package org.maplibre.compose.resource
+
+import java.net.URI
+
+internal actual fun readPlatformResourceBytes(url: String): ByteArray =
+  URI(url).toURL().openStream().use { it.readBytes() }

--- a/lib/maplibre-compose/src/desktopTest/kotlin/org/maplibre/compose/desktop/DesktopRuntimeOptionsTest.kt
+++ b/lib/maplibre-compose/src/desktopTest/kotlin/org/maplibre/compose/desktop/DesktopRuntimeOptionsTest.kt
@@ -39,20 +39,22 @@ class DesktopRuntimeOptionsTest {
 
   @Test
   fun repeating_the_same_normalized_configuration_is_harmless() {
-    val path = FfiTestPlatform.createCachePath()
+    val file = FfiTestPlatform.createCacheFile()
+    val path = file.toPath()
     val alias = path.parent.resolve("unused").resolve("..").resolve(path.fileName)
     try {
       MapLibre.configure(DesktopRuntimeOptions(path))
       MapLibre.configure(DesktopRuntimeOptions(alias))
     } finally {
       MlnFfiApplication.resetForTest()
-      FfiTestPlatform.deleteCachePath(path)
+      FfiTestPlatform.deleteCacheFile(file)
     }
   }
 
   @Test
   fun replacing_the_application_configuration_fails() {
-    val path = FfiTestPlatform.createCachePath()
+    val file = FfiTestPlatform.createCacheFile()
+    val path = file.toPath()
     try {
       MapLibre.configure(DesktopRuntimeOptions(path))
 
@@ -61,7 +63,7 @@ class DesktopRuntimeOptionsTest {
       }
     } finally {
       MlnFfiApplication.resetForTest()
-      FfiTestPlatform.deleteCachePath(path)
+      FfiTestPlatform.deleteCacheFile(file)
     }
   }
 }

--- a/lib/maplibre-compose/src/desktopTest/kotlin/org/maplibre/compose/desktop/bridge/LinuxVulkanOpenGlInteropTest.kt
+++ b/lib/maplibre-compose/src/desktopTest/kotlin/org/maplibre/compose/desktop/bridge/LinuxVulkanOpenGlInteropTest.kt
@@ -264,7 +264,7 @@ class LinuxVulkanOpenGlInteropTest {
         logger = null,
         renderBackend = host.backends.producer,
         layoutDirection = LayoutDirection.Ltr,
-        cachePath = cacheDirectory.resolve("cache.db"),
+        cacheFile = cacheDirectory.resolve("cache.db").toFile(),
       )
 
     private val hostSession =

--- a/lib/maplibre-compose/src/desktopTest/kotlin/org/maplibre/compose/mlnffi/FfiTestPlatform.desktop.kt
+++ b/lib/maplibre-compose/src/desktopTest/kotlin/org/maplibre/compose/mlnffi/FfiTestPlatform.desktop.kt
@@ -1,7 +1,7 @@
 package org.maplibre.compose.mlnffi
 
+import java.io.File
 import java.nio.file.Files
-import java.nio.file.Path
 import org.junit.Assume.assumeTrue
 import org.maplibre.nativeffi.Maplibre
 
@@ -12,13 +12,13 @@ internal actual object FfiTestPlatform {
     Maplibre.loadNativeLibrary()
   }
 
-  actual fun createCachePath(): Path {
+  actual fun createCacheFile(): File {
     initialize()
-    return Files.createTempDirectory("maplibre-ffi-test").resolve("cache.db")
+    return Files.createTempDirectory("maplibre-ffi-test").resolve("cache.db").toFile()
   }
 
-  actual fun deleteCachePath(path: Path) {
-    path.parent.toFile().deleteRecursively()
+  actual fun deleteCacheFile(file: File) {
+    file.parentFile?.deleteRecursively()
   }
 
   actual fun createRenderDriver(): FfiTestRenderDriver {

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/MlnFfiMapRuntimeLoop.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/MlnFfiMapRuntimeLoop.kt
@@ -1,7 +1,7 @@
 package org.maplibre.compose.map
 
 import co.touchlab.kermit.Logger
-import java.nio.file.Path
+import java.io.File
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
@@ -47,7 +47,7 @@ private const val SHUTDOWN_WAIT_MILLIS = 5_000L
 internal class MlnFfiMapRuntimeLoop(
   /** The extent the map is created with. Its scale factor is fixed for the map's lifetime. */
   private val extent: MlnFfiMapExtent,
-  private val cachePath: Path,
+  private val cacheFile: File,
   private val getLogger: () -> Logger?,
   /** Runs on the owner thread once the map exists, before it is published. */
   private val onMapCreated: (MapHandle) -> Unit,
@@ -175,7 +175,7 @@ internal class MlnFfiMapRuntimeLoop(
   private fun runLoop() {
     val owner =
       try {
-        MlnFfiRuntimeOwner.open(cachePath, getLogger, "MapLibre runtime").also { runtimeOwner = it }
+        MlnFfiRuntimeOwner.open(cacheFile, getLogger, "MapLibre runtime").also { runtimeOwner = it }
       } catch (error: Throwable) {
         logger?.e(error) { "Could not create the MapLibre runtime" }
         fail(error)

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -5,7 +5,7 @@ import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.DpRect
 import androidx.compose.ui.unit.LayoutDirection
 import co.touchlab.kermit.Logger
-import java.nio.file.Path
+import java.io.File
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.locks.ReentrantLock
@@ -127,7 +127,7 @@ internal class MlnFfiMapSession(
   renderBackend: MapRenderBackend,
   scaleFactor: Double = 1.0,
   @Volatile internal var layoutDirection: LayoutDirection,
-  private val cachePath: Path,
+  private val cacheFile: File,
 ) : MapAdapter, MlnFfiMapRenderer {
 
   override val backend: MapRenderBackend = renderBackend
@@ -357,7 +357,7 @@ internal class MlnFfiMapSession(
       val created =
         MlnFfiMapRuntimeLoop(
           extent = initialExtent,
-          cachePath = cachePath,
+          cacheFile = cacheFile,
           getLogger = { logger },
           onMapCreated = ::onMapCreated,
           onEvent = ::handleEvent,

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/MlnFfiMapView.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/MlnFfiMapView.kt
@@ -52,7 +52,7 @@ internal fun MlnFfiMapView(
         renderBackend = hostFactory.backends.producer,
         scaleFactor = scaleFactor,
         layoutDirection = layoutDirection,
-        cachePath = applicationOptions.cachePath,
+        cacheFile = applicationOptions.cacheFile,
       )
     }
 

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/mlnffi/MlnFfiRuntimeOptions.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/mlnffi/MlnFfiRuntimeOptions.kt
@@ -1,20 +1,20 @@
 package org.maplibre.compose.mlnffi
 
 import androidx.compose.runtime.Immutable
-import java.nio.file.Path
+import java.io.File
 import org.maplibre.compose.offline.MlnFfiOfflineManager
 
 /** Platform-resolved configuration for a MapLibre Native FFI runtime. */
 @Immutable
 internal data class MlnFfiRuntimeOptions(
-  val cachePath: Path,
+  val cacheFile: File,
   val maximumCacheSizeBytes: Long? = null,
 )
 
 /** Uses one stable lexical identity for a cache database without requiring it to exist yet. */
 internal fun MlnFfiRuntimeOptions.normalized(): MlnFfiRuntimeOptions {
-  val normalizedPath = cachePath.toAbsolutePath().normalize()
-  return if (normalizedPath == cachePath) this else copy(cachePath = normalizedPath)
+  val normalizedFile = cacheFile.absoluteFile.normalize()
+  return if (normalizedFile == cacheFile) this else copy(cacheFile = normalizedFile)
 }
 
 /** The one process-wide MapLibre Native configuration and the runtime that owns its cache. */
@@ -59,4 +59,4 @@ internal object MlnFfiApplication {
 }
 
 private fun MlnFfiRuntimeOptions.describe(): String =
-  "cachePath='$cachePath', maximumCacheSizeBytes=$maximumCacheSizeBytes"
+  "cacheFile='$cacheFile', maximumCacheSizeBytes=$maximumCacheSizeBytes"

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/offline/MlnFfiOfflineManager.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/offline/MlnFfiOfflineManager.kt
@@ -61,7 +61,7 @@ internal class MlnFfiOfflineManager(private val options: MlnFfiRuntimeOptions) :
   /** Owner-thread state: the packs this manager has seen, keyed by native region id. */
   private val packsById = mutableMapOf<Long, OfflinePack>()
 
-  private val runtime = MlnFfiOfflineRuntime(options.cachePath, logger, ::handleEvent)
+  private val runtime = MlnFfiOfflineRuntime(options.cacheFile, logger, ::handleEvent)
 
   /** The application has one writer; this prevents concurrent suspending calls from overlapping. */
   private val cacheBudgetMutex = Mutex()

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/offline/MlnFfiOfflineRuntime.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/offline/MlnFfiOfflineRuntime.kt
@@ -1,7 +1,7 @@
 package org.maplibre.compose.offline
 
 import co.touchlab.kermit.Logger
-import java.nio.file.Path
+import java.io.File
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
@@ -31,7 +31,7 @@ private const val PUMP_PARK_MILLIS = -1L
  * correctness.
  */
 internal class MlnFfiOfflineRuntime(
-  private val cachePath: Path,
+  private val cacheFile: File,
   private val logger: Logger,
   private val onEvent: (RuntimeEvent) -> Unit,
 ) {
@@ -156,7 +156,7 @@ internal class MlnFfiOfflineRuntime(
   private fun runLoop() {
     val runtime =
       try {
-        MlnFfiRuntimeOwner.open(cachePath, { logger }, "MapLibre offline runtime")
+        MlnFfiRuntimeOwner.open(cacheFile, { logger }, "MapLibre offline runtime")
           .also { runtimeOwner = it }
           .runtime
       } catch (error: Throwable) {

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/resource/MlnFfiBlockingWork.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/resource/MlnFfiBlockingWork.kt
@@ -1,6 +1,4 @@
 package org.maplibre.compose.resource
 
 /** Starts independent blocking work without allocating or shutting down a per-object executor. */
-internal fun startMlnFfiBlockingWork(name: String, work: () -> Unit) {
-  Thread.ofVirtual().name(name).start(work)
-}
+internal expect fun startMlnFfiBlockingWork(name: String, work: () -> Unit)

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/resource/MlnFfiResourceProvider.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/resource/MlnFfiResourceProvider.kt
@@ -133,7 +133,7 @@ private class FfiResourceRequest(private val handle: ResourceRequestHandle) : Ta
  */
 internal fun readResource(url: String, requestedUrl: String, logger: Logger?): ResourceResponse =
   try {
-    val bytes = URI(url).toURL().openStream().use { it.readBytes() }
+    val bytes = readPlatformResourceBytes(url)
     ResourceResponse(ResourceResponseStatus.OK).also {
       it.bytes = bytes
       // Packaged resources cannot change while the process runs.
@@ -141,15 +141,24 @@ internal fun readResource(url: String, requestedUrl: String, logger: Logger?): R
     }
   } catch (error: FileNotFoundException) {
     failure(url, requestedUrl, ResourceErrorReason.NOT_FOUND, "not found", error, logger)
-  } catch (error: java.nio.file.NoSuchFileException) {
-    // A `jar:` URL whose jar is missing fails from java.nio, not with a FileNotFoundException.
-    failure(url, requestedUrl, ResourceErrorReason.NOT_FOUND, "not found", error, logger)
   } catch (error: URISyntaxException) {
     failure(url, requestedUrl, ResourceErrorReason.OTHER, "is not a valid URI", error, logger)
   } catch (error: Throwable) {
     if (error is VirtualMachineError) throw error
-    failure(url, requestedUrl, ResourceErrorReason.OTHER, "could not be read", error, logger)
+    // `NoSuchFileException` starts at Android API 26, so keep it out of Android bytecode while
+    // preserving the desktop result for a jar whose backing file is missing.
+    val reason =
+      if (error::class.qualifiedName == "java.nio.file.NoSuchFileException") {
+        ResourceErrorReason.NOT_FOUND
+      } else {
+        ResourceErrorReason.OTHER
+      }
+    val what = if (reason == ResourceErrorReason.NOT_FOUND) "not found" else "could not be read"
+    failure(url, requestedUrl, reason, what, error, logger)
   }
+
+/** Reads a resource through the platform's packaged-resource and URL mechanisms. */
+internal expect fun readPlatformResourceBytes(url: String): ByteArray
 
 private fun failure(
   url: String,

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/resource/MlnFfiRuntimeOwner.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/resource/MlnFfiRuntimeOwner.kt
@@ -1,8 +1,7 @@
 package org.maplibre.compose.resource
 
 import co.touchlab.kermit.Logger
-import java.nio.file.Files
-import java.nio.file.Path
+import java.io.File
 import org.maplibre.nativeffi.runtime.RuntimeHandle
 import org.maplibre.nativeffi.runtime.RuntimeOptions
 
@@ -40,16 +39,22 @@ private constructor(
      * Creates a runtime and everything that hangs off it, or throws having closed whatever it got
      * as far as. [what] names the runtime in log lines.
      */
-    fun open(rawCachePath: Path, getLogger: () -> Logger?, what: String): MlnFfiRuntimeOwner {
-      val cachePath = rawCachePath.toAbsolutePath().normalize()
+    fun open(rawCacheFile: File, getLogger: () -> Logger?, what: String): MlnFfiRuntimeOwner {
+      val cacheFile = rawCacheFile.absoluteFile.normalize()
       // MapLibre opens the database as the runtime is created, and fails if the directory is
       // missing.
-      runCatching { cachePath.parent?.let(Files::createDirectories) }
+      runCatching {
+          cacheFile.parentFile?.let { directory ->
+            check(directory.mkdirs() || directory.isDirectory) {
+              "Could not create the MapLibre cache directory $directory"
+            }
+          }
+        }
         .onFailure { getLogger()?.w(it) { "Could not create the MapLibre cache directory" } }
 
       val runtime =
         try {
-          RuntimeHandle.create(RuntimeOptions().also { it.cachePath = cachePath.toString() })
+          RuntimeHandle.create(RuntimeOptions().also { it.cachePath = cacheFile.path })
         } catch (error: Throwable) {
           throw error
         }

--- a/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/map/MlnFfiMapClusterTest.kt
+++ b/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/map/MlnFfiMapClusterTest.kt
@@ -46,14 +46,14 @@ import org.maplibre.spatialk.geojson.dsl.buildFeatureCollection
 @OptIn(ExperimentalTestApi::class)
 class MlnFfiMapClusterTest {
 
-  private val cachePath = FfiTestPlatform.createCachePath()
+  private val cacheFile = FfiTestPlatform.createCacheFile()
 
   private val runtimeOptions =
-    MlnFfiRuntimeOptions(cachePath = cachePath, maximumCacheSizeBytes = null)
+    MlnFfiRuntimeOptions(cacheFile = cacheFile, maximumCacheSizeBytes = null)
 
   @AfterTest
   fun cleanUp() {
-    FfiTestPlatform.deleteCachePath(cachePath)
+    FfiTestPlatform.deleteCacheFile(cacheFile)
   }
 
   @Test

--- a/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/map/MlnFfiMapCompositionTest.kt
+++ b/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/map/MlnFfiMapCompositionTest.kt
@@ -49,17 +49,17 @@ import org.maplibre.spatialk.geojson.Position
 @OptIn(ExperimentalTestApi::class)
 class MlnFfiMapCompositionTest {
 
-  private val cachePath = FfiTestPlatform.createCachePath()
+  private val cacheFile = FfiTestPlatform.createCacheFile()
 
   private val runtimeOptions =
-    MlnFfiRuntimeOptions(cachePath = cachePath, maximumCacheSizeBytes = null)
+    MlnFfiRuntimeOptions(cacheFile = cacheFile, maximumCacheSizeBytes = null)
 
   /** Camera round trips lose a little precision through the projection; this is generous. */
   private val POSITION_TOLERANCE = 1e-4
 
   @AfterTest
   fun cleanUp() {
-    FfiTestPlatform.deleteCachePath(cachePath)
+    FfiTestPlatform.deleteCacheFile(cacheFile)
   }
 
   @Test

--- a/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/map/MlnFfiMapInputTest.kt
+++ b/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/map/MlnFfiMapInputTest.kt
@@ -53,18 +53,18 @@ import org.maplibre.spatialk.geojson.Position
 @OptIn(ExperimentalTestApi::class)
 class MlnFfiMapInputTest {
 
-  private val cachePath = FfiTestPlatform.createCachePath()
+  private val cacheFile = FfiTestPlatform.createCacheFile()
 
   /** Every click the map reported, including the one [runInputTest] uses to take focus. */
   private val clicks = mutableListOf<Position>()
   private val longClicks = mutableListOf<Position>()
 
   private val runtimeOptions =
-    MlnFfiRuntimeOptions(cachePath = cachePath, maximumCacheSizeBytes = null)
+    MlnFfiRuntimeOptions(cacheFile = cacheFile, maximumCacheSizeBytes = null)
 
   @AfterTest
   fun cleanUp() {
-    FfiTestPlatform.deleteCachePath(cachePath)
+    FfiTestPlatform.deleteCacheFile(cacheFile)
   }
 
   @Test

--- a/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/map/MlnFfiMapRepaintTest.kt
+++ b/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/map/MlnFfiMapRepaintTest.kt
@@ -42,14 +42,14 @@ import org.maplibre.spatialk.geojson.dsl.buildFeatureCollection
 @OptIn(ExperimentalTestApi::class)
 class MlnFfiMapRepaintTest {
 
-  private val cachePath = FfiTestPlatform.createCachePath()
+  private val cacheFile = FfiTestPlatform.createCacheFile()
 
   private val runtimeOptions =
-    MlnFfiRuntimeOptions(cachePath = cachePath, maximumCacheSizeBytes = null)
+    MlnFfiRuntimeOptions(cacheFile = cacheFile, maximumCacheSizeBytes = null)
 
   @AfterTest
   fun cleanUp() {
-    FfiTestPlatform.deleteCachePath(cachePath)
+    FfiTestPlatform.deleteCacheFile(cacheFile)
   }
 
   @Test

--- a/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/map/MlnFfiStyleSwitchTest.kt
+++ b/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/map/MlnFfiStyleSwitchTest.kt
@@ -40,14 +40,14 @@ import org.maplibre.spatialk.geojson.dsl.buildFeatureCollection
 @OptIn(ExperimentalTestApi::class)
 class MlnFfiStyleSwitchTest {
 
-  private val cachePath = FfiTestPlatform.createCachePath()
+  private val cacheFile = FfiTestPlatform.createCacheFile()
 
   private val runtimeOptions =
-    MlnFfiRuntimeOptions(cachePath = cachePath, maximumCacheSizeBytes = null)
+    MlnFfiRuntimeOptions(cacheFile = cacheFile, maximumCacheSizeBytes = null)
 
   @AfterTest
   fun cleanUp() {
-    FfiTestPlatform.deleteCachePath(cachePath)
+    FfiTestPlatform.deleteCacheFile(cacheFile)
   }
 
   @Test

--- a/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/mlnffi/BridgeMapFixture.kt
+++ b/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/mlnffi/BridgeMapFixture.kt
@@ -3,7 +3,7 @@ package org.maplibre.compose.mlnffi
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.LayoutDirection
 import co.touchlab.kermit.Logger
-import java.nio.file.Path
+import java.io.File
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
@@ -29,7 +29,7 @@ import org.maplibre.spatialk.geojson.Position
 internal class BridgeMapFixture
 private constructor(
   private val driver: FfiTestRenderDriver,
-  private val cachePath: Path,
+  private val cacheFile: File,
   private val initialExtent: MlnFfiMapExtent,
 ) : AutoCloseable {
 
@@ -49,7 +49,7 @@ private constructor(
       renderBackend = driver.backends.producer,
       scaleFactor = initialExtent.scaleFactor,
       layoutDirection = LayoutDirection.Ltr,
-      cachePath = cachePath,
+      cacheFile = cacheFile,
     )
 
   private val hostSession =
@@ -221,7 +221,7 @@ private constructor(
   override fun close() {
     runCatching { session.close() }
     runCatching { driver.close() }
-    FfiTestPlatform.deleteCachePath(cachePath)
+    FfiTestPlatform.deleteCacheFile(cacheFile)
   }
 
   private inner class RecordingCallbacks : MapAdapter.Callbacks {
@@ -278,12 +278,12 @@ private constructor(
     fun create(initialExtent: MlnFfiMapExtent = DEFAULT_EXTENT): BridgeMapFixture {
       FfiTestPlatform.initialize()
       val driver = FfiTestPlatform.createRenderDriver()
-      val cachePath = FfiTestPlatform.createCachePath()
+      val cacheFile = FfiTestPlatform.createCacheFile()
       return try {
-        BridgeMapFixture(driver, cachePath, initialExtent)
+        BridgeMapFixture(driver, cacheFile, initialExtent)
       } catch (error: Throwable) {
         runCatching { driver.close() }
-        FfiTestPlatform.deleteCachePath(cachePath)
+        FfiTestPlatform.deleteCacheFile(cacheFile)
         throw error
       }
     }

--- a/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/mlnffi/FfiTestPlatform.kt
+++ b/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/mlnffi/FfiTestPlatform.kt
@@ -1,6 +1,6 @@
 package org.maplibre.compose.mlnffi
 
-import java.nio.file.Path
+import java.io.File
 
 /** Platform services required by otherwise shared MapLibre Native FFI tests. */
 internal expect object FfiTestPlatform {
@@ -10,10 +10,10 @@ internal expect object FfiTestPlatform {
   fun initialize()
 
   /** A writable, test-unique cache database path. */
-  fun createCachePath(): Path
+  fun createCacheFile(): File
 
   /** Removes the cache path and any platform-owned directory containing it. */
-  fun deleteCachePath(path: Path)
+  fun deleteCacheFile(file: File)
 
   /** Creates the render driver for the native runtime packaged into this test process. */
   fun createRenderDriver(): FfiTestRenderDriver

--- a/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/offline/MlnFfiOfflineManagerTest.kt
+++ b/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/offline/MlnFfiOfflineManagerTest.kt
@@ -13,14 +13,14 @@ import org.maplibre.compose.mlnffi.MlnFfiRuntimeOptions
 /** Exercises the application cache's offline manager without a UI. */
 class MlnFfiOfflineManagerTest {
 
-  private val cachePath = FfiTestPlatform.createCachePath()
-  private val directory = requireNotNull(cachePath.parent).toFile()
+  private val cacheFile = FfiTestPlatform.createCacheFile()
+  private val directory = requireNotNull(cacheFile.parentFile)
 
-  private val options = MlnFfiRuntimeOptions(cachePath = cachePath, maximumCacheSizeBytes = null)
+  private val options = MlnFfiRuntimeOptions(cacheFile = cacheFile, maximumCacheSizeBytes = null)
 
   private val budgetedOptions =
     MlnFfiRuntimeOptions(
-      cachePath = directory.resolve("budgeted-cache.db").toPath(),
+      cacheFile = directory.resolve("budgeted-cache.db"),
       maximumCacheSizeBytes = 8L * 1024 * 1024,
     )
 
@@ -29,7 +29,7 @@ class MlnFfiOfflineManagerTest {
   @AfterTest
   fun cleanUp() {
     managers.forEach { it.closeForTest() }
-    FfiTestPlatform.deleteCachePath(cachePath)
+    FfiTestPlatform.deleteCacheFile(cacheFile)
   }
 
   /** A lost native completion would leave this suspending call hung. */

--- a/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/offline/MlnFfiOfflinePackTest.kt
+++ b/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/offline/MlnFfiOfflinePackTest.kt
@@ -24,10 +24,10 @@ import org.maplibre.spatialk.geojson.Position
  */
 class MlnFfiOfflinePackTest {
 
-  private val cachePath = FfiTestPlatform.createCachePath()
-  private val directory = requireNotNull(cachePath.parent).toFile()
+  private val cacheFile = FfiTestPlatform.createCacheFile()
+  private val directory = requireNotNull(cacheFile.parentFile)
 
-  private val options = MlnFfiRuntimeOptions(cachePath = cachePath, maximumCacheSizeBytes = null)
+  private val options = MlnFfiRuntimeOptions(cacheFile = cacheFile, maximumCacheSizeBytes = null)
   private val managers = mutableListOf<MlnFfiOfflineManager>()
 
   @AfterTest
@@ -35,7 +35,7 @@ class MlnFfiOfflinePackTest {
     // Must precede the delete, so the database is closed rather than pulled out from under a live
     // runtime.
     managers.forEach { it.closeForTest() }
-    FfiTestPlatform.deleteCachePath(cachePath)
+    FfiTestPlatform.deleteCacheFile(cacheFile)
   }
 
   @Test

--- a/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/offline/MlnFfiOfflineRuntimeTest.kt
+++ b/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/offline/MlnFfiOfflineRuntimeTest.kt
@@ -18,19 +18,19 @@ import org.maplibre.compose.mlnffi.FfiTestPlatform
  */
 class MlnFfiOfflineRuntimeTest {
 
-  private val cachePath = FfiTestPlatform.createCachePath()
+  private val cacheFile = FfiTestPlatform.createCacheFile()
 
   private val runtimes = mutableListOf<MlnFfiOfflineRuntime>()
 
   @AfterTest
   fun cleanUp() {
     runtimes.forEach { it.shutdown() }
-    FfiTestPlatform.deleteCachePath(cachePath)
+    FfiTestPlatform.deleteCacheFile(cacheFile)
   }
 
   private fun startRuntime(): MlnFfiOfflineRuntime =
     MlnFfiOfflineRuntime(
-        cachePath = cachePath,
+        cacheFile = cacheFile,
         logger = Logger.withTag("offline-runtime-test"),
         onEvent = {},
       )

--- a/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/offline/MlnFfiSharedCacheDatabaseTest.kt
+++ b/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/offline/MlnFfiSharedCacheDatabaseTest.kt
@@ -1,6 +1,6 @@
 package org.maplibre.compose.offline
 
-import java.nio.file.Path
+import java.io.File
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import kotlin.test.Test
@@ -21,7 +21,7 @@ class MlnFfiSharedCacheDatabaseTest {
 
   @Test
   fun two_runtimes_can_open_the_same_cache_database() {
-    val cache = FfiTestPlatform.createCachePath()
+    val cache = FfiTestPlatform.createCacheFile()
 
     val first = Executors.newSingleThreadExecutor()
     val second = Executors.newSingleThreadExecutor()
@@ -51,10 +51,10 @@ class MlnFfiSharedCacheDatabaseTest {
       second.shutdown()
       first.awaitTermination(10, TimeUnit.SECONDS)
       second.awaitTermination(10, TimeUnit.SECONDS)
-      FfiTestPlatform.deleteCachePath(cache)
+      FfiTestPlatform.deleteCacheFile(cache)
     }
   }
 
-  private fun createRuntime(cachePath: Path): RuntimeHandle =
-    RuntimeHandle.create(RuntimeOptions().also { it.cachePath = cachePath.toString() })
+  private fun createRuntime(cacheFile: File): RuntimeHandle =
+    RuntimeHandle.create(RuntimeOptions().also { it.cachePath = cacheFile.path })
 }


### PR DESCRIPTION
## Description

Stack 2/4 for #836, based on #840: introduces platform seams for blocking FFI work and packaged-resource reads while preserving Desktop behavior.

## Stack

1. #840 — Use `File` for shared FFI cache paths
2. **#841 — Add platform seams for FFI resource work**
3. #842 — Support platform-owned OpenGL surfaces
4. #836 — Port Android to the shared FFI implementation

## Test plan

Ran changed-file formatting checks plus Desktop library and test compilation.

## Checklist

**To your knowledge, are you making any breaking changes?**

No.

**Have you tested the changes? On which platforms?**

- Desktop: compiled the library and test sources.

## AI assistance

- **Tools:** Codex
- **Context:** Codex helped split the already-reviewed #836 implementation into independently compiling prerequisite commits and run validation.
