### PR TITLE
Import kotlin.concurrent.Volatile explicitly in mlnFfiShared

### DIFF
--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/layers/Layer.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/layers/Layer.kt
@@ -1,5 +1,6 @@
 package org.maplibre.compose.layers
 
+import kotlin.concurrent.Volatile
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/MlnFfiMapRuntimeLoop.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/MlnFfiMapRuntimeLoop.kt
@@ -5,6 +5,7 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.Volatile
 import kotlin.concurrent.withLock
 import kotlinx.io.files.Path
 import org.maplibre.compose.mlnffi.MlnFfiMapExtent

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.DpRect
 import androidx.compose.ui.unit.LayoutDirection
 import co.touchlab.kermit.Logger
+import kotlin.concurrent.Volatile
 import kotlin.concurrent.atomics.AtomicBoolean
 import kotlin.concurrent.atomics.AtomicLong
 import kotlin.concurrent.atomics.ExperimentalAtomicApi

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/mlnffi/MlnFfiRuntimeOptions.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/mlnffi/MlnFfiRuntimeOptions.kt
@@ -1,6 +1,7 @@
 package org.maplibre.compose.mlnffi
 
 import androidx.compose.runtime.Immutable
+import kotlin.concurrent.Volatile
 import kotlinx.io.files.Path
 import org.maplibre.compose.offline.MlnFfiOfflineManager
 

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/offline/MlnFfiOfflineRuntime.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/offline/MlnFfiOfflineRuntime.kt
@@ -3,6 +3,7 @@ package org.maplibre.compose.offline
 import co.touchlab.kermit.Logger
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.Volatile
 import kotlin.concurrent.withLock
 import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.io.files.Path

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/sources/Source.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/sources/Source.kt
@@ -1,5 +1,6 @@
 package org.maplibre.compose.sources
 
+import kotlin.concurrent.Volatile
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import org.maplibre.compose.style.StyleBinding


### PR DESCRIPTION
## Description

Import `kotlin.concurrent.Volatile` explicitly in the six `mlnFfiShared` files that use `@Volatile`, since it resolves through the JVM default imports today and Kotlin/Native has none of those.

## Prerequisites

- #867 — Move `mlnFfiShared` off `java.io.File` and `java.util.concurrent` (this PR is stacked on it)

## Test plan

Ran `./gradlew :lib:maplibre-compose:compileKotlinJvm`, `mise run test:desktop`, and `mise run check` on Linux x64.

## Checklist

**To your knowledge, are you making any breaking changes?**

No; on JVM the common declaration is a typealias to `kotlin.jvm.Volatile`, and the compiled fields stay volatile.

**Have you tested the changes? On which platforms?**

- Desktop: Linux x64 headless Vulkan tests.

## AI assistance

- **Tools:** Claude Code
- **Context:** Claude made these edits and ran the validation above, working from a list of JVM dependencies to remove from `mlnFfiShared`.
