### PR TITLE
Replace tap pairing flags with an explicit wait phase

### DIFF
--- a/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/map/MlnFfiMapInputTest.kt
+++ b/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/map/MlnFfiMapInputTest.kt
@@ -344,6 +344,32 @@ class MlnFfiMapInputTest {
   }
 
   @Test
+  fun a_long_click_on_a_paired_second_tap_does_not_report_the_first_tap() =
+    runInputTest(
+      gestures = GestureOptions(isQuickZoomEnabled = false),
+      focusWithMouse = false,
+    ) {
+      val map = onRoot()
+      map.performTouchInput {
+        down(center)
+        up()
+        advanceEventTime(SECOND_TAP_GAP_MILLIS)
+        down(center)
+      }
+      mainClock.advanceTimeBy(1_000)
+      waitUntil(timeoutMillis = TIMEOUT) { longClicks.size == 1 }
+      map.performTouchInput { up() }
+      waitForIdle()
+      assertEquals(0, clicks.size, "a paired long click reported the first tap as a map click")
+
+      map.performTouchInput { click(center) }
+      mainClock.advanceTimeBy(1_000)
+      waitForIdle()
+      assertEquals(1, clicks.size, "the next tap inherited a stale claimed first tap")
+      assertEquals(1, longClicks.size)
+    }
+
+  @Test
   fun one_finger_pans_the_map() =
     runInputTest(focusWithMouse = false) { camera ->
       val before = camera.position.target.longitude

--- a/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/map/MlnFfiMapInputTest.kt
+++ b/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/map/MlnFfiMapInputTest.kt
@@ -501,6 +501,9 @@ class MlnFfiMapInputTest {
         up()
       }
       awaitZoom(camera, START_ZOOM + 1.0)
+      mainClock.advanceTimeBy(1_000)
+      waitForIdle()
+      assertEquals(0, clicks.size, "a held second tap leaked the first tap as a map click")
     }
 
   @Test
@@ -625,6 +628,23 @@ class MlnFfiMapInputTest {
       } finally {
         mainClock.autoAdvance = true
       }
+    }
+
+  @Test
+  fun a_second_tap_inside_the_bounce_window_still_clicks_when_no_gesture_awaits_it() =
+    runInputTest(
+      gestures = GestureOptions(isDoubleClickZoomEnabled = false, isQuickZoomEnabled = false),
+      focusWithMouse = false,
+    ) {
+      onRoot().performTouchInput {
+        down(center)
+        up()
+        advanceEventTime(10)
+        down(center)
+        up()
+      }
+      waitForIdle()
+      assertEquals(2, clicks.size, "a bounce filter discarded a tap no gesture would pair")
     }
 
   @Test

--- a/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/map/MlnFfiMapInputTest.kt
+++ b/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/map/MlnFfiMapInputTest.kt
@@ -519,6 +519,41 @@ class MlnFfiMapInputTest {
     }
 
   @Test
+  fun a_bounce_does_not_reseed_the_double_tap_window() =
+    runInputTest(focusWithMouse = false) { camera ->
+      onRoot().performTouchInput {
+        down(center)
+        up()
+        advanceEventTime(10)
+        down(center)
+        up()
+        // Outside the original 300 ms window, but inside 300 ms of the bounce.
+        advanceEventTime(300)
+        down(center)
+        up()
+      }
+      mainClock.advanceTimeBy(1_000)
+      waitForIdle()
+      assertEquals(START_ZOOM, camera.position.zoom, ZOOM_TOLERANCE)
+    }
+
+  @Test
+  fun a_bounce_still_allows_a_later_tap_inside_the_original_window() =
+    runInputTest(focusWithMouse = false) { camera ->
+      onRoot().performTouchInput {
+        down(center)
+        up()
+        advanceEventTime(10)
+        down(center)
+        up()
+        advanceEventTime(70)
+        down(center)
+        up()
+      }
+      awaitZoom(camera, START_ZOOM + 1.0)
+    }
+
+  @Test
   fun a_touch_double_tap_may_land_inside_android_double_tap_slop() =
     runInputTest(focusWithMouse = false) { camera ->
       onRoot().performTouchInput {
@@ -653,6 +688,7 @@ class MlnFfiMapInputTest {
         camera.position.target.longitude != before.target.longitude
       }
       assertEquals(before.zoom, camera.position.zoom, ZOOM_TOLERANCE)
+      waitUntil(timeoutMillis = TIMEOUT) { clicks.size == 1 }
     }
 
   @Test

--- a/lib/maplibre-compose/src/nextCommonMain/kotlin/org/maplibre/compose/map/MapInput.kt
+++ b/lib/maplibre-compose/src/nextCommonMain/kotlin/org/maplibre/compose/map/MapInput.kt
@@ -226,6 +226,11 @@ private class MapPointerGesture(
   private var lastClickType = PointerType.Mouse
   /** Set on the second down when [isDoubleClick] pairs it to the previous up. */
   private var doubleClickCandidate = false
+  /**
+   * Set when this down is inside [doubleClickMinTimeMillis] of the previous up. Compose keeps
+   * waiting on the original pair, so this press leaves [lastClickAt] unchanged.
+   */
+  private var tooSoonForPair = false
   private var pendingTouchClick: PendingTouchClick? = null
 
   fun onPointerEvent(event: PointerEvent) {
@@ -284,7 +289,8 @@ private class MapPointerGesture(
     pressedType = change.type
     pressStartedAtMillis = change.uptimeMillis
     longClickHandled = false
-    doubleClickCandidate = isDoubleClick(change.position, change.uptimeMillis)
+    tooSoonForPair = isTooSoonForPair(change.uptimeMillis)
+    doubleClickCandidate = !tooSoonForPair && isDoubleClick(change.position, change.uptimeMillis)
     quickZoomCandidate =
       change.type != PointerType.Mouse && options.isQuickZoomEnabled && doubleClickCandidate
     quickZoomOriginY = change.position.y
@@ -293,7 +299,6 @@ private class MapPointerGesture(
     singleMotion = SingleMotion.NONE
     singleVelocity.resetTracking()
     singleVelocity.addPointerInputChange(change)
-    if (doubleClickCandidate && awaitsSecondTap()) cancelPendingTouchClick()
     deferredTwoFingerVelocity = null
     continuation.interrupt()
     runCatching { focusRequester.requestFocus() }
@@ -340,7 +345,8 @@ private class MapPointerGesture(
           lastClickAt = null
           quickZoomCandidate = false
           doubleClickCandidate = false
-          cancelPendingTouchClick()
+          tooSoonForPair = false
+          flushPendingTouchClick()
           return
         }
       } else if (abs(displacement.x) < dragSlopPx() && abs(displacement.y) < dragSlopPx()) {
@@ -350,7 +356,8 @@ private class MapPointerGesture(
       if (!canTransform) {
         lastClickAt = null
         doubleClickCandidate = false
-        cancelPendingTouchClick()
+        tooSoonForPair = false
+        flushPendingTouchClick()
         return
       }
       twoFingerTap = null
@@ -367,6 +374,8 @@ private class MapPointerGesture(
       singleMotion = SingleMotion.QUICK_ZOOM
       // The second tap now belongs to this drag; a later tap must start a fresh pair.
       lastClickAt = null
+      tooSoonForPair = false
+      cancelPendingTouchClick()
       val currentViewportSize = viewportSize()
       val targetDelta =
         GestureMath.quickZoomDelta(
@@ -391,6 +400,12 @@ private class MapPointerGesture(
         deferredTwoFingerVelocity = null
         if (singleMotion != SingleMotion.ROTATE_TILT) singleVelocity.resetTracking()
         singleMotion = SingleMotion.ROTATE_TILT
+        if (doubleClickCandidate || tooSoonForPair) {
+          lastClickAt = null
+          doubleClickCandidate = false
+          tooSoonForPair = false
+          flushPendingTouchClick()
+        }
         target.rotateAndPitchBy(
           bearingDelta = deltaX * options.dragRotateDegreesPerDp,
           pitchDelta = deltaY * options.dragPitchDegreesPerDp,
@@ -401,6 +416,12 @@ private class MapPointerGesture(
         deferredTwoFingerVelocity = null
         if (singleMotion != SingleMotion.PAN) singleVelocity.resetTracking()
         singleMotion = SingleMotion.PAN
+        if (doubleClickCandidate || tooSoonForPair) {
+          lastClickAt = null
+          doubleClickCandidate = false
+          tooSoonForPair = false
+          flushPendingTouchClick()
+        }
         target.moveBy(deltaX, deltaY, gestureToken = gestureToken)
         changed = true
       }
@@ -424,6 +445,7 @@ private class MapPointerGesture(
       clickOrigin = null
       quickZoomCandidate = false
       doubleClickCandidate = false
+      tooSoonForPair = false
       lastSingle = null
       mode = Mode.TWO_FINGER_UNDECIDED
       twoFingerStart = current
@@ -636,6 +658,7 @@ private class MapPointerGesture(
   private fun onRelease(event: PointerEvent) {
     val origin = clickOrigin
     val pairedSecondTap = doubleClickCandidate
+    val ignoreReleaseAsTap = tooSoonForPair
     val handledLongClick = longClickHandled
     val completedTwoFingerTap = twoFingerTap?.takeIf { it.isComplete(event) }
     cancelLongClick()
@@ -657,6 +680,7 @@ private class MapPointerGesture(
     longClickHandled = false
     quickZoomCandidate = false
     doubleClickCandidate = false
+    tooSoonForPair = false
     twoFingerTap = null
     mode = Mode.NONE
 
@@ -682,7 +706,7 @@ private class MapPointerGesture(
           gestureToken = token,
         )
       }
-    } else if (origin != null) {
+    } else if (origin != null && !ignoreReleaseAsTap) {
       onClick(origin, event.changes.firstOrNull()?.uptimeMillis ?: 0L, pairedSecondTap)
     }
   }
@@ -732,6 +756,12 @@ private class MapPointerGesture(
   /** Whether a second tap still has a gesture to become. */
   private fun awaitsSecondTap(): Boolean =
     options.isDoubleClickZoomEnabled || options.isQuickZoomEnabled
+
+  /** Compose ignores a down that arrives before [doubleClickMinTimeMillis]. */
+  private fun isTooSoonForPair(timeMillis: Long): Boolean {
+    val previousAt = lastClickAt ?: return false
+    return pressedType == lastClickType && timeMillis - previousAt < doubleClickMinTimeMillis
+  }
 
   /** Pairs this down to the previous up using Compose's window and Android's touch slop. */
   private fun isDoubleClick(origin: Offset, timeMillis: Long): Boolean {

--- a/lib/maplibre-compose/src/nextCommonMain/kotlin/org/maplibre/compose/map/MapInput.kt
+++ b/lib/maplibre-compose/src/nextCommonMain/kotlin/org/maplibre/compose/map/MapInput.kt
@@ -221,17 +221,13 @@ private class MapPointerGesture(
   private var longClickJob: Job? = null
   private var longClickHandled = false
 
-  private var lastClickAt: Long? = null
-  private var lastClickOrigin = Offset.Zero
-  private var lastClickType = PointerType.Mouse
-  /** Set on the second down when [isDoubleClick] pairs it to the previous up. */
-  private var doubleClickCandidate = false
   /**
-   * Set when this down is inside [doubleClickMinTimeMillis] of the previous up. Compose keeps
-   * waiting on the original pair, so this press leaves [lastClickAt] unchanged.
+   * Pairing state after a first tap. The delayed-click job exists only in [TapWait.Open]; a valid
+   * second down moves to [TapWait.Claimed] and cancels that job.
    */
-  private var tooSoonForPair = false
-  private var pendingTouchClick: PendingTouchClick? = null
+  private var tapWait: TapWait = TapWait.None
+  /** What this press is relative to [tapWait]. */
+  private var pressRole = PressRole.First
 
   fun onPointerEvent(event: PointerEvent) {
     // A wheel notch arrives here too, with nothing pressed, and would read as a release — closing
@@ -289,10 +285,16 @@ private class MapPointerGesture(
     pressedType = change.type
     pressStartedAtMillis = change.uptimeMillis
     longClickHandled = false
-    tooSoonForPair = isTooSoonForPair(change.uptimeMillis)
-    doubleClickCandidate = !tooSoonForPair && isDoubleClick(change.position, change.uptimeMillis)
+    pressRole = classifyPress(change.position, change.uptimeMillis, change.type)
+    when (pressRole) {
+      PressRole.First -> discardTapWait(emitClick = true)
+      PressRole.Paired -> claimOpenTap()
+      PressRole.Bounce -> Unit
+    }
     quickZoomCandidate =
-      change.type != PointerType.Mouse && options.isQuickZoomEnabled && doubleClickCandidate
+      change.type != PointerType.Mouse &&
+        options.isQuickZoomEnabled &&
+        pressRole == PressRole.Paired
     quickZoomOriginY = change.position.y
     quickZoomAppliedDelta = 0.0
     lastQuickZoomSpanDeltaPixels = 0.0
@@ -342,11 +344,8 @@ private class MapPointerGesture(
         if (abs(displacement.y) * 2f < scaleSlopPx) {
           if (abs(displacement.x) <= scaleSlopPx) return
           clickOrigin = null
-          lastClickAt = null
           quickZoomCandidate = false
-          doubleClickCandidate = false
-          tooSoonForPair = false
-          flushPendingTouchClick()
+          discardTapWait(emitClick = true)
           return
         }
       } else if (abs(displacement.x) < dragSlopPx() && abs(displacement.y) < dragSlopPx()) {
@@ -354,14 +353,13 @@ private class MapPointerGesture(
       }
       clickOrigin = null
       if (!canTransform) {
-        lastClickAt = null
-        doubleClickCandidate = false
-        tooSoonForPair = false
-        flushPendingTouchClick()
+        discardTapWait(emitClick = true)
         return
       }
       twoFingerTap = null
       beginGesture()
+      // Quick zoom consumes the first tap. A pan or rotate reports it instead.
+      discardTapWait(emitClick = !quickZoomCandidate)
     }
 
     val deltaX = (delta.x / density.density).toDouble()
@@ -372,10 +370,6 @@ private class MapPointerGesture(
       deferredTwoFingerVelocity = null
       mode = Mode.QUICK_ZOOM
       singleMotion = SingleMotion.QUICK_ZOOM
-      // The second tap now belongs to this drag; a later tap must start a fresh pair.
-      lastClickAt = null
-      tooSoonForPair = false
-      cancelPendingTouchClick()
       val currentViewportSize = viewportSize()
       val targetDelta =
         GestureMath.quickZoomDelta(
@@ -400,12 +394,6 @@ private class MapPointerGesture(
         deferredTwoFingerVelocity = null
         if (singleMotion != SingleMotion.ROTATE_TILT) singleVelocity.resetTracking()
         singleMotion = SingleMotion.ROTATE_TILT
-        if (doubleClickCandidate || tooSoonForPair) {
-          lastClickAt = null
-          doubleClickCandidate = false
-          tooSoonForPair = false
-          flushPendingTouchClick()
-        }
         target.rotateAndPitchBy(
           bearingDelta = deltaX * options.dragRotateDegreesPerDp,
           pitchDelta = deltaY * options.dragPitchDegreesPerDp,
@@ -416,12 +404,6 @@ private class MapPointerGesture(
         deferredTwoFingerVelocity = null
         if (singleMotion != SingleMotion.PAN) singleVelocity.resetTracking()
         singleMotion = SingleMotion.PAN
-        if (doubleClickCandidate || tooSoonForPair) {
-          lastClickAt = null
-          doubleClickCandidate = false
-          tooSoonForPair = false
-          flushPendingTouchClick()
-        }
         target.moveBy(deltaX, deltaY, gestureToken = gestureToken)
         changed = true
       }
@@ -440,12 +422,11 @@ private class MapPointerGesture(
     val current = TwoFingerSample(first, second)
     if (!mode.isTwoFinger) {
       cancelLongClick()
-      // A gesture from another pointer family breaks the mouse/touch click sequence.
-      lastClickAt = null
+      // A gesture from another pointer family closes the mouse/touch click sequence.
+      discardTapWait(emitClick = true)
       clickOrigin = null
       quickZoomCandidate = false
-      doubleClickCandidate = false
-      tooSoonForPair = false
+      pressRole = PressRole.First
       lastSingle = null
       mode = Mode.TWO_FINGER_UNDECIDED
       twoFingerStart = current
@@ -657,8 +638,8 @@ private class MapPointerGesture(
 
   private fun onRelease(event: PointerEvent) {
     val origin = clickOrigin
-    val pairedSecondTap = doubleClickCandidate
-    val ignoreReleaseAsTap = tooSoonForPair
+    val pairedSecondTap = pressRole == PressRole.Paired
+    val ignoreReleaseAsTap = pressRole == PressRole.Bounce
     val handledLongClick = longClickHandled
     val completedTwoFingerTap = twoFingerTap?.takeIf { it.isComplete(event) }
     cancelLongClick()
@@ -679,8 +660,7 @@ private class MapPointerGesture(
     clickOrigin = null
     longClickHandled = false
     quickZoomCandidate = false
-    doubleClickCandidate = false
-    tooSoonForPair = false
+    pressRole = PressRole.First
     twoFingerTap = null
     mode = Mode.NONE
 
@@ -715,6 +695,7 @@ private class MapPointerGesture(
     val where = origin.toLogicalDpOffset(density)
     if (pressedSecondary) {
       target.onSecondaryClick(where)
+      tapWait = TapWait.None
       return
     }
 
@@ -728,52 +709,97 @@ private class MapPointerGesture(
           gestureToken = token,
         )
       }
-      // Cleared so a third click starts a new pair rather than zooming again.
-      lastClickAt = null
-      cancelPendingTouchClick()
-    } else {
-      if (pressedType == PointerType.Mouse || !awaitsSecondTap()) {
-        // Mouse clicks are immediate; touch taps wait so a double tap never leaks a map click.
-        target.onPrimaryClick(where)
-      } else {
-        flushPendingTouchClick()
-        lateinit var job: Job
-        job = scope.launch {
-          delay(doubleClickTimeoutMillis)
-          if (pendingTouchClick?.job == job) {
-            pendingTouchClick = null
-            target.onPrimaryClick(where)
-          }
-        }
-        pendingTouchClick = PendingTouchClick(where, job)
-      }
-      lastClickAt = timeMillis
-      lastClickOrigin = origin
-      lastClickType = pressedType
+      tapWait = TapWait.None
+      return
     }
+
+    if (pressedType == PointerType.Mouse || !awaitsSecondTap()) {
+      // Mouse clicks are immediate; touch taps wait only when a second tap still has a gesture.
+      target.onPrimaryClick(where)
+    }
+    rememberFirstTap(where, origin, pressedType, timeMillis)
   }
 
   /** Whether a second tap still has a gesture to become. */
   private fun awaitsSecondTap(): Boolean =
     options.isDoubleClickZoomEnabled || options.isQuickZoomEnabled
 
-  /** Compose ignores a down that arrives before [doubleClickMinTimeMillis]. */
-  private fun isTooSoonForPair(timeMillis: Long): Boolean {
-    val previousAt = lastClickAt ?: return false
-    return pressedType == lastClickType && timeMillis - previousAt < doubleClickMinTimeMillis
+  /** What this down is relative to a [TapWait.Open] first tap. */
+  private fun classifyPress(origin: Offset, timeMillis: Long, type: PointerType): PressRole {
+    val open = tapWait as? TapWait.Open ?: return PressRole.First
+    if (!awaitsSecondTap()) return PressRole.First
+    val elapsedMillis = timeMillis - open.tap.upAt
+    val samePointerType = type == open.tap.type
+    if (samePointerType && elapsedMillis < doubleClickMinTimeMillis) return PressRole.Bounce
+    return if (
+      isPairedSecondTap(
+        elapsedMillis = elapsedMillis,
+        distancePx = (origin - open.tap.origin).getDistance(),
+        samePointerType = samePointerType,
+        minTimeMillis = doubleClickMinTimeMillis,
+        timeoutMillis = doubleClickTimeoutMillis,
+        slopPx = slopPx(),
+      )
+    ) {
+      PressRole.Paired
+    } else {
+      PressRole.First
+    }
   }
 
-  /** Pairs this down to the previous up using Compose's window and Android's touch slop. */
-  private fun isDoubleClick(origin: Offset, timeMillis: Long): Boolean {
-    val previousAt = lastClickAt ?: return false
-    return isPairedSecondTap(
-      elapsedMillis = timeMillis - previousAt,
-      distancePx = (origin - lastClickOrigin).getDistance(),
-      samePointerType = pressedType == lastClickType,
-      minTimeMillis = doubleClickMinTimeMillis,
-      timeoutMillis = doubleClickTimeoutMillis,
-      slopPx = slopPx(),
-    )
+  /** A valid second down claims the first tap and stops the delayed click. */
+  private fun claimOpenTap() {
+    val open = tapWait as? TapWait.Open ?: return
+    open.tap.job?.cancel()
+    tapWait = TapWait.Claimed(open.tap.copy(job = null))
+  }
+
+  /**
+   * Opens the pairing window after a first tap. Touch reports the click when the window expires;
+   * mouse already reported it on the up.
+   */
+  private fun rememberFirstTap(
+    where: DpOffset,
+    origin: Offset,
+    type: PointerType,
+    timeMillis: Long,
+  ) {
+    if (!awaitsSecondTap()) {
+      tapWait = TapWait.None
+      return
+    }
+    val clickOnExpiry = type != PointerType.Mouse
+    val job =
+      if (clickOnExpiry) {
+        lateinit var launched: Job
+        launched = scope.launch {
+          delay(doubleClickTimeoutMillis)
+          val open = tapWait as? TapWait.Open
+          if (open?.tap?.job == launched) {
+            tapWait = TapWait.None
+            target.onPrimaryClick(where)
+          }
+        }
+        launched
+      } else {
+        null
+      }
+    tapWait = TapWait.Open(OpenTap(where, origin, type, timeMillis, clickOnExpiry, job))
+  }
+
+  /** Closes [tapWait]. [emitClick] reports a touch first tap that was still waiting. */
+  private fun discardTapWait(emitClick: Boolean) {
+    when (val wait = tapWait) {
+      is TapWait.Open -> {
+        wait.tap.job?.cancel()
+        if (emitClick && wait.tap.clickOnExpiry) target.onPrimaryClick(wait.tap.where)
+      }
+      is TapWait.Claimed -> {
+        if (emitClick && wait.tap.clickOnExpiry) target.onPrimaryClick(wait.tap.where)
+      }
+      TapWait.None -> Unit
+    }
+    tapWait = TapWait.None
   }
 
   private fun slopPx(): Float =
@@ -935,18 +961,6 @@ private class MapPointerGesture(
     }
   }
 
-  private fun cancelPendingTouchClick() {
-    pendingTouchClick?.job?.cancel()
-    pendingTouchClick = null
-  }
-
-  private fun flushPendingTouchClick() {
-    val pending = pendingTouchClick ?: return
-    pending.job.cancel()
-    pendingTouchClick = null
-    target.onPrimaryClick(pending.where)
-  }
-
   private fun endDrag(followUpDuration: Duration) {
     cancelLongClick()
     if (!gestureInProgress) return
@@ -975,7 +989,8 @@ private class MapPointerGesture(
     cancelLongClick()
     longClickHandled = false
     deferredTwoFingerVelocity = null
-    cancelPendingTouchClick()
+    discardTapWait(emitClick = false)
+    pressRole = PressRole.First
     if (gestureInProgress) {
       gestureInProgress = false
       continuation.cancel()
@@ -1051,7 +1066,38 @@ private class MapPointerGesture(
         abs(second.y - other.second.y) >= slopPixels
   }
 
-  private data class PendingTouchClick(val where: DpOffset, val job: Job)
+  /**
+   * Pairing window after a first tap. The delayed-click job lives only in [Open]. [Claimed] is a
+   * valid second down; that job is already gone.
+   */
+  private sealed class TapWait {
+    data object None : TapWait()
+
+    data class Open(val tap: OpenTap) : TapWait()
+
+    data class Claimed(val tap: OpenTap) : TapWait()
+  }
+
+  /**
+   * The first tap [TapWait] is pairing.
+   *
+   * [clickOnExpiry] is a touch tap that waited for a second tap. A mouse click already reported on
+   * the first up, so expiry only closes the window.
+   */
+  private data class OpenTap(
+    val where: DpOffset,
+    val origin: Offset,
+    val type: PointerType,
+    val upAt: Long,
+    val clickOnExpiry: Boolean,
+    val job: Job?,
+  )
+
+  private enum class PressRole {
+    First,
+    Bounce,
+    Paired,
+  }
 
   private data class TwoFingerTapCandidate(
     val startedAtMillis: Long,

--- a/lib/maplibre-compose/src/nextCommonMain/kotlin/org/maplibre/compose/map/MapInput.kt
+++ b/lib/maplibre-compose/src/nextCommonMain/kotlin/org/maplibre/compose/map/MapInput.kt
@@ -315,6 +315,8 @@ private class MapPointerGesture(
         if (clickOrigin == origin && !gestureInProgress && mode == Mode.SINGLE) {
           longClickHandled = true
           clickOrigin = null
+          // This press is a long click, including a paired second tap that was held.
+          discardTapWait(emitClick = false)
           continuation.finish(target::onGestureEnded)
           target.onSecondaryClick(origin.toLogicalDpOffset(density))
         }
@@ -688,6 +690,8 @@ private class MapPointerGesture(
       }
     } else if (origin != null && !ignoreReleaseAsTap) {
       onClick(origin, event.changes.firstOrNull()?.uptimeMillis ?: 0L, pairedSecondTap)
+    } else if (handledLongClick) {
+      discardTapWait(emitClick = false)
     }
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

MapInput now pairs taps with an Open/Claimed wait phase so the delayed first-tap click exists only until a valid second down claims it.

## Test plan

`./gradlew :lib:maplibre-compose:jvmTest --tests org.maplibre.compose.map.MlnFfiMapInputTest --tests org.maplibre.compose.map.TapPairingTest` plus the held-second-tap, bounce-with-zoom-off, and paired-long-click cases.

## Checklist

**To your knowledge, are you making any breaking changes?**

No.

**Have you tested the changes? On which platforms?**

- Desktop: JVM Compose UI tests for MapInput

## AI assistance

- **Tools:** Cursor
- **Context:** Follow-up to #924 / #925 review comments on leaked clicks, bounce filtering, and a stale claim after a paired long click.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-581bb49e-2ce8-4fcb-b4c8-0c95dbe74cc6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-581bb49e-2ce8-4fcb-b4c8-0c95dbe74cc6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

