### PR TITLE
Make iOS interop interaction configurable

### DIFF
--- a/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/map/GestureOptions.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/map/GestureOptions.kt
@@ -1,6 +1,8 @@
 package org.maplibre.compose.map
 
 import androidx.compose.runtime.Immutable
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.viewinterop.UIKitInteropInteractionMode
 import kotlin.Boolean
 
 /**
@@ -13,14 +15,18 @@ import kotlin.Boolean
  *   by double tapping, holding, and moving the finger up and down.
  * @param isHapticFeedbackEnabled Set whether the user receives haptic feedback when rotating the
  *   map to due north.
+ * @param interactionMode Controls how Compose and the embedded map coordinate touch input.
  */
 @Immutable
+@OptIn(ExperimentalComposeUiApi::class)
 public actual data class GestureOptions(
   public val isRotateEnabled: Boolean = true,
   public val isScrollEnabled: Boolean = true,
   public val isTiltEnabled: Boolean = true,
   public val isZoomEnabled: Boolean = true,
   public val isHapticFeedbackEnabled: Boolean = true,
+  public val interactionMode: UIKitInteropInteractionMode =
+    UIKitInteropInteractionMode.NonCooperative,
 ) {
   public actual companion object Companion {
     public actual val Standard: GestureOptions = GestureOptions()

--- a/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/map/IosMapView.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/map/IosMapView.kt
@@ -46,6 +46,7 @@ internal actual fun ComposableMapView(
     onReset = onReset,
     logger = logger,
     callbacks = callbacks,
+    interactionMode = options.gestureOptions.interactionMode,
   )
 }
 
@@ -58,6 +59,7 @@ internal fun IosMapView(
   onReset: () -> Unit,
   logger: Logger?,
   callbacks: MapAdapter.Callbacks,
+  interactionMode: UIKitInteropInteractionMode,
 ) {
   var consumedInsets by remember { mutableStateOf(WindowInsets(0, 0, 0, 0)) }
   val insetPadding = WindowInsets.safeDrawing.afterConsuming(consumedInsets).asPaddingValues()
@@ -71,8 +73,7 @@ internal fun IosMapView(
 
     UIKitView(
       modifier = modifier.fillMaxSize(),
-      properties =
-        UIKitInteropProperties(interactionMode = UIKitInteropInteractionMode.NonCooperative),
+      properties = UIKitInteropProperties(interactionMode = interactionMode),
       factory = {
         val frame =
           CGRectMake(


### PR DESCRIPTION
## Description

Adds an iOS `GestureOptions.interactionMode` setting and passes it to `UIKitView`, preserving `NonCooperative` as the default; closes #708.

## Test plan

Ran `git diff --check` and attempted `compileKotlinIosSimulatorArm64`; the host's Xcode 27 stops SwiftPM first because it no longer supports the repository's iOS 12 deployment target, while a manual Swift package build succeeds with an iOS 15 target.

## Checklist

**To your knowledge, are you making any breaking changes?**

No; the new parameter defaults to the existing `NonCooperative` behavior.

**Have you tested the changes? On which platforms?**

- iOS: source and formatting checks completed; full compilation is pending CI on a supported Xcode toolchain.

## AI assistance

- **Tools:** Codex
- **Context:** Codex helped inspect the iOS map and gesture option flow, draft the focused API change, and diagnose the local Xcode deployment-target failure; this PR remains a draft for the account owner's review under the repository AI policy.
