### PR TITLE
Add a threading seam to mlnFfiShared

### DIFF
--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/mlnffi/MlnFfiGate.desktop.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/mlnffi/MlnFfiGate.desktop.kt
@@ -1,0 +1,36 @@
+package org.maplibre.compose.mlnffi
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+/**
+ * A latch of one count.
+ *
+ * Interruption ends a wait here and restores the interrupt flag, so a host that interrupts one of
+ * these threads sees the state it expects. The waiting code itself treats interruption as a reason
+ * to stop waiting rather than to retry, which is the behavior every platform can offer:
+ * Kotlin/Native has no thread interruption at all.
+ */
+internal actual class MlnFfiGate actual constructor() {
+  private val latch = CountDownLatch(1)
+
+  actual fun open() {
+    latch.countDown()
+  }
+
+  actual fun await() {
+    try {
+      latch.await()
+    } catch (interruption: InterruptedException) {
+      Thread.currentThread().interrupt()
+    }
+  }
+
+  actual fun await(timeoutMillis: Long): Boolean =
+    try {
+      latch.await(timeoutMillis, TimeUnit.MILLISECONDS)
+    } catch (interruption: InterruptedException) {
+      Thread.currentThread().interrupt()
+      latch.count == 0L
+    }
+}

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/mlnffi/MlnFfiOwnerThread.desktop.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/mlnffi/MlnFfiOwnerThread.desktop.kt
@@ -1,0 +1,27 @@
+package org.maplibre.compose.mlnffi
+
+internal actual class MlnFfiOwnerThread actual constructor(name: String, body: () -> Unit) {
+  private val delegate =
+    Thread(body, name).apply {
+      // A parked native pump ignores interruption, so a host that exits while a loop is still
+      // running has no way to stop it and must be free to leave it behind.
+      isDaemon = true
+    }
+
+  actual fun start() {
+    delegate.start()
+  }
+
+  actual fun isCurrent(): Boolean = Thread.currentThread() === delegate
+
+  actual fun join(timeoutMillis: Long): Boolean =
+    try {
+      delegate.join(timeoutMillis)
+      !delegate.isAlive
+    } catch (interruption: InterruptedException) {
+      Thread.currentThread().interrupt()
+      !delegate.isAlive
+    }
+}
+
+internal actual fun currentMlnFfiThreadName(): String = Thread.currentThread().name

--- a/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/mlnffi/MlnFfiOwnerThreadTest.kt
+++ b/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/mlnffi/MlnFfiOwnerThreadTest.kt
@@ -1,0 +1,26 @@
+package org.maplibre.compose.mlnffi
+
+import java.util.concurrent.CountDownLatch
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class MlnFfiOwnerThreadTest {
+  @Test
+  fun timedJoinRestoresCallerInterrupt() {
+    val releaseOwner = CountDownLatch(1)
+    val owner = MlnFfiOwnerThread("owner-thread-test") { releaseOwner.await() }
+    owner.start()
+
+    try {
+      Thread.currentThread().interrupt()
+
+      assertFalse(owner.join(10_000))
+      assertTrue(Thread.currentThread().isInterrupted)
+    } finally {
+      Thread.interrupted()
+      releaseOwner.countDown()
+      assertTrue(owner.join(10_000))
+    }
+  }
+}

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/MlnFfiMapRuntimeLoop.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/MlnFfiMapRuntimeLoop.kt
@@ -1,13 +1,12 @@
 package org.maplibre.compose.map
 
 import co.touchlab.kermit.Logger
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.LinkedBlockingQueue
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.Volatile
-import kotlin.concurrent.withLock
 import kotlinx.io.files.Path
+import org.maplibre.compose.mlnffi.MlnFfiGate
+import org.maplibre.compose.mlnffi.MlnFfiOwnerLock
+import org.maplibre.compose.mlnffi.MlnFfiOwnerThread
+import org.maplibre.compose.mlnffi.withLock
 import org.maplibre.compose.resource.MlnFfiRuntimeOwner
 import org.maplibre.nativeffi.map.MapHandle
 import org.maplibre.nativeffi.map.MapOptions
@@ -32,6 +31,7 @@ private const val SHUTDOWN_WAIT_MILLIS = 5_000L
  * The render session belongs to whichever thread attached it, and native refuses to destroy a map
  * that still has one attached, so teardown waits for that thread to close it.
  *
+ * This loop uses a dedicated [MlnFfiOwnerThread] rather than a dispatcher or a pooled executor.
  * maplibre-native-ffi#433 proposes an owner thread inside the C API, which would retire this class.
  */
 internal class MlnFfiMapRuntimeLoop(
@@ -55,13 +55,17 @@ internal class MlnFfiMapRuntimeLoop(
   /** Work for the owner thread; [OwnerTask.abandon] runs instead if it never gets to run. */
   private class OwnerTask(val run: (MapHandle) -> Unit, val abandon: () -> Unit)
 
-  private val tasks = LinkedBlockingQueue<OwnerTask>()
+  /**
+   * The owner thread. A parked pump ignores interruption, so [close] is the only way to stop it.
+   */
+  private val thread = MlnFfiOwnerThread("maplibre-compose-map", ::runLoop)
 
   /**
-   * Guards [accepting] and [wake] together: nothing may be queued after the final drain, and
-   * nothing may signal a wake source that is closing.
+   * Guards [tasks], [accepting], and [wake] together: nothing may be queued after the final drain,
+   * and nothing may signal a wake source that is closing.
    */
-  private val acceptLock = ReentrantLock()
+  private val acceptLock = MlnFfiOwnerLock(thread)
+  private val tasks = ArrayDeque<OwnerTask>()
   private var accepting = true
   private var wake: WakeSource? = null
 
@@ -70,7 +74,7 @@ internal class MlnFfiMapRuntimeLoop(
   /** Owner-thread state: the runtime and everything retired before it. */
   private var runtimeOwner: MlnFfiRuntimeOwner? = null
 
-  private val stopSignal = CountDownLatch(1)
+  private val stopSignal = MlnFfiGate()
 
   /** The map, once it exists. Null before creation and after teardown begins. */
   @Volatile
@@ -86,12 +90,6 @@ internal class MlnFfiMapRuntimeLoop(
   val scaleFactor: Double
     get() = extent.scaleFactor
 
-  private val thread =
-    Thread(::runLoop, "maplibre-compose-map").apply {
-      // A parking pump ignores interruption, so close() is the only way to stop this thread.
-      isDaemon = true
-    }
-
   fun start() {
     thread.start()
   }
@@ -102,28 +100,24 @@ internal class MlnFfiMapRuntimeLoop(
    * owner thread.
    */
   fun <T> call(action: (MapHandle) -> T): T? {
-    if (Thread.currentThread() === thread) return map?.let(action)
+    if (thread.isCurrent()) return map?.let(action)
     if (map == null) return null
 
     var result: Result<T>? = null
-    val done = CountDownLatch(1)
+    val done = MlnFfiGate()
     val posted =
       submit(
         run = { map ->
           result = runCatching { action(map) }
-          done.countDown()
+          done.open()
         },
-        abandon = { done.countDown() },
+        abandon = { done.open() },
       )
     if (!posted) return null
 
-    try {
-      done.await()
-    } catch (interruption: InterruptedException) {
-      Thread.currentThread().interrupt()
-      logger?.w(interruption) { "Interrupted while waiting for the map's owner thread" }
-      return null
-    }
+    done.await()
+    // Null when the wait ended before the owner thread reached the task, which the gate's own
+    // documentation allows.
     return result?.getOrThrow()
   }
 
@@ -145,15 +139,10 @@ internal class MlnFfiMapRuntimeLoop(
    */
   override fun close() {
     stopRequested = true
-    stopSignal.countDown()
+    stopSignal.open()
     acceptLock.withLock { wake?.signal() }
-    if (Thread.currentThread() === thread) return
-    try {
-      thread.join(SHUTDOWN_WAIT_MILLIS)
-    } catch (interruption: InterruptedException) {
-      Thread.currentThread().interrupt()
-    }
-    if (thread.isAlive) {
+    if (thread.isCurrent()) return
+    if (!thread.join(SHUTDOWN_WAIT_MILLIS)) {
       logger?.e { "The MapLibre map runtime thread did not stop within ${SHUTDOWN_WAIT_MILLIS}ms" }
     }
   }
@@ -202,7 +191,7 @@ internal class MlnFfiMapRuntimeLoop(
       // Queued work first: a task posted before the source was published set no wake flag.
       val ranTasks = runTasks(map)
       if (stopRequested) break
-      check(!acceptLock.isHeldByCurrentThread) { "the pump must not run under acceptLock" }
+      check(!acceptLock.isHeldByOwnerThread) { "the pump must not run under acceptLock" }
       // A batch that ran must not park: a task queuing nothing for native has nothing to wake it.
       runtime.pump(if (ranTasks) 0L else PUMP_PARK_MILLIS)
       drainEvents(runtime, map)
@@ -239,7 +228,8 @@ internal class MlnFfiMapRuntimeLoop(
   private fun runTasks(map: MapHandle): Boolean {
     var ran = false
     while (true) {
-      val task = tasks.poll() ?: break
+      // Taken one at a time, and run outside the lock: a task posts, closes, and calls back.
+      val task = acceptLock.withLock { tasks.removeFirstOrNull() } ?: break
       ran = true
       try {
         task.run(map)
@@ -252,11 +242,7 @@ internal class MlnFfiMapRuntimeLoop(
 
   /** Blocks until [close] is called, or the bound expires. */
   private fun awaitShutdown() {
-    try {
-      stopSignal.await(SHUTDOWN_WAIT_MILLIS, TimeUnit.MILLISECONDS)
-    } catch (interruption: InterruptedException) {
-      Thread.currentThread().interrupt()
-    }
+    stopSignal.await(SHUTDOWN_WAIT_MILLIS)
   }
 
   private fun fail(error: Throwable) {
@@ -267,14 +253,16 @@ internal class MlnFfiMapRuntimeLoop(
   }
 
   private fun rejectQueuedTasks() {
-    // Stop accepting and take the wake source out under the same lock, so nothing can signal a
-    // source that is about to close.
+    // Stop accepting, drain the queue, and take the wake source out under one lock, so the drain
+    // cannot race a task that would then never run and nothing can signal a source that is about to
+    // close.
+    val abandoned = mutableListOf<OwnerTask>()
     val source = acceptLock.withLock {
       accepting = false
+      abandoned.addAll(tasks)
+      tasks.clear()
       wake.also { wake = null }
     }
-    val abandoned = mutableListOf<OwnerTask>()
-    tasks.drainTo(abandoned)
     // Released rather than run: a caller blocked in call() would otherwise never be resumed.
     abandoned.forEach { runCatching { it.abandon() } }
     // A wake source is its own native handle, so closing the runtime does not release it.

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -41,6 +41,7 @@ import org.maplibre.compose.mlnffi.OpenGlTextureTarget
 import org.maplibre.compose.mlnffi.VulkanContextHandles
 import org.maplibre.compose.mlnffi.VulkanImageTarget
 import org.maplibre.compose.mlnffi.WglContextHandles
+import org.maplibre.compose.mlnffi.currentMlnFfiThreadName
 import org.maplibre.compose.mlnffi.withLock
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.compose.style.MlnFfiStyle
@@ -286,7 +287,7 @@ internal class MlnFfiMapSession(
     if (!hasRenderedAFrame) {
       hasRenderedAFrame = true
       logger?.i {
-        "Rendered the first map frame with $backend on ${Thread.currentThread().name}, " +
+        "Rendered the first map frame with $backend on ${currentMlnFfiThreadName()}, " +
           "extent ${frame.extent}"
       }
     }

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/mlnffi/MlnFfiGate.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/mlnffi/MlnFfiGate.kt
@@ -1,0 +1,23 @@
+package org.maplibre.compose.mlnffi
+
+/**
+ * A one-shot gate, opened once and awaited by any number of threads.
+ *
+ * Opening a gate that is already open changes nothing, and a wait on an open gate returns at once.
+ * A platform may also end a wait early when the host interrupts the waiting thread, so a caller
+ * reads the state that the gate guards rather than treating a returned wait as proof the gate
+ * opened.
+ *
+ * An actual over a condition variable waits in a loop over the open flag, because such a wait
+ * returns from a spurious wakeup as readily as from a signal.
+ */
+internal expect class MlnFfiGate() {
+  /** Opens the gate and releases every waiter. */
+  fun open()
+
+  /** Waits without a bound. */
+  fun await()
+
+  /** Waits up to [timeoutMillis], reporting whether the gate opened. */
+  fun await(timeoutMillis: Long): Boolean
+}

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/mlnffi/MlnFfiOwnerLock.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/mlnffi/MlnFfiOwnerLock.kt
@@ -1,0 +1,50 @@
+package org.maplibre.compose.mlnffi
+
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
+
+/**
+ * An [MlnFfiLock] that reports whether [owner] holds it.
+ *
+ * A runtime loop parks inside a native pump until a wake arrives, so it reaches that pump holding
+ * no lock that a caller needs to post work and signal the wake source. A loop that parked under
+ * such a lock would block every caller of the one call that could release it. The loops read
+ * [isHeldByOwnerThread] before each pump, which turns that deadlock into a failed check at the line
+ * that introduced it.
+ *
+ * The flag tracks [owner] alone, which is the only thread the check asks about. That thread is also
+ * the only one that writes the flag and the only one that reads it, so the flag needs no
+ * synchronization of its own.
+ */
+internal class MlnFfiOwnerLock(private val owner: MlnFfiOwnerThread) {
+  private val delegate = MlnFfiLock()
+
+  private var heldByOwner = false
+
+  /** Whether [owner] holds this lock. Read from that thread. */
+  val isHeldByOwnerThread: Boolean
+    get() = heldByOwner
+
+  fun lock() {
+    delegate.lock()
+    if (owner.isCurrent()) heldByOwner = true
+  }
+
+  fun unlock() {
+    if (owner.isCurrent()) heldByOwner = false
+    delegate.unlock()
+  }
+}
+
+/** Runs [block] holding [this], and releases the lock however [block] ends. */
+@OptIn(ExperimentalContracts::class)
+internal inline fun <T> MlnFfiOwnerLock.withLock(block: () -> T): T {
+  contract { callsInPlace(block, InvocationKind.EXACTLY_ONCE) }
+  lock()
+  try {
+    return block()
+  } finally {
+    unlock()
+  }
+}

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/mlnffi/MlnFfiOwnerThread.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/mlnffi/MlnFfiOwnerThread.kt
@@ -1,0 +1,41 @@
+package org.maplibre.compose.mlnffi
+
+/**
+ * One dedicated thread that runs [body] to completion and then exits.
+ *
+ * MapLibre binds a runtime to the thread that created it and allows one runtime per thread, so a
+ * loop that owns a runtime owns a thread with it. An actual starts one real OS thread that carries
+ * [name], runs [body] exactly once, and never migrates to another thread or returns to a pool. The
+ * thread keeps nothing alive: a host that exits while [body] is still running leaves the thread
+ * behind rather than waiting for it.
+ *
+ * A caller starts the thread once and joins it once.
+ *
+ * An actual over pthreads has three obligations that the JVM actual gets for free. Darwin's
+ * `pthread_setname_np` names only the calling thread, so the thread applies [name] to itself as the
+ * first thing it does, and a crash report from the moments before that shows an unnamed thread. The
+ * `StableRef` that carries [body] into the thread belongs to the thread body, which disposes it
+ * when [body] returns; [start] disposes it only when `pthread_create` fails, because no body will
+ * run to do it then. Darwin also has no timed join, so [join] waits on a completion flag that the
+ * thread publishes, and every such wait belongs in a loop over that flag, because a condition
+ * variable returns from a spurious wakeup as readily as from a signal.
+ */
+internal expect class MlnFfiOwnerThread(name: String, body: () -> Unit) {
+  /** Starts the thread. Called once. */
+  fun start()
+
+  /** Whether the calling thread is this one. */
+  fun isCurrent(): Boolean
+
+  /**
+   * Waits up to [timeoutMillis] for [body] to return, reporting whether it did.
+   *
+   * A false result leaves the thread running, and the caller reports the wedged loop rather than
+   * waiting again. An actual that allocated a control block for the thread keeps it allocated in
+   * that case, because the thread may still write to it.
+   */
+  fun join(timeoutMillis: Long): Boolean
+}
+
+/** The name of the calling thread, for diagnostics. */
+internal expect fun currentMlnFfiThreadName(): String

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/offline/MlnFfiOfflineManager.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/offline/MlnFfiOfflineManager.kt
@@ -5,7 +5,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalDensity
 import co.touchlab.kermit.Logger
-import java.util.concurrent.CountDownLatch
 import kotlin.concurrent.atomics.AtomicBoolean
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.coroutines.cancellation.CancellationException
@@ -14,6 +13,7 @@ import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import org.maplibre.compose.mlnffi.MlnFfiApplication
+import org.maplibre.compose.mlnffi.MlnFfiGate
 import org.maplibre.compose.mlnffi.MlnFfiRuntimeOptions
 import org.maplibre.nativeffi.error.MaplibreException
 import org.maplibre.nativeffi.error.MaplibreStatus
@@ -89,13 +89,13 @@ internal class MlnFfiOfflineManager(private val options: MlnFfiRuntimeOptions) :
   /** Does not let process-wide configuration publish a runtime whose startup or budget failed. */
   @OptIn(ExperimentalAtomicApi::class)
   private fun awaitConfiguredRuntime() {
-    val settled = CountDownLatch(1)
+    val settled = MlnFfiGate()
     val completed = AtomicBoolean(false)
     var outcome: Result<Unit>? = null
     fun complete(result: Result<Unit>) {
       if (completed.compareAndSet(false, true)) {
         outcome = result
-        settled.countDown()
+        settled.open()
       }
     }
 
@@ -120,13 +120,16 @@ internal class MlnFfiOfflineManager(private val options: MlnFfiRuntimeOptions) :
       )
     }
 
-    try {
-      settled.await()
-    } catch (interruption: InterruptedException) {
-      Thread.currentThread().interrupt()
-      failStartup("Interrupted while configuring MapLibre's offline runtime", interruption)
-    }
-    val failure = checkNotNull(outcome).exceptionOrNull()
+    settled.await()
+    // Null when the wait ended before the runtime settled, which the gate's own documentation
+    // allows. The runtime is unusable either way, so both outcomes take the same path.
+    val settledOutcome =
+      outcome
+        ?: failStartup(
+          "Could not configure MapLibre's offline runtime",
+          OfflineManagerException("The offline runtime never reported its configuration"),
+        )
+    val failure = settledOutcome.exceptionOrNull()
     if (failure != null) failStartup("Could not configure MapLibre's offline runtime", failure)
     if (initialSize != null) logger.d { "Ambient cache size set to $initialSize bytes" }
   }

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/offline/MlnFfiOfflineRuntime.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/offline/MlnFfiOfflineRuntime.kt
@@ -1,12 +1,13 @@
 package org.maplibre.compose.offline
 
 import co.touchlab.kermit.Logger
-import java.util.concurrent.LinkedBlockingQueue
-import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.Volatile
-import kotlin.concurrent.withLock
 import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.io.files.Path
+import org.maplibre.compose.mlnffi.MlnFfiOwnerLock
+import org.maplibre.compose.mlnffi.MlnFfiOwnerThread
+import org.maplibre.compose.mlnffi.currentMlnFfiThreadName
+import org.maplibre.compose.mlnffi.withLock
 import org.maplibre.compose.resource.MlnFfiRuntimeOwner
 import org.maplibre.nativeffi.runtime.OfflineOperationHandle
 import org.maplibre.nativeffi.runtime.RuntimeEvent
@@ -19,6 +20,9 @@ import org.maplibre.nativeffi.runtime.WakeSource
  * Parks until a wake arrives, for the same reason the map loop does; see `MlnFfiMapRuntimeLoop`.
  */
 private const val PUMP_PARK_MILLIS = -1L
+
+/** Names the owner thread, and names it again in the message a wrong-thread call fails with. */
+private const val OWNER_THREAD_NAME = "maplibre-compose-offline"
 
 /**
  * The thread that owns the offline manager's MapLibre runtime, and the only place native offline
@@ -51,13 +55,18 @@ internal class MlnFfiOfflineRuntime(
     val discard: (Throwable) -> Unit,
   )
 
-  private val tasks = LinkedBlockingQueue<OwnerTask>()
+  /**
+   * The owner thread. A parked pump ignores interruption, and it must never keep a shutting-down
+   * application alive, so [shutdown] is the only way to stop it.
+   */
+  private val thread = MlnFfiOwnerThread(OWNER_THREAD_NAME, ::runLoop)
 
   /**
-   * Guards [accepting] and [wake] together: no task may be queued after the final drain, and no
-   * signal may race the wake source's close.
+   * Guards [tasks], [accepting], and [wake] together: no task may be queued after the final drain,
+   * and no signal may race the wake source's close.
    */
-  private val acceptLock = ReentrantLock()
+  private val acceptLock = MlnFfiOwnerLock(thread)
+  private val tasks = ArrayDeque<OwnerTask>()
   private var accepting = true
 
   /**
@@ -74,22 +83,12 @@ internal class MlnFfiOfflineRuntime(
   /** The runtime and everything retired before it. Owner-thread state; see [MlnFfiRuntimeOwner]. */
   private var runtimeOwner: MlnFfiRuntimeOwner? = null
 
-  private val thread =
-    Thread(::runLoop, "maplibre-compose-offline").apply {
-      // The pump must never keep a shutting-down application alive, and a parking pump ignores
-      // interruption: shutdown() is the only way to stop this thread.
-      isDaemon = true
-    }
-
   fun start() {
     thread.start()
   }
 
   /** Waits for the owner thread to finish, reporting whether it did. For tests and diagnostics. */
-  fun awaitStopped(timeoutMillis: Long): Boolean {
-    thread.join(timeoutMillis)
-    return !thread.isAlive
-  }
+  fun awaitStopped(timeoutMillis: Long): Boolean = thread.join(timeoutMillis)
 
   /** Asks the owner thread to tear down. Returns immediately; nothing is awaited. */
   fun shutdown() {
@@ -188,7 +187,7 @@ internal class MlnFfiOfflineRuntime(
         // draining only after a pump returns would leave it parked behind.
         runTasks(runtime)
         if (stopRequested) break
-        check(!acceptLock.isHeldByCurrentThread) { "the pump must not run under acceptLock" }
+        check(!acceptLock.isHeldByOwnerThread) { "the pump must not run under acceptLock" }
         // The runtime makes no progress on its own: no event is delivered and no download advances
         // except inside a pump.
         runtime.pump(PUMP_PARK_MILLIS)
@@ -245,7 +244,8 @@ internal class MlnFfiOfflineRuntime(
 
   private fun runTasks(runtime: RuntimeHandle) {
     while (true) {
-      runTask(runtime, tasks.poll() ?: break)
+      // Taken one at a time, and run outside the lock: a task posts, discards, and calls back.
+      runTask(runtime, acceptLock.withLock { tasks.removeFirstOrNull() } ?: break)
     }
   }
 
@@ -292,12 +292,13 @@ internal class MlnFfiOfflineRuntime(
   private fun rejectQueuedTasks(reason: Throwable) {
     // Stop accepting first so the drain cannot race a task that would then never run, and take the
     // wake source out in the same critical section so nothing can signal one that is closing.
+    val abandoned = mutableListOf<OwnerTask>()
     val source = acceptLock.withLock {
       accepting = false
+      abandoned.addAll(tasks)
+      tasks.clear()
       wake.also { wake = null }
     }
-    val abandoned = mutableListOf<OwnerTask>()
-    tasks.drainTo(abandoned)
     abandoned.forEach { runCatching { it.reject(reason) } }
     // A wake source is its own native handle: closing the runtime does not release it.
     source?.let { closing ->
@@ -311,9 +312,9 @@ internal class MlnFfiOfflineRuntime(
   }
 
   private fun assertOwnerThread(operation: String) {
-    check(Thread.currentThread() === thread) {
-      "$operation must run on the offline runtime's own thread (${thread.name}), but ran on " +
-        "${Thread.currentThread().name}. MapLibre enforces this natively, so the failure would " +
+    check(thread.isCurrent()) {
+      "$operation must run on the offline runtime's own thread ($OWNER_THREAD_NAME), but ran on " +
+        "${currentMlnFfiThreadName()}. MapLibre enforces this natively, so the failure would " +
         "otherwise surface as a WrongThreadException at the FFI boundary."
     }
   }

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/resource/MlnFfiRuntimeOwner.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/resource/MlnFfiRuntimeOwner.kt
@@ -3,6 +3,7 @@ package org.maplibre.compose.resource
 import co.touchlab.kermit.Logger
 import kotlinx.io.files.Path
 import kotlinx.io.files.SystemFileSystem
+import org.maplibre.compose.mlnffi.currentMlnFfiThreadName
 import org.maplibre.compose.mlnffi.normalizeMlnFfiPath
 import org.maplibre.nativeffi.runtime.RuntimeHandle
 import org.maplibre.nativeffi.runtime.RuntimeOptions
@@ -66,7 +67,7 @@ private constructor(
         // Installed with the runtime rather than with the map, so nothing can request a resource
         // before the provider that serves it exists.
         runtime.setResourceProvider(provider)
-        getLogger()?.i { "Created the $what on ${Thread.currentThread().name}" }
+        getLogger()?.i { "Created the $what on ${currentMlnFfiThreadName()}" }
         owner
       } catch (error: Throwable) {
         // Unwinds in the same order a successful close uses, or the runtime's scheduler and


### PR DESCRIPTION
## Description

Move the map and offline runtime loops onto an internal `expect`/`actual` threading seam — `MlnFfiOwnerThread`, `MlnFfiGate`, `currentMlnFfiThreadName`, and an `MlnFfiOwnerLock` that keeps the pump's deadlock check — so `mlnFfiShared` no longer uses `java.util.concurrent`.

This adds the seam and its JVM actuals only; the iOS actuals come with the iOS port, and the `expect` KDoc states what they have to guarantee.

## Test plan

Ran `./gradlew :lib:maplibre-compose:compileKotlinJvm` and `compileTestKotlinJvm`, `mise run test:desktop` plus two more `:lib:maplibre-compose:jvmTest --rerun-tasks` runs, and `mise run check` on Linux x64.

## Checklist

**To your knowledge, are you making any breaking changes?**

No; every declaration involved is internal.

**Have you tested the changes? On which platforms?**

- Desktop: Linux x64 headless Vulkan tests.

## AI assistance

- **Tools:** Claude Code
- **Context:** Claude made these edits and ran the validation above, working from a research note on Kotlin/Native threading abstractions and a specified seam shape.