### PR TITLE
Add macOS desktop location backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ maps to your Compose UIs across Android, iOS, Desktop, and Web.
 ## Progress
 
 See [the status table][status] for a breakdown of supported features on each
-platform. Android, iOS, and Desktop have the most complete support; Desktop's
-one remaining gap is showing the user's location. Web covers the same styling
-and camera API, without offline packs or location.
+platform. Android, iOS, and Desktop have the most complete support; Desktop
+still needs user location on Windows. Web covers the same styling and camera
+API, without offline packs or location.
 
 | Target  | Progress                                                             |
 | ------- | -------------------------------------------------------------------- |

--- a/demo-app/desktop-glfw/build.gradle.kts
+++ b/demo-app/desktop-glfw/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.compose.desktop.application.dsl.TargetFormat
+
 plugins {
   id("module-conventions")
   id(libs.plugins.kotlin.jvm.get().pluginId)
@@ -22,26 +24,57 @@ dependencies {
 }
 
 /**
- * Runs the fixture. A plain `JavaExec` rather than the Compose Desktop application plugin, which
- * packages an AWT/Skiko application. Both JVM arguments are mandatory: GLFW must own AppKit's first
- * thread on macOS, and the FFI binding is refused native access without the other.
+ * Packages the compose-glfw host without `compose.desktop.currentOs`, so this module stays off the
+ * AWT runtime classpath. The module exists so its `MainDispatcherFactory`, which outranks
+ * `kotlinx-coroutines-swing`, never reaches the AWT demo.
  *
- * This stays a module of its own so that its `MainDispatcherFactory` service, which outranks
- * `kotlinx-coroutines-swing`, never reaches the AWT demo's runtime classpath.
+ * GLFW must own AppKit's first thread on macOS, and the FFI binding is refused native access
+ * without `--enable-native-access`.
  */
-val run by
-  tasks.registering(JavaExec::class) {
-    group = "application"
-    description = "Runs the compose-glfw desktop host fixture."
-
-    val sourceSets = extensions.getByType<SourceSetContainer>()
-    classpath = sourceSets.getByName("main").runtimeClasspath
+compose.desktop {
+  application {
     mainClass = "org.maplibre.compose.glfw.MainKt"
-    jvmArgs(NATIVE_ACCESS_JVM_ARGS)
+    jvmArgs += NATIVE_ACCESS_JVM_ARGS
     if (System.getProperty("os.name").lowercase().startsWith("mac")) {
-      jvmArgs("-XstartOnFirstThread")
+      jvmArgs += "-XstartOnFirstThread"
     }
-    javaLauncher = javaToolchains.launcherFor {
-      languageVersion = JavaLanguageVersion.of(libs.versions.java.toolchain.get().toInt())
+
+    nativeDistributions {
+      // jpackage runs jlink against this JDK, so it decides the Java version inside the installed
+      // application; without it the packaged app takes whatever JDK Gradle runs on, which can be
+      // older than the 24 the MapLibre Native FFI binding requires.
+      javaHome =
+        javaToolchains
+          .launcherFor {
+            languageVersion.set(JavaLanguageVersion.of(libs.versions.java.toolchain.get().toInt()))
+          }
+          .get()
+          .metadata
+          .installationPath
+          .asFile
+          .absolutePath
+
+      targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
+      packageName = "org.maplibre.compose.demoapp.glfw"
+      // https://youtrack.jetbrains.com/issue/CMP-2360
+      // packageVersion = providers.gradleProperty("maplibreReleaseVersion").get()
+      packageVersion = "1.0.0"
+
+      macOS {
+        val entitlements = project(":demo-app:desktop").file("entitlements.plist")
+        entitlementsFile.set(entitlements)
+        runtimeEntitlementsFile.set(entitlements)
+        infoPlist {
+          extraKeysRawXml =
+            """
+            <key>NSLocationWhenInUseUsageDescription</key>
+            <string>Example</string>
+            <key>NSLocationUsageDescription</key>
+            <string>Example</string>
+            """
+              .trimIndent()
+        }
+      }
     }
   }
+}

--- a/demo-app/desktop-glfw/src/main/kotlin/org/maplibre/compose/glfw/Main.kt
+++ b/demo-app/desktop-glfw/src/main/kotlin/org/maplibre/compose/glfw/Main.kt
@@ -18,8 +18,8 @@ import org.maplibre.compose.desktop.ProvideMapHost
  * The same `DemoApp` the Compose Desktop demo runs, in a GLFW window instead of an AWT one; the
  * only difference is which `ComposeMapHost` is in scope.
  *
- * Run it with `./gradlew :glfw-fixture:runGlfwFixture`. On macOS the launcher must pass
- * `-XstartOnFirstThread`; the Gradle task does.
+ * Run it with `mise run demo:desktop-glfw`. On macOS the launcher must pass `-XstartOnFirstThread`;
+ * the Gradle task does.
  */
 fun main() {
   MapLibre.configure(applicationId = "org.maplibre.compose.glfw-fixture")

--- a/demo-app/desktop/build.gradle.kts
+++ b/demo-app/desktop/build.gradle.kts
@@ -48,6 +48,23 @@ compose.desktop {
       // https://youtrack.jetbrains.com/issue/CMP-2360
       // packageVersion = providers.gradleProperty("maplibreReleaseVersion").get()
       packageVersion = "1.0.0"
+
+      macOS {
+        // jpackage signs with the hardened runtime. Core Location ignores authorization
+        // requests unless that runtime also has the location entitlement.
+        entitlementsFile.set(file("entitlements.plist"))
+        runtimeEntitlementsFile.set(file("entitlements.plist"))
+        infoPlist {
+          extraKeysRawXml =
+            """
+            <key>NSLocationWhenInUseUsageDescription</key>
+            <string>Example</string>
+            <key>NSLocationUsageDescription</key>
+            <string>Example</string>
+            """
+              .trimIndent()
+        }
+      }
     }
   }
 }

--- a/demo-app/desktop/entitlements.plist
+++ b/demo-app/desktop/entitlements.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+  <key>com.apple.security.personal-information.location</key>
+  <true/>
+</dict>
+</plist>

--- a/docs/src/content/docs/index.md
+++ b/docs/src/content/docs/index.md
@@ -41,7 +41,7 @@ to express an interactive map API in Compose.
 | Add images to the style                           |           ✅           |           ✅           |           ✅           |           ✅           |     ❌     |
 | Add Material 3 controls                           |           ✅           |           ✅           |           ✅           |           ✅           |     ❌     |
 | Download offline regions                          |           ✅           |           ✅           |           ✅           |           ❌           |     ❌     |
-| Show the user's location                          |           ✅           |           ✅           |       Linux only       |           ✅           |     ❌     |
+| Show the user's location                          |           ✅           |           ✅           |      Linux, macOS      |           ✅           |     ❌     |
 | Snapshot the map as an image                      |           ❌           |           ❌           |           ❌           |           ❌           |     ❌     |
 
 [compose]: https://www.jetbrains.com/compose-multiplatform/

--- a/docs/src/content/docs/location.mdx
+++ b/docs/src/content/docs/location.mdx
@@ -27,8 +27,9 @@ to permission and lifecycle state. `LocationPuck` draws the latest fix, and
 | **`LocationPuck`**                               | Visual indicator that displays the user's current position and bearing on the map. |
 | **`LocationTrackingEffect`**                     | Applies location changes to application or camera state.                           |
 
-Android and iOS provide default location and orientation providers. Web and
-Linux provide default location providers but no default orientation readings.
+Android and iOS provide default location and orientation providers. Web, Linux,
+and macOS provide default location providers but no default orientation
+readings.
 `LocationState.status` reports unsupported or misconfigured
 location setup without throwing.
 
@@ -139,3 +140,19 @@ window. A custom X11 or Wayland host can expose its window through
 Each desktop rendering runtime installs its matching backend. A missing backend
 reports an unsupported backend, and multiple backends report a configuration
 failure through `LocationState.status`.
+
+#### macOS desktop
+
+The backend uses
+[`CLLocationManager`](https://developer.apple.com/documentation/corelocation/cllocationmanager)
+on the AppKit main run loop. Compose Desktop's `Dispatchers.Main` is the Swing
+event-dispatch thread on the AWT host. The backend hops Core Location work to
+that run loop itself. Declare `NSLocationWhenInUseUsageDescription` in the app
+Info.plist. A sandboxed or hardened-runtime app also declares the
+`com.apple.security.personal-information.location` entitlement. jpackage
+enables the hardened runtime. Core Location reads those keys from the main
+bundle of a packaged `.app`. An unpackaged `java` process uses the JDK
+bundle. The backend reports that as a misconfiguration. The desktop demo's
+macOS task runs the packaged app.
+
+`minimumInterval` is ignored because Core Location filters only by distance.

--- a/docs/src/content/docs/location.mdx
+++ b/docs/src/content/docs/location.mdx
@@ -143,16 +143,10 @@ failure through `LocationState.status`.
 
 #### macOS desktop
 
-The backend uses
-[`CLLocationManager`](https://developer.apple.com/documentation/corelocation/cllocationmanager)
-on the AppKit main run loop. Compose Desktop's `Dispatchers.Main` is the Swing
-event-dispatch thread on the AWT host. The backend hops Core Location work to
-that run loop itself. Declare `NSLocationWhenInUseUsageDescription` in the app
-Info.plist. A sandboxed or hardened-runtime app also declares the
-`com.apple.security.personal-information.location` entitlement. jpackage
-enables the hardened runtime. Core Location reads those keys from the main
-bundle of a packaged `.app`. An unpackaged `java` process uses the JDK
-bundle. The backend reports that as a misconfiguration. The desktop demo's
-macOS task runs the packaged app.
+The backend uses Core Location. Add the
+[location usage description](https://developer.apple.com/documentation/corelocation/requesting-authorization-to-use-location-services)
+and
+[location entitlement](https://developer.apple.com/documentation/bundleresources/entitlements/com.apple.security.personal-information.location)
+that Apple requires.
 
 `minimumInterval` is ignored because Core Location filters only by distance.

--- a/docs/src/content/docs/roadmap.md
+++ b/docs/src/content/docs/roadmap.md
@@ -37,9 +37,9 @@ integration point rather than something wired into Skiko's internals.
 
 Next steps:
 
-- Add support for platform location services on macOS and Windows. Linux uses
-  the XDG Location portal. Desktop orientation providers still need platform
-  sensor integrations.
+- Add support for platform location services on Windows. Linux uses the XDG
+  Location portal, and macOS uses Core Location. Desktop orientation providers
+  still need platform sensor integrations.
 
 ### [Native core integration on Android and iOS](https://github.com/maplibre/maplibre-compose/issues/572)
 

--- a/lib/maplibre-compose-macos/MODULE.md
+++ b/lib/maplibre-compose-macos/MODULE.md
@@ -1,3 +1,3 @@
 # Module maplibre-compose-macos
 
-macOS integrations for MapLibre Compose applications.
+Core Location backend for MapLibre Compose desktop applications on macOS.

--- a/lib/maplibre-compose-macos/build.gradle.kts
+++ b/lib/maplibre-compose-macos/build.gradle.kts
@@ -28,4 +28,6 @@ dependencies {
   testImplementation(libs.kotlinx.coroutines.test)
 }
 
+tasks.test { jvmArgs(NATIVE_ACCESS_JVM_ARGS) }
+
 tasks.register("jvmTest") { dependsOn(tasks.test) }

--- a/lib/maplibre-compose-macos/build.gradle.kts
+++ b/lib/maplibre-compose-macos/build.gradle.kts
@@ -21,8 +21,11 @@ kotlin {
 
 dependencies {
   api(project(":lib:maplibre-compose"))
+  implementation(libs.lwjgl.core)
+  implementation(libs.kotlinx.coroutines.core)
 
   testImplementation(kotlin("test"))
+  testImplementation(libs.kotlinx.coroutines.test)
 }
 
 tasks.register("jvmTest") { dependsOn(tasks.test) }

--- a/lib/maplibre-compose-macos/src/main/kotlin/org/maplibre/compose/location/desktop/macos/CocoaMain.kt
+++ b/lib/maplibre-compose-macos/src/main/kotlin/org/maplibre/compose/location/desktop/macos/CocoaMain.kt
@@ -1,0 +1,108 @@
+package org.maplibre.compose.location.desktop.macos
+
+import java.lang.foreign.Arena
+import java.lang.foreign.FunctionDescriptor
+import java.lang.foreign.Linker
+import java.lang.foreign.MemorySegment
+import java.lang.foreign.ValueLayout.ADDRESS
+import java.lang.invoke.MethodHandles
+import java.lang.invoke.MethodType
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
+import org.lwjgl.system.MemoryUtil.NULL
+import org.lwjgl.system.macosx.DynamicLinkLoader.RTLD_LOCAL
+import org.lwjgl.system.macosx.DynamicLinkLoader.RTLD_NOW
+import org.lwjgl.system.macosx.DynamicLinkLoader.dlerror
+import org.lwjgl.system.macosx.DynamicLinkLoader.dlopen
+import org.lwjgl.system.macosx.DynamicLinkLoader.dlsym
+
+/**
+ * Runs work on the AppKit main run loop.
+ *
+ * Compose Desktop's `Dispatchers.Main` is the Swing event-dispatch thread on the AWT host. That
+ * thread does not pump a Cocoa `CFRunLoop`. Core Location delivers delegate callbacks on the run
+ * loop of the thread that created the manager, so location and authorization work has to hop here
+ * rather than to `Dispatchers.Main`.
+ *
+ * `dispatch_sync_f` deadlocks if the caller is already on that run loop, so [run] executes inline
+ * when
+ * [NSThread isMainThread](https://developer.apple.com/documentation/foundation/nsthread/ismainthread)
+ * is true.
+ */
+internal object CocoaMain {
+  private val linker = Linker.nativeLinker()
+  private val stubs = Arena.ofShared()
+  private val jobs = ConcurrentHashMap<Long, Runnable>()
+  private val nextId = AtomicLong(1)
+  private val dispatchLibrary: Long by lazy {
+    val handle = dlopen("/usr/lib/system/libdispatch.dylib", RTLD_NOW or RTLD_LOCAL)
+    check(handle != NULL) { "Failed to load libdispatch: ${dlerror()}" }
+    handle
+  }
+  private val mainQueue: MemorySegment by lazy {
+    val address = dlsym(dispatchLibrary, "_dispatch_main_q")
+    check(address != NULL) { "Failed to resolve _dispatch_main_q: ${dlerror()}" }
+    MemorySegment.ofAddress(address)
+  }
+  private val dispatchSyncF by lazy {
+    val address = dlsym(dispatchLibrary, "dispatch_sync_f")
+    check(address != NULL) { "Failed to resolve dispatch_sync_f: ${dlerror()}" }
+    linker.downcallHandle(
+      MemorySegment.ofAddress(address),
+      FunctionDescriptor.ofVoid(ADDRESS, ADDRESS, ADDRESS),
+    )
+  }
+  private val workStub: MemorySegment by lazy {
+    val handle =
+      MethodHandles.lookup()
+        .findStatic(
+          CocoaMain::class.java,
+          "invokeWork",
+          MethodType.methodType(Void.TYPE, MemorySegment::class.java),
+        )
+    linker.upcallStub(handle, FunctionDescriptor.ofVoid(ADDRESS), stubs)
+  }
+
+  fun <T> run(action: () -> T): T = run(isMainThread(), ::dispatchSyncToMain, action)
+
+  internal fun <T> run(
+    alreadyOnMain: Boolean,
+    dispatch: (Runnable) -> Unit,
+    action: () -> T,
+  ): T {
+    if (alreadyOnMain) return action()
+    val job = SyncJob(action)
+    dispatch(job)
+    return job.get()
+  }
+
+  fun isMainThread(): Boolean {
+    ObjectiveC.loadFramework("Foundation")
+    return ObjectiveC.sendLong(ObjectiveC.cls("NSThread"), "isMainThread") != 0L
+  }
+
+  private fun dispatchSyncToMain(work: Runnable) {
+    val id = nextId.incrementAndGet()
+    jobs[id] = work
+    try {
+      dispatchSyncF.invoke(mainQueue, MemorySegment.ofAddress(id), workStub)
+    } finally {
+      jobs.remove(id)
+    }
+  }
+
+  @JvmStatic
+  fun invokeWork(context: MemorySegment) {
+    jobs[context.address()]?.run()
+  }
+
+  private class SyncJob<T>(private val action: () -> T) : Runnable {
+    private var result: Result<T>? = null
+
+    override fun run() {
+      result = runCatching(action)
+    }
+
+    fun get(): T = checkNotNull(result) { "AppKit main-queue work did not run" }.getOrThrow()
+  }
+}

--- a/lib/maplibre-compose-macos/src/main/kotlin/org/maplibre/compose/location/desktop/macos/CoreLocation.kt
+++ b/lib/maplibre-compose-macos/src/main/kotlin/org/maplibre/compose/location/desktop/macos/CoreLocation.kt
@@ -35,7 +35,14 @@ internal const val CL_LOCATION_ACCURACY_BEST_FOR_NAVIGATION = -2.0
 internal const val CL_LOCATION_ACCURACY_BEST = -1.0
 internal const val CL_LOCATION_ACCURACY_HUNDRED_METERS = 100.0
 internal const val CL_LOCATION_ACCURACY_KILOMETER = 1000.0
-internal const val CL_LOCATION_ACCURACY_REDUCED = 500.0
+
+/** Fallback when `kCLLocationAccuracyReduced` cannot be resolved, such as off macOS. */
+internal const val CL_LOCATION_ACCURACY_REDUCED_FALLBACK = 6_380_000.0
+
+internal val CL_LOCATION_ACCURACY_REDUCED: Double by lazy {
+  ObjectiveC.exportedDoubleOrNull("kCLLocationAccuracyReduced")
+    ?: CL_LOCATION_ACCURACY_REDUCED_FALLBACK
+}
 
 internal data class CoreLocationFix(
   val latitude: Double,

--- a/lib/maplibre-compose-macos/src/main/kotlin/org/maplibre/compose/location/desktop/macos/CoreLocation.kt
+++ b/lib/maplibre-compose-macos/src/main/kotlin/org/maplibre/compose/location/desktop/macos/CoreLocation.kt
@@ -1,0 +1,163 @@
+package org.maplibre.compose.location.desktop.macos
+
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeSource
+import org.maplibre.compose.location.BearingWithAccuracy
+import org.maplibre.compose.location.Location
+import org.maplibre.compose.location.LocationAccuracy
+import org.maplibre.compose.location.LocationAccuracyAuthorization
+import org.maplibre.compose.location.LocationBackendAvailability
+import org.maplibre.compose.location.LocationPermission
+import org.maplibre.compose.location.LocationUnavailableReason
+import org.maplibre.compose.location.PositionWithAccuracy
+import org.maplibre.compose.location.SpeedWithAccuracy
+import org.maplibre.spatialk.geojson.Position
+import org.maplibre.spatialk.units.Bearing
+import org.maplibre.spatialk.units.extensions.degrees
+import org.maplibre.spatialk.units.extensions.meters
+
+internal const val CL_ERROR_DOMAIN = "kCLErrorDomain"
+internal const val CL_ERROR_LOCATION_UNKNOWN = 0L
+internal const val CL_ERROR_DENIED = 1L
+internal const val CL_ERROR_NETWORK = 2L
+internal const val CL_ERROR_PROMPT_DECLINED = 18L
+
+internal const val CL_AUTHORIZATION_NOT_DETERMINED = 0L
+internal const val CL_AUTHORIZATION_RESTRICTED = 1L
+internal const val CL_AUTHORIZATION_DENIED = 2L
+internal const val CL_AUTHORIZATION_AUTHORIZED_ALWAYS = 3L
+internal const val CL_AUTHORIZATION_AUTHORIZED_WHEN_IN_USE = 4L
+
+internal const val CL_ACCURACY_AUTHORIZATION_FULL = 0L
+
+internal const val CL_LOCATION_ACCURACY_BEST_FOR_NAVIGATION = -2.0
+internal const val CL_LOCATION_ACCURACY_BEST = -1.0
+internal const val CL_LOCATION_ACCURACY_HUNDRED_METERS = 100.0
+internal const val CL_LOCATION_ACCURACY_KILOMETER = 1000.0
+internal const val CL_LOCATION_ACCURACY_REDUCED = 500.0
+
+internal data class CoreLocationFix(
+  val latitude: Double,
+  val longitude: Double,
+  val altitude: Double,
+  val horizontalAccuracy: Double,
+  val verticalAccuracy: Double,
+  val course: Double,
+  val courseAccuracy: Double,
+  val speed: Double,
+  val speedAccuracy: Double,
+  val ageSeconds: Double,
+)
+
+internal data class CoreLocationError(val domain: String, val code: Long)
+
+internal interface CoreLocationDelegate {
+  fun didUpdateLocations(locations: List<CoreLocationFix>)
+
+  fun didFailWithError(error: CoreLocationError)
+
+  fun didChangeAuthorization()
+}
+
+internal interface CoreLocationManager : AutoCloseable {
+  var desiredAccuracy: Double
+  var distanceFilter: Double
+  val location: CoreLocationFix?
+  val authorizationStatus: Long
+  val accuracyAuthorization: Long
+
+  fun setDelegate(delegate: CoreLocationDelegate?)
+
+  fun startUpdatingLocation()
+
+  fun stopUpdatingLocation()
+
+  fun requestWhenInUseAuthorization()
+}
+
+internal interface CoreLocationClient : AutoCloseable {
+  val locationServicesEnabled: Boolean
+
+  val backendAvailability: LocationBackendAvailability
+    get() = LocationBackendAvailability.Available
+
+  fun createManager(): CoreLocationManager
+}
+
+internal fun LocationAccuracy.toDesiredAccuracy(): Double =
+  when (this) {
+    LocationAccuracy.BestForNavigation -> CL_LOCATION_ACCURACY_BEST_FOR_NAVIGATION
+    LocationAccuracy.High -> CL_LOCATION_ACCURACY_BEST
+    LocationAccuracy.Balanced -> CL_LOCATION_ACCURACY_HUNDRED_METERS
+    LocationAccuracy.Low -> CL_LOCATION_ACCURACY_KILOMETER
+    LocationAccuracy.Lowest -> CL_LOCATION_ACCURACY_REDUCED
+  }
+
+internal fun CoreLocationError.asUnavailableReason(
+  locationServicesEnabled: Boolean
+): LocationUnavailableReason =
+  when {
+    domain != CL_ERROR_DOMAIN -> LocationUnavailableReason.UnexpectedFailure
+    code == CL_ERROR_DENIED ->
+      if (locationServicesEnabled) {
+        LocationUnavailableReason.PermissionDenied
+      } else {
+        LocationUnavailableReason.ServicesDisabled
+      }
+    code == CL_ERROR_PROMPT_DECLINED -> LocationUnavailableReason.PermissionDenied
+    code == CL_ERROR_LOCATION_UNKNOWN || code == CL_ERROR_NETWORK ->
+      LocationUnavailableReason.TemporarilyUnavailable
+    else -> LocationUnavailableReason.UnexpectedFailure
+  }
+
+internal fun CoreLocationFix.asMapLibreLocation(): Location =
+  Location(
+    position =
+      PositionWithAccuracy(
+        value = Position(longitude = longitude, latitude = latitude, altitude = altitude),
+        accuracy = horizontalAccuracy.meters,
+      ),
+    altitudeAccuracy = if (verticalAccuracy >= 0.0) verticalAccuracy.meters else null,
+    course =
+      if (course >= 0.0) {
+        BearingWithAccuracy(
+          value = Bearing.North + course.degrees,
+          accuracy = if (courseAccuracy >= 0.0) courseAccuracy.degrees else null,
+        )
+      } else {
+        null
+      },
+    speed =
+      if (speed >= 0.0) {
+        SpeedWithAccuracy(
+          distancePerSecond = speed.meters,
+          accuracy = if (speedAccuracy >= 0.0) speedAccuracy.meters else null,
+        )
+      } else {
+        null
+      },
+    timestamp = TimeSource.Monotonic.markNow() - ageAtReceipt(),
+  )
+
+internal fun CoreLocationFix.ageAtReceipt(): Duration = ageSeconds.coerceAtLeast(0.0).seconds
+
+internal fun readPermission(
+  authorizationStatus: Long,
+  accuracyAuthorization: Long,
+): LocationPermission =
+  when (authorizationStatus) {
+    CL_AUTHORIZATION_AUTHORIZED_ALWAYS,
+    CL_AUTHORIZATION_AUTHORIZED_WHEN_IN_USE ->
+      LocationPermission.Granted(
+        if (accuracyAuthorization == CL_ACCURACY_AUTHORIZATION_FULL) {
+          LocationAccuracyAuthorization.Precise
+        } else {
+          LocationAccuracyAuthorization.Approximate
+        }
+      )
+    CL_AUTHORIZATION_NOT_DETERMINED -> LocationPermission.NotGranted(canRequest = true)
+    CL_AUTHORIZATION_DENIED,
+    CL_AUTHORIZATION_RESTRICTED -> LocationPermission.NotGranted(canRequest = false)
+    else -> LocationPermission.NotGranted(canRequest = null)
+  }

--- a/lib/maplibre-compose-macos/src/main/kotlin/org/maplibre/compose/location/desktop/macos/MacosLocationBackend.kt
+++ b/lib/maplibre-compose-macos/src/main/kotlin/org/maplibre/compose/location/desktop/macos/MacosLocationBackend.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.withContext
 import org.maplibre.compose.desktop.ComposeMapHost
 import org.maplibre.compose.location.DesktopLocationBackend
 import org.maplibre.compose.location.DesktopLocationPermissionRequester
@@ -98,7 +99,8 @@ internal constructor(
       }
       LocationBackendAvailability.Available -> Unit
     }
-    if (!client.locationServicesEnabled) {
+    val locationServicesEnabled = withContext(Dispatchers.IO) { client.locationServicesEnabled }
+    if (!locationServicesEnabled) {
       trySend(LocationEvent.Unavailable(LocationUnavailableReason.ServicesDisabled))
       close()
       return@callbackFlow
@@ -114,7 +116,7 @@ internal constructor(
       }
 
     try {
-      val delegate = UpdateDelegate(channel) { client.locationServicesEnabled }
+      val delegate = UpdateDelegate(channel, locationServicesEnabled)
       manager.setDelegate(delegate)
       manager.desiredAccuracy = request.accuracy.toDesiredAccuracy()
       manager.distanceFilter = request.minimumDistance.inMeters
@@ -138,16 +140,14 @@ internal constructor(
 
   private class UpdateDelegate(
     private val channel: SendChannel<LocationEvent>,
-    private val locationServicesEnabled: () -> Boolean,
+    private val locationServicesEnabled: Boolean,
   ) : CoreLocationDelegate {
     override fun didUpdateLocations(locations: List<CoreLocationFix>) {
       locations.forEach(::sendLocation)
     }
 
     override fun didFailWithError(error: CoreLocationError) {
-      channel.trySend(
-        LocationEvent.Unavailable(error.asUnavailableReason(locationServicesEnabled()))
-      )
+      channel.trySend(LocationEvent.Unavailable(error.asUnavailableReason(locationServicesEnabled)))
     }
 
     override fun didChangeAuthorization() = Unit

--- a/lib/maplibre-compose-macos/src/main/kotlin/org/maplibre/compose/location/desktop/macos/MacosLocationBackend.kt
+++ b/lib/maplibre-compose-macos/src/main/kotlin/org/maplibre/compose/location/desktop/macos/MacosLocationBackend.kt
@@ -3,6 +3,7 @@ package org.maplibre.compose.location.desktop.macos
 import java.util.Locale
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.channels.awaitClose
@@ -11,6 +12,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.maplibre.compose.desktop.ComposeMapHost
 import org.maplibre.compose.location.DesktopLocationBackend
@@ -78,6 +80,7 @@ public class MacosLocationProvider
 internal constructor(
   private val client: CoreLocationClient,
   private val dispatcher: CoroutineContext = Dispatchers.Main,
+  private val ioDispatcher: CoroutineContext = Dispatchers.IO,
 ) : DesktopLocationProvider {
   public constructor() : this(SystemCoreLocationClient())
 
@@ -99,7 +102,7 @@ internal constructor(
       }
       LocationBackendAvailability.Available -> Unit
     }
-    val locationServicesEnabled = withContext(Dispatchers.IO) { client.locationServicesEnabled }
+    val locationServicesEnabled = withContext(ioDispatcher) { client.locationServicesEnabled }
     if (!locationServicesEnabled) {
       trySend(LocationEvent.Unavailable(LocationUnavailableReason.ServicesDisabled))
       close()
@@ -116,7 +119,7 @@ internal constructor(
       }
 
     try {
-      val delegate = UpdateDelegate(channel, locationServicesEnabled)
+      val delegate = UpdateDelegate(this, channel, client, ioDispatcher)
       manager.setDelegate(delegate)
       manager.desiredAccuracy = request.accuracy.toDesiredAccuracy()
       manager.distanceFilter = request.minimumDistance.inMeters
@@ -139,15 +142,21 @@ internal constructor(
   }
 
   private class UpdateDelegate(
+    private val scope: CoroutineScope,
     private val channel: SendChannel<LocationEvent>,
-    private val locationServicesEnabled: Boolean,
+    private val client: CoreLocationClient,
+    private val ioDispatcher: CoroutineContext,
   ) : CoreLocationDelegate {
     override fun didUpdateLocations(locations: List<CoreLocationFix>) {
       locations.forEach(::sendLocation)
     }
 
     override fun didFailWithError(error: CoreLocationError) {
-      channel.trySend(LocationEvent.Unavailable(error.asUnavailableReason(locationServicesEnabled)))
+      scope.launch(ioDispatcher) {
+        channel.trySend(
+          LocationEvent.Unavailable(error.asUnavailableReason(client.locationServicesEnabled))
+        )
+      }
     }
 
     override fun didChangeAuthorization() = Unit

--- a/lib/maplibre-compose-macos/src/main/kotlin/org/maplibre/compose/location/desktop/macos/MacosLocationBackend.kt
+++ b/lib/maplibre-compose-macos/src/main/kotlin/org/maplibre/compose/location/desktop/macos/MacosLocationBackend.kt
@@ -1,28 +1,223 @@
 package org.maplibre.compose.location.desktop.macos
 
+import java.util.Locale
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.SendChannel
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.flowOn
 import org.maplibre.compose.desktop.ComposeMapHost
 import org.maplibre.compose.location.DesktopLocationBackend
 import org.maplibre.compose.location.DesktopLocationPermissionRequester
 import org.maplibre.compose.location.DesktopLocationProvider
+import org.maplibre.compose.location.LocationAccuracy
+import org.maplibre.compose.location.LocationBackendAvailability
+import org.maplibre.compose.location.LocationEvent
+import org.maplibre.compose.location.LocationPermission
+import org.maplibre.compose.location.LocationProvider
+import org.maplibre.compose.location.LocationRequest
+import org.maplibre.compose.location.LocationUnavailableReason
+import org.maplibre.spatialk.units.extensions.inMeters
 
-/** Scaffold for the macOS desktop location backend. */
+/** macOS desktop location backend backed by Core Location. */
 public class MacosLocationBackend : DesktopLocationBackend {
   override val id: String = "core-location"
 
-  // TODO: Implement location with CLLocationManager: requestWhenInUseAuthorization,
-  // startUpdatingLocation, stopUpdatingLocation, and the authorization, location, and error
-  // delegate callbacks. Map CLLocation fields and timestamps to the common API. Packages must
-  // declare NSLocationWhenInUseUsageDescription and the location entitlement.
-  //
-  // Implement orientation with headingAvailable, startUpdatingHeading, stopUpdatingHeading, and
-  // locationManager:didUpdateHeading:. Prefer trueHeading when valid, otherwise magneticHeading;
-  // map headingAccuracy and the CLHeading timestamp to the common API.
-  override fun isAvailable(): Boolean = false
+  override fun isAvailable(): Boolean =
+    System.getProperty("os.name").lowercase(Locale.ROOT).startsWith("mac")
 
   override fun createProvider(host: ComposeMapHost?): DesktopLocationProvider =
-    error("The macOS location backend is not implemented")
+    MacosLocationProvider()
 
   override fun createPermissionRequester(
     host: ComposeMapHost?
-  ): DesktopLocationPermissionRequester = error("The macOS location backend is not implemented")
+  ): DesktopLocationPermissionRequester = MacosLocationPermissionRequester()
+}
+
+/**
+ * A [LocationProvider] built on
+ * [`CLLocationManager`](https://developer.apple.com/documentation/corelocation/cllocationmanager).
+ *
+ * Each collection creates a
+ * [`CLLocationManager`](https://developer.apple.com/documentation/corelocation/cllocationmanager)
+ * on the AppKit main run loop, applies the request's accuracy and distance preferences, and stops
+ * the manager when collection ends. Compose Desktop's `Dispatchers.Main` is the Swing
+ * event-dispatch thread on the AWT host and does not pump that run loop, so Core Location work is
+ * marshaled there explicitly. The process's app Info.plist must declare
+ * `NSLocationWhenInUseUsageDescription`. [LocationRequest.minimumInterval] is ignored because Core
+ * Location filters only by distance.
+ *
+ * [LocationAccuracy.BestForNavigation] maps to
+ * [`kCLLocationAccuracyBestForNavigation`](https://developer.apple.com/documentation/corelocation/kcllocationaccuracybestfornavigation),
+ * [LocationAccuracy.High] maps to
+ * [`kCLLocationAccuracyBest`](https://developer.apple.com/documentation/corelocation/kcllocationaccuracybest),
+ * [LocationAccuracy.Balanced] maps to
+ * [`kCLLocationAccuracyHundredMeters`](https://developer.apple.com/documentation/corelocation/kcllocationaccuracyhundredmeters),
+ * [LocationAccuracy.Low] maps to
+ * [`kCLLocationAccuracyKilometer`](https://developer.apple.com/documentation/corelocation/kcllocationaccuracykilometer),
+ * and [LocationAccuracy.Lowest] maps to
+ * [`kCLLocationAccuracyReduced`](https://developer.apple.com/documentation/corelocation/kcllocationaccuracyreduced).
+ *
+ * [`kCLErrorDenied`](https://developer.apple.com/documentation/corelocation/clerror/denied) maps to
+ * [LocationUnavailableReason.ServicesDisabled] when location services are disabled and to
+ * [LocationUnavailableReason.PermissionDenied] otherwise.
+ * [`kCLErrorPromptDeclined`](https://developer.apple.com/documentation/corelocation/clerror/promptdeclined)
+ * also maps to [LocationUnavailableReason.PermissionDenied].
+ * [`kCLErrorLocationUnknown`](https://developer.apple.com/documentation/corelocation/clerror/locationunknown)
+ * and [`kCLErrorNetwork`](https://developer.apple.com/documentation/corelocation/clerror/network)
+ * map to [LocationUnavailableReason.TemporarilyUnavailable]. Other Core Location errors map to
+ * [LocationUnavailableReason.UnexpectedFailure].
+ */
+public class MacosLocationProvider
+internal constructor(
+  private val client: CoreLocationClient,
+  private val dispatcher: CoroutineContext = Dispatchers.Main,
+) : DesktopLocationProvider {
+  public constructor() : this(SystemCoreLocationClient())
+
+  override val backendAvailability: LocationBackendAvailability = client.backendAvailability
+
+  override fun updates(request: LocationRequest): Flow<LocationEvent> = callbackFlow {
+    when (val availability = backendAvailability) {
+      is LocationBackendAvailability.Misconfigured -> {
+        trySend(
+          LocationEvent.Unavailable(LocationUnavailableReason.Misconfigured, availability.cause)
+        )
+        close()
+        return@callbackFlow
+      }
+      LocationBackendAvailability.Unsupported -> {
+        trySend(LocationEvent.Unavailable(LocationUnavailableReason.Unsupported))
+        close()
+        return@callbackFlow
+      }
+      LocationBackendAvailability.Available -> Unit
+    }
+    if (!client.locationServicesEnabled) {
+      trySend(LocationEvent.Unavailable(LocationUnavailableReason.ServicesDisabled))
+      close()
+      return@callbackFlow
+    }
+
+    val manager =
+      try {
+        client.createManager()
+      } catch (error: Throwable) {
+        trySend(LocationEvent.Unavailable(LocationUnavailableReason.UnexpectedFailure, error))
+        close()
+        return@callbackFlow
+      }
+
+    try {
+      val delegate = UpdateDelegate(channel) { client.locationServicesEnabled }
+      manager.setDelegate(delegate)
+      manager.desiredAccuracy = request.accuracy.toDesiredAccuracy()
+      manager.distanceFilter = request.minimumDistance.inMeters
+      manager.location?.let(delegate::sendLocation)
+      manager.startUpdatingLocation()
+    } catch (error: Throwable) {
+      manager.close()
+      trySend(LocationEvent.Unavailable(LocationUnavailableReason.UnexpectedFailure, error))
+      close()
+      return@callbackFlow
+    }
+
+    // Retaining the delegate in this closure is required because CLLocationManager does not.
+    awaitClose { manager.close() }
+  }
+    .flowOn(dispatcher)
+
+  override fun close() {
+    client.close()
+  }
+
+  private class UpdateDelegate(
+    private val channel: SendChannel<LocationEvent>,
+    private val locationServicesEnabled: () -> Boolean,
+  ) : CoreLocationDelegate {
+    override fun didUpdateLocations(locations: List<CoreLocationFix>) {
+      locations.forEach(::sendLocation)
+    }
+
+    override fun didFailWithError(error: CoreLocationError) {
+      channel.trySend(
+        LocationEvent.Unavailable(error.asUnavailableReason(locationServicesEnabled()))
+      )
+    }
+
+    override fun didChangeAuthorization() = Unit
+
+    fun sendLocation(location: CoreLocationFix) {
+      channel.trySend(LocationEvent.Fix(location.asMapLibreLocation()))
+    }
+  }
+}
+
+/**
+ * Foreground Core Location permission requester.
+ *
+ * [`CLAuthorizationStatus`](https://developer.apple.com/documentation/corelocation/clauthorizationstatus)
+ * maps an authorized status to [LocationPermission.Granted], `notDetermined` to
+ * [LocationPermission.NotGranted] with `canRequest = true`, `denied` or `restricted` to `canRequest
+ * = false`, and an unrecognized value to `canRequest = null`.
+ * [`CLLocationManager.accuracyAuthorization`](https://developer.apple.com/documentation/corelocation/cllocationmanager/accuracyauthorization)
+ * distinguishes precise from approximate grants. A request calls
+ * [`requestWhenInUseAuthorization()`](https://developer.apple.com/documentation/corelocation/cllocationmanager/requestwheninuseauthorization())
+ * and starts location updates so macOS can present the system prompt.
+ */
+public class MacosLocationPermissionRequester
+internal constructor(private val client: CoreLocationClient) : DesktopLocationPermissionRequester {
+  public constructor() : this(SystemCoreLocationClient())
+
+  override val backendAvailability: LocationBackendAvailability = client.backendAvailability
+  private val mutableStatus =
+    MutableStateFlow<LocationPermission>(LocationPermission.NotGranted(canRequest = null))
+  override val status: StateFlow<LocationPermission> = mutableStatus
+  private val requestPending = AtomicBoolean()
+  private val manager = client.createManager()
+
+  private val delegate =
+    object : CoreLocationDelegate {
+      override fun didUpdateLocations(locations: List<CoreLocationFix>) = Unit
+
+      override fun didFailWithError(error: CoreLocationError) = Unit
+
+      override fun didChangeAuthorization() {
+        val permission = currentPermission()
+        mutableStatus.value = permission
+        if (permission != LocationPermission.NotGranted(canRequest = true)) {
+          manager.stopUpdatingLocation()
+        }
+        requestPending.set(false)
+      }
+    }
+
+  init {
+    manager.setDelegate(delegate)
+    mutableStatus.value = currentPermission()
+  }
+
+  override fun requestForegroundPermission() {
+    if (backendAvailability != LocationBackendAvailability.Available) return
+    val current = currentPermission()
+    if (current != LocationPermission.NotGranted(canRequest = true)) return
+    if (!requestPending.compareAndSet(false, true)) return
+    manager.requestWhenInUseAuthorization()
+    // macOS presents the system prompt when a location service starts, not from the
+    // authorization request alone.
+    manager.startUpdatingLocation()
+  }
+
+  override fun close() {
+    manager.close()
+    client.close()
+  }
+
+  private fun currentPermission(): LocationPermission =
+    readPermission(manager.authorizationStatus, manager.accuracyAuthorization)
 }

--- a/lib/maplibre-compose-macos/src/main/kotlin/org/maplibre/compose/location/desktop/macos/MacosLocationBackend.kt
+++ b/lib/maplibre-compose-macos/src/main/kotlin/org/maplibre/compose/location/desktop/macos/MacosLocationBackend.kt
@@ -152,16 +152,21 @@ internal constructor(
     }
 
     override fun didFailWithError(error: CoreLocationError) {
-      scope.launch(ioDispatcher) {
-        channel.trySend(
-          LocationEvent.Unavailable(error.asUnavailableReason(client.locationServicesEnabled))
-        )
+      if (error.domain == CL_ERROR_DOMAIN && error.code == CL_ERROR_DENIED) {
+        scope.launch(ioDispatcher) {
+          channel.trySend(
+            LocationEvent.Unavailable(error.asUnavailableReason(client.locationServicesEnabled))
+          )
+        }
+        return
       }
+      channel.trySend(LocationEvent.Unavailable(error.asUnavailableReason(true)))
     }
 
     override fun didChangeAuthorization() = Unit
 
     fun sendLocation(location: CoreLocationFix) {
+      if (location.horizontalAccuracy < 0.0) return
       channel.trySend(LocationEvent.Fix(location.asMapLibreLocation()))
     }
   }
@@ -194,7 +199,10 @@ internal constructor(private val client: CoreLocationClient) : DesktopLocationPe
     object : CoreLocationDelegate {
       override fun didUpdateLocations(locations: List<CoreLocationFix>) = Unit
 
-      override fun didFailWithError(error: CoreLocationError) = Unit
+      override fun didFailWithError(error: CoreLocationError) {
+        manager.stopUpdatingLocation()
+        requestPending.set(false)
+      }
 
       override fun didChangeAuthorization() {
         val permission = currentPermission()

--- a/lib/maplibre-compose-macos/src/main/kotlin/org/maplibre/compose/location/desktop/macos/ObjectiveC.kt
+++ b/lib/maplibre-compose-macos/src/main/kotlin/org/maplibre/compose/location/desktop/macos/ObjectiveC.kt
@@ -1,0 +1,244 @@
+package org.maplibre.compose.location.desktop.macos
+
+import java.lang.foreign.Arena
+import java.lang.foreign.FunctionDescriptor
+import java.lang.foreign.Linker
+import java.lang.foreign.MemoryLayout
+import java.lang.foreign.MemorySegment
+import java.lang.foreign.ValueLayout.ADDRESS
+import java.lang.foreign.ValueLayout.JAVA_DOUBLE
+import org.lwjgl.system.JNI
+import org.lwjgl.system.MemoryStack
+import org.lwjgl.system.MemoryUtil
+import org.lwjgl.system.MemoryUtil.NULL
+import org.lwjgl.system.macosx.DynamicLinkLoader.RTLD_LOCAL
+import org.lwjgl.system.macosx.DynamicLinkLoader.RTLD_NOW
+import org.lwjgl.system.macosx.DynamicLinkLoader.dlerror
+import org.lwjgl.system.macosx.DynamicLinkLoader.dlopen
+import org.lwjgl.system.macosx.ObjCRuntime
+
+/**
+ * Objective-C messaging for the macOS location backend, without a native library of our own.
+ *
+ * Messages are dispatched by calling the selector's implementation directly rather than through
+ * `objc_msgSend`, which has no single C prototype.
+ */
+internal object ObjectiveC {
+  private val linker = Linker.nativeLinker()
+  private val selectors = mutableMapOf<String, Long>()
+  private val classes = mutableMapOf<String, Long>()
+  private val frameworks = mutableMapOf<String, Long>()
+  private val coordinateLayout =
+    MemoryLayout.structLayout(
+      JAVA_DOUBLE.withName("latitude"),
+      JAVA_DOUBLE.withName("longitude"),
+    )
+
+  data class Coordinate(val latitude: Double, val longitude: Double)
+
+  fun allocInit(className: String): Long = sendPointer(sendPointer(cls(className), "alloc"), "init")
+
+  fun release(objectAddress: Long) {
+    if (objectAddress != NULL) {
+      sendVoid(objectAddress, "release")
+    }
+  }
+
+  fun autoreleasePool(): AutoreleasePool = AutoreleasePool(allocInit("NSAutoreleasePool"))
+
+  fun <T> runInAutoreleasePool(action: () -> T): T = autoreleasePool().use { action() }
+
+  fun sendPointer(receiver: Long, selectorName: String): Long {
+    val selector = selector(selectorName)
+    return JNI.invokePPP(receiver, selector, implementation(receiver, selector))
+  }
+
+  fun sendPointer(receiver: Long, selectorName: String, argument: Long): Long {
+    val selector = selector(selectorName)
+    return JNI.invokePPPP(receiver, selector, argument, implementation(receiver, selector))
+  }
+
+  fun sendLong(receiver: Long, selectorName: String): Long = sendPointer(receiver, selectorName)
+
+  fun sendDouble(receiver: Long, selectorName: String): Double {
+    val selector = selector(selectorName)
+    return JNI.invokePPD(receiver, selector, implementation(receiver, selector))
+  }
+
+  fun sendVoid(receiver: Long, selectorName: String) {
+    val selector = selector(selectorName)
+    JNI.invokePPV(receiver, selector, implementation(receiver, selector))
+  }
+
+  fun sendVoid(receiver: Long, selectorName: String, argument: Long) {
+    val selector = selector(selectorName)
+    JNI.invokePPPV(receiver, selector, argument, implementation(receiver, selector))
+  }
+
+  fun sendVoid(receiver: Long, selectorName: String, argument1: Long, argument2: Long) {
+    val selector = selector(selectorName)
+    val handle =
+      linker.downcallHandle(
+        MemorySegment.ofAddress(implementation(receiver, selector)),
+        FunctionDescriptor.ofVoid(ADDRESS, ADDRESS, ADDRESS, ADDRESS),
+      )
+    handle.invoke(
+      MemorySegment.ofAddress(receiver),
+      MemorySegment.ofAddress(selector),
+      MemorySegment.ofAddress(argument1),
+      MemorySegment.ofAddress(argument2),
+    )
+  }
+
+  fun sendVoidDouble(receiver: Long, selectorName: String, argument: Double) {
+    val selector = selector(selectorName)
+    val implementation = implementation(receiver, selector)
+    val handle =
+      linker.downcallHandle(
+        MemorySegment.ofAddress(implementation),
+        FunctionDescriptor.ofVoid(ADDRESS, ADDRESS, JAVA_DOUBLE),
+      )
+    handle.invoke(MemorySegment.ofAddress(receiver), MemorySegment.ofAddress(selector), argument)
+  }
+
+  fun sendCoordinate(receiver: Long, selectorName: String): Coordinate {
+    val selector = selector(selectorName)
+    val implementation = implementation(receiver, selector)
+    val handle =
+      linker.downcallHandle(
+        MemorySegment.ofAddress(implementation),
+        FunctionDescriptor.of(coordinateLayout, ADDRESS, ADDRESS),
+      )
+    Arena.ofConfined().use { arena ->
+      val result =
+        handle.invoke(
+          arena,
+          MemorySegment.ofAddress(receiver),
+          MemorySegment.ofAddress(selector),
+        ) as MemorySegment
+      return Coordinate(
+        latitude = result.get(JAVA_DOUBLE, 0),
+        longitude = result.get(JAVA_DOUBLE, JAVA_DOUBLE.byteSize()),
+      )
+    }
+  }
+
+  fun utf8String(nsString: Long): String {
+    if (nsString == NULL) return ""
+    val utf8 = sendPointer(nsString, "UTF8String")
+    return if (utf8 == NULL) "" else MemoryUtil.memUTF8(utf8)
+  }
+
+  fun nsString(value: String): Long =
+    MemoryStack.stackPush().use { stack ->
+      sendPointer(
+        cls("NSString"),
+        "stringWithUTF8String:",
+        MemoryUtil.memAddress(stack.UTF8(value)),
+      )
+    }
+
+  fun mainBundlePath(): String? {
+    val bundle = sendPointer(cls("NSBundle"), "mainBundle")
+    if (bundle == NULL) return null
+    val path = sendPointer(bundle, "bundlePath")
+    if (path == NULL) return null
+    return utf8String(path).ifEmpty { null }
+  }
+
+  fun infoDictionaryString(key: String): String? {
+    val bundle = sendPointer(cls("NSBundle"), "mainBundle")
+    if (bundle == NULL) return null
+    val value = sendPointer(bundle, "objectForInfoDictionaryKey:", nsString(key))
+    if (value == NULL) return null
+    return utf8String(value).ifEmpty { null }
+  }
+
+  fun infoPlistString(key: String): String? {
+    val bundlePath = mainBundlePath() ?: return null
+    val plist =
+      sendPointer(
+        cls("NSDictionary"),
+        "dictionaryWithContentsOfFile:",
+        nsString("$bundlePath/Contents/Info.plist"),
+      )
+    if (plist == NULL) return null
+    val value = sendPointer(plist, "objectForKey:", nsString(key))
+    if (value == NULL) return null
+    return utf8String(value).ifEmpty { null }
+  }
+
+  fun putInfoDictionaryString(key: String, value: String): Boolean {
+    val bundle = sendPointer(cls("NSBundle"), "mainBundle")
+    if (bundle == NULL) return false
+    val info = sendPointer(bundle, "infoDictionary")
+    if (info == NULL) return false
+    if (sendPointer(info, "isKindOfClass:", cls("NSMutableDictionary")) == 0L) return false
+    sendVoid(info, "setObject:forKey:", nsString(value), nsString(key))
+    return infoDictionaryString(key) != null
+  }
+
+  fun respondsTo(receiver: Long, selectorName: String): Boolean {
+    val objectClass = ObjCRuntime.object_getClass(receiver)
+    return objectClass != NULL &&
+      ObjCRuntime.class_respondsToSelector(objectClass, selector(selectorName))
+  }
+
+  @Synchronized
+  fun cls(name: String): Long =
+    classes.getOrPut(name) {
+      loadFrameworkForClass(name)
+      val value = ObjCRuntime.objc_getClass(name)
+      check(value != NULL) { "Objective-C class not found: $name" }
+      value
+    }
+
+  @Synchronized
+  fun selector(name: String): Long = selectors.getOrPut(name) { ObjCRuntime.sel_registerName(name) }
+
+  @Synchronized
+  fun loadFramework(framework: String): Long =
+    frameworks.getOrPut(framework) {
+      val path = "/System/Library/Frameworks/$framework.framework/$framework"
+      val handle = dlopen(path, RTLD_NOW or RTLD_LOCAL)
+      check(handle != NULL) { "Failed to load framework $path: ${dlerror()}" }
+      handle
+    }
+
+  private fun loadFrameworkForClass(className: String) {
+    when {
+      className.startsWith("CL") || className == DELEGATE_CLASS_NAME -> {
+        loadFramework("Foundation")
+        loadFramework("CoreLocation")
+      }
+      else -> loadFramework("Foundation")
+    }
+  }
+
+  private fun implementation(receiver: Long, selector: Long): Long {
+    check(receiver != NULL) { "Objective-C receiver is null" }
+    val objectClass = ObjCRuntime.object_getClass(receiver)
+    if (!ObjCRuntime.class_respondsToSelector(objectClass, selector)) {
+      throw IllegalStateException(
+        "Objective-C class ${ObjCRuntime.class_getName(objectClass)} does not respond to " +
+          "'${ObjCRuntime.sel_getName(selector)}'"
+      )
+    }
+    val implementation = ObjCRuntime.class_getMethodImplementation(objectClass, selector)
+    check(implementation != NULL) {
+      "Objective-C selector implementation not found: ${ObjCRuntime.sel_getName(selector)}"
+    }
+    return implementation
+  }
+
+  internal const val DELEGATE_CLASS_NAME = "MLCLocationDelegate"
+
+  internal class AutoreleasePool(private var pool: Long) : AutoCloseable {
+    override fun close() {
+      if (pool != NULL) {
+        sendVoid(pool, "drain")
+        pool = NULL
+      }
+    }
+  }
+}

--- a/lib/maplibre-compose-macos/src/main/kotlin/org/maplibre/compose/location/desktop/macos/ObjectiveC.kt
+++ b/lib/maplibre-compose-macos/src/main/kotlin/org/maplibre/compose/location/desktop/macos/ObjectiveC.kt
@@ -15,6 +15,7 @@ import org.lwjgl.system.macosx.DynamicLinkLoader.RTLD_LOCAL
 import org.lwjgl.system.macosx.DynamicLinkLoader.RTLD_NOW
 import org.lwjgl.system.macosx.DynamicLinkLoader.dlerror
 import org.lwjgl.system.macosx.DynamicLinkLoader.dlopen
+import org.lwjgl.system.macosx.DynamicLinkLoader.dlsym
 import org.lwjgl.system.macosx.ObjCRuntime
 
 /**
@@ -204,6 +205,23 @@ internal object ObjectiveC {
       check(handle != NULL) { "Failed to load framework $path: ${dlerror()}" }
       handle
     }
+
+  fun exportedDoubleOrNull(symbol: String): Double? {
+    for (framework in listOf("CoreLocation", "_LocationEssentials")) {
+      val handle =
+        try {
+          loadFramework(framework)
+        } catch (_: Throwable) {
+          continue
+        }
+      val address = dlsym(handle, symbol)
+      if (address == NULL) continue
+      return MemorySegment.ofAddress(address)
+        .reinterpret(JAVA_DOUBLE.byteSize())
+        .get(JAVA_DOUBLE, 0)
+    }
+    return null
+  }
 
   private fun loadFrameworkForClass(className: String) {
     when {

--- a/lib/maplibre-compose-macos/src/main/kotlin/org/maplibre/compose/location/desktop/macos/SystemCoreLocation.kt
+++ b/lib/maplibre-compose-macos/src/main/kotlin/org/maplibre/compose/location/desktop/macos/SystemCoreLocation.kt
@@ -25,7 +25,7 @@ internal class SystemCoreLocationClient : CoreLocationClient {
   }
 
   override val locationServicesEnabled: Boolean
-    get() = onMain {
+    get() = ObjectiveC.runInAutoreleasePool {
       ObjectiveC.sendLong(ObjectiveC.cls("CLLocationManager"), "locationServicesEnabled") != 0L
     }
 

--- a/lib/maplibre-compose-macos/src/main/kotlin/org/maplibre/compose/location/desktop/macos/SystemCoreLocation.kt
+++ b/lib/maplibre-compose-macos/src/main/kotlin/org/maplibre/compose/location/desktop/macos/SystemCoreLocation.kt
@@ -1,0 +1,306 @@
+package org.maplibre.compose.location.desktop.macos
+
+import java.lang.foreign.Arena
+import java.lang.foreign.FunctionDescriptor
+import java.lang.foreign.Linker
+import java.lang.foreign.MemorySegment
+import java.lang.foreign.ValueLayout.ADDRESS
+import java.lang.invoke.MethodHandles
+import java.lang.invoke.MethodType
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
+import org.lwjgl.system.MemoryUtil.NULL
+import org.lwjgl.system.macosx.ObjCRuntime
+import org.maplibre.compose.location.LocationBackendAvailability
+import org.maplibre.compose.location.desktop.macos.ObjectiveC.DELEGATE_CLASS_NAME
+
+internal class SystemCoreLocationClient : CoreLocationClient {
+  override val backendAvailability: LocationBackendAvailability
+
+  init {
+    ObjectiveC.loadFramework("Foundation")
+    ObjectiveC.loadFramework("CoreLocation")
+    CoreLocationDelegateClass.register()
+    backendAvailability = onMain { readUsageDescriptionAvailability() }
+  }
+
+  override val locationServicesEnabled: Boolean
+    get() = onMain {
+      ObjectiveC.sendLong(ObjectiveC.cls("CLLocationManager"), "locationServicesEnabled") != 0L
+    }
+
+  override fun createManager(): CoreLocationManager = SystemCoreLocationManager()
+
+  override fun close() = Unit
+}
+
+internal class SystemCoreLocationManager : CoreLocationManager {
+  private val manager: Long = onMain { ObjectiveC.allocInit("CLLocationManager") }
+  private var objcDelegate: Long = NULL
+  private val closed = AtomicBoolean()
+
+  override var desiredAccuracy: Double
+    get() = onMain { ObjectiveC.sendDouble(manager, "desiredAccuracy") }
+    set(value) {
+      onMain { ObjectiveC.sendVoidDouble(manager, "setDesiredAccuracy:", value) }
+    }
+
+  override var distanceFilter: Double
+    get() = onMain { ObjectiveC.sendDouble(manager, "distanceFilter") }
+    set(value) {
+      onMain { ObjectiveC.sendVoidDouble(manager, "setDistanceFilter:", value) }
+    }
+
+  override val location: CoreLocationFix?
+    get() = onMain {
+      val value = ObjectiveC.sendPointer(manager, "location")
+      if (value == NULL) null else readCoreLocation(value)
+    }
+
+  override val authorizationStatus: Long
+    get() = onMain { ObjectiveC.sendLong(manager, "authorizationStatus") }
+
+  override val accuracyAuthorization: Long
+    get() = onMain {
+      if (ObjectiveC.respondsTo(manager, "accuracyAuthorization")) {
+        ObjectiveC.sendLong(manager, "accuracyAuthorization")
+      } else {
+        CL_ACCURACY_AUTHORIZATION_FULL
+      }
+    }
+
+  override fun setDelegate(delegate: CoreLocationDelegate?) {
+    onMain {
+      if (objcDelegate != NULL) {
+        ObjectiveC.sendVoid(manager, "setDelegate:", NULL)
+        CoreLocationDelegateClass.unbind(objcDelegate)
+        ObjectiveC.release(objcDelegate)
+        objcDelegate = NULL
+      }
+      if (delegate != null) {
+        objcDelegate = ObjectiveC.allocInit(DELEGATE_CLASS_NAME)
+        CoreLocationDelegateClass.bind(objcDelegate, delegate)
+        ObjectiveC.sendVoid(manager, "setDelegate:", objcDelegate)
+      }
+    }
+  }
+
+  override fun startUpdatingLocation() {
+    onMain { ObjectiveC.sendVoid(manager, "startUpdatingLocation") }
+  }
+
+  override fun stopUpdatingLocation() {
+    onMain { ObjectiveC.sendVoid(manager, "stopUpdatingLocation") }
+  }
+
+  override fun requestWhenInUseAuthorization() {
+    onMain { ObjectiveC.sendVoid(manager, "requestWhenInUseAuthorization") }
+  }
+
+  override fun close() {
+    if (!closed.compareAndSet(false, true)) return
+    onMain {
+      ObjectiveC.sendVoid(manager, "stopUpdatingLocation")
+      if (objcDelegate != NULL) {
+        ObjectiveC.sendVoid(manager, "setDelegate:", NULL)
+        CoreLocationDelegateClass.unbind(objcDelegate)
+        ObjectiveC.release(objcDelegate)
+        objcDelegate = NULL
+      }
+      ObjectiveC.release(manager)
+    }
+  }
+}
+
+private fun <T> onMain(action: () -> T): T = CocoaMain.run {
+  ObjectiveC.runInAutoreleasePool(action)
+}
+
+private val usageDescriptionKeys =
+  listOf("NSLocationWhenInUseUsageDescription", "NSLocationUsageDescription")
+
+private fun readUsageDescriptionAvailability(): LocationBackendAvailability {
+  if (usageDescription() != null) return LocationBackendAvailability.Available
+  return LocationBackendAvailability.Misconfigured(
+    IllegalStateException(
+      "The main bundle${ObjectiveC.mainBundlePath()?.let { " at $it" } ?: ""} " +
+        "does not declare NSLocationWhenInUseUsageDescription. " +
+        "Core Location reads that key from the process's app Info.plist."
+    )
+  )
+}
+
+private fun usageDescription(): String? {
+  usageDescriptionKeys.firstNotNullOfOrNull(ObjectiveC::infoDictionaryString)?.let {
+    return it
+  }
+  // The JVM launcher can replace the live Info.plist. Copy the usage description from disk.
+  for (key in usageDescriptionKeys) {
+    val value = ObjectiveC.infoPlistString(key) ?: continue
+    if (ObjectiveC.putInfoDictionaryString(key, value)) return value
+  }
+  return null
+}
+
+internal object CoreLocationDelegateClass {
+  private val linker = Linker.nativeLinker()
+  private val stubs = Arena.ofShared()
+  private val handlers = ConcurrentHashMap<Long, CoreLocationDelegate>()
+  private val twoObjectArgs = FunctionDescriptor.ofVoid(ADDRESS, ADDRESS, ADDRESS, ADDRESS)
+  private val oneObjectArg = FunctionDescriptor.ofVoid(ADDRESS, ADDRESS, ADDRESS)
+
+  @Synchronized
+  fun register() {
+    val existing = ObjCRuntime.objc_getClass(DELEGATE_CLASS_NAME)
+    if (existing != NULL) return
+
+    val cls = ObjCRuntime.objc_allocateClassPair(ObjectiveC.cls("NSObject"), DELEGATE_CLASS_NAME, 0)
+    check(cls != NULL) { "Failed to allocate $DELEGATE_CLASS_NAME" }
+
+    val protocol = ObjCRuntime.objc_getProtocol("CLLocationManagerDelegate")
+    if (protocol != NULL) {
+      ObjCRuntime.class_addProtocol(cls, protocol)
+    }
+
+    addMethod(
+      cls,
+      "locationManager:didUpdateLocations:",
+      "v@:@@",
+      twoObjectArgs,
+      "didUpdateLocations",
+    )
+    addMethod(cls, "locationManager:didFailWithError:", "v@:@@", twoObjectArgs, "didFailWithError")
+    addMethod(
+      cls,
+      "locationManagerDidChangeAuthorization:",
+      "v@:@",
+      oneObjectArg,
+      "didChangeAuthorization",
+    )
+
+    ObjCRuntime.objc_registerClassPair(cls)
+  }
+
+  fun bind(objcDelegate: Long, delegate: CoreLocationDelegate) {
+    handlers[objcDelegate] = delegate
+  }
+
+  fun unbind(objcDelegate: Long) {
+    handlers.remove(objcDelegate)
+  }
+
+  private fun addMethod(
+    cls: Long,
+    selectorName: String,
+    types: String,
+    descriptor: FunctionDescriptor,
+    methodName: String,
+  ) {
+    val parameterCount = descriptor.argumentLayouts().size
+    val parameterTypes = Array(parameterCount) { MemorySegment::class.java }
+    val handle =
+      MethodHandles.lookup()
+        .findStatic(
+          CoreLocationDelegateClass::class.java,
+          methodName,
+          MethodType.methodType(
+            Void.TYPE,
+            parameterTypes[0],
+            *parameterTypes.drop(1).toTypedArray(),
+          ),
+        )
+    val stub = linker.upcallStub(handle, descriptor, stubs)
+    check(
+      ObjCRuntime.class_addMethod(cls, ObjectiveC.selector(selectorName), stub.address(), types)
+    ) {
+      "Failed to add $selectorName to $DELEGATE_CLASS_NAME"
+    }
+  }
+
+  @JvmStatic
+  fun didUpdateLocations(
+    self: MemorySegment,
+    @Suppress("UNUSED_PARAMETER") cmd: MemorySegment,
+    @Suppress("UNUSED_PARAMETER") manager: MemorySegment,
+    locations: MemorySegment,
+  ) {
+    invokeHandler(self) { delegate ->
+      delegate.didUpdateLocations(readLocations(locations.address()))
+    }
+  }
+
+  @JvmStatic
+  fun didFailWithError(
+    self: MemorySegment,
+    @Suppress("UNUSED_PARAMETER") cmd: MemorySegment,
+    @Suppress("UNUSED_PARAMETER") manager: MemorySegment,
+    error: MemorySegment,
+  ) {
+    invokeHandler(self) { delegate -> delegate.didFailWithError(readError(error.address())) }
+  }
+
+  @JvmStatic
+  fun didChangeAuthorization(
+    self: MemorySegment,
+    @Suppress("UNUSED_PARAMETER") cmd: MemorySegment,
+    @Suppress("UNUSED_PARAMETER") manager: MemorySegment,
+  ) {
+    invokeHandler(self) { delegate -> delegate.didChangeAuthorization() }
+  }
+
+  private inline fun invokeHandler(
+    self: MemorySegment,
+    crossinline action: (CoreLocationDelegate) -> Unit,
+  ) {
+    val delegate = handlers[self.address()] ?: return
+    try {
+      ObjectiveC.runInAutoreleasePool { action(delegate) }
+    } catch (_: Throwable) {
+      // Delegate IMPs must not throw into Core Location.
+    }
+  }
+}
+
+internal fun readLocations(array: Long): List<CoreLocationFix> {
+  if (array == NULL) return emptyList()
+  val count = ObjectiveC.sendLong(array, "count")
+  return (0L until count).map { index ->
+    readCoreLocation(ObjectiveC.sendPointer(array, "objectAtIndex:", index))
+  }
+}
+
+internal fun readCoreLocation(location: Long): CoreLocationFix {
+  check(location != NULL) { "CLLocation is null" }
+  val coordinate = ObjectiveC.sendCoordinate(location, "coordinate")
+  val timestamp = ObjectiveC.sendPointer(location, "timestamp")
+  val ageSeconds =
+    if (timestamp == NULL) 0.0
+    else (-ObjectiveC.sendDouble(timestamp, "timeIntervalSinceNow")).coerceAtLeast(0.0)
+  return CoreLocationFix(
+    latitude = coordinate.latitude,
+    longitude = coordinate.longitude,
+    altitude = ObjectiveC.sendDouble(location, "altitude"),
+    horizontalAccuracy = ObjectiveC.sendDouble(location, "horizontalAccuracy"),
+    verticalAccuracy = ObjectiveC.sendDouble(location, "verticalAccuracy"),
+    course = ObjectiveC.sendDouble(location, "course"),
+    courseAccuracy = optionalDouble(location, "courseAccuracy"),
+    speed = ObjectiveC.sendDouble(location, "speed"),
+    speedAccuracy = optionalDouble(location, "speedAccuracy"),
+    ageSeconds = ageSeconds,
+  )
+}
+
+internal fun readError(error: Long): CoreLocationError {
+  if (error == NULL) return CoreLocationError(domain = "", code = 0)
+  return CoreLocationError(
+    domain = ObjectiveC.utf8String(ObjectiveC.sendPointer(error, "domain")),
+    code = ObjectiveC.sendLong(error, "code"),
+  )
+}
+
+private fun optionalDouble(receiver: Long, selectorName: String): Double =
+  if (ObjectiveC.respondsTo(receiver, selectorName)) {
+    ObjectiveC.sendDouble(receiver, selectorName)
+  } else {
+    -1.0
+  }

--- a/lib/maplibre-compose-macos/src/test/kotlin/org/maplibre/compose/location/desktop/macos/MacosLocationProviderTest.kt
+++ b/lib/maplibre-compose-macos/src/test/kotlin/org/maplibre/compose/location/desktop/macos/MacosLocationProviderTest.kt
@@ -208,6 +208,46 @@ class MacosLocationProviderTest {
   }
 
   @Test
+  fun providerDropsFixesWithInvalidHorizontalAccuracy() = runTest {
+    val client = FakeCoreLocationClient()
+    val provider = MacosLocationProvider(client, Dispatchers.Unconfined, Dispatchers.Unconfined)
+    client.nextLocation = sampleFix().copy(horizontalAccuracy = -1.0)
+
+    val events = mutableListOf<LocationEvent>()
+    backgroundScope.launch(Dispatchers.Unconfined) {
+      provider.updates(LocationRequest()).collect { events += it }
+    }
+
+    assertTrue(events.isEmpty())
+    client.managers.single().boundDelegate?.didUpdateLocations(listOf(sampleFix()))
+    assertIs<LocationEvent.Fix>(events.single())
+  }
+
+  @Test
+  fun transientErrorKeepsCallbackOrderAheadOfLaterFix() = runTest {
+    val client = FakeCoreLocationClient()
+    val provider = MacosLocationProvider(client, Dispatchers.Unconfined, Dispatchers.Unconfined)
+    client.nextLocation = sampleFix()
+
+    val events = mutableListOf<LocationEvent>()
+    backgroundScope.launch(Dispatchers.Unconfined) {
+      provider.updates(LocationRequest()).collect { events += it }
+    }
+
+    assertIs<LocationEvent.Fix>(events.single())
+    val delegate = client.managers.single().boundDelegate
+    delegate?.didFailWithError(CoreLocationError(CL_ERROR_DOMAIN, CL_ERROR_LOCATION_UNKNOWN))
+    delegate?.didUpdateLocations(listOf(sampleFix().copy(latitude = 53.0)))
+
+    assertEquals(3, events.size)
+    assertEquals(
+      LocationUnavailableReason.TemporarilyUnavailable,
+      assertIs<LocationEvent.Unavailable>(events[1]).reason,
+    )
+    assertEquals(53.0, assertIs<LocationEvent.Fix>(events[2]).location.position.value.latitude)
+  }
+
+  @Test
   fun deniedErrorRechecksLocationServices() = runTest {
     val client = FakeCoreLocationClient()
     val provider = MacosLocationProvider(client, Dispatchers.Unconfined, Dispatchers.Unconfined)
@@ -267,6 +307,24 @@ class MacosLocationProviderTest {
     requester.close()
     assertTrue(manager.closed)
     assertTrue(client.closed)
+  }
+
+  @Test
+  fun permissionFailureClearsPendingRequest() {
+    val client = FakeCoreLocationClient()
+    val requester = MacosLocationPermissionRequester(client)
+    val manager = client.managers.single()
+
+    requester.requestForegroundPermission()
+    assertEquals(1, manager.whenInUseRequests)
+    assertTrue(manager.updating)
+
+    manager.boundDelegate?.didFailWithError(CoreLocationError(CL_ERROR_DOMAIN, CL_ERROR_DENIED))
+    assertFalse(manager.updating)
+
+    requester.requestForegroundPermission()
+    assertEquals(2, manager.whenInUseRequests)
+    assertTrue(manager.updating)
   }
 
   @Test

--- a/lib/maplibre-compose-macos/src/test/kotlin/org/maplibre/compose/location/desktop/macos/MacosLocationProviderTest.kt
+++ b/lib/maplibre-compose-macos/src/test/kotlin/org/maplibre/compose/location/desktop/macos/MacosLocationProviderTest.kt
@@ -12,6 +12,7 @@ import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import org.maplibre.compose.location.DesktopLocationBackend
 import org.maplibre.compose.location.LocationAccuracy
@@ -204,6 +205,29 @@ class MacosLocationProviderTest {
     val event = assertIs<LocationEvent.Unavailable>(provider.updates(LocationRequest()).first())
     assertEquals(LocationUnavailableReason.ServicesDisabled, event.reason)
     assertEquals(0, client.managers.size)
+  }
+
+  @Test
+  fun deniedErrorRechecksLocationServices() = runTest {
+    val client = FakeCoreLocationClient()
+    val provider = MacosLocationProvider(client, Dispatchers.Unconfined, Dispatchers.Unconfined)
+    client.nextLocation = sampleFix()
+
+    val events = mutableListOf<LocationEvent>()
+    backgroundScope.launch(Dispatchers.Unconfined) {
+      provider.updates(LocationRequest()).collect { events += it }
+    }
+
+    assertIs<LocationEvent.Fix>(events.single())
+    client.locationServicesEnabled = false
+    client.managers
+      .single()
+      .boundDelegate
+      ?.didFailWithError(CoreLocationError(CL_ERROR_DOMAIN, CL_ERROR_DENIED))
+
+    val unavailable = assertIs<LocationEvent.Unavailable>(events.last())
+    assertEquals(2, events.size)
+    assertEquals(LocationUnavailableReason.ServicesDisabled, unavailable.reason)
   }
 
   @Test

--- a/lib/maplibre-compose-macos/src/test/kotlin/org/maplibre/compose/location/desktop/macos/MacosLocationProviderTest.kt
+++ b/lib/maplibre-compose-macos/src/test/kotlin/org/maplibre/compose/location/desktop/macos/MacosLocationProviderTest.kt
@@ -106,6 +106,10 @@ class MacosLocationProviderTest {
     assertEquals(CL_LOCATION_ACCURACY_HUNDRED_METERS, LocationAccuracy.Balanced.toDesiredAccuracy())
     assertEquals(CL_LOCATION_ACCURACY_KILOMETER, LocationAccuracy.Low.toDesiredAccuracy())
     assertEquals(CL_LOCATION_ACCURACY_REDUCED, LocationAccuracy.Lowest.toDesiredAccuracy())
+    assertTrue(CL_LOCATION_ACCURACY_REDUCED != 500.0)
+    ObjectiveC.exportedDoubleOrNull("kCLLocationAccuracyReduced")?.let { exported ->
+      assertEquals(exported, CL_LOCATION_ACCURACY_REDUCED)
+    }
   }
 
   @Test

--- a/lib/maplibre-compose-macos/src/test/kotlin/org/maplibre/compose/location/desktop/macos/MacosLocationProviderTest.kt
+++ b/lib/maplibre-compose-macos/src/test/kotlin/org/maplibre/compose/location/desktop/macos/MacosLocationProviderTest.kt
@@ -1,0 +1,381 @@
+package org.maplibre.compose.location.desktop.macos
+
+import java.util.Locale
+import java.util.ServiceLoader
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.maplibre.compose.location.DesktopLocationBackend
+import org.maplibre.compose.location.LocationAccuracy
+import org.maplibre.compose.location.LocationAccuracyAuthorization
+import org.maplibre.compose.location.LocationBackendAvailability
+import org.maplibre.compose.location.LocationEvent
+import org.maplibre.compose.location.LocationPermission
+import org.maplibre.compose.location.LocationRequest
+import org.maplibre.compose.location.LocationUnavailableReason
+import org.maplibre.spatialk.units.Bearing
+import org.maplibre.spatialk.units.extensions.degrees
+import org.maplibre.spatialk.units.extensions.inMeters
+import org.maplibre.spatialk.units.extensions.meters
+
+class MacosLocationProviderTest {
+  @Test
+  fun serviceLoaderFindsMacosBackend() {
+    assertTrue(
+      ServiceLoader.load(DesktopLocationBackend::class.java).any { it is MacosLocationBackend }
+    )
+  }
+
+  @Test
+  fun isAvailableOnlyOnMac() {
+    val onMac = System.getProperty("os.name").lowercase(Locale.ROOT).startsWith("mac")
+    assertEquals(onMac, MacosLocationBackend().isAvailable())
+  }
+
+  @Test
+  fun mapsCoreLocationErrorsByRecoverability() {
+    assertEquals(
+      LocationUnavailableReason.ServicesDisabled,
+      CoreLocationError(CL_ERROR_DOMAIN, CL_ERROR_DENIED).asUnavailableReason(false),
+    )
+    assertEquals(
+      LocationUnavailableReason.PermissionDenied,
+      CoreLocationError(CL_ERROR_DOMAIN, CL_ERROR_DENIED).asUnavailableReason(true),
+    )
+    assertEquals(
+      LocationUnavailableReason.PermissionDenied,
+      CoreLocationError(CL_ERROR_DOMAIN, CL_ERROR_PROMPT_DECLINED).asUnavailableReason(true),
+    )
+    assertEquals(
+      LocationUnavailableReason.TemporarilyUnavailable,
+      CoreLocationError(CL_ERROR_DOMAIN, CL_ERROR_LOCATION_UNKNOWN).asUnavailableReason(true),
+    )
+    assertEquals(
+      LocationUnavailableReason.TemporarilyUnavailable,
+      CoreLocationError(CL_ERROR_DOMAIN, CL_ERROR_NETWORK).asUnavailableReason(true),
+    )
+    assertEquals(
+      LocationUnavailableReason.UnexpectedFailure,
+      CoreLocationError("example.error", 1).asUnavailableReason(true),
+    )
+  }
+
+  @Test
+  fun mapsAuthorizationStatus() {
+    assertEquals(
+      LocationPermission.Granted(LocationAccuracyAuthorization.Precise),
+      readPermission(CL_AUTHORIZATION_AUTHORIZED_ALWAYS, CL_ACCURACY_AUTHORIZATION_FULL),
+    )
+    assertEquals(
+      LocationPermission.Granted(LocationAccuracyAuthorization.Approximate),
+      readPermission(CL_AUTHORIZATION_AUTHORIZED_WHEN_IN_USE, 1),
+    )
+    assertEquals(
+      LocationPermission.NotGranted(canRequest = true),
+      readPermission(CL_AUTHORIZATION_NOT_DETERMINED, CL_ACCURACY_AUTHORIZATION_FULL),
+    )
+    assertEquals(
+      LocationPermission.NotGranted(canRequest = false),
+      readPermission(CL_AUTHORIZATION_DENIED, CL_ACCURACY_AUTHORIZATION_FULL),
+    )
+    assertEquals(
+      LocationPermission.NotGranted(canRequest = false),
+      readPermission(CL_AUTHORIZATION_RESTRICTED, CL_ACCURACY_AUTHORIZATION_FULL),
+    )
+    assertEquals(
+      LocationPermission.NotGranted(canRequest = null),
+      readPermission(99, CL_ACCURACY_AUTHORIZATION_FULL),
+    )
+  }
+
+  @Test
+  fun mapsAccuracyPreferences() {
+    assertEquals(
+      CL_LOCATION_ACCURACY_BEST_FOR_NAVIGATION,
+      LocationAccuracy.BestForNavigation.toDesiredAccuracy(),
+    )
+    assertEquals(CL_LOCATION_ACCURACY_BEST, LocationAccuracy.High.toDesiredAccuracy())
+    assertEquals(CL_LOCATION_ACCURACY_HUNDRED_METERS, LocationAccuracy.Balanced.toDesiredAccuracy())
+    assertEquals(CL_LOCATION_ACCURACY_KILOMETER, LocationAccuracy.Low.toDesiredAccuracy())
+    assertEquals(CL_LOCATION_ACCURACY_REDUCED, LocationAccuracy.Lowest.toDesiredAccuracy())
+  }
+
+  @Test
+  fun convertsCoreLocationFix() {
+    val location =
+      CoreLocationFix(
+          latitude = 52.0,
+          longitude = 13.0,
+          altitude = 40.0,
+          horizontalAccuracy = 8.0,
+          verticalAccuracy = 3.0,
+          course = 90.0,
+          courseAccuracy = 5.0,
+          speed = 3.0,
+          speedAccuracy = 0.5,
+          ageSeconds = 2.0,
+        )
+        .asMapLibreLocation()
+
+    assertEquals(52.0, location.position.value.latitude)
+    assertEquals(13.0, location.position.value.longitude)
+    assertEquals(40.0, location.position.value.altitude)
+    assertEquals(8.0, location.position.accuracy?.inMeters)
+    assertEquals(3.0, location.altitudeAccuracy?.inMeters)
+    assertEquals(3.0, location.speed?.distancePerSecond?.inMeters)
+    assertEquals(0.5, location.speed?.accuracy?.inMeters)
+    assertEquals(Bearing.North + 90.degrees, location.course?.value)
+    assertEquals(5.degrees, location.course?.accuracy)
+    assertTrue(location.timestamp.elapsedNow() >= 2.seconds)
+  }
+
+  @Test
+  fun omitsInvalidOptionalFixFields() {
+    val location =
+      CoreLocationFix(
+          latitude = 1.0,
+          longitude = 2.0,
+          altitude = 0.0,
+          horizontalAccuracy = 4.0,
+          verticalAccuracy = -1.0,
+          course = -1.0,
+          courseAccuracy = -1.0,
+          speed = -1.0,
+          speedAccuracy = -1.0,
+          ageSeconds = 0.0,
+        )
+        .asMapLibreLocation()
+
+    assertNull(location.altitudeAccuracy)
+    assertNull(location.course)
+    assertNull(location.speed)
+  }
+
+  @Test
+  fun providerForwardsClientUpdatesAndClosesItsManager() = runTest {
+    val client = FakeCoreLocationClient()
+    val provider = MacosLocationProvider(client, Dispatchers.Unconfined)
+    val fix = sampleFix()
+    client.nextLocation = fix
+
+    val event = assertIs<LocationEvent.Fix>(provider.updates(LocationRequest()).first())
+    assertEquals(52.0, event.location.position.value.latitude)
+    assertEquals(1, client.managers.size)
+    assertEquals(CL_LOCATION_ACCURACY_BEST, client.managers.single().desiredAccuracy)
+    assertEquals(1.0, client.managers.single().distanceFilter)
+    assertTrue(client.managers.single().closed)
+    assertFalse(client.managers.single().updating)
+
+    provider.close()
+    assertTrue(client.closed)
+  }
+
+  @Test
+  fun providerAppliesRequestPreferences() = runTest {
+    val client = FakeCoreLocationClient()
+    val provider = MacosLocationProvider(client, Dispatchers.Unconfined)
+    client.nextLocation = sampleFix()
+
+    provider
+      .updates(LocationRequest(accuracy = LocationAccuracy.Balanced, minimumDistance = 10.meters))
+      .first()
+
+    assertEquals(CL_LOCATION_ACCURACY_HUNDRED_METERS, client.managers.single().desiredAccuracy)
+    assertEquals(10.0, client.managers.single().distanceFilter)
+  }
+
+  @Test
+  fun missingLocationServicesEmitsServicesDisabled() = runTest {
+    val client = FakeCoreLocationClient(locationServicesEnabled = false)
+    val provider = MacosLocationProvider(client, Dispatchers.Unconfined)
+
+    val event = assertIs<LocationEvent.Unavailable>(provider.updates(LocationRequest()).first())
+    assertEquals(LocationUnavailableReason.ServicesDisabled, event.reason)
+    assertEquals(0, client.managers.size)
+  }
+
+  @Test
+  fun managerConstructionFailureIsUnexpected() = runTest {
+    val client = FakeCoreLocationClient(createFailure = IllegalStateException("native failed"))
+    val provider = MacosLocationProvider(client, Dispatchers.Unconfined)
+
+    val event = assertIs<LocationEvent.Unavailable>(provider.updates(LocationRequest()).first())
+    assertEquals(LocationUnavailableReason.UnexpectedFailure, event.reason)
+    assertIs<IllegalStateException>(event.cause)
+  }
+
+  @Test
+  fun overlappingPermissionRequestsStartOneAuthorizationRequest() {
+    val client = FakeCoreLocationClient()
+    val requester = MacosLocationPermissionRequester(client)
+    val manager = client.managers.single()
+
+    assertEquals(LocationPermission.NotGranted(canRequest = true), requester.status.value)
+
+    requester.requestForegroundPermission()
+    requester.requestForegroundPermission()
+    assertEquals(1, manager.whenInUseRequests)
+    assertTrue(manager.updating)
+
+    manager.authorizationStatus = CL_AUTHORIZATION_AUTHORIZED_WHEN_IN_USE
+    manager.boundDelegate?.didChangeAuthorization()
+    assertEquals(
+      LocationPermission.Granted(LocationAccuracyAuthorization.Precise),
+      requester.status.value,
+    )
+    assertFalse(manager.updating)
+
+    requester.requestForegroundPermission()
+    assertEquals(1, manager.whenInUseRequests)
+
+    requester.close()
+    assertTrue(manager.closed)
+    assertTrue(client.closed)
+  }
+
+  @Test
+  fun missingUsageDescriptionMarksProviderAndRequesterMisconfigured() = runTest {
+    val client = FakeCoreLocationClient(hasUsageDescription = false)
+    val provider = MacosLocationProvider(client, Dispatchers.Unconfined)
+    val requester = MacosLocationPermissionRequester(client)
+
+    assertIs<LocationBackendAvailability.Misconfigured>(provider.backendAvailability)
+    assertIs<LocationBackendAvailability.Misconfigured>(requester.backendAvailability)
+    val event = assertIs<LocationEvent.Unavailable>(provider.updates(LocationRequest()).first())
+    assertEquals(LocationUnavailableReason.Misconfigured, event.reason)
+    requester.requestForegroundPermission()
+    assertEquals(0, client.managers.single().whenInUseRequests)
+  }
+
+  @Test
+  fun deniedAuthorizationCannotBeRequestedAgain() {
+    val client = FakeCoreLocationClient()
+    val requester = MacosLocationPermissionRequester(client)
+    val manager = client.managers.single()
+
+    manager.authorizationStatus = CL_AUTHORIZATION_DENIED
+    manager.boundDelegate?.didChangeAuthorization()
+    requester.requestForegroundPermission()
+
+    assertEquals(LocationPermission.NotGranted(canRequest = false), requester.status.value)
+    assertEquals(0, manager.whenInUseRequests)
+  }
+
+  @Test
+  fun cocoaMainRunsInlineWhenAlreadyOnMain() {
+    var dispatched = false
+    val result =
+      CocoaMain.run(alreadyOnMain = true, dispatch = { dispatched = true }) {
+        42
+      }
+    assertEquals(42, result)
+    assertFalse(dispatched)
+  }
+
+  @Test
+  fun cocoaMainDispatchesWhenOffMainAndPropagatesResult() {
+    var dispatched = false
+    val result =
+      CocoaMain.run(
+        alreadyOnMain = false,
+        dispatch = { work ->
+          dispatched = true
+          work.run()
+        },
+      ) {
+        7
+      }
+    assertTrue(dispatched)
+    assertEquals(7, result)
+  }
+
+  @Test
+  fun cocoaMainPropagatesFailureFromDispatchedWork() {
+    val error =
+      assertFailsWith<IllegalStateException> {
+        CocoaMain.run(alreadyOnMain = false, dispatch = { it.run() }) { error("boom") }
+      }
+    assertEquals("boom", error.message)
+  }
+}
+
+private fun sampleFix(): CoreLocationFix =
+  CoreLocationFix(
+    latitude = 52.0,
+    longitude = 13.0,
+    altitude = 40.0,
+    horizontalAccuracy = 8.0,
+    verticalAccuracy = 3.0,
+    course = 90.0,
+    courseAccuracy = 5.0,
+    speed = 3.0,
+    speedAccuracy = 0.5,
+    ageSeconds = 0.0,
+  )
+
+private class FakeCoreLocationClient(
+  override var locationServicesEnabled: Boolean = true,
+  hasUsageDescription: Boolean = true,
+  private val createFailure: Throwable? = null,
+) : CoreLocationClient {
+  override val backendAvailability: LocationBackendAvailability =
+    if (hasUsageDescription) {
+      LocationBackendAvailability.Available
+    } else {
+      LocationBackendAvailability.Misconfigured(IllegalStateException("missing usage description"))
+    }
+  val managers = mutableListOf<FakeCoreLocationManager>()
+  var closed = false
+  var nextLocation: CoreLocationFix? = null
+
+  override fun createManager(): CoreLocationManager {
+    createFailure?.let { throw it }
+    return FakeCoreLocationManager(nextLocation).also { managers += it }
+  }
+
+  override fun close() {
+    closed = true
+  }
+}
+
+private class FakeCoreLocationManager(override var location: CoreLocationFix? = null) :
+  CoreLocationManager {
+  override var desiredAccuracy: Double = 0.0
+  override var distanceFilter: Double = 0.0
+  override var authorizationStatus: Long = CL_AUTHORIZATION_NOT_DETERMINED
+  override var accuracyAuthorization: Long = CL_ACCURACY_AUTHORIZATION_FULL
+  var boundDelegate: CoreLocationDelegate? = null
+  var updating = false
+  var whenInUseRequests = 0
+  var closed = false
+
+  override fun setDelegate(delegate: CoreLocationDelegate?) {
+    boundDelegate = delegate
+  }
+
+  override fun startUpdatingLocation() {
+    updating = true
+  }
+
+  override fun stopUpdatingLocation() {
+    updating = false
+  }
+
+  override fun requestWhenInUseAuthorization() {
+    whenInUseRequests += 1
+  }
+
+  override fun close() {
+    closed = true
+    stopUpdatingLocation()
+    boundDelegate = null
+  }
+}

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/location/LocationProvider.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/location/LocationProvider.kt
@@ -257,8 +257,9 @@ public object UnsupportedLocationProvider : LocationProvider {
  *
  * See [AndroidLocationProvider][org.maplibre.compose.location.AndroidLocationProvider],
  * [BrowserLocationProvider][org.maplibre.compose.location.BrowserLocationProvider],
- * [IosLocationProvider][org.maplibre.compose.location.IosLocationProvider], and
- * [LinuxPortalLocationProvider][org.maplibre.compose.location.desktop.linux.LinuxPortalLocationProvider].
+ * [IosLocationProvider][org.maplibre.compose.location.IosLocationProvider],
+ * [LinuxPortalLocationProvider][org.maplibre.compose.location.desktop.linux.LinuxPortalLocationProvider],
+ * and [MacosLocationProvider][org.maplibre.compose.location.desktop.macos.MacosLocationProvider].
  * Desktop implementations are installed through
  * [DesktopLocationBackend][org.maplibre.compose.location.DesktopLocationBackend].
  */
@@ -275,8 +276,9 @@ public object UnsupportedLocationProvider : LocationProvider {
  * [rememberAndroidLocationPermissionRequester][org.maplibre.compose.location.rememberAndroidLocationPermissionRequester],
  * [rememberBrowserLocationPermissionRequester][org.maplibre.compose.location.rememberBrowserLocationPermissionRequester],
  * [rememberIosLocationPermissionRequester][org.maplibre.compose.location.rememberIosLocationPermissionRequester],
+ * [LinuxPortalLocationPermissionRequester][org.maplibre.compose.location.desktop.linux.LinuxPortalLocationPermissionRequester],
  * and
- * [LinuxPortalLocationPermissionRequester][org.maplibre.compose.location.desktop.linux.LinuxPortalLocationPermissionRequester].
+ * [MacosLocationPermissionRequester][org.maplibre.compose.location.desktop.macos.MacosLocationPermissionRequester].
  * Desktop implementations are installed through
  * [DesktopLocationBackend][org.maplibre.compose.location.DesktopLocationBackend].
  */

--- a/mise.toml
+++ b/mise.toml
@@ -183,7 +183,14 @@ run = '''
 
 [tasks."demo:desktop"]
 description = "Run the demo app on this host."
-run = "./gradlew :demo-app:desktop:run"
+run = '''
+if [ "$(uname -s)" = Darwin ]; then
+  # Core Location reads the usage description from a packaged app Info.plist.
+  ./gradlew :demo-app:desktop:runDistributable
+else
+  ./gradlew :demo-app:desktop:run
+fi
+'''
 
 [tasks."demo:js"]
 description = "Run the demo app in a browser."

--- a/mise.toml
+++ b/mise.toml
@@ -203,7 +203,14 @@ run = '.mise/bin/run-ios-demo'
 
 [tasks."demo:desktop-glfw"]
 description = "Run the demo app on the compose-glfw desktop host instead of the AWT one."
-run = "./gradlew :demo-app:desktop-glfw:run"
+run = '''
+if [ "$(uname -s)" = Darwin ]; then
+  # Core Location reads the usage description from a packaged app Info.plist.
+  ./gradlew :demo-app:desktop-glfw:runDistributable
+else
+  ./gradlew :demo-app:desktop-glfw:run
+fi
+'''
 
 [tasks."publish:snapshot"]
 description = "Publish a snapshot build to Maven Central."


### PR DESCRIPTION
## Description
Add a Core Location desktop backend for macOS and package the demo with the usage description and hardened-runtime location entitlement so the system prompt can appear.

## Test plan
On a Mac, run `mise run demo:desktop`, open User Location, click Request permission, and confirm the system dialog and a fix.