### PR TITLE
Remove JVM-only APIs from the shared MapLibre Native FFI code

### DIFF
--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/map/MlnFfiPlatformDescription.desktop.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/map/MlnFfiPlatformDescription.desktop.kt
@@ -1,0 +1,7 @@
+package org.maplibre.compose.map
+
+internal actual val mlnFfiOperatingSystem: String
+  get() = System.getProperty("os.name") ?: "unknown"
+
+internal actual val mlnFfiArchitecture: String
+  get() = System.getProperty("os.arch") ?: "unknown"

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/resource/PlatformResourceReader.desktop.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/resource/PlatformResourceReader.desktop.kt
@@ -1,6 +1,24 @@
 package org.maplibre.compose.resource
 
+import java.io.FileNotFoundException
 import java.net.URI
+import java.net.URISyntaxException
+import java.nio.file.NoSuchFileException
 
 internal actual fun readPlatformResourceBytes(url: String): ByteArray =
-  URI(url).toURL().openStream().use { it.readBytes() }
+  try {
+    URI(url).toURL().openStream().use { it.readBytes() }
+  } catch (error: Throwable) {
+    if (error is VirtualMachineError) throw error
+    throw MlnFfiResourceReadException(classify(error), error)
+  }
+
+private fun classify(error: Throwable): MlnFfiResourceReadFailure =
+  when (error) {
+    // A jar whose backing file is missing arrives as `NoSuchFileException` rather than
+    // `FileNotFoundException`.
+    is FileNotFoundException,
+    is NoSuchFileException -> MlnFfiResourceReadFailure.NOT_FOUND
+    is URISyntaxException -> MlnFfiResourceReadFailure.INVALID_URL
+    else -> MlnFfiResourceReadFailure.UNREADABLE
+  }

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/util/FatalError.desktop.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/util/FatalError.desktop.kt
@@ -1,0 +1,5 @@
+package org.maplibre.compose.util
+
+internal actual fun rethrowIfFatal(error: Throwable) {
+  if (error is VirtualMachineError) throw error
+}

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/MlnFfiMapView.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/MlnFfiMapView.kt
@@ -20,6 +20,7 @@ import org.maplibre.compose.mlnffi.MlnFfiMapRenderer
 import org.maplibre.compose.mlnffi.MlnFfiMapSurface
 import org.maplibre.compose.mlnffi.backendDiagnostic
 import org.maplibre.compose.style.BaseStyle
+import org.maplibre.compose.util.rethrowIfFatal
 import org.maplibre.nativeffi.Maplibre
 import org.maplibre.nativeffi.render.RenderBackend
 
@@ -139,7 +140,7 @@ private fun createHost(
   return try {
     factory.create()
   } catch (error: Throwable) {
-    if (error is VirtualMachineError) throw error
+    rethrowIfFatal(error)
     MlnFfiMapHostResult.Failed("${factory.description} threw while creating a map host", error)
   }
 }
@@ -153,7 +154,7 @@ internal fun loadRuntimeBackends(logger: Logger?): Set<MapRenderBackend> =
     Maplibre.loadNativeLibrary()
     Maplibre.supportedRenderBackends().mapNotNullTo(mutableSetOf()) { it.toComposeBackend() }
   } catch (error: Throwable) {
-    if (error is VirtualMachineError) throw error
+    rethrowIfFatal(error)
     logger?.e(error) { "Could not load the MapLibre Native FFI runtime" }
     emptySet()
   }

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/MlnFfiMapView.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/MlnFfiMapView.kt
@@ -131,8 +131,8 @@ private fun createHost(
       runtimeBackends = runtimeBackends,
       hostBackends = factory.backends,
       hostDescription = factory.description,
-      operatingSystem = System.getProperty("os.name") ?: "unknown",
-      architecture = System.getProperty("os.arch") ?: "unknown",
+      operatingSystem = mlnFfiOperatingSystem,
+      architecture = mlnFfiArchitecture,
     )
   if (diagnostic != null) return MlnFfiMapHostResult.Failed(diagnostic)
 

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/MlnFfiPlatformDescription.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/MlnFfiPlatformDescription.kt
@@ -1,0 +1,7 @@
+package org.maplibre.compose.map
+
+/** The name of the operating system this process runs on, or `unknown` where none is reported. */
+internal expect val mlnFfiOperatingSystem: String
+
+/** The CPU architecture this process runs on, or `unknown` where none is reported. */
+internal expect val mlnFfiArchitecture: String

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/mlnffi/MlnFfiMapHost.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/mlnffi/MlnFfiMapHost.kt
@@ -16,7 +16,10 @@ internal data class MlnFfiMapFrame(
   val extent: MlnFfiMapExtent,
   val target: MlnFfiRenderTarget,
 
-  /** When this frame is expected to be presented, in `System.nanoTime` units, if the host knows. */
+  /**
+   * When this frame is expected to be presented, if the host knows. Nanoseconds on a monotonic
+   * clock whose origin is arbitrary, so only differences between frames mean anything.
+   */
   val presentationTimeNanos: Long?,
 )
 

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/mlnffi/MlnFfiMapSurface.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/mlnffi/MlnFfiMapSurface.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.IntSize
 import co.touchlab.kermit.Logger
 import kotlin.time.TimeSource
+import org.maplibre.compose.util.rethrowIfFatal
 
 /** The origin the frame clock counts from, fixed for the process so hosts can compare frames. */
 private val frameClockOrigin = TimeSource.Monotonic.markNow()
@@ -49,7 +50,7 @@ internal fun MlnFfiMapSurface(
           renderer.onSurfaceAvailable(session)
           session.requestFrame()
         } catch (error: Throwable) {
-          if (error is VirtualMachineError) throw error
+          rethrowIfFatal(error)
           failed = true
           logger?.e(error) { "Map renderer failed to take the host surface" }
           drawState.closeRenderer(renderer, logger)
@@ -80,7 +81,7 @@ internal fun MlnFfiMapSurface(
       renderer.onSurfaceChanged(extent)
       session?.requestFrame()
     } catch (error: Throwable) {
-      if (error is VirtualMachineError) throw error
+      rethrowIfFatal(error)
       failed = true
       logger?.e(error) { "Map host failed to resize to ${extent.width}x${extent.height}" }
       drawState.closeRenderer(renderer, logger)
@@ -119,7 +120,7 @@ internal fun MlnFfiMapSurface(
           }
         }
       } catch (error: Throwable) {
-        if (error is VirtualMachineError) throw error
+        rethrowIfFatal(error)
         if (!recoverFromFrameFailure(renderer, session, drawState, frameId, error, logger)) {
           failed = true
           drawState.closeRenderer(renderer, logger)
@@ -168,7 +169,7 @@ private fun recoverFromFrameFailure(
     session.requestFrame()
     true
   } catch (rearmError: Throwable) {
-    if (rearmError is VirtualMachineError) throw rearmError
+    rethrowIfFatal(rearmError)
     logger?.e(rearmError) { "Map renderer failed to take the surface back after frame $frameId" }
     false
   }

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/mlnffi/MlnFfiMapSurface.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/mlnffi/MlnFfiMapSurface.kt
@@ -16,6 +16,10 @@ import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.IntSize
 import co.touchlab.kermit.Logger
+import kotlin.time.TimeSource
+
+/** The origin the frame clock counts from, fixed for the process so hosts can compare frames. */
+private val frameClockOrigin = TimeSource.Monotonic.markNow()
 
 /** Hosts [renderer] on a Compose drawing surface, driving the frame loop. */
 @Composable
@@ -90,8 +94,9 @@ internal fun MlnFfiMapSurface(
     var drew = false
     if (host != null && session != null && !extent.isEmpty && !failed) {
       val frameId = drawState.nextFrameId()
+      val nowNanos = frameClockOrigin.elapsedNow().inWholeNanoseconds
       try {
-        when (val acquisition = host.acquireFrame(frameId, extent, System.nanoTime())) {
+        when (val acquisition = host.acquireFrame(frameId, extent, nowNanos)) {
           MlnFfiMapFrameAcquisition.NotReady -> session.requestFrame()
           is MlnFfiMapFrameAcquisition.Acquired -> {
             val frame = acquisition.frame

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/resource/MlnFfiResourceProvider.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/resource/MlnFfiResourceProvider.kt
@@ -2,6 +2,7 @@ package org.maplibre.compose.resource
 
 import co.touchlab.kermit.Logger
 import java.util.concurrent.atomic.AtomicBoolean
+import org.maplibre.compose.util.rethrowIfFatal
 import org.maplibre.nativeffi.resource.ResourceErrorReason
 import org.maplibre.nativeffi.resource.ResourceProviderCallback
 import org.maplibre.nativeffi.resource.ResourceProviderDecision
@@ -70,7 +71,7 @@ internal class MlnFfiResourceProvider(
         open.complete(read(url, requestedUrl))
       }
     } catch (error: Throwable) {
-      if (error is VirtualMachineError) throw error
+      rethrowIfFatal(error)
       logger?.w(error) { "Failed to answer the resource request for $url" }
     }
   }
@@ -95,7 +96,7 @@ internal class MlnFfiResourceProvider(
         )
       }
     } catch (error: Throwable) {
-      if (error is VirtualMachineError) throw error
+      rethrowIfFatal(error)
       logger?.w(error) { "Failed to refuse the resource request for $url" }
     }
   }

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/resource/MlnFfiResourceProvider.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/resource/MlnFfiResourceProvider.kt
@@ -1,9 +1,6 @@
 package org.maplibre.compose.resource
 
 import co.touchlab.kermit.Logger
-import java.io.FileNotFoundException
-import java.net.URI
-import java.net.URISyntaxException
 import java.util.concurrent.atomic.AtomicBoolean
 import org.maplibre.nativeffi.resource.ResourceErrorReason
 import org.maplibre.nativeffi.resource.ResourceProviderCallback
@@ -139,26 +136,33 @@ internal fun readResource(url: String, requestedUrl: String, logger: Logger?): R
       // Packaged resources cannot change while the process runs.
       it.mustRevalidate = false
     }
-  } catch (error: FileNotFoundException) {
-    failure(url, requestedUrl, ResourceErrorReason.NOT_FOUND, "not found", error, logger)
-  } catch (error: URISyntaxException) {
-    failure(url, requestedUrl, ResourceErrorReason.OTHER, "is not a valid URI", error, logger)
-  } catch (error: Throwable) {
-    if (error is VirtualMachineError) throw error
-    // `NoSuchFileException` starts at Android API 26, so keep it out of Android bytecode while
-    // preserving the desktop result for a jar whose backing file is missing.
-    val reason =
-      if (error::class.qualifiedName == "java.nio.file.NoSuchFileException") {
-        ResourceErrorReason.NOT_FOUND
-      } else {
-        ResourceErrorReason.OTHER
-      }
-    val what = if (reason == ResourceErrorReason.NOT_FOUND) "not found" else "could not be read"
-    failure(url, requestedUrl, reason, what, error, logger)
+  } catch (error: MlnFfiResourceReadException) {
+    failure(url, requestedUrl, error.failure.reason, error.failure.description, error.cause, logger)
   }
 
-/** Reads a resource through the platform's packaged-resource and URL mechanisms. */
+/**
+ * Reads a resource through the platform's packaged-resource and URL mechanisms. Every failure
+ * arrives as an [MlnFfiResourceReadException], so that each platform classifies its own read
+ * errors.
+ */
 internal expect fun readPlatformResourceBytes(url: String): ByteArray
+
+/** How a resource read failed, in the terms the caller reports it in. */
+internal enum class MlnFfiResourceReadFailure(
+  val reason: ResourceErrorReason,
+  /** Completes the sentence "Resource <url> …". */
+  val description: String,
+) {
+  NOT_FOUND(ResourceErrorReason.NOT_FOUND, "not found"),
+  INVALID_URL(ResourceErrorReason.OTHER, "is not a valid URI"),
+  UNREADABLE(ResourceErrorReason.OTHER, "could not be read"),
+}
+
+/** The classified failure of one [readPlatformResourceBytes] call. */
+internal class MlnFfiResourceReadException(
+  val failure: MlnFfiResourceReadFailure,
+  override val cause: Throwable,
+) : Exception(cause)
 
 private fun failure(
   url: String,
@@ -190,10 +194,25 @@ private fun failure(
 internal fun isMapLibresToFetch(resolvedUrl: String): Boolean =
   schemeOf(resolvedUrl).let { it == null || it in NETWORK_SCHEMES }
 
-/** The scheme of [url], or null when it has none or cannot be parsed. */
-internal fun schemeOf(url: String): String? =
-  try {
-    URI(url).scheme?.lowercase()
-  } catch (_: URISyntaxException) {
-    null
+/**
+ * The scheme of [url] in lowercase, or null when it has none or cannot be parsed.
+ *
+ * A scheme is a letter followed by letters, digits, `+`, `-`, or `.`, and then `:`, as RFC 3986
+ * defines it. A URL holding whitespace or a backslash reports no scheme at all, because neither
+ * character can appear in a URI; that keeps a Windows path such as `C:\dir\style.json` out of this
+ * provider.
+ */
+internal fun schemeOf(url: String): String? {
+  val end = url.indexOf(':')
+  if (end < 1 || !url[0].isAsciiLetter()) return null
+  for (index in 1 until end) {
+    val char = url[index]
+    if (!char.isAsciiLetter() && !char.isAsciiDigit() && char !in "+-.") return null
   }
+  if (url.any { it.isWhitespace() || it == '\\' }) return null
+  return url.substring(0, end).lowercase()
+}
+
+private fun Char.isAsciiLetter(): Boolean = this in 'a'..'z' || this in 'A'..'Z'
+
+private fun Char.isAsciiDigit(): Boolean = this in '0'..'9'

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/sources/ComputedSource.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/sources/ComputedSource.kt
@@ -14,6 +14,7 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import org.maplibre.compose.resource.startMlnFfiBlockingWork
+import org.maplibre.compose.util.rethrowIfFatal
 import org.maplibre.compose.util.toLatLngBounds
 import org.maplibre.nativeffi.geo.CanonicalTileId
 import org.maplibre.nativeffi.map.MapHandle
@@ -102,7 +103,7 @@ public actual class ComputedSource : Source {
       try {
         getFeatures(tileId.toBoundingBox(), tileId.z).toFfiGeoJson()
       } catch (error: Throwable) {
-        if (error is VirtualMachineError) throw error
+        rethrowIfFatal(error)
         requestedTiles.remove(tileId, request)
         // Reported rather than propagated; the tile stays blank until something invalidates it.
         binding.logger?.e(error) { "Computing tile $tileId of source '$id' failed" }

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/util/FatalError.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/util/FatalError.kt
@@ -1,0 +1,4 @@
+package org.maplibre.compose.util
+
+/** Rethrows [error] when the process cannot be expected to keep running. */
+internal expect fun rethrowIfFatal(error: Throwable)

--- a/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/offline/MlnFfiOfflinePackTest.kt
+++ b/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/offline/MlnFfiOfflinePackTest.kt
@@ -8,6 +8,8 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotSame
 import kotlin.test.assertTrue
 import kotlin.test.fail
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.TimeSource
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
@@ -355,9 +357,9 @@ class MlnFfiOfflinePackTest {
 
   /** Polls [condition] until it holds, failing rather than hanging if it never does. */
   private suspend fun await(describe: () -> String, condition: () -> Boolean) {
-    val deadline = System.nanoTime() + OPERATION_TIMEOUT_MILLIS * 1_000_000
+    val deadline = TimeSource.Monotonic.markNow() + OPERATION_TIMEOUT_MILLIS.milliseconds
     while (!condition()) {
-      if (System.nanoTime() > deadline) {
+      if (deadline.hasPassedNow()) {
         fail("Timed out after ${OPERATION_TIMEOUT_MILLIS}ms waiting for ${describe()}")
       }
       delay(POLL_MILLIS)

--- a/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/resource/MlnFfiResourceProviderTest.kt
+++ b/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/resource/MlnFfiResourceProviderTest.kt
@@ -47,6 +47,26 @@ class MlnFfiResourceProviderTest {
   }
 
   @Test
+  fun a_windows_path_has_no_scheme_so_its_drive_letter_stays_out_of_the_provider() {
+    assertNull(schemeOf("C:\\Users\\someone\\style.json"))
+    assertTrue(isMapLibresToFetch("C:\\Users\\someone\\style.json"))
+  }
+
+  @Test
+  fun a_scheme_starts_with_a_letter() {
+    assertNull(schemeOf("2fast:/style.json"))
+    assertNull(schemeOf(":/style.json"))
+    assertNull(schemeOf("/home/someone/style:json"))
+  }
+
+  @Test
+  fun a_scheme_may_hold_digits_and_punctuation_after_its_first_letter() {
+    assertEquals("view-source", schemeOf("view-source:https://example.invalid/"))
+    assertEquals("z39.50r", schemeOf("z39.50r:host/db"))
+    assertEquals("soap.beep+tls", schemeOf("soap.beep+tls:host"))
+  }
+
+  @Test
   fun schemeof_lowercases_so_callers_can_compare_against_lowercase_names() {
     assertEquals("jar", schemeOf("JAR:file:/app.jar!/style.json"))
   }

--- a/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/resource/MlnFfiResourceRequestTest.kt
+++ b/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/resource/MlnFfiResourceRequestTest.kt
@@ -9,6 +9,8 @@ import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeSource
 import org.maplibre.nativeffi.resource.ResourceErrorReason
 import org.maplibre.nativeffi.resource.ResourceResponse
 import org.maplibre.nativeffi.resource.ResourceResponseStatus
@@ -192,8 +194,8 @@ class MlnFfiResourceRequestTest {
     }
 
     fun awaitClose() {
-      val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(WAIT_SECONDS)
-      while (closes == 0 && System.nanoTime() < deadline) Thread.onSpinWait()
+      val deadline = TimeSource.Monotonic.markNow() + WAIT_SECONDS.seconds
+      while (closes == 0 && deadline.hasNotPassedNow()) Thread.onSpinWait()
       assertEquals(1, closes, "the request was never closed")
     }
   }


### PR DESCRIPTION
## Description

Replace the JVM-only URI parsing, resource read error classification, frame clock, platform description, and fatal error check in `mlnFfiShared` with multiplatform code and `expect` declarations actualized in `jvmMain`, so the source set moves toward Kotlin/Native compatibility.

## Test plan

Ran `./gradlew :lib:maplibre-compose:compileKotlinJvm`, `mise run test:desktop`, and `mise run check` on Linux x64.

## Checklist

**To your knowledge, are you making any breaking changes?**

No; every declaration involved is internal and the JVM behavior is unchanged.

**Have you tested the changes? On which platforms?**

- Desktop: Linux x64 headless Vulkan tests.

## AI assistance

- **Tools:** Claude Code
- **Context:** Claude made these edits and ran the validation above, working from a list of JVM dependencies to remove from `mlnFfiShared`.
