### PR TITLE
Add Nucleus Tao desktop demo host

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ per `./gradlew` invocation. Two together can fail in ways neither does alone.
 - `mise run build:ios:device`
 - `mise run demo:desktop`
 - `mise run demo:desktop-glfw`
+- `mise run demo:desktop-nucleus`
 - `mise run demo:android`
 - `mise run demo:ios` (pass `--device` for a connected iPhone)
 - `mise run demo:js`
@@ -138,6 +139,9 @@ rendering interactive maps across Android, iOS, Desktop, and Web platforms.
   - `desktop`: A JVM application that launches `common` on the AWT host
   - `desktop-glfw`: The same JVM application on the compose-glfw host. A module
     of its own so that its `MainDispatcherFactory`, which outranks
+    `kotlinx-coroutines-swing`, stays off the AWT runtime classpath.
+  - `desktop-nucleus`: The same JVM application on the Nucleus Tao host. A
+    module of its own so that Tao's `MainDispatcherFactory`, which outranks
     `kotlinx-coroutines-swing`, stays off the AWT runtime classpath.
   - `ios`: An Xcode project that embeds the framework `common` produces
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,12 +137,8 @@ rendering interactive maps across Android, iOS, Desktop, and Web platforms.
   - `common`: Every line of the app, and the only Kotlin Multiplatform module
   - `android`: An Android application that launches `common`
   - `desktop`: A JVM application that launches `common` on the AWT host
-  - `desktop-glfw`: The same JVM application on the compose-glfw host. A module
-    of its own so that its `MainDispatcherFactory`, which outranks
-    `kotlinx-coroutines-swing`, stays off the AWT runtime classpath.
-  - `desktop-nucleus`: The same JVM application on the Nucleus Tao host. A
-    module of its own so that Tao's `MainDispatcherFactory`, which outranks
-    `kotlinx-coroutines-swing`, stays off the AWT runtime classpath.
+  - `desktop-glfw`: The same JVM application on the compose-glfw host.
+  - `desktop-nucleus`: The same JVM application on the Nucleus Tao host.
   - `ios`: An Xcode project that embeds the framework `common` produces
 
   The browser app has no module of its own. Its entry point and page live in

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,6 +128,8 @@ launch on iOS. Every other host has a task:
 - Web: `mise run demo:js`
 - Desktop on the compose-glfw host instead of the AWT one:
   `mise run demo:desktop-glfw`
+- Desktop on the Nucleus Tao host instead of the AWT one:
+  `mise run demo:desktop-nucleus`
 
 ## Run the tests
 

--- a/demo-app/desktop-glfw/build.gradle.kts
+++ b/demo-app/desktop-glfw/build.gradle.kts
@@ -29,13 +29,14 @@ dependencies {
  * This stays a module of its own so that its `MainDispatcherFactory` service, which outranks
  * `kotlinx-coroutines-swing`, never reaches the AWT demo's runtime classpath.
  */
+val mainRuntimeClasspath = sourceSets.named("main").map { it.runtimeClasspath }
+
 val run by
   tasks.registering(JavaExec::class) {
     group = "application"
     description = "Runs the compose-glfw desktop host fixture."
 
-    val sourceSets = extensions.getByType<SourceSetContainer>()
-    classpath = sourceSets.getByName("main").runtimeClasspath
+    classpath = mainRuntimeClasspath.get()
     mainClass = "org.maplibre.compose.glfw.MainKt"
     jvmArgs(NATIVE_ACCESS_JVM_ARGS)
     if (System.getProperty("os.name").lowercase().startsWith("mac")) {

--- a/demo-app/desktop-nucleus/build.gradle.kts
+++ b/demo-app/desktop-nucleus/build.gradle.kts
@@ -1,0 +1,49 @@
+plugins {
+  id("module-conventions")
+  id(libs.plugins.kotlin.jvm.get().pluginId)
+  id(libs.plugins.kotlin.composeCompiler.get().pluginId)
+  id(libs.plugins.compose.get().pluginId)
+}
+
+val desktopHostPlatform = DesktopHostPlatform.current()
+
+kotlin {
+  jvmToolchain(libs.versions.java.toolchain.get().toInt())
+  compilerOptions { jvmTarget = project.getDesktopJvmTarget() }
+}
+
+dependencies {
+  implementation(project(":demo-app:common"))
+  implementation(project(":lib:maplibre-compose"))
+  implementation(libs.nucleus.application)
+  implementation(libs.nucleus.decoratedWindowTao)
+
+  runtimeOnly(project(":lib:${desktopHostPlatform.defaultRuntimeArtifactId}"))
+}
+
+/**
+ * Runs the fixture. A plain `JavaExec` rather than the Nucleus application plugin: this module only
+ * needs a runnable host for the shared demo, and packaging stays with the AWT desktop app.
+ *
+ * Both JVM arguments are mandatory on the hosts that need them: Tao must own AppKit's first thread
+ * on macOS, and the FFI binding is refused native access without the other.
+ *
+ * This stays a module of its own so that Tao's `MainDispatcherFactory`, which outranks
+ * `kotlinx-coroutines-swing`, never reaches the AWT demo's runtime classpath.
+ */
+val run by
+  tasks.registering(JavaExec::class) {
+    group = "application"
+    description = "Runs the Nucleus Tao desktop host fixture."
+
+    val sourceSets = extensions.getByType<SourceSetContainer>()
+    classpath = sourceSets.getByName("main").runtimeClasspath
+    mainClass = "org.maplibre.compose.nucleus.MainKt"
+    jvmArgs(NATIVE_ACCESS_JVM_ARGS)
+    if (System.getProperty("os.name").lowercase().startsWith("mac")) {
+      jvmArgs("-XstartOnFirstThread")
+    }
+    javaLauncher = javaToolchains.launcherFor {
+      languageVersion = JavaLanguageVersion.of(libs.versions.java.toolchain.get().toInt())
+    }
+  }

--- a/demo-app/desktop-nucleus/build.gradle.kts
+++ b/demo-app/desktop-nucleus/build.gradle.kts
@@ -31,13 +31,14 @@ dependencies {
  * This stays a module of its own so that Tao's `MainDispatcherFactory`, which outranks
  * `kotlinx-coroutines-swing`, never reaches the AWT demo's runtime classpath.
  */
+val mainRuntimeClasspath = sourceSets.named("main").map { it.runtimeClasspath }
+
 val run by
   tasks.registering(JavaExec::class) {
     group = "application"
     description = "Runs the Nucleus Tao desktop host fixture."
 
-    val sourceSets = extensions.getByType<SourceSetContainer>()
-    classpath = sourceSets.getByName("main").runtimeClasspath
+    classpath = mainRuntimeClasspath.get()
     mainClass = "org.maplibre.compose.nucleus.MainKt"
     jvmArgs(NATIVE_ACCESS_JVM_ARGS)
     if (System.getProperty("os.name").lowercase().startsWith("mac")) {

--- a/demo-app/desktop-nucleus/src/main/kotlin/org/maplibre/compose/nucleus/Main.kt
+++ b/demo-app/desktop-nucleus/src/main/kotlin/org/maplibre/compose/nucleus/Main.kt
@@ -15,9 +15,6 @@ import org.maplibre.compose.desktop.desktopCachePath
 /**
  * The same `DemoApp` the Compose Desktop demo runs, in a Nucleus Tao window instead of an AWT one;
  * the only difference is which `ComposeGpuHost` is in scope.
- *
- * Run it with `mise run demo:desktop-nucleus`. On macOS the launcher must pass
- * `-XstartOnFirstThread`; the Gradle task does.
  */
 fun main() {
   MapLibre.configure(

--- a/demo-app/desktop-nucleus/src/main/kotlin/org/maplibre/compose/nucleus/Main.kt
+++ b/demo-app/desktop-nucleus/src/main/kotlin/org/maplibre/compose/nucleus/Main.kt
@@ -1,0 +1,40 @@
+package org.maplibre.compose.nucleus
+
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.rememberWindowState
+import dev.nucleusframework.application.DecoratedWindow
+import dev.nucleusframework.application.NucleusBackend
+import dev.nucleusframework.application.nucleusApplication
+import org.maplibre.compose.demoapp.DemoApp
+import org.maplibre.compose.desktop.DesktopRuntimeOptions
+import org.maplibre.compose.desktop.MapLibre
+import org.maplibre.compose.desktop.ProvideMapHost
+import org.maplibre.compose.desktop.desktopCachePath
+
+/**
+ * The same `DemoApp` the Compose Desktop demo runs, in a Nucleus Tao window instead of an AWT one;
+ * the only difference is which `ComposeGpuHost` is in scope.
+ *
+ * Run it with `mise run demo:desktop-nucleus`. On macOS the launcher must pass
+ * `-XstartOnFirstThread`; the Gradle task does.
+ */
+fun main() {
+  MapLibre.configure(
+    DesktopRuntimeOptions(cachePath = desktopCachePath("org.maplibre.compose.nucleus-fixture"))
+  )
+  nucleusApplication(
+    backend = NucleusBackend.Tao,
+    // A fixture, not a shipped app: allow parallel launches next to other demos.
+    enableSingleInstance = false,
+  ) {
+    DecoratedWindow(
+      onCloseRequest = ::exitApplication,
+      title = "MapLibre Compose on Nucleus Tao",
+      state = rememberWindowState(size = DpSize(960.dp, 640.dp)),
+    ) {
+      val host = rememberTaoComposeGpuHost() ?: return@DecoratedWindow
+      ProvideMapHost(host = host) { DemoApp() }
+    }
+  }
+}

--- a/demo-app/desktop-nucleus/src/main/kotlin/org/maplibre/compose/nucleus/TaoComposeGpuHost.kt
+++ b/demo-app/desktop-nucleus/src/main/kotlin/org/maplibre/compose/nucleus/TaoComposeGpuHost.kt
@@ -17,8 +17,8 @@ import org.maplibre.compose.mlnffi.NativeHandle
 /**
  * A [ComposeGpuHost] over a Nucleus Tao surface's own graphics context.
  *
- * Tao publishes what Compose draws with through [TaoGpuRenderContext], so this hands it over
- * unchanged: no AWT, no Skiko reflection.
+ * Tao publishes what Compose requires through [TaoGpuRenderContext], so this hands it over
+ * unchanged.
  */
 public class TaoComposeGpuHost(private val renderContext: TaoGpuRenderContext) : ComposeGpuHost {
 

--- a/demo-app/desktop-nucleus/src/main/kotlin/org/maplibre/compose/nucleus/TaoComposeGpuHost.kt
+++ b/demo-app/desktop-nucleus/src/main/kotlin/org/maplibre/compose/nucleus/TaoComposeGpuHost.kt
@@ -1,0 +1,79 @@
+package org.maplibre.compose.nucleus
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import dev.nucleusframework.window.tao.TaoGpuRenderContext
+import dev.nucleusframework.window.tao.TaoMetalRenderContext
+import dev.nucleusframework.window.tao.TaoOpenGlRenderContext
+import dev.nucleusframework.window.tao.TaoRenderBackend
+import dev.nucleusframework.window.tao.rememberTaoGpuRenderContext
+import org.maplibre.compose.desktop.ComposeGpuContext
+import org.maplibre.compose.desktop.ComposeGpuHost
+import org.maplibre.compose.desktop.MetalComposeGpuContext
+import org.maplibre.compose.desktop.OpenGlComposeGpuContext
+import org.maplibre.compose.mlnffi.ComposeRenderBackend
+import org.maplibre.compose.mlnffi.NativeHandle
+
+/**
+ * A [ComposeGpuHost] over a Nucleus Tao surface's own graphics context.
+ *
+ * Tao publishes what Compose draws with through [TaoGpuRenderContext], so this hands it over
+ * unchanged: no AWT, no Skiko reflection.
+ */
+public class TaoComposeGpuHost(private val renderContext: TaoGpuRenderContext) : ComposeGpuHost {
+
+  override val description: String
+    get() = "the Nucleus Tao host on ${backend.name.lowercase()}"
+
+  override val backend: ComposeRenderBackend
+    get() =
+      when (renderContext.backend) {
+        TaoRenderBackend.METAL -> ComposeRenderBackend.METAL
+        TaoRenderBackend.OPENGL -> ComposeRenderBackend.OPENGL
+      }
+
+  override fun gpuContext(): ComposeGpuContext =
+    when (val context = renderContext) {
+      is TaoMetalRenderContext ->
+        MetalComposeGpuContext(
+          skiaContext = context.skiaContext,
+          device = NativeHandle(context.metalDevicePtr),
+        )
+      is TaoOpenGlRenderContext ->
+        OpenGlComposeGpuContext(
+          skiaContext = context.skiaContext,
+          // Tao draws to the window itself, so the bind is just make-current; nesting restores the
+          // previous context and invalidates Skia's GL cache for us.
+          withContextCurrent = { action ->
+            checkNotNull(context.withContextCurrent { action.run() }) {
+              "$description could not make the GL context current"
+            }
+          },
+        )
+      // Tao keeps a private intermediate type in the sealed hierarchy; public callers only see the
+      // Metal and OpenGL leaves above.
+      else ->
+        error(
+          "$description reported an unsupported TaoGpuRenderContext: ${context::class.simpleName}"
+        )
+    }
+
+  override fun runOnGpuThread(action: Runnable) {
+    renderContext.runOnGpuThread {
+      action.run()
+    }
+  }
+}
+
+/**
+ * The [ComposeGpuHost] for the Nucleus Tao surface this composable is running in, or null while
+ * that surface has no GPU context yet.
+ *
+ * Keyed on the render context, which Tao replaces when it rebuilds a surface's graphics stack, so
+ * that a new context recreates the map's bridge and drops every stale native handle.
+ */
+@Composable
+public fun rememberTaoComposeGpuHost(): ComposeGpuHost? {
+  val renderContext = rememberTaoGpuRenderContext() ?: return null
+  return remember(renderContext) { TaoComposeGpuHost(renderContext) }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ androidx-activity = "1.13.0"
 bytesize = "2.2.1"
 composeGlfw = "0.2.0"
 htmlConverterCompose = "1.1.1"
+nucleus = "2.4.0"
 kermit = "2.1.0"
 kotlin-wrappers = "2026.8.0"
 kotlinx-coroutines = "1.11.0"
@@ -59,6 +60,8 @@ androidx-navigation-compose = { module = "org.jetbrains.androidx.navigation:navi
 bytesize = { module = "me.saket.bytesize:bytesize", version.ref = "bytesize" }
 composeGlfw = { module = "dev.sargunv:compose-glfw", version.ref = "composeGlfw" }
 htmlConverterCompose = { module = "be.digitalia.compose.htmlconverter:htmlconverter", version.ref = "htmlConverterCompose" }
+nucleus-application = { module = "dev.nucleusframework:nucleus.nucleus-application", version.ref = "nucleus" }
+nucleus-decoratedWindowTao = { module = "dev.nucleusframework:nucleus.decorated-window-tao", version.ref = "nucleus" }
 kermit = { group = "co.touchlab", name = "kermit", version.ref = "kermit" }
 kotlin-wrappers-browser = { group = "org.jetbrains.kotlin-wrappers", name = "kotlin-browser", version.ref = "kotlin-wrappers" }
 kotlin-wrappers-js = { group = "org.jetbrains.kotlin-wrappers", name = "kotlin-js", version.ref = "kotlin-wrappers" }

--- a/mise.toml
+++ b/mise.toml
@@ -198,6 +198,10 @@ run = '.mise/bin/run-ios-demo'
 description = "Run the demo app on the compose-glfw desktop host instead of the AWT one."
 run = "./gradlew :demo-app:desktop-glfw:run"
 
+[tasks."demo:desktop-nucleus"]
+description = "Run the demo app on the Nucleus Tao desktop host instead of the AWT one."
+run = "./gradlew :demo-app:desktop-nucleus:run"
+
 [tasks."publish:snapshot"]
 description = "Publish a snapshot build to Maven Central."
 run = ".mise/bin/gradle-with-version snapshot publishToMavenCentral"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -38,6 +38,7 @@ include(
   ":demo-app:android",
   ":demo-app:desktop",
   ":demo-app:desktop-glfw",
+  ":demo-app:desktop-nucleus",
   ":lib",
   ":lib:maplibre-compose",
   ":lib:maplibre-compose-material3",


### PR DESCRIPTION
Adds a `demo-app/desktop-nucleus` fixture that runs the shared demo on [Nucleus](https://nucleusframework.dev/en/) via `rememberTaoGpuRenderContext`, mirroring the compose-glfw host.

