### PR TITLE
Move mlnFfiShared off java.io.File and java.util.concurrent

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,7 @@ htmlConverterCompose = "1.1.1"
 kermit = "2.1.0"
 kotlin-wrappers = "2026.8.0"
 kotlinx-coroutines = "1.11.0"
+kotlinx-io = "0.9.1"
 ktor = "3.5.2"
 lifecycleRuntimeCompose = "2.10.0"
 lwjgl = "3.4.2"
@@ -65,6 +66,7 @@ kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-
 kotlinx-coroutines-playServices = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-play-services", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-swing = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-swing", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
+kotlinx-io-core = { module = "org.jetbrains.kotlinx:kotlinx-io-core", version.ref = "kotlinx-io" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "ktor" }
 ktor-client-js = { module = "io.ktor:ktor-client-js", version.ref = "ktor" }

--- a/lib/maplibre-compose/build.gradle.kts
+++ b/lib/maplibre-compose/build.gradle.kts
@@ -80,6 +80,8 @@ kotlin {
       dependencies {
         // Backend-independent binding only; the application selects the native runtime.
         implementation(libs.maplibre.nativeFfi)
+        // Multiplatform filesystem paths, so this source set stays free of java.io.File.
+        implementation(libs.kotlinx.io.core)
       }
     }
 

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/DesktopRuntimeOptions.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/DesktopRuntimeOptions.kt
@@ -58,6 +58,6 @@ internal fun absoluteEnvironmentPath(value: String?): Path? =
   value?.takeIf { it.isNotBlank() }?.let(Paths::get)?.takeIf(Path::isAbsolute)
 
 internal fun DesktopRuntimeOptions.toMlnFfiRuntimeOptions(): MlnFfiRuntimeOptions =
-  MlnFfiRuntimeOptions(cachePath.toFile(), maximumCacheSizeBytes)
+  MlnFfiRuntimeOptions(kotlinx.io.files.Path(cachePath.toString()), maximumCacheSizeBytes)
 
 private val APPLICATION_ID = Regex("[A-Za-z0-9_-]+(?:\\.[A-Za-z0-9_-]+)*")

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/mlnffi/MlnFfiLock.desktop.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/mlnffi/MlnFfiLock.desktop.kt
@@ -1,0 +1,15 @@
+package org.maplibre.compose.mlnffi
+
+import java.util.concurrent.locks.ReentrantLock
+
+internal actual class MlnFfiLock actual constructor(fair: Boolean) {
+  private val delegate = ReentrantLock(fair)
+
+  actual fun lock() {
+    delegate.lock()
+  }
+
+  actual fun unlock() {
+    delegate.unlock()
+  }
+}

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/mlnffi/MlnFfiPath.desktop.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/mlnffi/MlnFfiPath.desktop.kt
@@ -1,0 +1,7 @@
+package org.maplibre.compose.mlnffi
+
+import java.nio.file.Paths
+import kotlinx.io.files.Path
+
+internal actual fun normalizeMlnFfiPath(path: Path): Path =
+  Path(Paths.get(path.toString()).toAbsolutePath().normalize().toString())

--- a/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/desktop/DesktopRuntimeOptionsTest.kt
+++ b/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/desktop/DesktopRuntimeOptionsTest.kt
@@ -40,7 +40,7 @@ class DesktopRuntimeOptionsTest {
   @Test
   fun repeating_the_same_normalized_configuration_is_harmless() {
     val file = FfiTestPlatform.createCacheFile()
-    val path = file.toPath()
+    val path = Paths.get(file.toString())
     val alias = path.parent.resolve("unused").resolve("..").resolve(path.fileName)
     try {
       MapLibre.configure(DesktopRuntimeOptions(path))
@@ -54,7 +54,7 @@ class DesktopRuntimeOptionsTest {
   @Test
   fun replacing_the_application_configuration_fails() {
     val file = FfiTestPlatform.createCacheFile()
-    val path = file.toPath()
+    val path = Paths.get(file.toString())
     try {
       MapLibre.configure(DesktopRuntimeOptions(path))
 

--- a/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/desktop/bridge/LinuxVulkanOpenGlInteropTest.kt
+++ b/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/desktop/bridge/LinuxVulkanOpenGlInteropTest.kt
@@ -14,6 +14,7 @@ import kotlin.test.assertIs
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.TimeSource
+import kotlinx.io.files.Path
 import org.jetbrains.skia.Bitmap
 import org.jetbrains.skia.ColorAlphaType
 import org.jetbrains.skia.ColorType
@@ -264,7 +265,7 @@ class LinuxVulkanOpenGlInteropTest {
         logger = null,
         renderBackend = host.backends.producer,
         layoutDirection = LayoutDirection.Ltr,
-        cacheFile = cacheDirectory.resolve("cache.db").toFile(),
+        cacheFile = Path(cacheDirectory.resolve("cache.db").toString()),
       )
 
     private val hostSession =

--- a/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/mlnffi/FfiTestPlatform.desktop.kt
+++ b/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/mlnffi/FfiTestPlatform.desktop.kt
@@ -2,6 +2,7 @@ package org.maplibre.compose.mlnffi
 
 import java.io.File
 import java.nio.file.Files
+import kotlinx.io.files.Path
 import org.junit.Assume.assumeTrue
 import org.maplibre.nativeffi.Maplibre
 
@@ -12,13 +13,13 @@ internal actual object FfiTestPlatform {
     Maplibre.loadNativeLibrary()
   }
 
-  actual fun createCacheFile(): File {
+  actual fun createCacheFile(): Path {
     initialize()
-    return Files.createTempDirectory("maplibre-ffi-test").resolve("cache.db").toFile()
+    return Path(Files.createTempDirectory("maplibre-ffi-test").resolve("cache.db").toString())
   }
 
-  actual fun deleteCacheFile(file: File) {
-    file.parentFile?.deleteRecursively()
+  actual fun deleteCacheFile(file: Path) {
+    file.parent?.let { File(it.toString()).deleteRecursively() }
   }
 
   actual fun createRenderDriver(): FfiTestRenderDriver {

--- a/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/mlnffi/FfiTestPlatform.desktop.kt
+++ b/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/mlnffi/FfiTestPlatform.desktop.kt
@@ -1,7 +1,9 @@
 package org.maplibre.compose.mlnffi
 
 import java.io.File
+import java.net.URI
 import java.nio.file.Files
+import java.nio.file.Paths
 import kotlinx.io.files.Path
 import org.junit.Assume.assumeTrue
 import org.maplibre.nativeffi.Maplibre
@@ -32,3 +34,7 @@ internal actual object FfiTestPlatform {
     error("JUnit did not abort skipped test: $reason")
   }
 }
+
+internal actual fun fileUrlOf(path: Path): String = Paths.get(path.toString()).toUri().toString()
+
+internal actual fun pathOfFileUrl(url: String): Path = Path(Paths.get(URI(url)).toString())

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/layers/Layer.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/layers/Layer.kt
@@ -1,5 +1,6 @@
 package org.maplibre.compose.layers
 
+import kotlin.concurrent.Volatile
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/MlnFfiMapRuntimeLoop.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/MlnFfiMapRuntimeLoop.kt
@@ -1,12 +1,12 @@
 package org.maplibre.compose.map
 
 import co.touchlab.kermit.Logger
-import java.io.File
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
+import kotlinx.io.files.Path
 import org.maplibre.compose.mlnffi.MlnFfiMapExtent
 import org.maplibre.compose.resource.MlnFfiRuntimeOwner
 import org.maplibre.nativeffi.map.MapHandle
@@ -47,7 +47,7 @@ private const val SHUTDOWN_WAIT_MILLIS = 5_000L
 internal class MlnFfiMapRuntimeLoop(
   /** The extent the map is created with. Its scale factor is fixed for the map's lifetime. */
   private val extent: MlnFfiMapExtent,
-  private val cacheFile: File,
+  private val cacheFile: Path,
   private val getLogger: () -> Logger?,
   /** Runs on the owner thread once the map exists, before it is published. */
   private val onMapCreated: (MapHandle) -> Unit,

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/MlnFfiMapRuntimeLoop.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/MlnFfiMapRuntimeLoop.kt
@@ -5,6 +5,7 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.Volatile
 import kotlin.concurrent.withLock
 import kotlinx.io.files.Path
 import org.maplibre.compose.mlnffi.MlnFfiMapExtent

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalAtomicApi::class)
+
 package org.maplibre.compose.map
 
 import androidx.compose.foundation.layout.PaddingValues
@@ -5,11 +7,10 @@ import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.DpRect
 import androidx.compose.ui.unit.LayoutDirection
 import co.touchlab.kermit.Logger
-import java.io.File
-import java.util.concurrent.atomic.AtomicBoolean
-import java.util.concurrent.atomic.AtomicLong
-import java.util.concurrent.locks.ReentrantLock
-import kotlin.concurrent.withLock
+import kotlin.concurrent.atomics.AtomicBoolean
+import kotlin.concurrent.atomics.AtomicLong
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+import kotlin.concurrent.atomics.incrementAndFetch
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.math.PI
@@ -20,6 +21,7 @@ import kotlin.time.DurationUnit
 import kotlin.time.TimeSource
 import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.io.files.Path
 import kotlinx.serialization.json.JsonObject
 import org.maplibre.compose.camera.CameraMoveReason
 import org.maplibre.compose.camera.CameraPosition
@@ -29,6 +31,7 @@ import org.maplibre.compose.mlnffi.EglContextHandles
 import org.maplibre.compose.mlnffi.MapRenderBackend
 import org.maplibre.compose.mlnffi.MetalTextureTarget
 import org.maplibre.compose.mlnffi.MlnFfiFrameResult
+import org.maplibre.compose.mlnffi.MlnFfiLock
 import org.maplibre.compose.mlnffi.MlnFfiMapExtent
 import org.maplibre.compose.mlnffi.MlnFfiMapFrame
 import org.maplibre.compose.mlnffi.MlnFfiMapHostSession
@@ -41,6 +44,7 @@ import org.maplibre.compose.mlnffi.OpenGlTextureTarget
 import org.maplibre.compose.mlnffi.VulkanContextHandles
 import org.maplibre.compose.mlnffi.VulkanImageTarget
 import org.maplibre.compose.mlnffi.WglContextHandles
+import org.maplibre.compose.mlnffi.withLock
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.compose.style.MlnFfiStyle
 import org.maplibre.compose.style.StyleBinding
@@ -130,14 +134,14 @@ internal class MlnFfiMapSession(
   renderBackend: MapRenderBackend,
   scaleFactor: Double = 1.0,
   @Volatile internal var layoutDirection: LayoutDirection,
-  private val cacheFile: File,
+  private val cacheFile: Path,
 ) : MapAdapter, MlnFfiMapRenderer {
 
   override val backend: MapRenderBackend = renderBackend
   private val initialExtent = MlnFfiMapExtent.fromLogical(1, 1, scaleFactor)
 
   /** Guards loop startup and actions accepted before it. */
-  private val stateLock = ReentrantLock()
+  private val stateLock = MlnFfiLock()
 
   @Volatile private var loop: MlnFfiMapRuntimeLoop? = null
 
@@ -303,7 +307,7 @@ internal class MlnFfiMapSession(
     if (!ensureAttached(map, frame)) return MlnFfiFrameResult.SKIPPED
     // Consumed before rendering, so an update the loop publishes during the render below is not
     // discarded along with the one being drawn.
-    if (!renderRequested.getAndSet(false)) return MlnFfiFrameResult.SKIPPED
+    if (!renderRequested.exchange(false)) return MlnFfiFrameResult.SKIPPED
     // Taken before the render and kept, so the cap measures start-to-start. Measuring from the end
     // of the last render is short by that render's duration, which near the display's own rate is
     // enough to reject every second frame.
@@ -459,7 +463,7 @@ internal class MlnFfiMapSession(
         attachedTarget = key
         retargetCount++
         // The replacement texture holds nothing yet; this request buys the frame that fills it.
-        renderRequested.set(true)
+        renderRequested.store(true)
         return true
       }
     }
@@ -480,7 +484,7 @@ internal class MlnFfiMapSession(
     attachCount++
     publishAttachedViewport()
     // The new texture holds nothing yet; this request buys the frame that fills it.
-    renderRequested.set(true)
+    renderRequested.store(true)
     return true
   }
 
@@ -727,7 +731,7 @@ internal class MlnFfiMapSession(
 
   /** Marks a frame worth drawing and asks the host for one. Safe from any thread. */
   private fun requestRender() {
-    renderRequested.set(true)
+    renderRequested.store(true)
     hostSession?.requestFrame()
   }
 
@@ -1174,7 +1178,7 @@ internal class MlnFfiMapSession(
   // region input, called from Compose
 
   /** Allocates a newer gesture identity. Its begin is queued with its first camera command. */
-  fun onGestureStarted(): GestureToken = GestureToken(nextGestureToken.incrementAndGet())
+  fun onGestureStarted(): GestureToken = GestureToken(nextGestureToken.incrementAndFetch())
 
   /**
    * Queues a token-matched end. The owner loop applies it only after the native events produced by

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.DpRect
 import androidx.compose.ui.unit.LayoutDirection
 import co.touchlab.kermit.Logger
+import kotlin.concurrent.Volatile
 import kotlin.concurrent.atomics.AtomicBoolean
 import kotlin.concurrent.atomics.AtomicLong
 import kotlin.concurrent.atomics.ExperimentalAtomicApi

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/mlnffi/MlnFfiLock.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/mlnffi/MlnFfiLock.kt
@@ -1,0 +1,32 @@
+package org.maplibre.compose.mlnffi
+
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
+
+/**
+ * Mutual exclusion between the threads MapLibre calls on.
+ *
+ * A holder releases this lock before acquiring it again. Reentrance and ownership queries belong to
+ * a lock type of their own, which this integration adds when something needs them.
+ *
+ * [fair] hands the lock to the longest waiter, which keeps one thread from starving another while
+ * both answer a stream of MapLibre callbacks. It costs throughput, so it is off by default.
+ */
+internal expect class MlnFfiLock(fair: Boolean = false) {
+  fun lock()
+
+  fun unlock()
+}
+
+/** Runs [block] holding [this], and releases the lock however [block] ends. */
+@OptIn(ExperimentalContracts::class)
+internal inline fun <T> MlnFfiLock.withLock(block: () -> T): T {
+  contract { callsInPlace(block, InvocationKind.EXACTLY_ONCE) }
+  lock()
+  try {
+    return block()
+  } finally {
+    unlock()
+  }
+}

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/mlnffi/MlnFfiPath.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/mlnffi/MlnFfiPath.kt
@@ -1,0 +1,12 @@
+package org.maplibre.compose.mlnffi
+
+import kotlinx.io.files.Path
+
+/**
+ * Resolves [path] to one absolute lexical form, so that two spellings of the same location compare
+ * equal. A path with no file behind it normalizes like any other.
+ *
+ * `SystemFileSystem.resolve` answers the same question against the filesystem, and fails when the
+ * path names nothing, so it cannot serve a cache database that this call is about to create.
+ */
+internal expect fun normalizeMlnFfiPath(path: Path): Path

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/mlnffi/MlnFfiRuntimeOptions.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/mlnffi/MlnFfiRuntimeOptions.kt
@@ -1,19 +1,19 @@
 package org.maplibre.compose.mlnffi
 
 import androidx.compose.runtime.Immutable
-import java.io.File
+import kotlinx.io.files.Path
 import org.maplibre.compose.offline.MlnFfiOfflineManager
 
 /** Platform-resolved configuration for a MapLibre Native FFI runtime. */
 @Immutable
 internal data class MlnFfiRuntimeOptions(
-  val cacheFile: File,
+  val cacheFile: Path,
   val maximumCacheSizeBytes: Long? = null,
 )
 
 /** Uses one stable lexical identity for a cache database without requiring it to exist yet. */
 internal fun MlnFfiRuntimeOptions.normalized(): MlnFfiRuntimeOptions {
-  val normalizedFile = cacheFile.absoluteFile.normalize()
+  val normalizedFile = normalizeMlnFfiPath(cacheFile)
   return if (normalizedFile == cacheFile) this else copy(cacheFile = normalizedFile)
 }
 
@@ -21,11 +21,13 @@ internal fun MlnFfiRuntimeOptions.normalized(): MlnFfiRuntimeOptions {
 internal object MlnFfiApplication {
   private class State(val options: MlnFfiRuntimeOptions, val offlineManager: MlnFfiOfflineManager)
 
+  private val lock = MlnFfiLock()
+
   @Volatile private var state: State? = null
 
   fun configure(rawOptions: MlnFfiRuntimeOptions) {
     val options = rawOptions.normalized()
-    synchronized(this) {
+    lock.withLock {
       val existing = state
       if (existing != null) {
         check(existing.options == options) {
@@ -53,7 +55,7 @@ internal object MlnFfiApplication {
    * Stops and forgets the process-wide owner. Tests only; production configuration is permanent.
    */
   internal fun resetForTest(): Boolean {
-    val previous = synchronized(this) { state.also { state = null } } ?: return true
+    val previous = lock.withLock { state.also { state = null } } ?: return true
     return previous.offlineManager.closeForTest()
   }
 }

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/mlnffi/MlnFfiRuntimeOptions.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/mlnffi/MlnFfiRuntimeOptions.kt
@@ -1,6 +1,7 @@
 package org.maplibre.compose.mlnffi
 
 import androidx.compose.runtime.Immutable
+import kotlin.concurrent.Volatile
 import kotlinx.io.files.Path
 import org.maplibre.compose.offline.MlnFfiOfflineManager
 

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/offline/MlnFfiOfflineManager.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/offline/MlnFfiOfflineManager.kt
@@ -1,5 +1,3 @@
-@file:OptIn(ExperimentalAtomicApi::class)
-
 package org.maplibre.compose.offline
 
 import androidx.compose.runtime.Composable
@@ -89,6 +87,7 @@ internal class MlnFfiOfflineManager(private val options: MlnFfiRuntimeOptions) :
   }
 
   /** Does not let process-wide configuration publish a runtime whose startup or budget failed. */
+  @OptIn(ExperimentalAtomicApi::class)
   private fun awaitConfiguredRuntime() {
     val settled = CountDownLatch(1)
     val completed = AtomicBoolean(false)

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/offline/MlnFfiOfflineManager.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/offline/MlnFfiOfflineManager.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalAtomicApi::class)
+
 package org.maplibre.compose.offline
 
 import androidx.compose.runtime.Composable
@@ -6,7 +8,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalDensity
 import co.touchlab.kermit.Logger
 import java.util.concurrent.CountDownLatch
-import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.concurrent.atomics.AtomicBoolean
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.coroutines.resumeWithException
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -88,7 +91,7 @@ internal class MlnFfiOfflineManager(private val options: MlnFfiRuntimeOptions) :
   /** Does not let process-wide configuration publish a runtime whose startup or budget failed. */
   private fun awaitConfiguredRuntime() {
     val settled = CountDownLatch(1)
-    val completed = AtomicBoolean()
+    val completed = AtomicBoolean(false)
     var outcome: Result<Unit>? = null
     fun complete(result: Result<Unit>) {
       if (completed.compareAndSet(false, true)) {

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/offline/MlnFfiOfflineRuntime.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/offline/MlnFfiOfflineRuntime.kt
@@ -3,6 +3,7 @@ package org.maplibre.compose.offline
 import co.touchlab.kermit.Logger
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.Volatile
 import kotlin.concurrent.withLock
 import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.io.files.Path

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/offline/MlnFfiOfflineRuntime.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/offline/MlnFfiOfflineRuntime.kt
@@ -1,11 +1,11 @@
 package org.maplibre.compose.offline
 
 import co.touchlab.kermit.Logger
-import java.io.File
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 import kotlin.coroutines.cancellation.CancellationException
+import kotlinx.io.files.Path
 import org.maplibre.compose.resource.MlnFfiRuntimeOwner
 import org.maplibre.nativeffi.runtime.OfflineOperationHandle
 import org.maplibre.nativeffi.runtime.RuntimeEvent
@@ -31,7 +31,7 @@ private const val PUMP_PARK_MILLIS = -1L
  * correctness.
  */
 internal class MlnFfiOfflineRuntime(
-  private val cacheFile: File,
+  private val cacheFile: Path,
   private val logger: Logger,
   private val onEvent: (RuntimeEvent) -> Unit,
 ) {

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/resource/MlnFfiResourceProvider.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/resource/MlnFfiResourceProvider.kt
@@ -1,5 +1,3 @@
-@file:OptIn(ExperimentalAtomicApi::class)
-
 package org.maplibre.compose.resource
 
 import co.touchlab.kermit.Logger
@@ -30,6 +28,7 @@ private val NETWORK_SCHEMES = setOf("http", "https")
  * Installed with the runtime. Provider-owned [ResourceRequestHandle] instances remain valid
  * independently of runtime teardown, so accepted reads can safely finish after [close].
  */
+@OptIn(ExperimentalAtomicApi::class)
 internal class MlnFfiResourceProvider(
   private val getLogger: () -> Logger?,
   /** Turns a URL into a response. Test seam: a fake can hold a read open mid-shutdown. */

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/resource/MlnFfiResourceProvider.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/resource/MlnFfiResourceProvider.kt
@@ -1,10 +1,13 @@
+@file:OptIn(ExperimentalAtomicApi::class)
+
 package org.maplibre.compose.resource
 
 import co.touchlab.kermit.Logger
 import java.io.FileNotFoundException
 import java.net.URI
 import java.net.URISyntaxException
-import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.concurrent.atomics.AtomicBoolean
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import org.maplibre.nativeffi.resource.ResourceErrorReason
 import org.maplibre.nativeffi.resource.ResourceProviderCallback
 import org.maplibre.nativeffi.resource.ResourceProviderDecision
@@ -55,7 +58,7 @@ internal class MlnFfiResourceProvider(
 
   /** Queues [request] for the reader, or refuses it if this provider is shutting down. */
   fun take(request: TakenResourceRequest, url: String, requestedUrl: String) {
-    if (!accepting.get()) {
+    if (!accepting.load()) {
       refuse(request, url, requestedUrl)
       return
     }
@@ -105,7 +108,7 @@ internal class MlnFfiResourceProvider(
 
   /** Stops taking new reads. Accepted reads own their handles and finish independently. */
   override fun close() {
-    accepting.set(false)
+    accepting.store(false)
   }
 }
 

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/resource/MlnFfiRuntimeOwner.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/resource/MlnFfiRuntimeOwner.kt
@@ -1,7 +1,9 @@
 package org.maplibre.compose.resource
 
 import co.touchlab.kermit.Logger
-import java.io.File
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+import org.maplibre.compose.mlnffi.normalizeMlnFfiPath
 import org.maplibre.nativeffi.runtime.RuntimeHandle
 import org.maplibre.nativeffi.runtime.RuntimeOptions
 
@@ -39,22 +41,16 @@ private constructor(
      * Creates a runtime and everything that hangs off it, or throws having closed whatever it got
      * as far as. [what] names the runtime in log lines.
      */
-    fun open(rawCacheFile: File, getLogger: () -> Logger?, what: String): MlnFfiRuntimeOwner {
-      val cacheFile = rawCacheFile.absoluteFile.normalize()
+    fun open(rawCacheFile: Path, getLogger: () -> Logger?, what: String): MlnFfiRuntimeOwner {
+      val cacheFile = normalizeMlnFfiPath(rawCacheFile)
       // MapLibre opens the database as the runtime is created, and fails if the directory is
       // missing.
-      runCatching {
-        cacheFile.parentFile?.let { directory ->
-          check(directory.mkdirs() || directory.isDirectory) {
-            "Could not create the MapLibre cache directory $directory"
-          }
-        }
-      }
+      runCatching { cacheFile.parent?.let { SystemFileSystem.createDirectories(it) } }
         .onFailure { getLogger()?.w(it) { "Could not create the MapLibre cache directory" } }
 
       val runtime =
         try {
-          RuntimeHandle.create(RuntimeOptions().also { it.cachePath = cacheFile.path })
+          RuntimeHandle.create(RuntimeOptions().also { it.cachePath = cacheFile.toString() })
         } catch (error: Throwable) {
           throw error
         }

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/sources/ComputedSource.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/sources/ComputedSource.kt
@@ -1,5 +1,4 @@
 @file:JvmName("MlnFfiComputedSourceKt")
-@file:OptIn(ExperimentalAtomicApi::class)
 
 package org.maplibre.compose.sources
 
@@ -29,6 +28,7 @@ import org.maplibre.spatialk.geojson.Position
  * A source whose tiles this application generates: MapLibre decides which tiles it needs, asks
  * [getFeatures] for each, and asks again whenever one is invalidated.
  */
+@OptIn(ExperimentalAtomicApi::class)
 public actual class ComputedSource : Source {
 
   private val options: ComputedSourceOptions

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/sources/ComputedSource.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/sources/ComputedSource.kt
@@ -1,11 +1,11 @@
 @file:JvmName("MlnFfiComputedSourceKt")
+@file:OptIn(ExperimentalAtomicApi::class)
 
 package org.maplibre.compose.sources
 
-import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.atomic.AtomicLong
-import java.util.concurrent.locks.ReentrantLock
-import kotlin.concurrent.withLock
+import kotlin.concurrent.atomics.AtomicLong
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+import kotlin.concurrent.atomics.incrementAndFetch
 import kotlin.math.PI
 import kotlin.math.atan
 import kotlin.math.pow
@@ -13,6 +13,8 @@ import kotlin.math.sinh
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
+import org.maplibre.compose.mlnffi.MlnFfiLock
+import org.maplibre.compose.mlnffi.withLock
 import org.maplibre.compose.resource.startMlnFfiBlockingWork
 import org.maplibre.compose.util.toLatLngBounds
 import org.maplibre.nativeffi.geo.CanonicalTileId
@@ -33,20 +35,24 @@ public actual class ComputedSource : Source {
   private val getFeatures: (bounds: BoundingBox, zoomLevel: Int) -> FeatureCollection<*, *>
 
   /**
-   * Tiles MapLibre has asked for and has not cancelled. Concurrent because MapLibre worker threads
-   * add and cancel entries while the map's owner thread takes them.
+   * Tiles MapLibre has asked for and has not cancelled, guarded by [requestedTilesLock] because
+   * MapLibre worker threads add and cancel entries while the map's owner thread takes them.
    */
-  private val requestedTiles = ConcurrentHashMap<CanonicalTileId, Long>()
-  private val nextRequest = AtomicLong()
+  private val requestedTiles = mutableMapOf<CanonicalTileId, Long>()
+  private val requestedTilesLock = MlnFfiLock()
+  private val nextRequest = AtomicLong(0L)
 
-  /** Keeps this source's application callback serialized without owning a worker executor. */
-  private val computeLock = ReentrantLock(true)
+  /**
+   * Keeps this source's application callback serialized without owning a worker executor. Fair, so
+   * a stream of tile requests cannot starve one thread that is already waiting to compute.
+   */
+  private val computeLock = MlnFfiLock(fair = true)
 
   private val callback =
     object : CustomGeometrySourceCallback {
       override fun fetchTile(tileId: CanonicalTileId) {
-        val request = nextRequest.incrementAndGet()
-        requestedTiles[tileId] = request
+        val request = nextRequest.incrementAndFetch()
+        requestedTilesLock.withLock { requestedTiles[tileId] = request }
         startMlnFfiBlockingWork("maplibre-computed-source-$id") {
           computeLock.withLock { answer(tileId, request) }
         }
@@ -55,7 +61,7 @@ public actual class ComputedSource : Source {
       override fun cancelTile(tileId: CanonicalTileId) {
         // Forgetting the tile is what stops it; [answer] rechecks on the owner thread before it
         // writes, so a cancel arriving any time up to the write is honored.
-        requestedTiles.remove(tileId)
+        requestedTilesLock.withLock { requestedTiles.remove(tileId) }
       }
     }
 
@@ -97,13 +103,13 @@ public actual class ComputedSource : Source {
 
   /** Computes one tile and delivers it away from MapLibre's callback thread. */
   private fun answer(tileId: CanonicalTileId, request: Long) {
-    if (requestedTiles[tileId] != request) return
+    if (requestedTilesLock.withLock { requestedTiles[tileId] } != request) return
     val data =
       try {
         getFeatures(tileId.toBoundingBox(), tileId.z).toFfiGeoJson()
       } catch (error: Throwable) {
         if (error is VirtualMachineError) throw error
-        requestedTiles.remove(tileId, request)
+        forgetTile(tileId, request)
         // Reported rather than propagated; the tile stays blank until something invalidates it.
         binding.logger?.e(error) { "Computing tile $tileId of source '$id' failed" }
         return
@@ -111,11 +117,17 @@ public actual class ComputedSource : Source {
     // The cancellation check shares the owner-thread hop with the write, so nothing can cancel
     // between deciding to write and writing.
     binding.mutateMap { map ->
-      if (requestedTiles.remove(tileId, request)) {
+      if (forgetTile(tileId, request)) {
         map.setCustomGeometrySourceTileData(id, tileId, data)
       }
     }
   }
+
+  /** Drops [tileId] if it is still the answer to [request], reporting whether it was. */
+  private fun forgetTile(tileId: CanonicalTileId, request: Long): Boolean =
+    requestedTilesLock.withLock {
+      if (requestedTiles[tileId] != request) false else requestedTiles.remove(tileId) != null
+    }
 
   public actual fun invalidateBounds(bounds: BoundingBox) {
     mutate { map -> map.invalidateCustomGeometrySourceRegion(id, bounds.toLatLngBounds()) }
@@ -130,7 +142,7 @@ public actual class ComputedSource : Source {
     val geoJson = data.toFfiGeoJson()
     val tileId = tileId(zoomLevel, x, y)
     // Forgotten first, so an answer still in flight does not overwrite what was just supplied.
-    requestedTiles.remove(tileId)
+    requestedTilesLock.withLock { requestedTiles.remove(tileId) }
     mutate { map -> map.setCustomGeometrySourceTileData(id, tileId, geoJson) }
   }
 

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/sources/Source.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/sources/Source.kt
@@ -1,5 +1,6 @@
 package org.maplibre.compose.sources
 
+import kotlin.concurrent.Volatile
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import org.maplibre.compose.style.StyleBinding

--- a/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/layers/LayerClickOrderTest.kt
+++ b/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/layers/LayerClickOrderTest.kt
@@ -1,5 +1,3 @@
-@file:OptIn(ExperimentalAtomicApi::class)
-
 package org.maplibre.compose.layers
 
 import androidx.compose.foundation.layout.fillMaxSize
@@ -135,6 +133,7 @@ class LayerClickOrderTest {
    * [BACK] in the style. [frontResult] is what [FRONT]'s handlers return, so a test can either stop
    * the event there or let it fall through.
    */
+  @OptIn(ExperimentalAtomicApi::class)
   private fun runLayerClickTest(
     composeFrontLayerFirst: Boolean,
     frontResult: ClickResult = ClickResult.Consume,

--- a/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/layers/LayerClickOrderTest.kt
+++ b/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/layers/LayerClickOrderTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalAtomicApi::class)
+
 package org.maplibre.compose.layers
 
 import androidx.compose.foundation.layout.fillMaxSize
@@ -13,7 +15,9 @@ import androidx.compose.ui.test.performMouseInput
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.unit.DpOffset
 import co.touchlab.kermit.Logger
-import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+import kotlin.concurrent.atomics.incrementAndFetch
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -136,7 +140,7 @@ class LayerClickOrderTest {
     frontResult: ClickResult = ClickResult.Consume,
     body: ComposeUiTest.(center: Offset) -> Unit,
   ) = runFfiComposeUiTest {
-    val frames = AtomicInteger()
+    val frames = AtomicInt(0)
     lateinit var cameraState: CameraState
 
     setFfiTestMapContent(runtimeOptions) {
@@ -148,7 +152,7 @@ class LayerClickOrderTest {
         modifier = Modifier.fillMaxSize(),
         baseStyle = BaseStyle.Empty,
         cameraState = cameraState,
-        onFrame = { frames.incrementAndGet() },
+        onFrame = { frames.incrementAndFetch() },
         logger = Logger.withTag("layer-click-order"),
       ) {
         val source = rememberGeoJsonSource(data = GeoJsonData.JsonString(WORLD_POLYGON))
@@ -195,7 +199,7 @@ class LayerClickOrderTest {
       }
     }
 
-    waitUntil(timeoutMillis = TIMEOUT) { frames.get() > 0 }
+    waitUntil(timeoutMillis = TIMEOUT) { frames.load() > 0 }
 
     val map = assertNotNull(cameraState.map, "the camera never attached to a map")
     val size = onRoot().fetchSemanticsNode().size

--- a/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/layers/UnsupportedLayerPropertyTest.kt
+++ b/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/layers/UnsupportedLayerPropertyTest.kt
@@ -3,7 +3,6 @@ package org.maplibre.compose.layers
 import co.touchlab.kermit.LogWriter
 import co.touchlab.kermit.Logger
 import co.touchlab.kermit.Severity
-import java.util.concurrent.CopyOnWriteArrayList
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -19,6 +18,7 @@ import org.maplibre.compose.expressions.value.StringValue
 import org.maplibre.compose.expressions.value.SymbolOverlap
 import org.maplibre.compose.expressions.value.TextRotationAlignment
 import org.maplibre.compose.mlnffi.BridgeMapFixture
+import org.maplibre.compose.mlnffi.RecordingList
 import org.maplibre.compose.sources.GeoJsonData
 import org.maplibre.compose.sources.GeoJsonOptions
 import org.maplibre.compose.sources.GeoJsonSource
@@ -174,7 +174,7 @@ class UnsupportedLayerPropertyTest {
      * Warnings the library logged. Kermit's writers are global and cannot be removed, so this is
      * installed once; each platform test process runs without parallel forks.
      */
-    val CAPTURED = CopyOnWriteArrayList<String>()
+    val CAPTURED = RecordingList<String>()
 
     init {
       Logger.addLogWriter(

--- a/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/map/MlnFfiMapClusterTest.kt
+++ b/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/map/MlnFfiMapClusterTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalAtomicApi::class)
+
 package org.maplibre.compose.map
 
 import androidx.compose.foundation.layout.fillMaxSize
@@ -8,7 +10,9 @@ import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.unit.DpRect
 import androidx.compose.ui.unit.dp
 import co.touchlab.kermit.Logger
-import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+import kotlin.concurrent.atomics.incrementAndFetch
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -58,7 +62,7 @@ class MlnFfiMapClusterTest {
 
   @Test
   fun a_clustered_source_answers_the_supercluster_queries() = runFfiComposeUiTest {
-    val frames = AtomicInteger()
+    val frames = AtomicInt(0)
 
     lateinit var source: GeoJsonSource
     lateinit var cameraState: CameraState
@@ -73,7 +77,7 @@ class MlnFfiMapClusterTest {
         baseStyle = BaseStyle.Empty,
         cameraState = cameraState,
         logger = Logger.withTag("cluster-test"),
-        onFrame = { frames.incrementAndGet() },
+        onFrame = { frames.incrementAndFetch() },
       ) {
         source =
           rememberGeoJsonSource(
@@ -85,7 +89,7 @@ class MlnFfiMapClusterTest {
       }
     }
 
-    waitUntil(timeoutMillis = SETTLE_TIMEOUT_MILLIS) { frames.get() > 0 }
+    waitUntil(timeoutMillis = SETTLE_TIMEOUT_MILLIS) { frames.load() > 0 }
     val session = assertNotNull(cameraState.map as? MlnFfiMapSession, "no FFI session")
 
     fun queryAll(): List<Feature<Geometry, JsonObject?>> {
@@ -105,7 +109,7 @@ class MlnFfiMapClusterTest {
     val cluster =
       assertNotNull(
         hits.firstOrNull { source.isCluster(it) },
-        "No cluster was rendered after ${frames.get()} frames; ${hits.size} hits were $hits",
+        "No cluster was rendered after ${frames.load()} frames; ${hits.size} hits were $hits",
       )
 
     val expansionZoom = source.getClusterExpansionZoom(cluster)

--- a/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/map/MlnFfiMapCompositionTest.kt
+++ b/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/map/MlnFfiMapCompositionTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalAtomicApi::class)
+
 package org.maplibre.compose.map
 
 import androidx.compose.runtime.Composable
@@ -13,8 +15,9 @@ import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.unit.LayoutDirection
 import co.touchlab.kermit.Logger
-import java.util.concurrent.CopyOnWriteArrayList
-import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+import kotlin.concurrent.atomics.incrementAndFetch
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -34,6 +37,7 @@ import org.maplibre.compose.expressions.dsl.switch
 import org.maplibre.compose.layers.FillLayer
 import org.maplibre.compose.mlnffi.FfiTestPlatform
 import org.maplibre.compose.mlnffi.MlnFfiRuntimeOptions
+import org.maplibre.compose.mlnffi.RecordingList
 import org.maplibre.compose.mlnffi.runFfiComposeUiTest
 import org.maplibre.compose.mlnffi.setFfiTestMapContent
 import org.maplibre.compose.offline.rememberOfflineManager
@@ -318,17 +322,17 @@ class MlnFfiMapCompositionTest {
     body: ComposeUiTest.(MutableList<String>) -> Unit,
     content: @Composable (MutableList<String>, onFrame: () -> Unit) -> Unit,
   ) = runFfiComposeUiTest {
-    val errors = CopyOnWriteArrayList<String>()
-    val frames = AtomicInteger()
-    setFfiTestMapContent(runtimeOptions) { content(errors) { frames.incrementAndGet() } }
-    waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) { frames.get() > 0 || errors.isNotEmpty() }
+    val errors = RecordingList<String>()
+    val frames = AtomicInt(0)
+    setFfiTestMapContent(runtimeOptions) { content(errors) { frames.incrementAndFetch() } }
+    waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) { frames.load() > 0 || errors.isNotEmpty() }
     assertTrue(errors.isEmpty(), "The composition reported errors: $errors")
     body(errors)
     waitForIdle()
     assertTrue(errors.isEmpty(), "The composition reported errors: $errors")
     // Without this the test would pass by doing nothing: a map that never gets a frame never
     // creates a runtime or a style.
-    assertTrue(frames.get() > 0, "No frame reached MapLibre; the map never rendered.")
+    assertTrue(frames.load() > 0, "No frame reached MapLibre; the map never rendered.")
   }
 
   private companion object {

--- a/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/map/MlnFfiMapInputTest.kt
+++ b/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/map/MlnFfiMapInputTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalAtomicApi::class)
+
 package org.maplibre.compose.map
 
 import androidx.compose.foundation.clickable
@@ -29,7 +31,9 @@ import androidx.compose.ui.test.swipe
 import androidx.compose.ui.test.withKeyDown
 import androidx.compose.ui.unit.dp
 import co.touchlab.kermit.Logger
-import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+import kotlin.concurrent.atomics.incrementAndFetch
 import kotlin.math.abs
 import kotlin.test.AfterTest
 import kotlin.test.Test
@@ -218,22 +222,25 @@ class MlnFfiMapInputTest {
 
   @Test
   fun a_map_click_does_not_also_click_its_parent() {
-    val parentClicks = AtomicInteger()
+    val parentClicks = AtomicInt(0)
 
-    runInputTest(focusWithMouse = false, parentOnClick = parentClicks::incrementAndGet) {
+    runInputTest(focusWithMouse = false, parentOnClick = { parentClicks.incrementAndFetch() }) {
       onRoot().performMouseInput { click(center) }
       waitUntil(timeoutMillis = TIMEOUT) { clicks.size == 1 }
       waitForIdle()
 
-      assertEquals(0, parentClicks.get())
+      assertEquals(0, parentClicks.load())
     }
   }
 
   @Test
   fun a_map_long_click_does_not_also_long_click_its_parent() {
-    val parentLongClicks = AtomicInteger()
+    val parentLongClicks = AtomicInt(0)
 
-    runInputTest(focusWithMouse = false, parentOnLongClick = parentLongClicks::incrementAndGet) {
+    runInputTest(
+      focusWithMouse = false,
+      parentOnLongClick = { parentLongClicks.incrementAndFetch() },
+    ) {
       val map = onRoot()
       map.performTouchInput { down(0, center) }
       mainClock.advanceTimeBy(1_000)
@@ -241,7 +248,7 @@ class MlnFfiMapInputTest {
       map.performTouchInput { up(0) }
       waitForIdle()
 
-      assertEquals(0, parentLongClicks.get())
+      assertEquals(0, parentLongClicks.load())
     }
   }
 
@@ -658,7 +665,7 @@ class MlnFfiMapInputTest {
     parentOnLongClick: (() -> Unit)? = null,
     body: androidx.compose.ui.test.ComposeUiTest.(CameraState) -> Unit,
   ) = runFfiComposeUiTest {
-    val frames = AtomicInteger()
+    val frames = AtomicInt(0)
     val initialPosition = CameraPosition(target = Position(0.0, 0.0), zoom = START_ZOOM)
     lateinit var cameraState: CameraState
 
@@ -678,7 +685,7 @@ class MlnFfiMapInputTest {
             longClicks.add(position)
             ClickResult.Pass
           },
-          onFrame = { frames.incrementAndGet() },
+          onFrame = { frames.incrementAndFetch() },
           logger = Logger.withTag("input-test"),
         )
       }
@@ -697,7 +704,7 @@ class MlnFfiMapInputTest {
 
     cameraState.awaitProjection()
     cameraState.position = initialPosition
-    waitUntil(timeoutMillis = TIMEOUT) { frames.get() > 0 }
+    waitUntil(timeoutMillis = TIMEOUT) { frames.load() > 0 }
     waitUntil(timeoutMillis = TIMEOUT) {
       kotlin.math.abs(cameraState.position.zoom - START_ZOOM) < 0.001
     }

--- a/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/map/MlnFfiMapRepaintTest.kt
+++ b/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/map/MlnFfiMapRepaintTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalAtomicApi::class)
+
 package org.maplibre.compose.map
 
 import androidx.compose.runtime.Composable
@@ -9,7 +11,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
 import co.touchlab.kermit.Logger
-import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+import kotlin.concurrent.atomics.incrementAndFetch
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertTrue
@@ -84,25 +88,25 @@ class MlnFfiMapRepaintTest {
    */
   private fun runRepaintTest(mutate: ComposeUiTest.() -> Unit, content: @Composable () -> Unit) =
     runFfiComposeUiTest {
-      val frames = AtomicInteger()
+      val frames = AtomicInt(0)
 
       setFfiTestMapContent(runtimeOptions) {
         MaplibreMap(
           modifier = Modifier,
           baseStyle = BaseStyle.Empty,
           logger = Logger.withTag("repaint-test"),
-          onFrame = { frames.incrementAndGet() },
+          onFrame = { frames.incrementAndFetch() },
           content = content,
         )
       }
 
       // The map advances on a thread of its own, so settling means observing a real quiet window.
       // Comparing two adjacent reads can succeed before an already-queued startup frame lands.
-      waitUntil(timeoutMillis = SETTLE_TIMEOUT_MILLIS) { frames.get() > 0 }
-      var before = frames.get()
+      waitUntil(timeoutMillis = SETTLE_TIMEOUT_MILLIS) { frames.load() > 0 }
+      var before = frames.load()
       var unchangedSince = TimeSource.Monotonic.markNow()
       waitUntil(timeoutMillis = SETTLE_TIMEOUT_MILLIS) {
-        val current = frames.get()
+        val current = frames.load()
         if (current != before) {
           before = current
           unchangedSince = TimeSource.Monotonic.markNow()
@@ -112,10 +116,10 @@ class MlnFfiMapRepaintTest {
 
       mutate()
 
-      waitUntil(timeoutMillis = SETTLE_TIMEOUT_MILLIS) { frames.get() > before }
+      waitUntil(timeoutMillis = SETTLE_TIMEOUT_MILLIS) { frames.load() > before }
       assertTrue(
-        frames.get() > before,
-        "The change produced no new rendered frame ($before before, ${frames.get()} " +
+        frames.load() > before,
+        "The change produced no new rendered frame ($before before, ${frames.load()} " +
           "after), so it would not appear until something else woke the render loop.",
       )
     }

--- a/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/map/MlnFfiStyleSwitchTest.kt
+++ b/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/map/MlnFfiStyleSwitchTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalAtomicApi::class)
+
 package org.maplibre.compose.map
 
 import androidx.compose.runtime.getValue
@@ -7,7 +9,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.test.ExperimentalTestApi
 import co.touchlab.kermit.Logger
-import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+import kotlin.concurrent.atomics.incrementAndFetch
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -52,7 +56,7 @@ class MlnFfiStyleSwitchTest {
 
   @Test
   fun rotating_the_base_style_with_content_composed_over_it() = runFfiComposeUiTest {
-    val frames = AtomicInteger()
+    val frames = AtomicInt(0)
     val errors = mutableListOf<String>()
     var loadsFinished = 0
     var style by mutableStateOf(STYLES[0])
@@ -68,7 +72,7 @@ class MlnFfiStyleSwitchTest {
         logger = Logger.withTag("style-switch-test"),
         onMapLoadFailed = { errors += "mapLoadFailed: $it" },
         onMapLoadFinished = { loadsFinished++ },
-        onFrame = { frames.incrementAndGet() },
+        onFrame = { frames.incrementAndFetch() },
       ) {
         val points = rememberGeoJsonSource(data = GeoJsonData.Features(pointAt(longitude = 0.0)))
         // Two layers on one source at different anchors, so the re-add order matters.
@@ -88,17 +92,17 @@ class MlnFfiStyleSwitchTest {
 
     // Each style finishes loading before the next is chosen; switching mid-load is a separate race
     // this test deliberately does not cover.
-    waitUntil(timeoutMillis = SETTLE_TIMEOUT_MILLIS) { loadsFinished > 0 && frames.get() > 0 }
+    waitUntil(timeoutMillis = SETTLE_TIMEOUT_MILLIS) { loadsFinished > 0 && frames.load() > 0 }
     val session = requireNotNull(cameraState.map as? MlnFfiMapSession) { "no desktop session" }
     assertStyleLayers(session, style, extraLayer)
 
     repeat(ROTATIONS) { round ->
       val loadsBefore = loadsFinished
-      val framesBefore = frames.get()
+      val framesBefore = frames.load()
       style = STYLES[(round + 1) % STYLES.size]
       extraLayer = !extraLayer
       waitUntil(timeoutMillis = SETTLE_TIMEOUT_MILLIS) {
-        loadsFinished > loadsBefore && frames.get() > framesBefore
+        loadsFinished > loadsBefore && frames.load() > framesBefore
       }
       assertStyleLayers(session, style, extraLayer)
     }

--- a/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/mlnffi/BridgeMapFixture.kt
+++ b/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/mlnffi/BridgeMapFixture.kt
@@ -3,7 +3,6 @@ package org.maplibre.compose.mlnffi
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.LayoutDirection
 import co.touchlab.kermit.Logger
-import java.io.File
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
@@ -12,6 +11,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
+import kotlinx.io.files.Path
 import org.maplibre.compose.camera.CameraMoveReason
 import org.maplibre.compose.map.MapAdapter
 import org.maplibre.compose.map.MlnFfiMapSession
@@ -29,7 +29,7 @@ import org.maplibre.spatialk.geojson.Position
 internal class BridgeMapFixture
 private constructor(
   private val driver: FfiTestRenderDriver,
-  private val cacheFile: File,
+  private val cacheFile: Path,
   private val initialExtent: MlnFfiMapExtent,
 ) : AutoCloseable {
 

--- a/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/mlnffi/FfiTestPlatform.kt
+++ b/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/mlnffi/FfiTestPlatform.kt
@@ -1,6 +1,6 @@
 package org.maplibre.compose.mlnffi
 
-import java.io.File
+import kotlinx.io.files.Path
 
 /** Platform services required by otherwise shared MapLibre Native FFI tests. */
 internal expect object FfiTestPlatform {
@@ -10,10 +10,10 @@ internal expect object FfiTestPlatform {
   fun initialize()
 
   /** A writable, test-unique cache database path. */
-  fun createCacheFile(): File
+  fun createCacheFile(): Path
 
   /** Removes the cache path and any platform-owned directory containing it. */
-  fun deleteCacheFile(file: File)
+  fun deleteCacheFile(file: Path)
 
   /** Creates the render driver for the native runtime packaged into this test process. */
   fun createRenderDriver(): FfiTestRenderDriver

--- a/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/mlnffi/FfiTestPlatform.kt
+++ b/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/mlnffi/FfiTestPlatform.kt
@@ -22,6 +22,18 @@ internal expect object FfiTestPlatform {
   fun skip(reason: String): Nothing
 }
 
+/**
+ * The `file:` URL naming [path], built the way the platform builds one.
+ *
+ * A Windows path carries a drive letter and a backslash separator, and any path may carry
+ * characters a URL must percent-encode, so this conversion belongs to the platform rather than to
+ * string concatenation.
+ */
+internal expect fun fileUrlOf(path: Path): String
+
+/** The path [url] names. Inverse of [fileUrlOf], so that a test can check the round trip. */
+internal expect fun pathOfFileUrl(url: String): Path
+
 /** Feature availability of the packaged FFI runtime/binding pair. */
 internal data class FfiTestRuntimeCapabilities(val customGeometrySourceCallbacks: Boolean)
 

--- a/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/mlnffi/FileUrlTest.kt
+++ b/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/mlnffi/FileUrlTest.kt
@@ -1,0 +1,61 @@
+package org.maplibre.compose.mlnffi
+
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+
+/**
+ * Covers the `file:` URL the offline tests hand to MapLibre.
+ *
+ * Concatenating `file://` onto a path passes on Linux and macOS and fails on Windows, where a path
+ * starts with a drive letter and separates with backslashes, so these assertions state the form the
+ * URL takes rather than the string one platform happens to produce.
+ */
+class FileUrlTest {
+
+  private val cacheFile = FfiTestPlatform.createCacheFile()
+  private val directory = requireNotNull(cacheFile.parent)
+
+  @AfterTest
+  fun cleanUp() {
+    FfiTestPlatform.deleteCacheFile(cacheFile)
+  }
+
+  @Test
+  fun a_file_url_names_an_absolute_path() {
+    val url = fileUrlOf(Path(directory, "style.json"))
+
+    assertTrue(url.startsWith("file:///"), "an absolute path takes the empty-authority form: $url")
+    assertFalse(url.contains('\\'), "a URL separates with forward slashes: $url")
+    assertTrue(url.endsWith("/style.json"), "the file name survives the conversion: $url")
+  }
+
+  @Test
+  fun a_file_url_round_trips_back_to_its_path() {
+    val file = Path(directory, "round trip.json")
+
+    assertEquals(file, pathOfFileUrl(fileUrlOf(file)))
+  }
+
+  @Test
+  fun a_file_url_escapes_a_space() {
+    val url = fileUrlOf(Path(directory, "round trip.json"))
+
+    assertFalse(url.contains(' '), "a space is reserved and must be escaped: $url")
+    assertTrue(url.endsWith("/round%20trip.json"), "the escaped name survives: $url")
+  }
+
+  /** The conversion is lexical, so a file that exists reaches the same URL as one that does not. */
+  @Test
+  fun a_file_url_does_not_depend_on_the_file_existing() {
+    val file = Path(directory, "written.json")
+    val before = fileUrlOf(file)
+    SystemFileSystem.sink(file).close()
+
+    assertEquals(before, fileUrlOf(file))
+  }
+}

--- a/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/mlnffi/RecordingList.kt
+++ b/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/mlnffi/RecordingList.kt
@@ -1,0 +1,35 @@
+package org.maplibre.compose.mlnffi
+
+/**
+ * A list that records what MapLibre's threads did, and that a test thread reads while they are
+ * still recording.
+ *
+ * Every read takes a snapshot, so iterating this list is safe while another thread appends to it.
+ */
+internal class RecordingList<T> : AbstractMutableList<T>() {
+  private val lock = MlnFfiLock()
+  private val items = mutableListOf<T>()
+
+  override val size: Int
+    get() = lock.withLock { items.size }
+
+  override fun get(index: Int): T = lock.withLock { items[index] }
+
+  override fun set(index: Int, element: T): T = lock.withLock { items.set(index, element) }
+
+  override fun add(element: T): Boolean = lock.withLock { items.add(element) }
+
+  override fun add(index: Int, element: T) {
+    lock.withLock { items.add(index, element) }
+  }
+
+  override fun removeAt(index: Int): T = lock.withLock { items.removeAt(index) }
+
+  override fun clear() {
+    lock.withLock { items.clear() }
+  }
+
+  override fun iterator(): MutableIterator<T> = lock.withLock { items.toMutableList() }.iterator()
+
+  override fun toString(): String = lock.withLock { items.toString() }
+}

--- a/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/mlnffi/RecordingList.kt
+++ b/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/mlnffi/RecordingList.kt
@@ -5,6 +5,8 @@ package org.maplibre.compose.mlnffi
  * still recording.
  *
  * Every read takes a snapshot, so iterating this list is safe while another thread appends to it.
+ * Removal through an iterator fails, because it would reach the snapshot rather than this list;
+ * that also rules out `remove`, `removeAll`, `retainAll`, and `removeIf`, which are built on it.
  */
 internal class RecordingList<T> : AbstractMutableList<T>() {
   private val lock = MlnFfiLock()
@@ -29,7 +31,16 @@ internal class RecordingList<T> : AbstractMutableList<T>() {
     lock.withLock { items.clear() }
   }
 
-  override fun iterator(): MutableIterator<T> = lock.withLock { items.toMutableList() }.iterator()
+  override fun iterator(): MutableIterator<T> {
+    val snapshot = lock.withLock { items.toMutableList() }.iterator()
+    return object : MutableIterator<T> by snapshot {
+      override fun remove(): Nothing =
+        throw UnsupportedOperationException(
+          "A RecordingList read takes a snapshot, so a removal through its iterator would reach " +
+            "that snapshot and leave the list itself unchanged. Remove by index instead."
+        )
+    }
+  }
 
   override fun toString(): String = lock.withLock { items.toString() }
 }

--- a/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/offline/MlnFfiOfflineManagerTest.kt
+++ b/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/offline/MlnFfiOfflineManagerTest.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
+import kotlinx.io.files.Path
 import org.maplibre.compose.mlnffi.FfiTestPlatform
 import org.maplibre.compose.mlnffi.MlnFfiRuntimeOptions
 
@@ -14,13 +15,13 @@ import org.maplibre.compose.mlnffi.MlnFfiRuntimeOptions
 class MlnFfiOfflineManagerTest {
 
   private val cacheFile = FfiTestPlatform.createCacheFile()
-  private val directory = requireNotNull(cacheFile.parentFile)
+  private val directory = requireNotNull(cacheFile.parent)
 
   private val options = MlnFfiRuntimeOptions(cacheFile = cacheFile, maximumCacheSizeBytes = null)
 
   private val budgetedOptions =
     MlnFfiRuntimeOptions(
-      cacheFile = directory.resolve("budgeted-cache.db"),
+      cacheFile = Path(directory, "budgeted-cache.db"),
       maximumCacheSizeBytes = 8L * 1024 * 1024,
     )
 

--- a/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/offline/MlnFfiOfflinePackTest.kt
+++ b/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/offline/MlnFfiOfflinePackTest.kt
@@ -11,6 +11,10 @@ import kotlin.test.fail
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
+import kotlinx.io.buffered
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+import kotlinx.io.writeString
 import org.maplibre.compose.mlnffi.FfiTestPlatform
 import org.maplibre.compose.mlnffi.MlnFfiRuntimeOptions
 import org.maplibre.spatialk.geojson.BoundingBox
@@ -25,7 +29,7 @@ import org.maplibre.spatialk.geojson.Position
 class MlnFfiOfflinePackTest {
 
   private val cacheFile = FfiTestPlatform.createCacheFile()
-  private val directory = requireNotNull(cacheFile.parentFile)
+  private val directory = requireNotNull(cacheFile.parent)
 
   private val options = MlnFfiRuntimeOptions(cacheFile = cacheFile, maximumCacheSizeBytes = null)
   private val managers = mutableListOf<MlnFfiOfflineManager>()
@@ -317,9 +321,12 @@ class MlnFfiOfflinePackTest {
 
   private fun writeStyle(name: String): String {
     // No sources and no layers, so MapLibre has exactly one resource to fetch.
-    val file = directory.resolve(name)
-    file.writeText("""{"version":8,"name":"offline test","sources":{},"layers":[]}""")
-    return file.toURI().toString()
+    val file = Path(directory, name)
+    SystemFileSystem.sink(file).buffered().use {
+      it.writeString("""{"version":8,"name":"offline test","sources":{},"layers":[]}""")
+    }
+    // The directory is an absolute temporary path, so this needs no escaping.
+    return "file://$file"
   }
 
   /**

--- a/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/offline/MlnFfiOfflinePackTest.kt
+++ b/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/offline/MlnFfiOfflinePackTest.kt
@@ -17,6 +17,7 @@ import kotlinx.io.files.SystemFileSystem
 import kotlinx.io.writeString
 import org.maplibre.compose.mlnffi.FfiTestPlatform
 import org.maplibre.compose.mlnffi.MlnFfiRuntimeOptions
+import org.maplibre.compose.mlnffi.fileUrlOf
 import org.maplibre.spatialk.geojson.BoundingBox
 import org.maplibre.spatialk.geojson.Polygon
 import org.maplibre.spatialk.geojson.Position
@@ -325,8 +326,7 @@ class MlnFfiOfflinePackTest {
     SystemFileSystem.sink(file).buffered().use {
       it.writeString("""{"version":8,"name":"offline test","sources":{},"layers":[]}""")
     }
-    // The directory is an absolute temporary path, so this needs no escaping.
-    return "file://$file"
+    return fileUrlOf(file)
   }
 
   /**

--- a/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/offline/MlnFfiOfflineRuntimeTest.kt
+++ b/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/offline/MlnFfiOfflineRuntimeTest.kt
@@ -1,9 +1,12 @@
+@file:OptIn(ExperimentalAtomicApi::class)
+
 package org.maplibre.compose.offline
 
 import co.touchlab.kermit.Logger
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.concurrent.atomics.AtomicBoolean
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertFalse
@@ -91,16 +94,16 @@ class MlnFfiOfflineRuntimeTest {
     val cancelled = AtomicBoolean(false)
     val ran = AtomicBoolean(false)
     val queueDrained = CountDownLatch(1)
-    runtime.post(task = { ran.set(true) }, reject = {}, isCancelled = cancelled::get)
+    runtime.post(task = { ran.store(true) }, reject = {}, isCancelled = cancelled::load)
     runtime.post(task = { queueDrained.countDown() }, reject = {})
 
-    cancelled.set(true)
+    cancelled.store(true)
     releaseBlocker.countDown()
     assertTrue(
       queueDrained.await(RESPONSE_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS),
       "the owner thread did not drain the queued work",
     )
-    assertFalse(ran.get(), "the cancelled task must not run")
+    assertFalse(ran.load(), "the cancelled task must not run")
   }
 
   /** Shutdown signals the wake source directly, because the accept gate may already be closed. */

--- a/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/offline/MlnFfiSharedCacheDatabaseTest.kt
+++ b/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/offline/MlnFfiSharedCacheDatabaseTest.kt
@@ -1,11 +1,11 @@
 package org.maplibre.compose.offline
 
-import java.io.File
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import kotlin.test.Test
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+import kotlinx.io.files.Path
 import org.maplibre.compose.mlnffi.FfiTestPlatform
 import org.maplibre.nativeffi.runtime.RuntimeHandle
 import org.maplibre.nativeffi.runtime.RuntimeOptions
@@ -55,6 +55,6 @@ class MlnFfiSharedCacheDatabaseTest {
     }
   }
 
-  private fun createRuntime(cacheFile: File): RuntimeHandle =
-    RuntimeHandle.create(RuntimeOptions().also { it.cachePath = cacheFile.path })
+  private fun createRuntime(cacheFile: Path): RuntimeHandle =
+    RuntimeHandle.create(RuntimeOptions().also { it.cachePath = cacheFile.toString() })
 }

--- a/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/resource/MlnFfiResourceRequestTest.kt
+++ b/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/resource/MlnFfiResourceRequestTest.kt
@@ -1,5 +1,3 @@
-@file:OptIn(ExperimentalAtomicApi::class)
-
 package org.maplibre.compose.resource
 
 import java.util.concurrent.CountDownLatch
@@ -166,6 +164,7 @@ class MlnFfiResourceRequestTest {
     ResourceResponse(ResourceResponseStatus.OK).also { it.bytes = body.toByteArray() }
 
   /** A request the provider can take, recording what it did with it. */
+  @OptIn(ExperimentalAtomicApi::class)
   private class RecordedRequest(private val cancelled: Boolean = false) : TakenResourceRequest {
     private val responses = RecordingList<ResourceResponse>()
     private val answered = CountDownLatch(1)

--- a/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/resource/MlnFfiResourceRequestTest.kt
+++ b/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/resource/MlnFfiResourceRequestTest.kt
@@ -1,14 +1,18 @@
+@file:OptIn(ExperimentalAtomicApi::class)
+
 package org.maplibre.compose.resource
 
-import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+import kotlin.concurrent.atomics.incrementAndFetch
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import org.maplibre.compose.mlnffi.RecordingList
 import org.maplibre.nativeffi.resource.ResourceErrorReason
 import org.maplibre.nativeffi.resource.ResourceResponse
 import org.maplibre.nativeffi.resource.ResourceResponseStatus
@@ -26,7 +30,7 @@ private const val WAIT_SECONDS = 10L
  */
 class MlnFfiResourceRequestTest {
 
-  private val reads = CopyOnWriteArrayList<String>()
+  private val reads = RecordingList<String>()
   private val providers = mutableListOf<MlnFfiResourceProvider>()
 
   @AfterTest
@@ -163,9 +167,9 @@ class MlnFfiResourceRequestTest {
 
   /** A request the provider can take, recording what it did with it. */
   private class RecordedRequest(private val cancelled: Boolean = false) : TakenResourceRequest {
-    private val responses = CopyOnWriteArrayList<ResourceResponse>()
+    private val responses = RecordingList<ResourceResponse>()
     private val answered = CountDownLatch(1)
-    private val closeCount = AtomicInteger()
+    private val closeCount = AtomicInt(0)
 
     override fun isCancelled(): Boolean = cancelled
 
@@ -175,14 +179,14 @@ class MlnFfiResourceRequestTest {
     }
 
     override fun close() {
-      closeCount.incrementAndGet()
+      closeCount.incrementAndFetch()
     }
 
     val completions: Int
       get() = responses.size
 
     val closes: Int
-      get() = closeCount.get()
+      get() = closeCount.load()
 
     val response: ResourceResponse
       get() = responses.single()

--- a/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/sources/ComputedSourceTest.kt
+++ b/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/sources/ComputedSourceTest.kt
@@ -2,7 +2,6 @@ package org.maplibre.compose.sources
 
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
-import java.util.concurrent.ConcurrentLinkedQueue
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -13,6 +12,7 @@ import kotlinx.serialization.json.put
 import org.maplibre.compose.layers.FillLayer
 import org.maplibre.compose.mlnffi.BridgeMapFixture
 import org.maplibre.compose.mlnffi.FfiTestPlatform
+import org.maplibre.compose.mlnffi.RecordingList
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.compose.style.MlnFfiStyle
 import org.maplibre.spatialk.geojson.BoundingBox
@@ -28,7 +28,7 @@ import org.maplibre.spatialk.geojson.Position
 class ComputedSourceTest {
 
   /** Every request MapLibre made, recorded from whichever thread the source answered on. */
-  private val requests = ConcurrentLinkedQueue<Request>()
+  private val requests = RecordingList<Request>()
 
   private data class Request(val zoom: Int, val bounds: BoundingBox, val thread: String)
 

--- a/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/sources/ImageSourceAttachTest.kt
+++ b/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/sources/ImageSourceAttachTest.kt
@@ -1,13 +1,13 @@
 package org.maplibre.compose.sources
 
 import androidx.compose.ui.graphics.ImageBitmap
-import java.util.concurrent.ConcurrentLinkedQueue
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
 import org.maplibre.compose.mlnffi.BridgeMapFixture
+import org.maplibre.compose.mlnffi.RecordingList
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.compose.style.MlnFfiStyle
 import org.maplibre.compose.util.PositionQuad
@@ -24,7 +24,7 @@ import org.maplibre.spatialk.geojson.Position
  */
 class ImageSourceAttachTest {
 
-  private val records = ConcurrentLinkedQueue<LogRecord>()
+  private val records = RecordingList<LogRecord>()
 
   init {
     // Process-global; safe because each platform test process runs without parallel forks.


### PR DESCRIPTION
## Description

Replace `java.io.File` with kotlinx-io `Path` (a new dependency, `org.jetbrains.kotlinx:kotlinx-io-core:0.9.1`) and the `java.util.concurrent` atomics, locks, and concurrent collections with multiplatform equivalents in `mlnFfiShared`, so the source set moves toward Kotlin/Native compatibility.

## Test plan

Ran `./gradlew :lib:maplibre-compose:compileKotlinJvm`, `mise run test:desktop`, `mise run test:android`, and `mise run check` on Linux x64.

## Checklist

**To your knowledge, are you making any breaking changes?**

No; the public desktop API keeps its `java.nio.file.Path`, converted at the boundary, and every other declaration involved is internal.

**Have you tested the changes? On which platforms?**

- Desktop: Linux x64 headless Vulkan tests.
- Android: host unit tests only.

## AI assistance

- **Tools:** Claude Code
- **Context:** Claude made these edits and ran the validation above, working from a list of JVM dependencies to remove from `mlnFfiShared`.
