### PR TITLE
Defer queued base-style reload to the next update cycle on iOS

### DIFF
--- a/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/map/AndroidMapAdapter.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/map/AndroidMapAdapter.kt
@@ -127,12 +127,21 @@ internal class AndroidMapAdapter(
     lastBaseStyle = null
   }
 
+  // Unlike onStyleLoadSettled, safe to retry immediately: a failed load never produced a
+  // SafeStyle, so there's no in-flight content to unload out from under.
+  private fun onStyleLoadFailed() {
+    pendingBaseStyle = null
+    val next = queuedBaseStyle ?: return
+    queuedBaseStyle = null
+    beginStyleLoad(next)
+  }
+
   init {
     mapView.addOnDidFinishLoadingMapListener { callbacks.onMapFinishedLoading(this) }
     mapView.addOnSourceChangedListener { callbacks.onSourceChanged(this, it) }
     mapView.addOnDidFailLoadingMapListener {
       callbacks.onMapFailLoading(it)
-      onStyleLoadSettled()
+      onStyleLoadFailed()
     }
 
     map.addOnCameraMoveStartedListener { reason ->

--- a/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/map/AndroidMapAdapter.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/map/AndroidMapAdapter.kt
@@ -122,20 +122,8 @@ internal class AndroidMapAdapter(
     pendingBaseStyle = null
     if (queuedBaseStyle == null) return
     queuedBaseStyle = null
-    // Deliberately do NOT call beginStyleLoad(next) here. This method runs synchronously
-    // inside map.setStyle's native completion callback, not from AndroidView's `update`
-    // block — the only entry point SafeStyle's kdoc establishes as "early enough" for
-    // content subcomposition to observe an unload before the next native style transition
-    // begins. Calling beginStyleLoad directly here would unload the SafeStyle this same
-    // callback just created via callbacks.onStyleChanged(this, newStyle) above and
-    // immediately start tearing down the native style again, all before Compose's own
-    // recomposition cadence ever gets a chance to finish applying layer-property updates
-    // (e.g. SymbolLayer.setIconImage) against it — the same race #917/#948 fixed on iOS,
-    // where the analogous bug surfaces as an uncaught MLNInvalidStyleLayerException;
-    // Android's variant is a catchable-but-unhandled IllegalStateException("invalid native
-    // peer"). Instead, forcing a mismatch against lastBaseStyle makes the *next*
-    // setBaseStyle(style) call — driven by AndroidView's update block, on its
-    // established-safe cadence — restart the queued load.
+    // Not beginStyleLoad(next) directly: this runs inside map.setStyle's native callback, not
+    // AndroidView's update block, which SafeStyle's kdoc requires for unload ordering.
     lastBaseStyle = null
   }
 

--- a/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/map/AndroidMapAdapter.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/map/AndroidMapAdapter.kt
@@ -120,9 +120,23 @@ internal class AndroidMapAdapter(
 
   private fun onStyleLoadSettled() {
     pendingBaseStyle = null
-    val next = queuedBaseStyle ?: return
+    if (queuedBaseStyle == null) return
     queuedBaseStyle = null
-    beginStyleLoad(next)
+    // Deliberately do NOT call beginStyleLoad(next) here. This method runs synchronously
+    // inside map.setStyle's native completion callback, not from AndroidView's `update`
+    // block — the only entry point SafeStyle's kdoc establishes as "early enough" for
+    // content subcomposition to observe an unload before the next native style transition
+    // begins. Calling beginStyleLoad directly here would unload the SafeStyle this same
+    // callback just created via callbacks.onStyleChanged(this, newStyle) above and
+    // immediately start tearing down the native style again, all before Compose's own
+    // recomposition cadence ever gets a chance to finish applying layer-property updates
+    // (e.g. SymbolLayer.setIconImage) against it — the same race #917/#948 fixed on iOS,
+    // where the analogous bug surfaces as an uncaught MLNInvalidStyleLayerException;
+    // Android's variant is a catchable-but-unhandled IllegalStateException("invalid native
+    // peer"). Instead, forcing a mismatch against lastBaseStyle makes the *next*
+    // setBaseStyle(style) call — driven by AndroidView's update block, on its
+    // established-safe cadence — restart the queued load.
+    lastBaseStyle = null
   }
 
   init {

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/sources/Source.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/sources/Source.kt
@@ -1,7 +1,7 @@
 package org.maplibre.compose.sources
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.remember
 import org.maplibre.compose.style.LocalStyleNode
 
@@ -32,9 +32,9 @@ public fun getBaseSource(id: String): Source? {
 internal fun <T : Source> rememberUserSource(factory: (String) -> T, update: T.() -> Unit): T {
   val node = LocalStyleNode.current
   val source = remember(node) { factory(node.sourceManager.nextId()) }
-  LaunchedEffect(source, update, node.style.isUnloaded) {
-    if (!node.style.isUnloaded) source.update()
-  }
+  // SideEffect, not LaunchedEffect: applies synchronously with composition, matching the
+  // ordering LayerNode's ComposeNode update block gets — see SafeStyle's kdoc.
+  SideEffect { if (!node.style.isUnloaded) source.update() }
   return source
 }
 

--- a/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/map/IosMapAdapter.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/map/IosMapAdapter.kt
@@ -151,7 +151,7 @@ internal class IosMapAdapter(
     override fun mapViewDidFailLoadingMap(mapView: MLNMapView, withError: NSError) {
       map.logger?.e { "Map failed to load: $withError" }
       map.callbacks.onMapFailLoading(withError.localizedFailureReason)
-      map.onStyleLoadSettled()
+      map.onStyleLoadFailed()
     }
 
     override fun mapViewDidFinishLoadingMap(mapView: MLNMapView) {
@@ -268,6 +268,15 @@ internal class IosMapAdapter(
     // Not beginStyleLoad(next) directly: this runs inside the native delegate callback, not
     // UIKitView's update block, which SafeStyle's kdoc requires for unload ordering.
     lastBaseStyle = null
+  }
+
+  // Unlike onStyleLoadSettled, safe to retry immediately: a failed load never produced a
+  // SafeStyle, so there's no in-flight content to unload out from under.
+  private fun onStyleLoadFailed() {
+    pendingBaseStyle = null
+    val next = queuedBaseStyle ?: return
+    queuedBaseStyle = null
+    beginStyleLoad(next)
   }
 
   private var hasReceivedStyleCallback = false

--- a/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/map/IosMapAdapter.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/map/IosMapAdapter.kt
@@ -263,9 +263,11 @@ internal class IosMapAdapter(
 
   private fun onStyleLoadSettled() {
     pendingBaseStyle = null
-    val next = queuedBaseStyle ?: return
+    if (queuedBaseStyle == null) return
     queuedBaseStyle = null
-    beginStyleLoad(next)
+    // Not beginStyleLoad(next) directly: this runs inside the native delegate callback, not
+    // UIKitView's update block, which SafeStyle's kdoc requires for unload ordering.
+    lastBaseStyle = null
   }
 
   private var hasReceivedStyleCallback = false


### PR DESCRIPTION
## Summary

Follow-up to #917 (the overlapping-style-load coalescing fix). 

That fixes queued-style replay in `IosMapAdapter.onStyleLoadSettled()` calls
`beginStyleLoad()` directly, synchronously from inside the native
`didFinishLoadingStyle`/`mapViewDidFinishLoadingMap` delegate callback not from `IosMapView`'s `UIKitView` `update` block, which `SafeStyle`'s own kdoc establishes as the only entry point "early enough" for content subcomposition to observe an unload before the next native style transition begins:

```kotlin
/**
 * A style that tolerates being used after it has been replaced: during a style switch the
 * outgoing style's content is briefly still composed while anchors and sources already name the
 * incoming style's layers. ...
 *
 * Every platform must unload the outgoing style when a new one is *requested* ..., and must do
 * so before the content subcomposition applies its changes — `AndroidView`'s `update` block is
 * early enough, a `LaunchedEffect` is not.
 */
```

I use Map-Libre in my app with two different themes: light and dark

Two rapid style changes back-to-back (e.g. fast theme-picker taps 
Auto/Light/Dark) hit this: `setBaseStyle` queues the second request while
the first is in flight, then `onStyleLoadSettled()` replays it the instant
the first load's delegate callback fires — immediately unloading the
`SafeStyle` this same callback just handed to `callbacks.onStyleChanged`,
before Compose's own recomposition cadence gets a chance to finish
applying pending layer-property updates (e.g. `SymbolLayer.setIconImage`)
against it. 

MapLibre iOS throws an uncaught `MLNInvalidStyleLayerException`
from inside the native layer setter in that window — unrecoverable, since
Kotlin/Native cannot catch a raw `NSException`.

Confirmed against production crash telemetry from an app using this
library: `SIGABRT` inside `SymbolLayer`'s `iconImage` cache update,
preceded in-session by two rapid theme-picker taps ~4s apart, ~1.3s before
the crash — the exact repro shape #917 already documents for the original
race.

## Fix

`onStyleLoadSettled()` now only clears `pendingBaseStyle` and forces a
`lastBaseStyle` mismatch, instead of calling `beginStyleLoad()` itself. The
queued style's load restarts on the *next* `setBaseStyle(style)` call —
driven by `UIKitView`'s `update` block, on its established-safe cadence —
preserving the ordering guarantee `SafeStyle` depends on.

## Test plan

- [x] `compileKotlinIosSimulatorArm64` builds clean against the change
- [ ] On-device rapid theme-toggle repro (same class of test #917 used) —
      happy to run this if a maintainer wants it before merge, or if
      there's an existing overlapping-style-load test harness this should
      hook into (I see #918 added desktop-side coverage for the original
      fix)