### PR TITLE
Expose CameraStateSaver as public API

### DIFF
--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/CameraStateSaver.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/CameraStateSaver.kt
@@ -9,7 +9,8 @@ import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import org.maplibre.spatialk.geojson.Position
 
-internal object CameraStateSaver : Saver<CameraState, Map<String, Double>> {
+/** Saves and restores a [CameraState] with `rememberSaveable`. */
+public object CameraStateSaver : Saver<CameraState, Map<String, Double>> {
   override fun SaverScope.save(value: CameraState): Map<String, Double> {
     val position = value.position
     return mapOf(


### PR DESCRIPTION
## Description

Makes `CameraStateSaver` public so callers can use `CameraState` with `rememberSaveable` outside `rememberCameraState`; closes #721.

## Test plan

Ran `JAVA_HOME=/tmp/maplibre-jdk25/zulu25.36.15-ca-jdk25.0.4-macosx_aarch64/Contents/Home ./gradlew --no-daemon :lib:maplibre-compose:compileKotlinJvm` successfully on macOS.

## Checklist

**To your knowledge, are you making any breaking changes?**

No; this is an additive public API change.

**Have you tested the changes? On which platforms?**

- Desktop: compiled the JVM library target on macOS.

## AI assistance

- **Tools:** Codex
- **Context:** Codex helped inspect the existing API and contribution rules, draft the visibility and KDoc change, and run the validation command; this PR remains a draft for the account owner's review under the repository AI policy.
