### PR TITLE
Add the 3D Manhattan demo

### DIFF
--- a/demo-app/common/build.gradle.kts
+++ b/demo-app/common/build.gradle.kts
@@ -47,10 +47,19 @@ kotlin {
     // Desktop-only render toggles: tile borders, parse status, and the Surface/Texture hint.
     val mlnFfiShared by creating { dependsOn(commonMain.get()) }
 
+    // The offline API exists only on the MapLibre Native platforms, so the offline demo UI lives
+    // in this set and the web target gets an empty actual.
+    val maplibreNativeShared by creating { dependsOn(commonMain.get()) }
+
+    androidMain { dependsOn(maplibreNativeShared) }
+
     jvmMain {
       dependsOn(nonIosShared)
       dependsOn(mlnFfiShared)
+      dependsOn(maplibreNativeShared)
     }
+
+    iosMain { dependsOn(maplibreNativeShared) }
 
     jsMain { dependsOn(nonIosShared) }
 

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/Demo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/Demo.kt
@@ -2,6 +2,8 @@ package org.maplibre.compose.demoapp
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.UiComposable
+import org.maplibre.compose.camera.CameraPosition
+import org.maplibre.compose.demoapp.demos.Manhattan3dDemo
 import org.maplibre.compose.util.MaplibreComposable
 import org.maplibre.spatialk.geojson.BoundingBox
 import org.maplibre.spatialk.geojson.Position
@@ -19,6 +21,13 @@ interface Demo {
   val preferredStyle: DemoStyle?
     get() = null
 
+  /**
+   * The exact camera the flight ends at. Null fits [region] to the viewport instead; set this when
+   * the demo needs a composed view, such as a pitched skyline.
+   */
+  val camera: CameraPosition?
+    get() = null
+
   @MaplibreComposable @Composable fun MapContent() {}
 
   /** Controls shown in the sheet or side panel while this demo is selected. */
@@ -33,4 +42,4 @@ val Demo.center: Position
     )
 
 /** Demos appear in the shell in this order. */
-val allDemos: List<Demo> = listOf()
+val allDemos: List<Demo> = listOf(Manhattan3dDemo)

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoMap.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoMap.kt
@@ -25,6 +25,7 @@ import kotlin.math.roundToInt
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.vectorResource
+import org.maplibre.compose.camera.CameraState
 import org.maplibre.compose.demoapp.generated.Res
 import org.maplibre.compose.demoapp.generated.filter_center_focus_24px
 import org.maplibre.compose.map.MapOptions
@@ -39,6 +40,15 @@ val DemoFlightDuration = 2.seconds
 /** Padding between a demo's region and the edge of the map viewport. */
 val DemoRegionPadding = PaddingValues(48.dp)
 
+private suspend fun CameraState.flyToDemo(demo: Demo) {
+  val camera = demo.camera
+  if (camera != null) {
+    animateTo(finalPosition = camera, duration = DemoFlightDuration)
+  } else {
+    animateTo(boundingBox = demo.region, padding = DemoRegionPadding, duration = DemoFlightDuration)
+  }
+}
+
 /** The shared map, the pointer pin back to the selected demo, and the diagnostic overlays. */
 @Composable
 fun DemoMap(state: DemoAppState, sheetInsets: WindowInsets = WindowInsets(0)) {
@@ -47,11 +57,7 @@ fun DemoMap(state: DemoAppState, sheetInsets: WindowInsets = WindowInsets(0)) {
   LaunchedEffect(state.selectedDemo) {
     val demo = state.selectedDemo ?: return@LaunchedEffect
     demo.preferredStyle?.let { state.selectedStyle = it }
-    state.cameraState.animateTo(
-      boundingBox = demo.region,
-      padding = DemoRegionPadding,
-      duration = DemoFlightDuration,
-    )
+    state.cameraState.flyToDemo(demo)
   }
 
   Box(Modifier.fillMaxSize()) {
@@ -82,24 +88,18 @@ fun DemoMap(state: DemoAppState, sheetInsets: WindowInsets = WindowInsets(0)) {
 
     val scope = rememberCoroutineScope()
     state.selectedDemo?.let { demo ->
-      PointerPinButton(
-        cameraState = state.cameraState,
-        targetPosition = demo.center,
-        onClick = {
-          scope.launch {
-            state.cameraState.animateTo(
-              boundingBox = demo.region,
-              padding = DemoRegionPadding,
-              duration = DemoFlightDuration,
-            )
-          }
-        },
-        modifier = Modifier.fillMaxSize().padding(insets.asPaddingValues()),
-      ) {
-        Icon(
-          vectorResource(Res.drawable.filter_center_focus_24px),
-          contentDescription = "Fly back to ${demo.name}",
-        )
+      // The pin fills this box to place itself; sizing the pin itself is up to its content.
+      Box(Modifier.fillMaxSize().padding(insets.asPaddingValues())) {
+        PointerPinButton(
+          cameraState = state.cameraState,
+          targetPosition = demo.center,
+          onClick = { scope.launch { state.cameraState.flyToDemo(demo) } },
+        ) {
+          Icon(
+            vectorResource(Res.drawable.filter_center_focus_24px),
+            contentDescription = "Fly back to ${demo.name}",
+          )
+        }
       }
     }
 

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/Manhattan3dDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/Manhattan3dDemo.kt
@@ -1,0 +1,34 @@
+package org.maplibre.compose.demoapp.demos
+
+import androidx.compose.runtime.Composable
+import org.maplibre.compose.camera.CameraPosition
+import org.maplibre.compose.demoapp.Demo
+import org.maplibre.compose.demoapp.OpenFreeMap
+import org.maplibre.spatialk.geojson.BoundingBox
+import org.maplibre.spatialk.geojson.Position
+
+object Manhattan3dDemo : Demo {
+  override val name = "3D Manhattan"
+  override val description = "Liberty's building extrusions pitched over the financial district."
+  override val region = BoundingBox(west = -74.020, south = 40.700, east = -73.993, north = 40.722)
+  override val preferredStyle = OpenFreeMap.Liberty
+
+  override val camera =
+    CameraPosition(
+      target = Position(longitude = -74.0109, latitude = 40.7085),
+      zoom = 14.2,
+      bearing = 2.0,
+      tilt = 60.0,
+    )
+
+  @Composable
+  override fun Panel() {
+    OfflineRegionSection(region = region, styleUrl = preferredStyle.base.uri, packName = name)
+  }
+}
+
+/**
+ * A panel section that downloads [region] in the style at [styleUrl] for offline use, with progress
+ * and a delete control. The section is empty on the web target, which has no offline API.
+ */
+@Composable expect fun OfflineRegionSection(region: BoundingBox, styleUrl: String, packName: String)

--- a/demo-app/common/src/jsMain/kotlin/org/maplibre/compose/demoapp/demos/OfflineRegionSection.kt
+++ b/demo-app/common/src/jsMain/kotlin/org/maplibre/compose/demoapp/demos/OfflineRegionSection.kt
@@ -1,0 +1,8 @@
+package org.maplibre.compose.demoapp.demos
+
+import androidx.compose.runtime.Composable
+import org.maplibre.spatialk.geojson.BoundingBox
+
+// The web platform has no offline API, so the section is empty.
+@Composable
+actual fun OfflineRegionSection(region: BoundingBox, styleUrl: String, packName: String) {}

--- a/demo-app/common/src/maplibreNativeShared/kotlin/org/maplibre/compose/demoapp/demos/OfflineRegionSection.kt
+++ b/demo-app/common/src/maplibreNativeShared/kotlin/org/maplibre/compose/demoapp/demos/OfflineRegionSection.kt
@@ -1,0 +1,62 @@
+package org.maplibre.compose.demoapp.demos
+
+import androidx.compose.foundation.clickable
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import kotlinx.coroutines.launch
+import org.maplibre.compose.demoapp.design.SectionHeader
+import org.maplibre.compose.material3.OfflinePackListItem
+import org.maplibre.compose.offline.OfflinePackDefinition
+import org.maplibre.compose.offline.rememberOfflineManager
+import org.maplibre.spatialk.geojson.BoundingBox
+
+@Composable
+actual fun OfflineRegionSection(region: BoundingBox, styleUrl: String, packName: String) {
+  val offlineManager = rememberOfflineManager()
+  val scope = rememberCoroutineScope()
+  val metadata = remember(packName) { packName.encodeToByteArray() }
+  val pack = offlineManager.packs.firstOrNull { it.metadata?.contentEquals(metadata) == true }
+  var creating by remember { mutableStateOf(false) }
+
+  SectionHeader("Offline")
+  if (pack != null) {
+    OfflinePackListItem(pack = pack, offlineManager = offlineManager) { Text(packName) }
+  } else {
+    ListItem(
+      headlineContent = { Text("Download this region") },
+      supportingContent = { Text("For use without a network") },
+      colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+      modifier =
+        Modifier.clickable(enabled = !creating) {
+          creating = true
+          scope.launch {
+            try {
+              val newPack =
+                offlineManager.create(
+                  definition =
+                    OfflinePackDefinition.TilePyramid(
+                      styleUrl = styleUrl,
+                      bounds = region,
+                      minZoom = 12,
+                      maxZoom = 15,
+                    ),
+                  metadata = metadata,
+                )
+              offlineManager.resume(newPack)
+            } finally {
+              creating = false
+            }
+          }
+        },
+    )
+  }
+}

--- a/demo-app/common/src/maplibreNativeShared/kotlin/org/maplibre/compose/demoapp/demos/OfflineRegionSection.kt
+++ b/demo-app/common/src/maplibreNativeShared/kotlin/org/maplibre/compose/demoapp/demos/OfflineRegionSection.kt
@@ -3,6 +3,7 @@ package org.maplibre.compose.demoapp.demos
 import androidx.compose.foundation.clickable
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.ListItemDefaults
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -12,6 +13,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 import org.maplibre.compose.demoapp.design.SectionHeader
 import org.maplibre.compose.material3.OfflinePackListItem
@@ -26,6 +28,7 @@ actual fun OfflineRegionSection(region: BoundingBox, styleUrl: String, packName:
   val metadata = remember(packName) { packName.encodeToByteArray() }
   val pack = offlineManager.packs.firstOrNull { it.metadata?.contentEquals(metadata) == true }
   var creating by remember { mutableStateOf(false) }
+  var errorMessage by remember { mutableStateOf<String?>(null) }
 
   SectionHeader("Offline")
   if (pack != null) {
@@ -33,11 +36,19 @@ actual fun OfflineRegionSection(region: BoundingBox, styleUrl: String, packName:
   } else {
     ListItem(
       headlineContent = { Text("Download this region") },
-      supportingContent = { Text("For use without a network") },
+      supportingContent = {
+        Text(
+          text = errorMessage ?: "For use without a network",
+          color =
+            if (errorMessage != null) MaterialTheme.colorScheme.error
+            else MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+      },
       colors = ListItemDefaults.colors(containerColor = Color.Transparent),
       modifier =
         Modifier.clickable(enabled = !creating) {
           creating = true
+          errorMessage = null
           scope.launch {
             try {
               val newPack =
@@ -52,6 +63,10 @@ actual fun OfflineRegionSection(region: BoundingBox, styleUrl: String, packName:
                   metadata = metadata,
                 )
               offlineManager.resume(newPack)
+            } catch (e: CancellationException) {
+              throw e
+            } catch (e: Exception) {
+              errorMessage = e.message ?: "Couldn't download this region"
             } finally {
               creating = false
             }


### PR DESCRIPTION
**Description:** First phase-2 demo: a pitched camera over lower Manhattan on Liberty, with an offline download section exercising the offline API.

**Test plan:** All targets compile and the demo was exercised in the desktop app.