### PR TITLE
Support platform-owned OpenGL surfaces

### DIFF
--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -35,6 +35,8 @@ import org.maplibre.compose.mlnffi.MlnFfiMapHostSession
 import org.maplibre.compose.mlnffi.MlnFfiMapRenderer
 import org.maplibre.compose.mlnffi.MlnFfiRecoverableFrameException
 import org.maplibre.compose.mlnffi.MlnFfiRenderTarget
+import org.maplibre.compose.mlnffi.OpenGlContextHandles
+import org.maplibre.compose.mlnffi.OpenGlSurfaceTarget
 import org.maplibre.compose.mlnffi.OpenGlTextureTarget
 import org.maplibre.compose.mlnffi.VulkanContextHandles
 import org.maplibre.compose.mlnffi.VulkanImageTarget
@@ -71,6 +73,7 @@ import org.maplibre.nativeffi.query.RenderedQueryGeometry
 import org.maplibre.nativeffi.render.MetalBorrowedTextureDescriptor
 import org.maplibre.nativeffi.render.NativePointer
 import org.maplibre.nativeffi.render.OpenGLBorrowedTextureDescriptor
+import org.maplibre.nativeffi.render.OpenGLSurfaceDescriptor
 import org.maplibre.nativeffi.render.RenderSessionHandle
 import org.maplibre.nativeffi.render.RenderTargetExtent
 import org.maplibre.nativeffi.render.VulkanBorrowedTextureDescriptor
@@ -493,6 +496,7 @@ internal class MlnFfiMapSession(
         target.makeContextCurrent()
         map.attachOpenGLBorrowedTexture(target.toDescriptor(extent))
       }
+      is OpenGlSurfaceTarget -> map.attachOpenGLSurface(target.toDescriptor(extent))
     }
 
   /**
@@ -516,6 +520,7 @@ internal class MlnFfiMapSession(
           target.makeContextCurrent()
           session.setOpenGLBorrowedTextureTarget(target.toDescriptor(extent))
         }
+        is OpenGlSurfaceTarget -> session.setOpenGLSurfaceTarget(target.toDescriptor(extent))
       }
     } catch (error: InvalidArgumentException) {
       // A replacement belonging to another device.
@@ -576,13 +581,16 @@ internal class MlnFfiMapSession(
       extent = extent.toFfiExtent(),
       physicalWidth = extent.physicalWidth.coerceAtLeast(1),
       physicalHeight = extent.physicalHeight.coerceAtLeast(1),
-      context =
-        when (val handles = context) {
-          is EglContextHandles -> handles.toFfi()
-          is WglContextHandles -> handles.toFfi()
-        },
+      context = context.toFfi(),
       texture = textureName,
       target = textureTarget,
+    )
+
+  private fun OpenGlSurfaceTarget.toDescriptor(extent: MlnFfiMapExtent) =
+    OpenGLSurfaceDescriptor(
+      extent = extent.toFfiExtent(),
+      context = context.toFfi(),
+      surface = NativePointer.ofAddress(surface.address),
     )
 
   // endregion
@@ -1355,6 +1363,12 @@ private fun VulkanContextHandles.toFfi() =
     getInstanceProcAddr = NativePointer.ofAddress(getInstanceProcAddr.address),
     getDeviceProcAddr = NativePointer.ofAddress(getDeviceProcAddr.address),
   )
+
+private fun OpenGlContextHandles.toFfi() =
+  when (this) {
+    is EglContextHandles -> toFfi()
+    is WglContextHandles -> toFfi()
+  }
 
 private fun EglContextHandles.toFfi() =
   org.maplibre.nativeffi.render.EglContextDescriptor(

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/MlnFfiMapView.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/MlnFfiMapView.kt
@@ -16,6 +16,7 @@ import org.maplibre.compose.mlnffi.MapRenderBackend
 import org.maplibre.compose.mlnffi.MlnFfiApplication
 import org.maplibre.compose.mlnffi.MlnFfiMapHostFactory
 import org.maplibre.compose.mlnffi.MlnFfiMapHostResult
+import org.maplibre.compose.mlnffi.MlnFfiMapRenderer
 import org.maplibre.compose.mlnffi.MlnFfiMapSurface
 import org.maplibre.compose.mlnffi.backendDiagnostic
 import org.maplibre.compose.style.BaseStyle
@@ -34,8 +35,6 @@ internal fun MlnFfiMapView(
   callbacks: MapAdapter.Callbacks,
   options: MapOptions,
 ) {
-  val applicationOptions = MlnFfiApplication.options
-  val layoutDirection = LocalLayoutDirection.current
   val density = LocalDensity.current
 
   // Safe to call off the owner thread: it only inspects what the loaded library was built with.
@@ -44,12 +43,50 @@ internal fun MlnFfiMapView(
   val hostResult =
     remember(hostFactory, runtimeBackends, scaleFactor) { createHost(runtimeBackends, hostFactory) }
 
+  MlnFfiMapView(
+    renderBackend = hostFactory.backends.producer,
+    surface = { renderer, surfaceModifier, surfaceLogger ->
+      MlnFfiMapSurface(
+        renderer = renderer,
+        hostResult = hostResult,
+        modifier = surfaceModifier,
+        logger = surfaceLogger,
+      )
+    },
+    modifier = modifier,
+    style = style,
+    update = update,
+    onReset = onReset,
+    logger = logger,
+    callbacks = callbacks,
+    options = options,
+  )
+}
+
+/** A map rendered by a platform surface that owns its presentation loop. */
+@Composable
+internal fun MlnFfiMapView(
+  renderBackend: MapRenderBackend,
+  surface: @Composable (MlnFfiMapRenderer, Modifier, Logger?) -> Unit,
+  modifier: Modifier,
+  style: BaseStyle,
+  update: (map: MapAdapter) -> Unit,
+  onReset: () -> Unit,
+  logger: Logger?,
+  callbacks: MapAdapter.Callbacks,
+  options: MapOptions,
+) {
+  val applicationOptions = MlnFfiApplication.options
+  val layoutDirection = LocalLayoutDirection.current
+  val density = LocalDensity.current
+  val scaleFactor = density.density.toDouble()
+
   val session =
-    remember(hostFactory.backends, scaleFactor, applicationOptions) {
+    remember(renderBackend, scaleFactor, applicationOptions) {
       MlnFfiMapSession(
         callbacks = callbacks,
         logger = logger,
-        renderBackend = hostFactory.backends.producer,
+        renderBackend = renderBackend,
         scaleFactor = scaleFactor,
         layoutDirection = layoutDirection,
         cacheFile = applicationOptions.cacheFile,
@@ -80,19 +117,9 @@ internal fun MlnFfiMapView(
   val inputScope = rememberCoroutineScope()
   val continuation = remember(session, inputScope) { GestureContinuation(inputScope) }
 
-  MlnFfiMapSurface(
-    renderer = session,
-    hostResult = hostResult,
-    modifier =
-      modifier.mlnFfiMapInput(
-        session,
-        options.gestureOptions,
-        density,
-        focusRequester,
-        continuation,
-      ),
-    logger = logger,
-  )
+  val inputModifier =
+    modifier.mlnFfiMapInput(session, options.gestureOptions, density, focusRequester, continuation)
+  surface(session, inputModifier, logger)
 }
 
 private fun createHost(
@@ -121,7 +148,7 @@ private fun createHost(
  * Reports which backends the packaged MapLibre Native FFI runtime was built with. Empty rather than
  * throwing when no runtime is on the classpath; negotiation reports that as a diagnostic.
  */
-private fun loadRuntimeBackends(logger: Logger?): Set<MapRenderBackend> =
+internal fun loadRuntimeBackends(logger: Logger?): Set<MapRenderBackend> =
   try {
     Maplibre.loadNativeLibrary()
     Maplibre.supportedRenderBackends().mapNotNullTo(mutableSetOf()) { it.toComposeBackend() }

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/mlnffi/MlnFfiRenderTarget.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/mlnffi/MlnFfiRenderTarget.kt
@@ -105,7 +105,7 @@ internal data class MetalTextureTarget(
 /** Platform context handles MapLibre needs to render into an OpenGL target. */
 internal sealed interface OpenGlContextHandles
 
-/** EGL context handles, used on Linux. */
+/** EGL context handles, used by EGL hosts. */
 @Immutable
 internal data class EglContextHandles(
   /** `EGLDisplay`. */
@@ -118,7 +118,7 @@ internal data class EglContextHandles(
   val getProcAddress: NativeHandle,
 ) : OpenGlContextHandles
 
-/** WGL context handles, used on Windows. */
+/** WGL context handles, used by WGL hosts. */
 @Immutable
 internal data class WglContextHandles(
   /** `HDC`. */
@@ -154,6 +154,20 @@ internal data class OpenGlTextureTarget(
    * the context is already current.
    */
   val makeContextCurrent: () -> Unit,
+  override val extent: MlnFfiMapExtent,
+  override val generation: Long,
+) : MlnFfiRenderTarget {
+  override val backend: MapRenderBackend
+    get() = MapRenderBackend.OPENGL
+}
+
+/** A platform-native OpenGL surface MapLibre renders into and presents directly. */
+@Immutable
+internal data class OpenGlSurfaceTarget(
+  /** Platform context handles for [surface]. */
+  val context: OpenGlContextHandles,
+  /** Provider-native surface handle, or zero when the context identifies a WebGL canvas. */
+  val surface: NativeHandle,
   override val extent: MlnFfiMapExtent,
   override val generation: Long,
 ) : MlnFfiRenderTarget {


### PR DESCRIPTION
## Description

Stack 3/4 for #836, based on #841: adds a platform-owned OpenGL surface target and a backend-neutral Compose host path without changing existing Desktop presentation.

## Stack

1. #840 — Use `File` for shared FFI cache paths
2. #841 — Add platform seams for FFI resource work
3. **#842 — Support platform-owned OpenGL surfaces**
4. #836 — Port Android to the shared FFI implementation

## Test plan

Ran changed-file formatting checks plus Desktop library and test compilation.

## Checklist

**To your knowledge, are you making any breaking changes?**

No.

**Have you tested the changes? On which platforms?**

- Desktop: compiled the library and test sources.

## AI assistance

- **Tools:** Codex
- **Context:** Codex helped split the already-reviewed #836 implementation into independently compiling prerequisite commits and run validation.
