### PR TITLE
Pin the local GL JS worker in MapFixture tests

### DIFF
--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/testing/GlJsMapFixture.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/testing/GlJsMapFixture.kt
@@ -12,7 +12,9 @@ import kotlinx.coroutines.promise
 import org.khronos.webgl.Uint8Array
 import org.khronos.webgl.get
 import org.maplibre.compose.gljs.GlJsFrameTarget
+import org.maplibre.compose.gljs.GlJsRuntime
 import org.maplibre.compose.gljs.GlJsSurfaceSession
+import org.maplibre.compose.gljs.LOCAL_WORKER_URL
 import org.maplibre.compose.gljs.yieldToBrowser
 import org.maplibre.compose.map.GestureTarget
 import org.maplibre.compose.map.GlJsMapSession
@@ -139,7 +141,12 @@ internal class GlJsMapFixture(private val extent: MapExtent) : MapFixture {
   }
 }
 
-internal actual fun createMapFixture(extent: MapExtent): MapFixture = GlJsMapFixture(extent)
+internal actual fun createMapFixture(extent: MapExtent): MapFixture {
+  // `pointAtWorker` keeps the first call. Pin the Karma-served worker here so a MapFixture
+  // test that runs before `runBrowserMapTest` still keeps the suite off the CDN.
+  GlJsRuntime.pointAtWorker(LOCAL_WORKER_URL)
+  return GlJsMapFixture(extent)
+}
 
 internal actual val mapLibreFlavor: MapLibreFlavor = MapLibreFlavor.GL_JS
 
@@ -150,5 +157,7 @@ internal actual val mapLibreFlavor: MapLibreFlavor = MapLibreFlavor.GL_JS
 
 actual typealias MapTestResult = JsPromise
 
-internal actual fun runMapTest(block: suspend () -> Unit): MapTestResult =
-  MainScope().promise { block() }.unsafeCast<JsPromise>()
+internal actual fun runMapTest(block: suspend () -> Unit): MapTestResult {
+  GlJsRuntime.pointAtWorker(LOCAL_WORKER_URL)
+  return MainScope().promise { block() }.unsafeCast<JsPromise>()
+}


### PR DESCRIPTION
## Description
Pin Karma's local MapLibre worker before any MapFixture test builds a map, so an earlier suite cannot lock later tests onto the CDN URL.

## Test plan
`mise run test:js` (142 tests, 0 failures locally with Playwright Chrome 151).