### PR TITLE
Show the synchronous GeoJSON demo on every platform

### DIFF
--- a/demo-app/common/src/androidMain/kotlin/org/maplibre/compose/demoapp/util/Platform.android.kt
+++ b/demo-app/common/src/androidMain/kotlin/org/maplibre/compose/demoapp/util/Platform.android.kt
@@ -6,7 +6,6 @@ import org.maplibre.compose.demoapp.demos.GestureOptionsDemo
 import org.maplibre.compose.demoapp.demos.GmsLocationDemo
 import org.maplibre.compose.demoapp.demos.OfflineManagerDemo
 import org.maplibre.compose.demoapp.demos.RenderOptionsDemo
-import org.maplibre.compose.demoapp.demos.SynchronousGeoJsonUpdatesDemo
 
 actual object Platform {
   actual val name = "Android"
@@ -19,6 +18,5 @@ actual object Platform {
       OfflineManagerDemo,
       RenderOptionsDemo,
       GmsLocationDemo,
-      SynchronousGeoJsonUpdatesDemo,
     )
 }

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoState.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoState.kt
@@ -20,6 +20,7 @@ import org.maplibre.compose.demoapp.demos.MapControlsDemo
 import org.maplibre.compose.demoapp.demos.MapManipulationDemo
 import org.maplibre.compose.demoapp.demos.MarkersDemo
 import org.maplibre.compose.demoapp.demos.StyleSelectorDemo
+import org.maplibre.compose.demoapp.demos.SynchronousGeoJsonUpdatesDemo
 import org.maplibre.compose.demoapp.demos.UserLocationDemo
 import org.maplibre.compose.demoapp.util.Platform
 import org.maplibre.compose.location.LocationState
@@ -84,6 +85,7 @@ class DemoState(
       StyleSelectorDemo,
       CameraStateDemo,
       AnimatedLayerDemo,
+      SynchronousGeoJsonUpdatesDemo,
       MarkersDemo,
       MapClickDemo,
       ClusteredPointsDemo,

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/SynchronousGeoJsonUpdatesDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/SynchronousGeoJsonUpdatesDemo.kt
@@ -183,7 +183,11 @@ fun SynchronousGeoJsonUpdatesDemoSheet(
     )
     Text(text = "Zoom: $zoomLevel", modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp))
     Text(
-      text = "Android only. The point updates every 50 ms.",
+      text = "The point updates every 50 ms.",
+      modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+    )
+    Text(
+      text = "Synchronous updates reduce latency and can reduce frame rate.",
       modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
     )
     Text(

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Layers.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Layers.kt
@@ -99,9 +99,6 @@ fun Layers() {
         data = GeoJsonData.JsonString("""{"type":"FeatureCollection","features":[]}"""),
         options = GeoJsonOptions(synchronousUpdate = true),
       )
-    // Android only for now: other platforms currently ignore this option.
-    // Use this only for small, frequently updated in-memory GeoJSON sources.
-    // Synchronous updates can reduce update latency, but may reduce frame rate.
     CircleLayer(id = "live-positions", source = livePositions)
     // #endregion synchronous-geojson-updates
   }

--- a/demo-app/common/src/jvmMain/kotlin/org/maplibre/compose/demoapp/util/Platform.desktop.kt
+++ b/demo-app/common/src/jvmMain/kotlin/org/maplibre/compose/demoapp/util/Platform.desktop.kt
@@ -4,7 +4,6 @@ import org.maplibre.compose.demoapp.demos.Demo
 import org.maplibre.compose.demoapp.demos.GestureOptionsDemo
 import org.maplibre.compose.demoapp.demos.OfflineManagerDemo
 import org.maplibre.compose.demoapp.demos.RenderOptionsDemo
-import org.maplibre.compose.demoapp.demos.SynchronousGeoJsonUpdatesDemo
 
 actual object Platform {
   actual val name = System.getProperty("os.name")!!
@@ -15,7 +14,6 @@ actual object Platform {
     listOf(
       GestureOptionsDemo,
       RenderOptionsDemo,
-      SynchronousGeoJsonUpdatesDemo,
       OfflineManagerDemo,
     )
 }

--- a/docs/src/content/docs/layers.mdx
+++ b/docs/src/content/docs/layers.mdx
@@ -28,8 +28,8 @@ style, but you can also declare new sources:
 <Code code={inside("MaplibreMap {", region(layers, "amtrak-1"))} lang="kotlin" />
 
 For small, frequently updated in-memory GeoJSON sources, you can opt into
-synchronous updates. Android, iOS, and desktop apply the option; the browser
-parses GeoJSON on a worker and ignores it.
+synchronous updates. That reduces update latency and can reduce frame rate.
+Android, iOS, and desktop apply the option. The browser ignores it.
 
 <Code code={inside("MaplibreMap {", region(layers, "synchronous-geojson-updates"))} lang="kotlin" />
 

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/MlnFfiMapRuntimeLoop.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/MlnFfiMapRuntimeLoop.kt
@@ -105,10 +105,23 @@ internal class MlnFfiMapRuntimeLoop(
    * Runs [action] on the owner thread and waits for its result. Returns null when there is no map,
    * or when the loop stopped before the work could run. Runs inline when the caller is already the
    * owner thread.
+   *
+   * [abandon] runs when [action] will not run: the loop has already stopped, or a queued task is
+   * dropped. It does not run when the wait ends while that task is still pending.
    */
-  fun <T> call(action: (MapHandle) -> T): T? {
-    if (thread.isCurrent()) return map?.let(action)
-    if (map == null) return null
+  fun <T> call(action: (MapHandle) -> T, abandon: () -> Unit = {}): T? {
+    if (thread.isCurrent()) {
+      val current = map
+      if (current == null) {
+        abandon()
+        return null
+      }
+      return action(current)
+    }
+    if (map == null) {
+      abandon()
+      return null
+    }
 
     var result: Result<T>? = null
     val done = MlnFfiGate()
@@ -118,9 +131,18 @@ internal class MlnFfiMapRuntimeLoop(
           result = runCatching { action(map) }
           done.open()
         },
-        abandon = { done.open() },
+        abandon = {
+          try {
+            abandon()
+          } finally {
+            done.open()
+          }
+        },
       )
-    if (!posted) return null
+    if (!posted) {
+      abandon()
+      return null
+    }
 
     done.await()
     // Null when the wait ended before the owner thread reached the task, which the gate's own

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -211,9 +211,12 @@ internal class MlnFfiMapSession(
     /**
      * `addSource`, `removeSource` and `removeImage` notify mbgl of nothing, so they render stale.
      */
-    override fun <T> mutateMap(action: (MapHandle) -> T): T? {
-      if (!isLoaded) return null
-      return runOnMap { map -> action(map).also { map.requestRepaint() } }
+    override fun <T> mutateMap(abandon: () -> Unit, action: (MapHandle) -> T): T? {
+      if (!isLoaded) {
+        abandon()
+        return null
+      }
+      return runOnMap(abandon) { map -> action(map).also { map.requestRepaint() } }
     }
 
     override fun <T> withRenderSession(action: (RenderSessionHandle) -> T): T? {
@@ -755,7 +758,16 @@ internal class MlnFfiMapSession(
 
   private fun <T> withMap(fallback: T, action: (MapHandle) -> T): T = loop?.call(action) ?: fallback
 
-  private fun <T> runOnMap(action: (MapHandle) -> T): T? = loop?.call(action)
+  private fun <T> runOnMap(action: (MapHandle) -> T): T? = runOnMap({}, action)
+
+  private fun <T> runOnMap(abandon: () -> Unit, action: (MapHandle) -> T): T? {
+    val current = loop
+    if (current == null) {
+      abandon()
+      return null
+    }
+    return current.call(action, abandon)
+  }
 
   /** The render session lives on the host's renderer thread. */
   private fun <T> withRendererAccess(action: () -> T): T? {

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/sources/GeoJsonSource.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/sources/GeoJsonSource.kt
@@ -26,6 +26,12 @@ public actual class GeoJsonSource : Source {
   /** The URI form of [data], when it is one. */
   private var dataUrl: String?
 
+  /**
+   * Parsed and indexed on the caller, then installed on the owner thread. Null for a URL source,
+   * and after [addTo] consumes it.
+   */
+  private var prepared: GeoJsonSourceDataHandle? = null
+
   public actual constructor(id: String, data: GeoJsonData, options: GeoJsonOptions) : super(id) {
     this.options = options
     this.data = data.toDataJson()
@@ -42,22 +48,37 @@ public actual class GeoJsonSource : Source {
     put("synchronousUpdate", options.synchronousUpdate)
   }
 
+  override fun prepareForAttach() {
+    if (dataUrl != null) return
+    if (prepared != null) return
+    prepared = prepareData()
+  }
+
+  override fun abandonPrepareForAttach() {
+    prepared?.close()
+    prepared = null
+  }
+
   override fun addTo(map: MapHandle) {
     val url = dataUrl
     if (url != null) {
       map.addGeoJsonSourceUrl(id, url, options.toFfiOptions())
     } else {
-      prepareData().use { map.addGeoJsonSourceData(id, it) }
+      takePrepared().use { map.addGeoJsonSourceData(id, it) }
     }
   }
 
   public actual fun setData(data: GeoJsonData) {
     this.data = data.toDataJson()
     this.dataUrl = (data as? GeoJsonData.Uri)?.uri
+    prepared?.close()
+    prepared = null
     if (data is GeoJsonData.Uri) {
       mutate { map -> map.setGeoJsonSourceUrl(id, data.uri) }
     } else {
       // Prepared outside the lambda so the map's owner thread does not parse or index the data.
+      // synchronousTiling is independent of this: it only changes where viewport tiles are sliced
+      // after the cheap install, on the owner thread (true) or a worker (false).
       prepareData().use { prepared ->
         mutate { map -> map.setGeoJsonSourceData(id, prepared) }
       }
@@ -67,6 +88,9 @@ public actual class GeoJsonSource : Source {
   /** Prepared with the options the source was added with; a mismatch is rejected at install. */
   private fun prepareData(): GeoJsonSourceDataHandle =
     GeoJsonSourceDataHandle.create(data.toJsonBytes(), options.toFfiOptions())
+
+  private fun takePrepared(): GeoJsonSourceDataHandle =
+    prepared?.also { prepared = null } ?: prepareData()
 
   public actual fun isCluster(feature: Feature<*, JsonObject?>): Boolean {
     return CLUSTER_ID_PROPERTY in feature.properties.orEmpty()
@@ -187,6 +211,8 @@ private fun GeoJsonOptions.toFfiOptions(): GeoJsonSourceOptions =
     it.clusterMaxZoom = clusterMaxZoom.toDouble()
     it.clusterMinPoints = clusterMinPoints
     it.lineMetrics = lineMetrics
+    // Viewport tile slicing during the update pass on the owner thread, not JSON parse. Parse and
+    // index happen in [GeoJsonSourceDataHandle.create], which the caller runs off that thread.
     it.synchronousTiling = synchronousUpdate
     it.clusterProperties = clusterPropertiesBytes()
   }

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/sources/GeoJsonSource.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/sources/GeoJsonSource.kt
@@ -55,8 +55,9 @@ public actual class GeoJsonSource : Source {
   }
 
   override fun abandonPrepareForAttach() {
-    prepared?.close()
+    val handle = prepared ?: return
     prepared = null
+    handle.close()
   }
 
   override fun addTo(map: MapHandle) {

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/sources/Source.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/sources/Source.kt
@@ -32,28 +32,37 @@ public actual sealed class Source(internal actual val id: String) {
       "Source '$id' already belongs to another loaded style; create a separate source instance " +
         "for each map"
     }
-    val added = binding.mutateMap { map ->
-      // A layer may attach its source before the source effect runs, so re-attaching the same
-      // binding is idempotent; any other descriptor with this ID is rejected.
-      if (this.binding === binding && map.styleSourceExists(id)) return@mutateMap false
-      check(!map.styleSourceExists(id)) {
-        "Source ID '$id' is already owned by a different live source descriptor"
-      }
+    // Before the owner-thread hop: GeoJSON parse and index must not run on the pump.
+    if (!isAttached) prepareForAttach()
+    val added =
       try {
-        addTo(map)
-      } catch (error: Throwable) {
-        if (error is MaplibreException) {
-          // Native reports what was wrong with the definition but never whose.
-          throw IllegalStateException(
-            "Could not add source '$id' of type " +
-              "'${(toJson()["type"] as? JsonPrimitive)?.content}': ${error.message}",
-            error,
-          )
+        binding.mutateMap { map ->
+          // A layer may attach its source before the source effect runs, so re-attaching the same
+          // binding is idempotent; any other descriptor with this ID is rejected.
+          if (this.binding === binding && map.styleSourceExists(id)) return@mutateMap false
+          check(!map.styleSourceExists(id)) {
+            "Source ID '$id' is already owned by a different live source descriptor"
+          }
+          try {
+            addTo(map)
+          } catch (error: Throwable) {
+            if (error is MaplibreException) {
+              // Native reports what was wrong with the definition but never whose.
+              throw IllegalStateException(
+                "Could not add source '$id' of type " +
+                  "'${(toJson()["type"] as? JsonPrimitive)?.content}': ${error.message}",
+                error,
+              )
+            }
+            throw error
+          }
+          true
         }
+      } catch (error: Throwable) {
+        abandonPrepareForAttach()
         throw error
       }
-      true
-    }
+    if (added != true) abandonPrepareForAttach()
     check(added != null) {
       "Source '$id' was not added: its style is no longer loaded. Any layer referencing it will " +
         "fail to attach."
@@ -61,6 +70,15 @@ public actual sealed class Source(internal actual val id: String) {
     if (!added) return
     this.binding = binding
   }
+
+  /**
+   * Runs on the caller before [addTo] hops to the owner thread. Override to do work that must not
+   * run on the pump, such as GeoJSON parse and index.
+   */
+  internal open fun prepareForAttach() {}
+
+  /** Releases work from [prepareForAttach] when [addTo] did not run. */
+  internal open fun abandonPrepareForAttach() {}
 
   /**
    * Creates this source on [map], on the map's owner thread. MapLibre Native accepts only `vector`,

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/sources/Source.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/sources/Source.kt
@@ -42,7 +42,7 @@ public actual sealed class Source(internal actual val id: String) {
     }
     val added =
       try {
-        binding.mutateMap { map ->
+        binding.mutateMap(abandon = { abandonPrepareForAttach() }) { map ->
           // A layer may attach its source before the source effect runs, so re-attaching the same
           // binding is idempotent; any other descriptor with this ID is rejected.
           if (this.binding === binding && map.styleSourceExists(id)) return@mutateMap false
@@ -60,8 +60,9 @@ public actual sealed class Source(internal actual val id: String) {
         abandonPrepareForAttach()
         throw error
       }
-    // Only when addTo did not run. A null result can mean the owner-thread wait ended while the
-    // queued add is still pending, and closing the prepared handle then races that add.
+    // addTo ran and found the source already present. A null result can mean the owner-thread wait
+    // ended while the queued add is still pending; mutateMap's abandon releases prepared data only
+    // when that add is dropped.
     if (added == false) abandonPrepareForAttach()
     check(added != null) {
       "Source '$id' was not added: its style is no longer loaded. Any layer referencing it will " +

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/sources/Source.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/sources/Source.kt
@@ -33,7 +33,13 @@ public actual sealed class Source(internal actual val id: String) {
         "for each map"
     }
     // Before the owner-thread hop: GeoJSON parse and index must not run on the pump.
-    if (!isAttached) prepareForAttach()
+    if (!isAttached) {
+      try {
+        prepareForAttach()
+      } catch (error: Throwable) {
+        throw wrapAddError(error)
+      }
+    }
     val added =
       try {
         binding.mutateMap { map ->
@@ -46,15 +52,7 @@ public actual sealed class Source(internal actual val id: String) {
           try {
             addTo(map)
           } catch (error: Throwable) {
-            if (error is MaplibreException) {
-              // Native reports what was wrong with the definition but never whose.
-              throw IllegalStateException(
-                "Could not add source '$id' of type " +
-                  "'${(toJson()["type"] as? JsonPrimitive)?.content}': ${error.message}",
-                error,
-              )
-            }
-            throw error
+            throw wrapAddError(error)
           }
           true
         }
@@ -62,7 +60,9 @@ public actual sealed class Source(internal actual val id: String) {
         abandonPrepareForAttach()
         throw error
       }
-    if (added != true) abandonPrepareForAttach()
+    // Only when addTo did not run. A null result can mean the owner-thread wait ended while the
+    // queued add is still pending, and closing the prepared handle then races that add.
+    if (added == false) abandonPrepareForAttach()
     check(added != null) {
       "Source '$id' was not added: its style is no longer loaded. Any layer referencing it will " +
         "fail to attach."
@@ -70,6 +70,18 @@ public actual sealed class Source(internal actual val id: String) {
     if (!added) return
     this.binding = binding
   }
+
+  /** Native reports what was wrong with the definition but never whose. */
+  private fun wrapAddError(error: Throwable): Throwable =
+    if (error is MaplibreException) {
+      IllegalStateException(
+        "Could not add source '$id' of type " +
+          "'${(toJson()["type"] as? JsonPrimitive)?.content}': ${error.message}",
+        error,
+      )
+    } else {
+      error
+    }
 
   /**
    * Runs on the caller before [addTo] hops to the owner thread. Override to do work that must not

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/style/MlnFfiStyleBinding.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/style/MlnFfiStyleBinding.kt
@@ -19,7 +19,15 @@ internal interface MlnFfiStyleBinding : StyleBinding {
   fun <T> readMap(action: (MapHandle) -> T): T?
 
   /** Requests a repaint after native accepts the mutation. */
-  fun <T> mutateMap(action: (MapHandle) -> T): T?
+  fun <T> mutateMap(action: (MapHandle) -> T): T? = mutateMap({}, action)
+
+  /**
+   * Requests a repaint after native accepts the mutation.
+   *
+   * [abandon] runs when [action] will not run. It does not run when the owner-thread wait ends
+   * while the mutation is still pending.
+   */
+  fun <T> mutateMap(abandon: () -> Unit, action: (MapHandle) -> T): T?
 
   /**
    * Null when the style has unloaded or no session is attached yet — a session exists only between
@@ -82,7 +90,10 @@ internal interface MlnFfiStyleBinding : StyleBinding {
 
         override fun <T> readMap(action: (MapHandle) -> T): T? = null
 
-        override fun <T> mutateMap(action: (MapHandle) -> T): T? = null
+        override fun <T> mutateMap(abandon: () -> Unit, action: (MapHandle) -> T): T? {
+          abandon()
+          return null
+        }
 
         override fun <T> withRenderSession(action: (RenderSessionHandle) -> T): T? = null
       }


### PR DESCRIPTION
## Description

Move the synchronous GeoJSON demo to the common list and prepare desktop GeoJSON off the map owner thread on first add.

## Test plan

Open the demo on Android, iOS, desktop, and the browser, and toggle synchronousUpdate while the point is moving.