### PR TITLE
Bridge Compose OpenGL on Windows through ANGLE/D3D11

### DIFF
--- a/buildSrc/src/main/kotlin/ffi.kt
+++ b/buildSrc/src/main/kotlin/ffi.kt
@@ -57,7 +57,7 @@ enum class DesktopHostPlatform(
    * natives. Follows the platform rather than the map's backend: Skiko and compose-glfw agree.
    */
   private val presentsThroughOpenGl: Boolean
-    get() = os == "linux"
+    get() = os == "linux" || os == "windows"
 
   /**
    * Dependency notation for the compose-glfw runtime this platform needs. Its backend names the

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/bridge/AngleEgl.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/bridge/AngleEgl.kt
@@ -1,0 +1,332 @@
+package org.maplibre.compose.desktop.bridge
+
+import java.lang.foreign.Arena
+import java.lang.foreign.FunctionDescriptor
+import java.lang.foreign.Linker
+import java.lang.foreign.MemorySegment
+import java.lang.foreign.ValueLayout
+import java.lang.invoke.MethodHandle
+
+/**
+ * The slice of EGL this host needs to wrap an `ID3D11Texture2D` as a GL
+ * texture via `EGL_ANGLE_d3d_texture_client_buffer`.
+ */
+internal object AngleEgl {
+  const val EGL_NONE = 0x3038
+  const val EGL_DRAW = 0x3059
+  const val EGL_READ = 0x305A
+  const val EGL_BACK_BUFFER = 0x3084
+  const val EGL_TEXTURE_2D = 0x305F
+  const val EGL_TEXTURE_RGBA = 0x305E
+  const val EGL_TEXTURE_FORMAT = 0x3080
+  const val EGL_TEXTURE_TARGET = 0x3081
+  const val EGL_CONFIG_ID = 0x3028
+  const val EGL_DEVICE_EXT = 0x322C
+  const val EGL_D3D11_DEVICE_ANGLE = 0x33A1
+  const val EGL_D3D_TEXTURE_ANGLE = 0x33A3
+  const val EGL_TRUE = 1
+  const val GL_TEXTURE_BINDING_2D = 0x8069
+
+  private val linker = Linker.nativeLinker()
+
+  fun currentDisplay(): Long = invokeAddress(eglGetCurrentDisplay).address()
+
+  fun currentContext(): Long = invokeAddress(eglGetCurrentContext).address()
+
+  fun currentSurface(which: Int): Long = invokeAddress(eglGetCurrentSurface, which).address()
+
+  fun angleD3d11Device(): Long {
+    val display = currentDisplay()
+    check(display != 0L) { "No EGL display is current" }
+    Arena.ofConfined().use { arena ->
+      val deviceOut = arena.allocate(ValueLayout.ADDRESS)
+      checkEgl(
+        invokeInt(eglQueryDisplayAttribEXT, address(display), EGL_DEVICE_EXT, deviceOut) == EGL_TRUE,
+        "eglQueryDisplayAttribEXT(EGL_DEVICE_EXT)",
+      )
+      val device = deviceOut.get(ValueLayout.ADDRESS, 0).address()
+      check(device != 0L) { "EGL display has no EGL_DEVICE_EXT" }
+      val d3dOut = arena.allocate(ValueLayout.ADDRESS)
+      checkEgl(
+        invokeInt(
+          eglQueryDeviceAttribEXT,
+          address(device),
+          EGL_D3D11_DEVICE_ANGLE,
+          d3dOut,
+        ) == EGL_TRUE,
+        "eglQueryDeviceAttribEXT(EGL_D3D11_DEVICE_ANGLE)",
+      )
+      val d3d = d3dOut.get(ValueLayout.ADDRESS, 0).address()
+      check(d3d != 0L) { "ANGLE EGL device has no ID3D11Device" }
+      return d3d
+    }
+  }
+
+  fun currentConfig(): Long {
+    val display = currentDisplay()
+    val context = currentContext()
+    check(display != 0L && context != 0L) { "No EGL context is current" }
+    Arena.ofConfined().use { arena ->
+      val configIdOut = arena.allocate(ValueLayout.JAVA_INT)
+      checkEgl(
+        invokeInt(eglQueryContext, address(display), address(context), EGL_CONFIG_ID, configIdOut) ==
+          EGL_TRUE,
+        "eglQueryContext(EGL_CONFIG_ID)",
+      )
+      val attribs = arena.allocate(ValueLayout.JAVA_INT, 3)
+      attribs.setAtIndex(ValueLayout.JAVA_INT, 0, EGL_CONFIG_ID)
+      attribs.setAtIndex(ValueLayout.JAVA_INT, 1, configIdOut.get(ValueLayout.JAVA_INT, 0))
+      attribs.setAtIndex(ValueLayout.JAVA_INT, 2, EGL_NONE)
+      val configOut = arena.allocate(ValueLayout.ADDRESS)
+      val countOut = arena.allocate(ValueLayout.JAVA_INT)
+      checkEgl(
+        invokeInt(
+          eglChooseConfig,
+          address(display),
+          attribs,
+          configOut,
+          1,
+          countOut,
+        ) == EGL_TRUE && countOut.get(ValueLayout.JAVA_INT, 0) > 0,
+        "eglChooseConfig(EGL_CONFIG_ID)",
+      )
+      return configOut.get(ValueLayout.ADDRESS, 0).address()
+    }
+  }
+
+  /**
+   * Wraps [d3dTexture] (must belong to ANGLE's D3D11 device) as a `GL_TEXTURE_2D`.
+   * Restores the previously current draw surface before returning.
+   */
+  fun bindD3dTexture(d3dTexture: Long): AngleBoundD3dTexture {
+    val display = currentDisplay()
+    val context = currentContext()
+    val config = currentConfig()
+    val hostDraw = currentSurface(EGL_DRAW)
+    val hostRead = currentSurface(EGL_READ)
+    check(display != 0L && context != 0L && config != 0L) { "ANGLE EGL trio is incomplete" }
+    Arena.ofConfined().use { arena ->
+      val attribs = arena.allocate(ValueLayout.JAVA_INT, 5)
+      attribs.setAtIndex(ValueLayout.JAVA_INT, 0, EGL_TEXTURE_FORMAT)
+      attribs.setAtIndex(ValueLayout.JAVA_INT, 1, EGL_TEXTURE_RGBA)
+      attribs.setAtIndex(ValueLayout.JAVA_INT, 2, EGL_TEXTURE_TARGET)
+      attribs.setAtIndex(ValueLayout.JAVA_INT, 3, EGL_TEXTURE_2D)
+      attribs.setAtIndex(ValueLayout.JAVA_INT, 4, EGL_NONE)
+      val pbuffer =
+        invokeAddress(
+            eglCreatePbufferFromClientBuffer,
+            address(display),
+            EGL_D3D_TEXTURE_ANGLE,
+            address(d3dTexture),
+            address(config),
+            attribs,
+          )
+          .address()
+      check(pbuffer != 0L) { "eglCreatePbufferFromClientBuffer failed: 0x${eglError().toString(16)}" }
+      try {
+        checkEgl(
+          invokeInt(
+            eglMakeCurrent,
+            address(display),
+            address(pbuffer),
+            address(pbuffer),
+            address(context),
+          ) == EGL_TRUE,
+          "eglMakeCurrent(pbuffer)",
+        )
+        val previous = AngleGl.getInteger(GL_TEXTURE_BINDING_2D)
+        val textureName = AngleGl.genTextures()
+        try {
+          AngleGl.bindTexture(org.lwjgl.opengl.GL11.GL_TEXTURE_2D, textureName)
+          AngleGl.texParameteri(
+            org.lwjgl.opengl.GL11.GL_TEXTURE_2D,
+            org.lwjgl.opengl.GL11.GL_TEXTURE_MIN_FILTER,
+            org.lwjgl.opengl.GL11.GL_LINEAR,
+          )
+          AngleGl.texParameteri(
+            org.lwjgl.opengl.GL11.GL_TEXTURE_2D,
+            org.lwjgl.opengl.GL11.GL_TEXTURE_MAG_FILTER,
+            org.lwjgl.opengl.GL11.GL_LINEAR,
+          )
+          AngleGl.texParameteri(
+            org.lwjgl.opengl.GL11.GL_TEXTURE_2D,
+            org.lwjgl.opengl.GL11.GL_TEXTURE_WRAP_S,
+            org.lwjgl.opengl.GL12.GL_CLAMP_TO_EDGE,
+          )
+          AngleGl.texParameteri(
+            org.lwjgl.opengl.GL11.GL_TEXTURE_2D,
+            org.lwjgl.opengl.GL11.GL_TEXTURE_WRAP_T,
+            org.lwjgl.opengl.GL12.GL_CLAMP_TO_EDGE,
+          )
+          checkEgl(
+            invokeInt(eglBindTexImage, address(display), address(pbuffer), EGL_BACK_BUFFER) ==
+              EGL_TRUE,
+            "eglBindTexImage",
+          )
+          AngleGl.bindTexture(org.lwjgl.opengl.GL11.GL_TEXTURE_2D, previous)
+          restoreCurrent(display, hostDraw, hostRead, context)
+          return AngleBoundD3dTexture(textureName, display, pbuffer)
+        } catch (error: Throwable) {
+          if (error is VirtualMachineError) throw error
+          AngleGl.deleteTextures(textureName)
+          throw error
+        }
+      } catch (error: Throwable) {
+        if (error is VirtualMachineError) throw error
+        restoreCurrent(display, hostDraw, hostRead, context)
+        invokeInt(eglDestroySurface, address(display), address(pbuffer))
+        throw error
+      }
+    }
+  }
+
+  fun release(bound: AngleBoundD3dTexture) {
+    if (bound.display != 0L && bound.pbuffer != 0L) {
+      runCatching {
+        invokeInt(eglReleaseTexImage, address(bound.display), address(bound.pbuffer), EGL_BACK_BUFFER)
+      }
+      runCatching { invokeInt(eglDestroySurface, address(bound.display), address(bound.pbuffer)) }
+    }
+    if (bound.textureName != 0 && AngleGl.isUsable()) {
+      runCatching { AngleGl.deleteTextures(bound.textureName) }
+    }
+  }
+
+  private fun restoreCurrent(display: Long, draw: Long, read: Long, context: Long) {
+    if (draw != 0L && context != 0L) {
+      invokeInt(eglMakeCurrent, address(display), address(draw), address(read), address(context))
+    } else {
+      invokeInt(eglMakeCurrent, address(display), address(0), address(0), address(0))
+    }
+  }
+
+  private fun eglError(): Int = invokeInt(eglGetError)
+
+  private fun checkEgl(ok: Boolean, operation: String) {
+    check(ok) { "$operation failed with EGL error 0x${eglError().toString(16)}" }
+  }
+
+  private val eglGetCurrentDisplay = bind("eglGetCurrentDisplay", FunctionDescriptor.of(ValueLayout.ADDRESS))
+  private val eglGetCurrentContext = bind("eglGetCurrentContext", FunctionDescriptor.of(ValueLayout.ADDRESS))
+  private val eglGetCurrentSurface =
+    bind("eglGetCurrentSurface", FunctionDescriptor.of(ValueLayout.ADDRESS, ValueLayout.JAVA_INT))
+  private val eglGetError = bind("eglGetError", FunctionDescriptor.of(ValueLayout.JAVA_INT))
+  private val eglQueryDisplayAttribEXT =
+    bind(
+      "eglQueryDisplayAttribEXT",
+      FunctionDescriptor.of(
+        ValueLayout.JAVA_INT,
+        ValueLayout.ADDRESS,
+        ValueLayout.JAVA_INT,
+        ValueLayout.ADDRESS,
+      ),
+    )
+  private val eglQueryDeviceAttribEXT =
+    bind(
+      "eglQueryDeviceAttribEXT",
+      FunctionDescriptor.of(
+        ValueLayout.JAVA_INT,
+        ValueLayout.ADDRESS,
+        ValueLayout.JAVA_INT,
+        ValueLayout.ADDRESS,
+      ),
+    )
+  private val eglQueryContext =
+    bind(
+      "eglQueryContext",
+      FunctionDescriptor.of(
+        ValueLayout.JAVA_INT,
+        ValueLayout.ADDRESS,
+        ValueLayout.ADDRESS,
+        ValueLayout.JAVA_INT,
+        ValueLayout.ADDRESS,
+      ),
+    )
+  private val eglChooseConfig =
+    bind(
+      "eglChooseConfig",
+      FunctionDescriptor.of(
+        ValueLayout.JAVA_INT,
+        ValueLayout.ADDRESS,
+        ValueLayout.ADDRESS,
+        ValueLayout.ADDRESS,
+        ValueLayout.JAVA_INT,
+        ValueLayout.ADDRESS,
+      ),
+    )
+  private val eglCreatePbufferFromClientBuffer =
+    bind(
+      "eglCreatePbufferFromClientBuffer",
+      FunctionDescriptor.of(
+        ValueLayout.ADDRESS,
+        ValueLayout.ADDRESS,
+        ValueLayout.JAVA_INT,
+        ValueLayout.ADDRESS,
+        ValueLayout.ADDRESS,
+        ValueLayout.ADDRESS,
+      ),
+    )
+  private val eglBindTexImage =
+    bind(
+      "eglBindTexImage",
+      FunctionDescriptor.of(
+        ValueLayout.JAVA_INT,
+        ValueLayout.ADDRESS,
+        ValueLayout.ADDRESS,
+        ValueLayout.JAVA_INT,
+      ),
+    )
+  private val eglReleaseTexImage =
+    bind(
+      "eglReleaseTexImage",
+      FunctionDescriptor.of(
+        ValueLayout.JAVA_INT,
+        ValueLayout.ADDRESS,
+        ValueLayout.ADDRESS,
+        ValueLayout.JAVA_INT,
+      ),
+    )
+  private val eglDestroySurface =
+    bind(
+      "eglDestroySurface",
+      FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS, ValueLayout.ADDRESS),
+    )
+  private val eglMakeCurrent =
+    bind(
+      "eglMakeCurrent",
+      FunctionDescriptor.of(
+        ValueLayout.JAVA_INT,
+        ValueLayout.ADDRESS,
+        ValueLayout.ADDRESS,
+        ValueLayout.ADDRESS,
+        ValueLayout.ADDRESS,
+      ),
+    )
+
+  private fun bind(name: String, descriptor: FunctionDescriptor): Lazy<MethodHandle?> = lazy {
+    val addr = AngleEglFunctionProvider.address(name)
+    if (addr == 0L) null else linker.downcallHandle(MemorySegment.ofAddress(addr), descriptor)
+  }
+
+  private fun invokeInt(target: Lazy<MethodHandle?>, vararg args: Any?): Int =
+    requireHandle(target).invokeWithArguments(*args) as Int
+
+  private fun invokeAddress(target: Lazy<MethodHandle?>, vararg args: Any?): MemorySegment =
+    requireHandle(target).invokeWithArguments(*args) as MemorySegment
+
+  private fun requireHandle(target: Lazy<MethodHandle?>): MethodHandle =
+    checkNotNull(target.value) { "ANGLE EGL function is missing" }
+
+  private fun address(value: Long): MemorySegment = MemorySegment.ofAddress(value)
+}
+
+/** A GL texture whose storage is an ANGLE pbuffer wrapping a D3D11 texture. */
+internal class AngleBoundD3dTexture(
+  val textureName: Int,
+  val display: Long,
+  val pbuffer: Long,
+) : AutoCloseable {
+  override fun close() {
+    AngleEgl.release(this)
+  }
+}

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/bridge/AngleEglFunctionProvider.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/bridge/AngleEglFunctionProvider.kt
@@ -1,0 +1,64 @@
+package org.maplibre.compose.desktop.bridge
+
+import java.lang.foreign.Arena
+import java.lang.foreign.FunctionDescriptor
+import java.lang.foreign.Linker
+import java.lang.foreign.MemorySegment
+import java.lang.foreign.SymbolLookup
+import java.lang.foreign.ValueLayout
+import java.nio.ByteBuffer
+import org.lwjgl.system.FunctionProvider
+
+/**
+ * Resolves OpenGL ES entry points the same way Nucleus/Skia does on Windows:
+ * `eglGetProcAddress` first, then `libGLESv2` for core 2.0 symbols that some
+ * ANGLE builds do not publish through EGL.
+ *
+ * The host must have made that EGL context current before any GL call.
+ */
+internal object AngleEglFunctionProvider : FunctionProvider {
+  private val linker = Linker.nativeLinker()
+  private val eglGetProcAddress =
+    linker.downcallHandle(
+      findEglGetProcAddress(),
+      FunctionDescriptor.of(ValueLayout.ADDRESS, ValueLayout.ADDRESS),
+    )
+  private val glesLookup =
+    runCatching { SymbolLookup.libraryLookup("libGLESv2", Arena.global()) }.getOrNull()
+      ?: runCatching { SymbolLookup.libraryLookup("GLESv2", Arena.global()) }.getOrNull()
+
+  override fun getFunctionAddress(functionName: ByteBuffer): Long {
+    val remaining = functionName.remaining()
+    if (remaining <= 0) return 0L
+    val bytes = ByteArray(remaining)
+    val view = functionName.duplicate()
+    view.get(bytes)
+    var end = bytes.size
+    while (end > 0 && bytes[end - 1] == 0.toByte()) end -= 1
+    return address(String(bytes, 0, end, Charsets.US_ASCII))
+  }
+
+  fun address(name: String): Long {
+    Arena.ofConfined().use { arena ->
+      val cName = arena.allocateFrom(name)
+      val fromEgl = (eglGetProcAddress.invokeExact(cName) as MemorySegment).address()
+      if (fromEgl != 0L) return fromEgl
+      return glesLookup?.find(name)?.map { it.address() }?.orElse(0L) ?: 0L
+    }
+  }
+
+  private fun findEglGetProcAddress(): MemorySegment {
+    val loaded = SymbolLookup.loaderLookup().find("eglGetProcAddress")
+    if (loaded.isPresent) return loaded.get()
+    for (library in listOf("libEGL", "EGL")) {
+      val found =
+        runCatching { SymbolLookup.libraryLookup(library, Arena.global()).find("eglGetProcAddress") }
+          .getOrNull()
+      if (found != null && found.isPresent) return found.get()
+    }
+    error(
+      "eglGetProcAddress is not in this process. Load ANGLE's libEGL before " +
+        "creating a MapLibre OpenGL host on Windows."
+    )
+  }
+}

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/bridge/AngleGl.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/bridge/AngleGl.kt
@@ -1,0 +1,230 @@
+package org.maplibre.compose.desktop.bridge
+
+import java.lang.foreign.Arena
+import java.lang.foreign.FunctionDescriptor
+import java.lang.foreign.Linker
+import java.lang.foreign.MemorySegment
+import java.lang.foreign.ValueLayout
+import java.lang.invoke.MethodHandle
+import java.nio.ByteBuffer
+
+/**
+ * Direct GLES 3 calls through ANGLE. LWJGL's desktop `GL.createCapabilities`
+ * binds 1.1 entry points to `opengl32`/`wglGetProcAddress`, which are not the
+ * current context on a Tao/ANGLE surface.
+ */
+internal object AngleGl {
+  private val linker = Linker.nativeLinker()
+
+  fun isUsable(): Boolean = address("glGetError") != 0L && address("glGenTextures") != 0L
+
+  fun address(name: String): Long = AngleEglFunctionProvider.address(name)
+
+  fun getError(): Int = invokeInt(glGetError)
+
+  fun getInteger(pname: Int): Int =
+    Arena.ofConfined().use { arena ->
+      val out = arena.allocate(ValueLayout.JAVA_INT)
+      invokeVoid(glGetIntegerv, pname, out)
+      out.get(ValueLayout.JAVA_INT, 0)
+    }
+
+  fun getStringi(name: Int, index: Int): String? {
+    val pointer = invokeAddress(glGetStringi, name, index)
+    if (pointer.address() == 0L) return null
+    return pointer.reinterpret(1024).getString(0)
+  }
+
+  fun genTextures(): Int =
+    Arena.ofConfined().use { arena ->
+      val out = arena.allocate(ValueLayout.JAVA_INT)
+      invokeVoid(glGenTextures, 1, out)
+      out.get(ValueLayout.JAVA_INT, 0)
+    }
+
+  fun deleteTextures(texture: Int) {
+    if (texture == 0) return
+    Arena.ofConfined().use { arena ->
+      val names = arena.allocate(ValueLayout.JAVA_INT)
+      names.set(ValueLayout.JAVA_INT, 0, texture)
+      invokeVoid(glDeleteTextures, 1, names)
+    }
+  }
+
+  fun bindTexture(target: Int, texture: Int) {
+    invokeVoid(glBindTexture, target, texture)
+  }
+
+  fun texParameteri(target: Int, pname: Int, param: Int) {
+    invokeVoid(glTexParameteri, target, pname, param)
+  }
+
+  fun texImage2D(
+    target: Int,
+    level: Int,
+    internalFormat: Int,
+    width: Int,
+    height: Int,
+    border: Int,
+    format: Int,
+    type: Int,
+    pixels: ByteBuffer?,
+  ) {
+    invokeVoid(
+      glTexImage2D,
+      target,
+      level,
+      internalFormat,
+      width,
+      height,
+      border,
+      format,
+      type,
+      pixels.toSegment(),
+    )
+  }
+
+  fun texSubImage2D(
+    target: Int,
+    level: Int,
+    xOffset: Int,
+    yOffset: Int,
+    width: Int,
+    height: Int,
+    format: Int,
+    type: Int,
+    pixels: ByteBuffer,
+  ) {
+    invokeVoid(
+      glTexSubImage2D,
+      target,
+      level,
+      xOffset,
+      yOffset,
+      width,
+      height,
+      format,
+      type,
+      pixels.toSegment(),
+    )
+  }
+
+  fun genFramebuffers(): Int =
+    Arena.ofConfined().use { arena ->
+      val out = arena.allocate(ValueLayout.JAVA_INT)
+      invokeVoid(glGenFramebuffers, 1, out)
+      out.get(ValueLayout.JAVA_INT, 0)
+    }
+
+  fun deleteFramebuffers(framebuffer: Int) {
+    if (framebuffer == 0) return
+    Arena.ofConfined().use { arena ->
+      val names = arena.allocate(ValueLayout.JAVA_INT)
+      names.set(ValueLayout.JAVA_INT, 0, framebuffer)
+      invokeVoid(glDeleteFramebuffers, 1, names)
+    }
+  }
+
+  fun bindFramebuffer(target: Int, framebuffer: Int) {
+    invokeVoid(glBindFramebuffer, target, framebuffer)
+  }
+
+  fun framebufferTexture2D(target: Int, attachment: Int, textarget: Int, texture: Int, level: Int) {
+    invokeVoid(glFramebufferTexture2D, target, attachment, textarget, texture, level)
+  }
+
+  fun checkFramebufferStatus(target: Int): Int = invokeInt(glCheckFramebufferStatus, target)
+
+  private val glGetError = bind("glGetError", FunctionDescriptor.of(ValueLayout.JAVA_INT))
+  private val glGetIntegerv =
+    bind("glGetIntegerv", FunctionDescriptor.ofVoid(ValueLayout.JAVA_INT, ValueLayout.ADDRESS))
+  private val glGetStringi =
+    bind(
+      "glGetStringi",
+      FunctionDescriptor.of(ValueLayout.ADDRESS, ValueLayout.JAVA_INT, ValueLayout.JAVA_INT),
+    )
+  private val glGenTextures =
+    bind("glGenTextures", FunctionDescriptor.ofVoid(ValueLayout.JAVA_INT, ValueLayout.ADDRESS))
+  private val glDeleteTextures =
+    bind("glDeleteTextures", FunctionDescriptor.ofVoid(ValueLayout.JAVA_INT, ValueLayout.ADDRESS))
+  private val glBindTexture =
+    bind("glBindTexture", FunctionDescriptor.ofVoid(ValueLayout.JAVA_INT, ValueLayout.JAVA_INT))
+  private val glTexParameteri =
+    bind(
+      "glTexParameteri",
+      FunctionDescriptor.ofVoid(ValueLayout.JAVA_INT, ValueLayout.JAVA_INT, ValueLayout.JAVA_INT),
+    )
+  private val glTexImage2D =
+    bind(
+      "glTexImage2D",
+      FunctionDescriptor.ofVoid(
+        ValueLayout.JAVA_INT,
+        ValueLayout.JAVA_INT,
+        ValueLayout.JAVA_INT,
+        ValueLayout.JAVA_INT,
+        ValueLayout.JAVA_INT,
+        ValueLayout.JAVA_INT,
+        ValueLayout.JAVA_INT,
+        ValueLayout.JAVA_INT,
+        ValueLayout.ADDRESS,
+      ),
+    )
+  private val glTexSubImage2D =
+    bind(
+      "glTexSubImage2D",
+      FunctionDescriptor.ofVoid(
+        ValueLayout.JAVA_INT,
+        ValueLayout.JAVA_INT,
+        ValueLayout.JAVA_INT,
+        ValueLayout.JAVA_INT,
+        ValueLayout.JAVA_INT,
+        ValueLayout.JAVA_INT,
+        ValueLayout.JAVA_INT,
+        ValueLayout.JAVA_INT,
+        ValueLayout.ADDRESS,
+      ),
+    )
+  private val glGenFramebuffers =
+    bind("glGenFramebuffers", FunctionDescriptor.ofVoid(ValueLayout.JAVA_INT, ValueLayout.ADDRESS))
+  private val glDeleteFramebuffers =
+    bind("glDeleteFramebuffers", FunctionDescriptor.ofVoid(ValueLayout.JAVA_INT, ValueLayout.ADDRESS))
+  private val glBindFramebuffer =
+    bind("glBindFramebuffer", FunctionDescriptor.ofVoid(ValueLayout.JAVA_INT, ValueLayout.JAVA_INT))
+  private val glFramebufferTexture2D =
+    bind(
+      "glFramebufferTexture2D",
+      FunctionDescriptor.ofVoid(
+        ValueLayout.JAVA_INT,
+        ValueLayout.JAVA_INT,
+        ValueLayout.JAVA_INT,
+        ValueLayout.JAVA_INT,
+        ValueLayout.JAVA_INT,
+      ),
+    )
+  private val glCheckFramebufferStatus =
+    bind("glCheckFramebufferStatus", FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.JAVA_INT))
+
+  private fun bind(name: String, descriptor: FunctionDescriptor): Lazy<MethodHandle?> = lazy {
+    val addr = address(name)
+    if (addr == 0L) null else linker.downcallHandle(MemorySegment.ofAddress(addr), descriptor)
+  }
+
+  private fun invokeVoid(target: Lazy<MethodHandle?>, vararg args: Any?) {
+    requireHandle(target).invokeWithArguments(*args)
+  }
+
+  private fun invokeInt(target: Lazy<MethodHandle?>, vararg args: Any?): Int =
+    requireHandle(target).invokeWithArguments(*args) as Int
+
+  private fun invokeAddress(target: Lazy<MethodHandle?>, vararg args: Any?): MemorySegment =
+    requireHandle(target).invokeWithArguments(*args) as MemorySegment
+
+  private fun requireHandle(target: Lazy<MethodHandle?>): MethodHandle =
+    checkNotNull(target.value) { "ANGLE GL function is missing" }
+
+  private fun ByteBuffer?.toSegment(): MemorySegment {
+    if (this == null) return MemorySegment.NULL
+    check(isDirect) { "ANGLE texture uploads need a direct ByteBuffer" }
+    return MemorySegment.ofBuffer(this)
+  }
+}

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/bridge/ComposeMapHostBridge.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/bridge/ComposeMapHostBridge.kt
@@ -32,7 +32,9 @@ internal class ComposeMapHostFactory(private val mapHost: ComposeMapHost) : MlnF
       val host =
         when (mapHost.backend) {
           ComposeRenderBackend.METAL -> MetalMapHost(mapHost)
-          ComposeRenderBackend.OPENGL -> VulkanOpenGlMapHost(mapHost)
+          ComposeRenderBackend.OPENGL ->
+            if (isWindowsDesktop()) VulkanOpenGlWin32MapHost(mapHost)
+            else VulkanOpenGlMapHost(mapHost)
           ComposeRenderBackend.DIRECT3D12 -> VulkanDirect3D12MapHost(mapHost)
         }
       MlnFfiMapHostResult.Created(host)
@@ -87,7 +89,9 @@ internal fun <T> ComposeMapHost.withOpenGlContextOrNull(
   var result: Result<T>? = null
   context.withContextCurrent {
     result = runCatching {
-      ensureCapabilities()
+      // Tao/ANGLE is GLES. LWJGL desktop capabilities bind opengl32 and are
+      // not the current context; Windows uses [AngleGl] instead.
+      if (!isWindowsDesktop()) ensureCapabilities()
       action(context)
     }
   }

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/bridge/OpenGlPresenter.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/bridge/OpenGlPresenter.kt
@@ -7,7 +7,6 @@ import org.jetbrains.skia.BackendRenderTarget
 import org.jetbrains.skia.ContentChangeMode
 import org.jetbrains.skia.DirectContext
 import org.jetbrains.skia.FramebufferFormat
-import org.jetbrains.skia.Rect
 import org.jetbrains.skia.SamplingMode
 import org.jetbrains.skia.Surface
 import org.jetbrains.skia.SurfaceColorFormat
@@ -49,7 +48,11 @@ internal class OpenGlPresenter : AutoCloseable {
   ): Boolean {
     var drew = false
     scope.drawIntoCanvas { composeCanvas ->
-      ensureCapabilities()
+      if (isWindowsDesktop()) {
+        check(AngleGl.isUsable()) { "Compose's ANGLE context has no usable GLES entry points" }
+      } else {
+        ensureCapabilities()
+      }
       val presenter =
         presenters.getOrPut(target.textureName) { TexturePresenter(target.textureName) }
       presenter.draw(
@@ -108,15 +111,24 @@ internal class OpenGlPresenter : AutoCloseable {
       // render incorrectly unless told to re-read it.
       context.resetGLAll()
       currentSurface.notifyContentWillChange(ContentChangeMode.DISCARD)
-      currentSurface.makeImageSnapshot().use { image ->
-        canvas.drawImageRect(
-          image = image,
-          src = Rect.makeWH(image.width.toFloat(), image.height.toFloat()),
-          dst = Rect.makeWH(destinationWidth, destinationHeight),
-          samplingMode = SamplingMode.LINEAR,
-          paint = null,
-          strict = true,
-        )
+      if (isWindowsDesktop()) {
+        val scaleX = if (width == 0) 1f else destinationWidth / width.toFloat()
+        val scaleY = if (height == 0) 1f else destinationHeight / height.toFloat()
+        canvas.save()
+        canvas.scale(scaleX, scaleY)
+        currentSurface.draw(canvas, 0, 0, SamplingMode.LINEAR, null)
+        canvas.restore()
+      } else {
+        currentSurface.makeImageSnapshot().use { image ->
+          canvas.drawImageRect(
+            image = image,
+            src = org.jetbrains.skia.Rect.makeWH(image.width.toFloat(), image.height.toFloat()),
+            dst = org.jetbrains.skia.Rect.makeWH(destinationWidth, destinationHeight),
+            samplingMode = SamplingMode.LINEAR,
+            paint = null,
+            strict = true,
+          )
+        }
       }
     }
 
@@ -165,6 +177,7 @@ internal class OpenGlPresenter : AutoCloseable {
     }
 
     private fun createFramebuffer(target: OpenGlTextureTarget): Int {
+      if (isWindowsDesktop()) return createAngleFramebuffer(target)
       ensureCapabilities()
       val previous = glGetInteger(GL_FRAMEBUFFER_BINDING)
       val next = glGenFramebuffers()
@@ -188,6 +201,32 @@ internal class OpenGlPresenter : AutoCloseable {
         throw error
       } finally {
         glBindFramebuffer(GL_FRAMEBUFFER, previous)
+      }
+    }
+
+    private fun createAngleFramebuffer(target: OpenGlTextureTarget): Int {
+      val previous = AngleGl.getInteger(GL_FRAMEBUFFER_BINDING)
+      val next = AngleGl.genFramebuffers()
+      try {
+        AngleGl.bindFramebuffer(GL_FRAMEBUFFER, next)
+        AngleGl.framebufferTexture2D(
+          GL_FRAMEBUFFER,
+          GL_COLOR_ATTACHMENT0,
+          target.textureTarget,
+          target.textureName,
+          0,
+        )
+        val status = AngleGl.checkFramebufferStatus(GL_FRAMEBUFFER)
+        checkGl("glFramebufferTexture2D")
+        check(status == GL_FRAMEBUFFER_COMPLETE) {
+          "OpenGL framebuffer for texture $textureName is incomplete: 0x${status.toString(16)}"
+        }
+        return next
+      } catch (error: RuntimeException) {
+        runCatching { AngleGl.deleteFramebuffers(next) }
+        throw error
+      } finally {
+        AngleGl.bindFramebuffer(GL_FRAMEBUFFER, previous)
       }
     }
 
@@ -216,8 +255,12 @@ internal class OpenGlPresenter : AutoCloseable {
       renderTarget = null
       if (framebuffer != 0) {
         runCatching {
-          ensureCapabilities()
-          glDeleteFramebuffers(framebuffer)
+          if (isWindowsDesktop()) {
+            if (AngleGl.isUsable()) AngleGl.deleteFramebuffers(framebuffer)
+          } else {
+            ensureCapabilities()
+            glDeleteFramebuffers(framebuffer)
+          }
         }
         framebuffer = 0
       }
@@ -242,6 +285,6 @@ internal fun clearGlErrors() {
 }
 
 internal fun checkGl(operation: String) {
-  val error = glGetError()
+  val error = if (isWindowsDesktop()) AngleGl.getError() else glGetError()
   check(error == GL_NO_ERROR) { "$operation failed with GL error 0x${error.toString(16)}" }
 }

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/bridge/VulkanOpenGlWin32MapHost.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/bridge/VulkanOpenGlWin32MapHost.kt
@@ -102,10 +102,28 @@ internal class VulkanOpenGlWin32MapHost(private val gpuHost: ComposeMapHost) : M
   private val presenter = OpenGlPresenter()
   private val frameCompletion = ComposeFrameCompletion()
   private var vulkan: WindowsOpenGlVulkanContext? = null
-  private var texture: WindowsOpenGlSharedTexture? = null
+
+  // Pipelined triple buffer. MapLibre renders back-to-back on the renderer thread — up to
+  // [MAX_IN_FLIGHT_RENDERS] queued — while Compose presents [displayedGeneration], the newest
+  // completed texture. The slow native render therefore never blocks the caller (the window's
+  // only event-loop thread on Tao) and the map's content rate matches native throughput.
+  private val textures = linkedMapOf<Long, WindowsOpenGlSharedTexture>()
   private val retiredTextures = mutableMapOf<Long, WindowsOpenGlSharedTexture>()
+  private var displayedGeneration = 0L
   private var generation = 0L
   private var currentExtent = MapExtent.Empty
+
+  private class PendingRender(val task: java.util.concurrent.FutureTask<*>, val generation: Long)
+
+  private val pendingRenders = ArrayDeque<PendingRender>()
+
+  private companion object {
+    /** One on screen, one completing, one free to start on — the minimum that never stalls. */
+    const val TEXTURE_SLOTS = 3
+
+    /** Renders queued on the renderer thread; two keeps it busy back-to-back. */
+    const val MAX_IN_FLIGHT_RENDERS = 2
+  }
 
   override val backends: RenderBackendPair =
     RenderBackendPair(MapRenderBackend.VULKAN, ComposeRenderBackend.OPENGL)
@@ -117,26 +135,75 @@ internal class VulkanOpenGlWin32MapHost(private val gpuHost: ComposeMapHost) : M
   ): MlnFfiMapFrameAcquisition =
     gpuHost.withOpenGlContextOrNull { context ->
       frameCompletion.prepare(context.skiaContext, ::abandonContext)
-      if (texture == null || extent != currentExtent) recreateTexture(extent)
+      if (textures.isEmpty() || extent != currentExtent) recreateTextures(extent)
+      val targetGeneration = freeGeneration() ?: pendingRenders.first().generation
       MlnFfiMapFrameAcquisition.Acquired(
         MlnFfiMapFrame(
           frameId = frameId,
           extent = extent,
           target =
-            requireNotNull(texture) { "Windows OpenGL texture is not initialized" }
+            requireNotNull(textures[targetGeneration]) {
+                "Windows OpenGL texture is not initialized"
+              }
               .exported
-              .target(generation),
+              .target(targetGeneration),
           presentationTimeNanos = presentationTimeNanos,
         )
       )
     } ?: MlnFfiMapFrameAcquisition.NotReady
 
-  override fun completeProducerAccess(frame: MlnFfiMapFrame) {
-    rendererThread.run { vulkan?.waitIdle() }
-  }
+  /** A live texture neither on screen nor targeted by a queued render. */
+  private fun freeGeneration(): Long? =
+    textures.keys.firstOrNull { candidate ->
+      candidate != displayedGeneration && pendingRenders.none { it.generation == candidate }
+    }
 
-  override fun <T> withProducerAccess(frame: MlnFfiMapFrame, action: () -> T): T =
-    rendererThread.run(action)
+  // MapLibre's own Vulkan backend waits for the frame's GPU work before render() returns, so a
+  // consumed pipelined render is already safe to sample; a queue-wide wait here would stall the
+  // caller behind the next in-flight render.
+  override fun completeProducerAccess(frame: MlnFfiMapFrame) {}
+
+  override fun <T> withProducerAccess(frame: MlnFfiMapFrame, action: () -> T): T {
+    val head = pendingRenders.firstOrNull()
+    var consumed: Any? = null
+    var hasConsumed = false
+    if (head != null && head.task.isDone) {
+      pendingRenders.removeFirst()
+      val result =
+        try {
+          head.task.get()
+        } catch (error: java.util.concurrent.ExecutionException) {
+          throw error.cause ?: error
+        }
+      // A render into a texture a resize has retired is dropped rather than displayed.
+      if (textures.containsKey(head.generation)) {
+        displayedGeneration = head.generation
+        consumed = result
+        hasConsumed = true
+      }
+    }
+
+    val targetGeneration = (frame.target as? VulkanImageTarget)?.generation
+    val canSubmit =
+      pendingRenders.size < MAX_IN_FLIGHT_RENDERS &&
+        targetGeneration != null &&
+        textures.containsKey(targetGeneration) &&
+        targetGeneration != displayedGeneration &&
+        pendingRenders.none { it.generation == targetGeneration }
+    if (canSubmit) {
+      val task = java.util.concurrent.FutureTask(action::invoke)
+      if (rendererThread.post { task.run() }) {
+        pendingRenders.addLast(PendingRender(task, checkNotNull(targetGeneration)))
+      } else if (!hasConsumed) {
+        // The renderer thread is gone (host closing); fall back to the synchronous path.
+        return rendererThread.run(action)
+      }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    return if (hasConsumed) consumed as T
+    else org.maplibre.compose.mlnffi.MlnFfiFrameResult.SKIPPED as T
+  }
 
   override fun <T> withRendererAccess(action: () -> T): T = rendererThread.run(action)
 
@@ -146,8 +213,16 @@ internal class VulkanOpenGlWin32MapHost(private val gpuHost: ComposeMapHost) : M
     if (target !is VulkanImageTarget) return false
     return gpuHost.withOpenGlContextOrNull { context ->
       frameCompletion.prepare(context.skiaContext, ::abandonContext)
-      val sharedTexture =
-        if (target.generation == generation) texture else retiredTextures[target.generation]
+      // The loop replays the last RENDERED frame's target, but with pipelined rendering the
+      // texture to present is the newest completed one; the loop's token only marks that a
+      // frame has been rendered at all.
+      val presentedGeneration =
+        if (displayedGeneration in textures || displayedGeneration in retiredTextures) {
+          displayedGeneration
+        } else {
+          target.generation
+        }
+      val sharedTexture = textures[presentedGeneration] ?: retiredTextures[presentedGeneration]
       val imported = sharedTexture?.imported ?: return@withOpenGlContextOrNull false
       // Context replacement abandons GL names. Presenting texture 0 builds an
       // incomplete FBO; the next acquireFrame reallocates in the new context.
@@ -156,15 +231,22 @@ internal class VulkanOpenGlWin32MapHost(private val gpuHost: ComposeMapHost) : M
         presenter.draw(
           scope,
           context.skiaContext,
-          imported.target(target.generation),
+          imported.target(presentedGeneration),
           frameCompletion,
         )
-      if (drew) disposeRetiredTextures(exceptGeneration = target.generation)
+      // An in-flight render may still write a just-retired texture; defer disposal.
+      if (drew && pendingRenders.isEmpty()) {
+        disposeRetiredTextures(exceptGeneration = presentedGeneration)
+      }
       drew
     } ?: false
   }
 
   override fun close() {
+    // The Vulkan device must outlive any in-flight render.
+    while (pendingRenders.isNotEmpty()) {
+      runCatching { pendingRenders.removeFirst().task.get() }
+    }
     try {
       frameCompletion.abandon()
       runCatching {
@@ -184,7 +266,7 @@ internal class VulkanOpenGlWin32MapHost(private val gpuHost: ComposeMapHost) : M
     }
   }
 
-  private fun recreateTexture(extent: MapExtent) {
+  private fun recreateTextures(extent: MapExtent) {
     if (extent.isEmpty) {
       disposeAllTextures()
       currentExtent = MapExtent.Empty
@@ -200,15 +282,35 @@ internal class VulkanOpenGlWin32MapHost(private val gpuHost: ComposeMapHost) : M
     val context =
       vulkan
         ?: rendererThread.run { WindowsOpenGlVulkanContext.create(adapterLuid) }.also { vulkan = it }
+    val created = ArrayList<WindowsOpenGlSharedTexture>(TEXTURE_SLOTS)
+    try {
+      repeat(TEXTURE_SLOTS) { created += createTexture(context, angleDevice, extent) }
+    } catch (error: RuntimeException) {
+      created.forEach { runCatching(it::close) }
+      throw error
+    }
+    retireCurrentTextures()
+    created.forEach { slot ->
+      generation += 1
+      textures[generation] = slot
+    }
+    currentExtent = extent
+  }
+
+  private fun createTexture(
+    context: WindowsOpenGlVulkanContext,
+    angleDevice: Long,
+    extent: MapExtent,
+  ): WindowsOpenGlSharedTexture {
     val d3d11 = WindowsD3D11Interop.createSharedTextureOnDevice(angleDevice, extent)
     try {
       val exported = rendererThread.run { context.importD3D11Texture(d3d11.sharedHandle, extent) }
       try {
-        val imported = WindowsOpenGlImportedTexture.bindAngle(d3d11.texture, extent)
-        texture?.let { retiredTextures[generation] = it }
-        texture = WindowsOpenGlSharedTexture(d3d11, exported, imported)
-        currentExtent = extent
-        generation += 1
+        return WindowsOpenGlSharedTexture(
+          d3d11,
+          exported,
+          WindowsOpenGlImportedTexture.bindAngle(d3d11.texture, extent),
+        )
       } catch (error: RuntimeException) {
         exported.close()
         throw error
@@ -219,10 +321,14 @@ internal class VulkanOpenGlWin32MapHost(private val gpuHost: ComposeMapHost) : M
     }
   }
 
+  private fun retireCurrentTextures() {
+    retiredTextures.putAll(textures)
+    textures.clear()
+  }
+
   private fun abandonContext() {
     presenter.abandon()
-    texture?.let { retiredTextures[generation] = it }
-    texture = null
+    retireCurrentTextures()
     retiredTextures.values.forEach(WindowsOpenGlSharedTexture::abandonImported)
     currentExtent = MapExtent.Empty
   }
@@ -239,8 +345,7 @@ internal class VulkanOpenGlWin32MapHost(private val gpuHost: ComposeMapHost) : M
   }
 
   private fun disposeAllTextures() {
-    texture?.close()
-    texture = null
+    retireCurrentTextures()
     disposeRetiredTextures()
   }
 

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/bridge/VulkanOpenGlWin32MapHost.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/bridge/VulkanOpenGlWin32MapHost.kt
@@ -1,0 +1,627 @@
+package org.maplibre.compose.desktop.bridge
+
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import org.lwjgl.opengl.GL11.GL_RGBA8
+import org.lwjgl.opengl.GL11.GL_TEXTURE_2D
+import org.lwjgl.system.MemoryStack
+import org.lwjgl.system.MemoryUtil.NULL
+import org.lwjgl.vulkan.EXTDebugUtils.VK_EXT_DEBUG_UTILS_EXTENSION_NAME
+import org.lwjgl.vulkan.KHRExternalMemoryWin32.VK_KHR_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME
+import org.lwjgl.vulkan.KHRExternalMemoryWin32.VK_STRUCTURE_TYPE_IMPORT_MEMORY_WIN32_HANDLE_INFO_KHR
+import org.lwjgl.vulkan.KHRExternalMemoryWin32.VK_STRUCTURE_TYPE_MEMORY_WIN32_HANDLE_PROPERTIES_KHR
+import org.lwjgl.vulkan.KHRExternalMemoryWin32.vkGetMemoryWin32HandlePropertiesKHR
+import org.lwjgl.vulkan.KHRPortabilityEnumeration.VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR
+import org.lwjgl.vulkan.KHRPortabilityEnumeration.VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME
+import org.lwjgl.vulkan.KHRPortabilitySubset.VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME
+import org.lwjgl.vulkan.VK10.VK_FORMAT_R8G8B8A8_UNORM
+import org.lwjgl.vulkan.VK10.VK_IMAGE_ASPECT_COLOR_BIT
+import org.lwjgl.vulkan.VK10.VK_IMAGE_LAYOUT_GENERAL
+import org.lwjgl.vulkan.VK10.VK_IMAGE_LAYOUT_UNDEFINED
+import org.lwjgl.vulkan.VK10.VK_IMAGE_TILING_OPTIMAL
+import org.lwjgl.vulkan.VK10.VK_IMAGE_TYPE_2D
+import org.lwjgl.vulkan.VK10.VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT
+import org.lwjgl.vulkan.VK10.VK_IMAGE_USAGE_SAMPLED_BIT
+import org.lwjgl.vulkan.VK10.VK_IMAGE_VIEW_TYPE_2D
+import org.lwjgl.vulkan.VK10.VK_SAMPLE_COUNT_1_BIT
+import org.lwjgl.vulkan.VK10.VK_SHARING_MODE_EXCLUSIVE
+import org.lwjgl.vulkan.VK10.VK_STRUCTURE_TYPE_APPLICATION_INFO
+import org.lwjgl.vulkan.VK10.VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO
+import org.lwjgl.vulkan.VK10.VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO
+import org.lwjgl.vulkan.VK10.VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO
+import org.lwjgl.vulkan.VK10.VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO
+import org.lwjgl.vulkan.VK10.VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO
+import org.lwjgl.vulkan.VK10.VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO
+import org.lwjgl.vulkan.VK10.vkAllocateMemory
+import org.lwjgl.vulkan.VK10.vkBindImageMemory
+import org.lwjgl.vulkan.VK10.vkCreateDevice
+import org.lwjgl.vulkan.VK10.vkCreateImage
+import org.lwjgl.vulkan.VK10.vkCreateImageView
+import org.lwjgl.vulkan.VK10.vkCreateInstance
+import org.lwjgl.vulkan.VK10.vkDestroyDevice
+import org.lwjgl.vulkan.VK10.vkDestroyImage
+import org.lwjgl.vulkan.VK10.vkDestroyImageView
+import org.lwjgl.vulkan.VK10.vkDestroyInstance
+import org.lwjgl.vulkan.VK10.vkDeviceWaitIdle
+import org.lwjgl.vulkan.VK10.vkEnumeratePhysicalDevices
+import org.lwjgl.vulkan.VK10.vkFreeMemory
+import org.lwjgl.vulkan.VK10.vkGetDeviceQueue
+import org.lwjgl.vulkan.VK10.vkGetImageMemoryRequirements
+import org.lwjgl.vulkan.VK10.vkQueueWaitIdle
+import org.lwjgl.vulkan.VK11.VK_API_VERSION_1_1
+import org.lwjgl.vulkan.VK11.VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_BIT
+import org.lwjgl.vulkan.VK11.VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO
+import org.lwjgl.vulkan.VK11.VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO
+import org.lwjgl.vulkan.VK11.VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ID_PROPERTIES
+import org.lwjgl.vulkan.VK11.VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2
+import org.lwjgl.vulkan.VK11.vkGetPhysicalDeviceProperties2
+import org.lwjgl.vulkan.VkApplicationInfo
+import org.lwjgl.vulkan.VkDevice
+import org.lwjgl.vulkan.VkDeviceCreateInfo
+import org.lwjgl.vulkan.VkDeviceQueueCreateInfo
+import org.lwjgl.vulkan.VkExtent3D
+import org.lwjgl.vulkan.VkExternalMemoryImageCreateInfo
+import org.lwjgl.vulkan.VkImageCreateInfo
+import org.lwjgl.vulkan.VkImageSubresourceRange
+import org.lwjgl.vulkan.VkImageViewCreateInfo
+import org.lwjgl.vulkan.VkImportMemoryWin32HandleInfoKHR
+import org.lwjgl.vulkan.VkInstance
+import org.lwjgl.vulkan.VkInstanceCreateInfo
+import org.lwjgl.vulkan.VkMemoryAllocateInfo
+import org.lwjgl.vulkan.VkMemoryDedicatedAllocateInfo
+import org.lwjgl.vulkan.VkMemoryRequirements
+import org.lwjgl.vulkan.VkMemoryWin32HandlePropertiesKHR
+import org.lwjgl.vulkan.VkPhysicalDevice
+import org.lwjgl.vulkan.VkPhysicalDeviceIDProperties
+import org.lwjgl.vulkan.VkPhysicalDeviceProperties2
+import org.lwjgl.vulkan.VkQueue
+import org.maplibre.compose.desktop.ComposeMapHost
+import org.maplibre.compose.map.MapExtent
+import org.maplibre.compose.mlnffi.ComposeRenderBackend
+import org.maplibre.compose.mlnffi.EglContextHandles
+import org.maplibre.compose.mlnffi.MapRenderBackend
+import org.maplibre.compose.mlnffi.MlnFfiHostException
+import org.maplibre.compose.mlnffi.MlnFfiMapFrame
+import org.maplibre.compose.mlnffi.MlnFfiMapFrameAcquisition
+import org.maplibre.compose.mlnffi.MlnFfiMapHost
+import org.maplibre.compose.mlnffi.MlnFfiRenderTarget
+import org.maplibre.compose.mlnffi.NativeHandle
+import org.maplibre.compose.mlnffi.OpenGlTextureTarget
+import org.maplibre.compose.mlnffi.RenderBackendPair
+import org.maplibre.compose.mlnffi.TextureOrigin
+import org.maplibre.compose.mlnffi.VulkanContextHandles
+import org.maplibre.compose.mlnffi.VulkanImageTarget
+
+/**
+ * Bridges MapLibre's Vulkan rendering into Compose's ANGLE/GLES context on Windows.
+ *
+ * MapLibre draws into a D3D11 texture created on ANGLE's device. Vulkan imports the NT handle;
+ * Compose samples the same texture via `EGL_ANGLE_d3d_texture_client_buffer`.
+ */
+internal class VulkanOpenGlWin32MapHost(private val gpuHost: ComposeMapHost) : MlnFfiMapHost {
+  private val rendererThread = MapRendererThread("maplibre-windows-vulkan-gl-renderer")
+  private val presenter = OpenGlPresenter()
+  private val frameCompletion = ComposeFrameCompletion()
+  private var vulkan: WindowsOpenGlVulkanContext? = null
+  private var texture: WindowsOpenGlSharedTexture? = null
+  private val retiredTextures = mutableMapOf<Long, WindowsOpenGlSharedTexture>()
+  private var generation = 0L
+  private var currentExtent = MapExtent.Empty
+
+  override val backends: RenderBackendPair =
+    RenderBackendPair(MapRenderBackend.VULKAN, ComposeRenderBackend.OPENGL)
+
+  override fun acquireFrame(
+    frameId: Long,
+    extent: MapExtent,
+    presentationTimeNanos: Long?,
+  ): MlnFfiMapFrameAcquisition =
+    gpuHost.withOpenGlContextOrNull { context ->
+      frameCompletion.prepare(context.skiaContext, ::abandonContext)
+      if (texture == null || extent != currentExtent) recreateTexture(extent)
+      MlnFfiMapFrameAcquisition.Acquired(
+        MlnFfiMapFrame(
+          frameId = frameId,
+          extent = extent,
+          target =
+            requireNotNull(texture) { "Windows OpenGL texture is not initialized" }
+              .exported
+              .target(generation),
+          presentationTimeNanos = presentationTimeNanos,
+        )
+      )
+    } ?: MlnFfiMapFrameAcquisition.NotReady
+
+  override fun completeProducerAccess(frame: MlnFfiMapFrame) {
+    rendererThread.run { vulkan?.waitIdle() }
+  }
+
+  override fun <T> withProducerAccess(frame: MlnFfiMapFrame, action: () -> T): T =
+    rendererThread.run(action)
+
+  override fun <T> withRendererAccess(action: () -> T): T = rendererThread.run(action)
+
+  override fun enqueueRenderer(action: () -> Unit): Boolean = rendererThread.post(action)
+
+  override fun draw(scope: DrawScope, target: MlnFfiRenderTarget): Boolean {
+    if (target !is VulkanImageTarget) return false
+    return gpuHost.withOpenGlContextOrNull { context ->
+      frameCompletion.prepare(context.skiaContext, ::abandonContext)
+      val sharedTexture =
+        if (target.generation == generation) texture else retiredTextures[target.generation]
+      val imported = sharedTexture?.imported ?: return@withOpenGlContextOrNull false
+      val drew =
+        presenter.draw(
+          scope,
+          context.skiaContext,
+          imported.target(target.generation),
+          frameCompletion,
+        )
+      if (drew) disposeRetiredTextures(exceptGeneration = target.generation)
+      drew
+    } ?: false
+  }
+
+  override fun close() {
+    try {
+      frameCompletion.abandon()
+      runCatching {
+        gpuHost.withOpenGlContext {
+          disposeAllTextures()
+          presenter.close()
+        }
+      }
+    } finally {
+      val closing = vulkan
+      vulkan = null
+      try {
+        closing?.close()
+      } finally {
+        rendererThread.close()
+      }
+    }
+  }
+
+  private fun recreateTexture(extent: MapExtent) {
+    if (extent.isEmpty) {
+      disposeAllTextures()
+      currentExtent = MapExtent.Empty
+      generation += 1
+      return
+    }
+
+    val angleDevice = AngleEgl.angleD3d11Device()
+    val context =
+      vulkan
+        ?: rendererThread
+          .run { WindowsOpenGlVulkanContext.create(WindowsD3D11Interop.adapterLuidOf(angleDevice)) }
+          .also { vulkan = it }
+    val d3d11 = WindowsD3D11Interop.createSharedTextureOnDevice(angleDevice, extent)
+    try {
+      val exported = rendererThread.run { context.importD3D11Texture(d3d11.sharedHandle, extent) }
+      try {
+        val imported = WindowsOpenGlImportedTexture.bindAngle(d3d11.texture, extent)
+        texture?.let { retiredTextures[generation] = it }
+        texture = WindowsOpenGlSharedTexture(d3d11, exported, imported)
+        currentExtent = extent
+        generation += 1
+      } catch (error: RuntimeException) {
+        exported.close()
+        throw error
+      }
+    } catch (error: RuntimeException) {
+      d3d11.close()
+      throw error
+    }
+  }
+
+  private fun abandonContext() {
+    presenter.abandon()
+    texture?.let { retiredTextures[generation] = it }
+    texture = null
+    retiredTextures.values.forEach(WindowsOpenGlSharedTexture::abandonImported)
+    currentExtent = MapExtent.Empty
+  }
+
+  private fun disposeRetiredTextures(exceptGeneration: Long? = null) {
+    val iterator = retiredTextures.iterator()
+    while (iterator.hasNext()) {
+      val entry = iterator.next()
+      if (entry.key != exceptGeneration) {
+        entry.value.close()
+        iterator.remove()
+      }
+    }
+  }
+
+  private fun disposeAllTextures() {
+    texture?.close()
+    texture = null
+    disposeRetiredTextures()
+  }
+
+  private inner class WindowsOpenGlSharedTexture(
+    val d3d11: WindowsD3D11SharedTexture,
+    val exported: WindowsOpenGlExportedVulkanTexture,
+    val imported: WindowsOpenGlImportedTexture,
+  ) : AutoCloseable {
+    override fun close() {
+      presenter.forget(imported.textureName)
+      imported.close()
+      exported.close()
+      d3d11.close()
+    }
+
+    fun abandonImported() {
+      imported.abandon()
+    }
+  }
+}
+
+/** The Vulkan instance, device, and queue MapLibre renders with on the Windows OpenGL path. */
+internal class WindowsOpenGlVulkanContext
+private constructor(private val preferredAdapterLuid: Long) : AutoCloseable {
+  private var instance: VkInstance? = null
+  private var physicalDevice: VkPhysicalDevice? = null
+  private var device: VkDevice? = null
+  private var graphicsQueue: VkQueue? = null
+  private var graphicsQueueFamilyIndex = 0
+
+  val handles: VulkanContextHandles
+    get() =
+      VulkanContextHandles(
+        instance = NativeHandle(instance().address()),
+        physicalDevice = NativeHandle(physicalDevice().address()),
+        device = NativeHandle(device().address()),
+        graphicsQueue = NativeHandle(graphicsQueue().address()),
+        graphicsQueueFamilyIndex = graphicsQueueFamilyIndex,
+        getInstanceProcAddr = NativeHandle(vulkanFunctionAddress("vkGetInstanceProcAddr")),
+        getDeviceProcAddr = NativeHandle(vulkanFunctionAddress("vkGetDeviceProcAddr")),
+      )
+
+  fun importD3D11Texture(sharedHandle: Long, extent: MapExtent): WindowsOpenGlExportedVulkanTexture =
+    WindowsOpenGlExportedVulkanTexture.create(this, sharedHandle, extent)
+
+  fun waitIdle() {
+    graphicsQueue?.let { checkVulkan(vkQueueWaitIdle(it), "vkQueueWaitIdle") }
+      ?: device?.let { checkVulkan(vkDeviceWaitIdle(it), "vkDeviceWaitIdle") }
+  }
+
+  internal fun physicalDevice(): VkPhysicalDevice =
+    checkNotNull(physicalDevice) { "Vulkan physical device is not initialized" }
+
+  internal fun device(): VkDevice = checkNotNull(device) { "Vulkan device is not initialized" }
+
+  private fun instance(): VkInstance =
+    checkNotNull(instance) { "Vulkan instance is not initialized" }
+
+  private fun graphicsQueue(): VkQueue =
+    checkNotNull(graphicsQueue) { "Vulkan graphics queue is not initialized" }
+
+  private fun createInstance() {
+    ensureVulkanFunctionProvider()
+    MemoryStack.stackPush().use { stack ->
+      val available = stack.vulkanInstanceExtensions()
+      val extensions = LinkedHashSet<String>()
+      val enablePortability = VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME in available
+      if (enablePortability) extensions.add(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME)
+      if (VK_EXT_DEBUG_UTILS_EXTENSION_NAME in available) {
+        extensions.add(VK_EXT_DEBUG_UTILS_EXTENSION_NAME)
+      }
+      val app =
+        VkApplicationInfo.calloc(stack)
+          .sType(VK_STRUCTURE_TYPE_APPLICATION_INFO)
+          .pApplicationName(stack.UTF8("maplibre-compose"))
+          .pEngineName(stack.UTF8("maplibre-native-ffi"))
+          .apiVersion(VK_API_VERSION_1_1)
+      val createInfo =
+        VkInstanceCreateInfo.calloc(stack)
+          .sType(VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO)
+          .pApplicationInfo(app)
+          .ppEnabledExtensionNames(stack.vulkanStringBuffer(extensions))
+      if (enablePortability) createInfo.flags(VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR)
+      val out = stack.mallocPointer(1)
+      checkVulkan(vkCreateInstance(createInfo, null, out), "vkCreateInstance")
+      instance = VkInstance(out[0], createInfo)
+    }
+  }
+
+  private fun pickPhysicalDeviceAndQueue() {
+    MemoryStack.stackPush().use { stack ->
+      val count = stack.mallocInt(1)
+      checkVulkan(
+        vkEnumeratePhysicalDevices(instance(), count, null),
+        "vkEnumeratePhysicalDevices(count)",
+      )
+      check(count[0] != 0) { "No Vulkan physical devices found" }
+      val devices = stack.mallocPointer(count[0])
+      checkVulkan(
+        vkEnumeratePhysicalDevices(instance(), count, devices),
+        "vkEnumeratePhysicalDevices",
+      )
+      var fallback: Pair<VkPhysicalDevice, Int>? = null
+      for (index in 0..<devices.capacity()) {
+        val candidate = VkPhysicalDevice(devices[index], instance())
+        if (VK_KHR_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME !in stack.vulkanDeviceExtensions(candidate)
+        ) {
+          continue
+        }
+        val queueFamily = stack.findVulkanGraphicsQueueFamily(candidate)
+        if (queueFamily < 0) continue
+        if (preferredAdapterLuid == 0L || deviceLuid(candidate) == preferredAdapterLuid) {
+          physicalDevice = candidate
+          graphicsQueueFamilyIndex = queueFamily
+          return
+        }
+        if (fallback == null) fallback = candidate to queueFamily
+      }
+      fallback?.let { (candidate, queueFamily) ->
+        physicalDevice = candidate
+        graphicsQueueFamilyIndex = queueFamily
+        return
+      }
+      throw MlnFfiHostException(
+        "No Vulkan device supports graphics and $VK_KHR_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME"
+      )
+    }
+  }
+
+  private fun deviceLuid(candidate: VkPhysicalDevice): Long {
+    MemoryStack.stackPush().use { stack ->
+      val id =
+        VkPhysicalDeviceIDProperties.calloc(stack)
+          .sType(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ID_PROPERTIES)
+      val properties =
+        VkPhysicalDeviceProperties2.calloc(stack)
+          .sType(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2)
+          .pNext(id.address())
+      vkGetPhysicalDeviceProperties2(candidate, properties)
+      return id.deviceLUID().getLong(0)
+    }
+  }
+
+  private fun createDevice() {
+    MemoryStack.stackPush().use { stack ->
+      val deviceExtensions = stack.vulkanDeviceExtensions(physicalDevice())
+      check(VK_KHR_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME in deviceExtensions) {
+        "Selected Vulkan device does not support $VK_KHR_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME"
+      }
+      val extensions = LinkedHashSet<String>()
+      extensions.add(VK_KHR_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME)
+      if (VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME in deviceExtensions) {
+        extensions.add(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)
+      }
+      val priorities = stack.floats(1.0f)
+      val queueInfo =
+        VkDeviceQueueCreateInfo.calloc(1, stack)
+          .sType(VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO)
+          .queueFamilyIndex(graphicsQueueFamilyIndex)
+          .pQueuePriorities(priorities)
+      val createInfo =
+        VkDeviceCreateInfo.calloc(stack)
+          .sType(VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO)
+          .pQueueCreateInfos(queueInfo)
+          .ppEnabledExtensionNames(stack.vulkanStringBuffer(extensions))
+      val out = stack.mallocPointer(1)
+      checkVulkan(vkCreateDevice(physicalDevice(), createInfo, null, out), "vkCreateDevice")
+      device = VkDevice(out[0], physicalDevice(), createInfo)
+      val queueOut = stack.mallocPointer(1)
+      vkGetDeviceQueue(device(), graphicsQueueFamilyIndex, 0, queueOut)
+      graphicsQueue = VkQueue(queueOut[0], device())
+    }
+  }
+
+  override fun close() {
+    device?.let {
+      vkDeviceWaitIdle(it)
+      vkDestroyDevice(it, null)
+      device = null
+    }
+    instance?.let {
+      vkDestroyInstance(it, null)
+      instance = null
+    }
+  }
+
+  companion object {
+    fun create(preferredAdapterLuid: Long = 0L): WindowsOpenGlVulkanContext {
+      val context = WindowsOpenGlVulkanContext(preferredAdapterLuid)
+      try {
+        context.createInstance()
+        context.pickPhysicalDeviceAndQueue()
+        context.createDevice()
+        return context
+      } catch (error: RuntimeException) {
+        context.close()
+        throw error
+      }
+    }
+  }
+}
+
+/** A `VkImage` whose memory is the imported D3D11 texture MapLibre renders into. */
+internal class WindowsOpenGlExportedVulkanTexture
+private constructor(
+  private val context: WindowsOpenGlVulkanContext,
+  private val sharedHandle: Long,
+  private val extent: MapExtent,
+) : AutoCloseable {
+  private var image = NULL
+  private var memory = NULL
+  private var view = NULL
+
+  fun target(generation: Long): VulkanImageTarget =
+    VulkanImageTarget(
+      context = context.handles,
+      image = NativeHandle(image),
+      imageView = NativeHandle(view),
+      format = VK_FORMAT_R8G8B8A8_UNORM,
+      initialLayout = VK_IMAGE_LAYOUT_UNDEFINED,
+      finalLayout = VK_IMAGE_LAYOUT_GENERAL,
+      queueFamilyIndex = context.handles.graphicsQueueFamilyIndex,
+      extent = extent,
+      generation = generation,
+    )
+
+  private fun create() {
+    MemoryStack.stackPush().use { stack ->
+      val externalImageInfo =
+        VkExternalMemoryImageCreateInfo.calloc(stack)
+          .sType(VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO)
+          .handleTypes(VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_BIT)
+      val imageInfo =
+        VkImageCreateInfo.calloc(stack)
+          .sType(VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO)
+          .pNext(externalImageInfo.address())
+          .imageType(VK_IMAGE_TYPE_2D)
+          .format(VK_FORMAT_R8G8B8A8_UNORM)
+          .extent(
+            VkExtent3D.calloc(stack)
+              .width(extent.physicalWidth)
+              .height(extent.physicalHeight)
+              .depth(1)
+          )
+          .mipLevels(1)
+          .arrayLayers(1)
+          .samples(VK_SAMPLE_COUNT_1_BIT)
+          .tiling(VK_IMAGE_TILING_OPTIMAL)
+          .usage(VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT or VK_IMAGE_USAGE_SAMPLED_BIT)
+          .sharingMode(VK_SHARING_MODE_EXCLUSIVE)
+          .initialLayout(VK_IMAGE_LAYOUT_UNDEFINED)
+      val imageOut = stack.mallocLong(1)
+      checkVulkan(vkCreateImage(context.device(), imageInfo, null, imageOut), "vkCreateImage")
+      image = imageOut[0]
+
+      val requirements = VkMemoryRequirements.calloc(stack)
+      vkGetImageMemoryRequirements(context.device(), image, requirements)
+      val handleProperties =
+        VkMemoryWin32HandlePropertiesKHR.calloc(stack)
+          .sType(VK_STRUCTURE_TYPE_MEMORY_WIN32_HANDLE_PROPERTIES_KHR)
+      checkVulkan(
+        vkGetMemoryWin32HandlePropertiesKHR(
+          context.device(),
+          VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_BIT,
+          sharedHandle,
+          handleProperties,
+        ),
+        "vkGetMemoryWin32HandlePropertiesKHR",
+      )
+      val dedicated =
+        VkMemoryDedicatedAllocateInfo.calloc(stack)
+          .sType(VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO)
+          .image(image)
+      val importInfo =
+        VkImportMemoryWin32HandleInfoKHR.calloc(stack)
+          .sType(VK_STRUCTURE_TYPE_IMPORT_MEMORY_WIN32_HANDLE_INFO_KHR)
+          .handleType(VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_BIT)
+          .handle(sharedHandle)
+          .pNext(dedicated.address())
+      val allocateInfo =
+        VkMemoryAllocateInfo.calloc(stack)
+          .sType(VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO)
+          .pNext(importInfo.address())
+          .allocationSize(requirements.size())
+          .memoryTypeIndex(
+            findVulkanDeviceLocalMemoryType(
+              context.physicalDevice(),
+              requirements.memoryTypeBits() and handleProperties.memoryTypeBits(),
+              "No compatible Vulkan memory type found for imported D3D11 texture",
+            )
+          )
+      val memoryOut = stack.mallocLong(1)
+      checkVulkan(
+        vkAllocateMemory(context.device(), allocateInfo, null, memoryOut),
+        "vkAllocateMemory",
+      )
+      memory = memoryOut[0]
+      checkVulkan(vkBindImageMemory(context.device(), image, memory, 0), "vkBindImageMemory")
+
+      val viewInfo =
+        VkImageViewCreateInfo.calloc(stack)
+          .sType(VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO)
+          .image(image)
+          .viewType(VK_IMAGE_VIEW_TYPE_2D)
+          .format(VK_FORMAT_R8G8B8A8_UNORM)
+          .subresourceRange(
+            VkImageSubresourceRange.calloc(stack)
+              .aspectMask(VK_IMAGE_ASPECT_COLOR_BIT)
+              .baseMipLevel(0)
+              .levelCount(1)
+              .baseArrayLayer(0)
+              .layerCount(1)
+          )
+      val viewOut = stack.mallocLong(1)
+      checkVulkan(vkCreateImageView(context.device(), viewInfo, null, viewOut), "vkCreateImageView")
+      view = viewOut[0]
+    }
+  }
+
+  override fun close() {
+    context.waitIdle()
+    if (view != NULL) {
+      vkDestroyImageView(context.device(), view, null)
+      view = NULL
+    }
+    if (image != NULL) {
+      vkDestroyImage(context.device(), image, null)
+      image = NULL
+    }
+    if (memory != NULL) {
+      vkFreeMemory(context.device(), memory, null)
+      memory = NULL
+    }
+  }
+
+  companion object {
+    fun create(
+      context: WindowsOpenGlVulkanContext,
+      sharedHandle: Long,
+      extent: MapExtent,
+    ): WindowsOpenGlExportedVulkanTexture {
+      val texture = WindowsOpenGlExportedVulkanTexture(context, sharedHandle, extent)
+      try {
+        texture.create()
+        return texture
+      } catch (error: RuntimeException) {
+        texture.close()
+        throw error
+      }
+    }
+  }
+}
+
+/** Compose's GL texture: ANGLE's pbuffer wrapping the same D3D11 allocation. */
+internal class WindowsOpenGlImportedTexture
+private constructor(private val extent: MapExtent, private var binding: AngleBoundD3dTexture?) :
+  AutoCloseable {
+  val textureName: Int
+    get() = binding?.textureName ?: 0
+
+  fun target(generation: Long): OpenGlTextureTarget =
+    OpenGlTextureTarget(
+      context =
+        EglContextHandles(NativeHandle(0), NativeHandle(0), NativeHandle(0), NativeHandle(0)),
+      textureName = textureName,
+      textureTarget = GL_TEXTURE_2D,
+      format = GL_RGBA8,
+      origin = TextureOrigin.TOP_LEFT,
+      makeContextCurrent = {},
+      extent = extent,
+      generation = generation,
+    )
+
+  override fun close() {
+    binding?.close()
+    abandon()
+  }
+
+  fun abandon() {
+    binding = null
+  }
+
+  companion object {
+    fun bindAngle(d3dTexture: Long, extent: MapExtent): WindowsOpenGlImportedTexture {
+      check(AngleGl.isUsable()) { "Compose's ANGLE context has no usable GLES entry points" }
+      return WindowsOpenGlImportedTexture(extent, AngleEgl.bindD3dTexture(d3dTexture))
+    }
+  }
+}

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/bridge/VulkanOpenGlWin32MapHost.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/bridge/VulkanOpenGlWin32MapHost.kt
@@ -149,6 +149,9 @@ internal class VulkanOpenGlWin32MapHost(private val gpuHost: ComposeMapHost) : M
       val sharedTexture =
         if (target.generation == generation) texture else retiredTextures[target.generation]
       val imported = sharedTexture?.imported ?: return@withOpenGlContextOrNull false
+      // Context replacement abandons GL names. Presenting texture 0 builds an
+      // incomplete FBO; the next acquireFrame reallocates in the new context.
+      if (imported.textureName == 0) return@withOpenGlContextOrNull false
       val drew =
         presenter.draw(
           scope,
@@ -190,11 +193,13 @@ internal class VulkanOpenGlWin32MapHost(private val gpuHost: ComposeMapHost) : M
     }
 
     val angleDevice = AngleEgl.angleD3d11Device()
+    val adapterLuid = WindowsD3D11Interop.adapterLuidOf(angleDevice)
+    check(adapterLuid != 0L) {
+      "ANGLE's ID3D11Device has no DXGI adapter LUID; cannot pick a matching Vulkan device"
+    }
     val context =
       vulkan
-        ?: rendererThread
-          .run { WindowsOpenGlVulkanContext.create(WindowsD3D11Interop.adapterLuidOf(angleDevice)) }
-          .also { vulkan = it }
+        ?: rendererThread.run { WindowsOpenGlVulkanContext.create(adapterLuid) }.also { vulkan = it }
     val d3d11 = WindowsD3D11Interop.createSharedTextureOnDevice(angleDevice, extent)
     try {
       val exported = rendererThread.run { context.importD3D11Texture(d3d11.sharedHandle, extent) }
@@ -338,7 +343,9 @@ private constructor(private val preferredAdapterLuid: Long) : AutoCloseable {
         vkEnumeratePhysicalDevices(instance(), count, devices),
         "vkEnumeratePhysicalDevices",
       )
-      var fallback: Pair<VkPhysicalDevice, Int>? = null
+      check(preferredAdapterLuid != 0L) {
+        "Cannot select a Vulkan device without ANGLE's adapter LUID"
+      }
       for (index in 0..<devices.capacity()) {
         val candidate = VkPhysicalDevice(devices[index], instance())
         if (VK_KHR_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME !in stack.vulkanDeviceExtensions(candidate)
@@ -347,20 +354,14 @@ private constructor(private val preferredAdapterLuid: Long) : AutoCloseable {
         }
         val queueFamily = stack.findVulkanGraphicsQueueFamily(candidate)
         if (queueFamily < 0) continue
-        if (preferredAdapterLuid == 0L || deviceLuid(candidate) == preferredAdapterLuid) {
-          physicalDevice = candidate
-          graphicsQueueFamilyIndex = queueFamily
-          return
-        }
-        if (fallback == null) fallback = candidate to queueFamily
-      }
-      fallback?.let { (candidate, queueFamily) ->
+        if (deviceLuid(candidate) != preferredAdapterLuid) continue
         physicalDevice = candidate
         graphicsQueueFamilyIndex = queueFamily
         return
       }
       throw MlnFfiHostException(
-        "No Vulkan device supports graphics and $VK_KHR_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME"
+        "No Vulkan device matches ANGLE's adapter and supports " +
+          "$VK_KHR_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME"
       )
     }
   }
@@ -423,7 +424,8 @@ private constructor(private val preferredAdapterLuid: Long) : AutoCloseable {
   }
 
   companion object {
-    fun create(preferredAdapterLuid: Long = 0L): WindowsOpenGlVulkanContext {
+    fun create(preferredAdapterLuid: Long): WindowsOpenGlVulkanContext {
+      require(preferredAdapterLuid != 0L) { "ANGLE adapter LUID is required" }
       val context = WindowsOpenGlVulkanContext(preferredAdapterLuid)
       try {
         context.createInstance()

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/bridge/VulkanSupport.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/bridge/VulkanSupport.kt
@@ -16,6 +16,9 @@ import org.lwjgl.vulkan.VkPhysicalDevice
 import org.lwjgl.vulkan.VkPhysicalDeviceMemoryProperties
 import org.lwjgl.vulkan.VkQueueFamilyProperties
 
+internal fun isWindowsDesktop(): Boolean =
+  System.getProperty("os.name")?.lowercase().orEmpty().contains("win")
+
 internal fun checkVulkan(status: Int, operation: String) {
   check(status == VK_SUCCESS) { "$operation failed with Vulkan status $status" }
 }
@@ -38,12 +41,18 @@ internal fun MemoryStack.vulkanInstanceExtensions(): Set<String> {
     vkEnumerateInstanceExtensionProperties(null as String?, count, null),
     "vkEnumerateInstanceExtensionProperties(count)",
   )
-  val props = VkExtensionProperties.calloc(count[0], this)
-  checkVulkan(
-    vkEnumerateInstanceExtensionProperties(null as String?, count, props),
-    "vkEnumerateInstanceExtensionProperties",
-  )
-  return buildSet { props.forEach { add(it.extensionNameString()) } }
+  if (count[0] == 0) return emptySet()
+  // Heap: a typical ICD reports enough extensions to overflow LWJGL's 32 KiB thread stack.
+  val props = VkExtensionProperties.calloc(count[0])
+  try {
+    checkVulkan(
+      vkEnumerateInstanceExtensionProperties(null as String?, count, props),
+      "vkEnumerateInstanceExtensionProperties",
+    )
+    return buildSet { props.forEach { add(it.extensionNameString()) } }
+  } finally {
+    props.free()
+  }
 }
 
 internal fun MemoryStack.vulkanDeviceExtensions(device: VkPhysicalDevice): Set<String> {
@@ -52,12 +61,17 @@ internal fun MemoryStack.vulkanDeviceExtensions(device: VkPhysicalDevice): Set<S
     vkEnumerateDeviceExtensionProperties(device, null as String?, count, null),
     "vkEnumerateDeviceExtensionProperties(count)",
   )
-  val props = VkExtensionProperties.calloc(count[0], this)
-  checkVulkan(
-    vkEnumerateDeviceExtensionProperties(device, null as String?, count, props),
-    "vkEnumerateDeviceExtensionProperties",
-  )
-  return buildSet { props.forEach { add(it.extensionNameString()) } }
+  if (count[0] == 0) return emptySet()
+  val props = VkExtensionProperties.calloc(count[0])
+  try {
+    checkVulkan(
+      vkEnumerateDeviceExtensionProperties(device, null as String?, count, props),
+      "vkEnumerateDeviceExtensionProperties",
+    )
+    return buildSet { props.forEach { add(it.extensionNameString()) } }
+  } finally {
+    props.free()
+  }
 }
 
 internal fun MemoryStack.vulkanStringBuffer(values: Set<String>): PointerBuffer {

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/bridge/WindowsD3D11Interop.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/bridge/WindowsD3D11Interop.kt
@@ -64,43 +64,42 @@ internal object WindowsD3D11Interop {
   fun adapterLuidOf(device: Long): Long {
     Arena.ofConfined().use { arena ->
       val dxgiOut = arena.allocate(ValueLayout.ADDRESS)
-      if (
+      checkHResult(
         invokeHResult(
           comMethod(device, IUNKNOWN_QUERY_INTERFACE_INDEX),
           address(device),
           iid(arena, 0x54ec77fa, 0x1377, 0x44e6, 0x8c, 0x32, 0x88, 0xfd, 0x5f, 0x44, 0xc8, 0x4c),
           dxgiOut,
-        ) < 0
-      ) {
-        return 0L
-      }
+        ),
+        "ID3D11Device::QueryInterface(IDXGIDevice)",
+      )
       val dxgi = dxgiOut.get(ValueLayout.ADDRESS, 0).address()
       try {
         val adapterOut = arena.allocate(ValueLayout.ADDRESS)
-        if (
+        checkHResult(
           invokeInt(
             comMethod(dxgi, IDXGI_DEVICE_GET_ADAPTER_INDEX),
             FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS, ValueLayout.ADDRESS),
             address(dxgi),
             adapterOut,
-          ) < 0
-        ) {
-          return 0L
-        }
+          ),
+          "IDXGIDevice::GetAdapter",
+        )
         val adapter = adapterOut.get(ValueLayout.ADDRESS, 0).address()
         try {
           val desc = arena.allocate(DXGI_ADAPTER_DESC_SIZE)
-          if (
+          checkHResult(
             invokeInt(
               comMethod(adapter, IDXGI_ADAPTER_GET_DESC_INDEX),
               FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS, ValueLayout.ADDRESS),
               address(adapter),
               desc,
-            ) < 0
-          ) {
-            return 0L
-          }
-          return desc.get(ValueLayout.JAVA_LONG, DXGI_ADAPTER_DESC_LUID_OFFSET)
+            ),
+            "IDXGIAdapter::GetDesc",
+          )
+          val luid = desc.get(ValueLayout.JAVA_LONG, DXGI_ADAPTER_DESC_LUID_OFFSET)
+          check(luid != 0L) { "IDXGIAdapter::GetDesc returned a zero LUID" }
+          return luid
         } finally {
           release(adapter)
         }

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/bridge/WindowsD3D11Interop.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/bridge/WindowsD3D11Interop.kt
@@ -1,0 +1,260 @@
+package org.maplibre.compose.desktop.bridge
+
+import java.lang.foreign.Arena
+import java.lang.foreign.FunctionDescriptor
+import java.lang.foreign.Linker
+import java.lang.foreign.MemorySegment
+import java.lang.foreign.SymbolLookup
+import java.lang.foreign.ValueLayout
+import org.lwjgl.system.MemoryUtil.NULL
+import org.maplibre.compose.map.MapExtent
+
+/** A D3D11 texture on ANGLE's device, exported as an NT handle for Vulkan. */
+internal class WindowsD3D11SharedTexture(
+  val sharedHandle: Long,
+  val texture: Long,
+) : AutoCloseable {
+  override fun close() {
+    WindowsD3D11Interop.release(texture)
+    WindowsD3D11Interop.closeSharedHandle(sharedHandle)
+  }
+}
+
+/** The D3D11/DXGI calls this host needs, via the JDK foreign-function API. */
+internal object WindowsD3D11Interop {
+  private const val DXGI_FORMAT_R8G8B8A8_UNORM = 28
+  private const val D3D11_BIND_SHADER_RESOURCE = 0x8
+  private const val D3D11_BIND_RENDER_TARGET = 0x20
+  private const val D3D11_RESOURCE_MISC_SHARED = 0x2
+  private const val D3D11_RESOURCE_MISC_SHARED_NTHANDLE = 0x800
+  private const val GENERIC_ALL = 0x10000000
+  private const val IUNKNOWN_QUERY_INTERFACE_INDEX = 0
+  private const val IUNKNOWN_RELEASE_INDEX = 2
+  private const val ID3D11_DEVICE_CREATE_TEXTURE_2D_INDEX = 5
+  private const val IDXGI_DEVICE_GET_ADAPTER_INDEX = 7
+  private const val IDXGI_ADAPTER_GET_DESC_INDEX = 8
+  private const val IDXGI_RESOURCE1_CREATE_SHARED_HANDLE_INDEX = 13
+  private const val DXGI_ADAPTER_DESC_LUID_OFFSET = 296L
+  private const val DXGI_ADAPTER_DESC_SIZE = 304L
+
+  private val linker = Linker.nativeLinker()
+  private val closeHandle =
+    linker.downcallHandle(
+      SymbolLookup.libraryLookup("kernel32", Arena.global()).findOrThrow("CloseHandle"),
+      FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS),
+    )
+
+  /**
+   * Allocates on [device] so ANGLE can wrap the same `ID3D11Texture2D`. Does not take ownership of
+   * [device].
+   */
+  fun createSharedTextureOnDevice(device: Long, extent: MapExtent): WindowsD3D11SharedTexture {
+    check(!extent.isEmpty) { "Cannot create a D3D11 texture for an empty extent" }
+    Arena.ofConfined().use { arena ->
+      val texture = createTexture(arena, device, extent)
+      try {
+        return WindowsD3D11SharedTexture(createSharedHandle(arena, texture), texture)
+      } catch (error: RuntimeException) {
+        release(texture)
+        throw error
+      }
+    }
+  }
+
+  fun adapterLuidOf(device: Long): Long {
+    Arena.ofConfined().use { arena ->
+      val dxgiOut = arena.allocate(ValueLayout.ADDRESS)
+      if (
+        invokeHResult(
+          comMethod(device, IUNKNOWN_QUERY_INTERFACE_INDEX),
+          address(device),
+          iid(arena, 0x54ec77fa, 0x1377, 0x44e6, 0x8c, 0x32, 0x88, 0xfd, 0x5f, 0x44, 0xc8, 0x4c),
+          dxgiOut,
+        ) < 0
+      ) {
+        return 0L
+      }
+      val dxgi = dxgiOut.get(ValueLayout.ADDRESS, 0).address()
+      try {
+        val adapterOut = arena.allocate(ValueLayout.ADDRESS)
+        if (
+          invokeInt(
+            comMethod(dxgi, IDXGI_DEVICE_GET_ADAPTER_INDEX),
+            FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS, ValueLayout.ADDRESS),
+            address(dxgi),
+            adapterOut,
+          ) < 0
+        ) {
+          return 0L
+        }
+        val adapter = adapterOut.get(ValueLayout.ADDRESS, 0).address()
+        try {
+          val desc = arena.allocate(DXGI_ADAPTER_DESC_SIZE)
+          if (
+            invokeInt(
+              comMethod(adapter, IDXGI_ADAPTER_GET_DESC_INDEX),
+              FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS, ValueLayout.ADDRESS),
+              address(adapter),
+              desc,
+            ) < 0
+          ) {
+            return 0L
+          }
+          return desc.get(ValueLayout.JAVA_LONG, DXGI_ADAPTER_DESC_LUID_OFFSET)
+        } finally {
+          release(adapter)
+        }
+      } finally {
+        release(dxgi)
+      }
+    }
+  }
+
+  fun closeSharedHandle(handle: Long) {
+    if (handle != NULL) closeHandle.invokeWithArguments(address(handle))
+  }
+
+  fun release(instance: Long) {
+    if (instance != NULL) {
+      invokeInt(
+        comMethod(instance, IUNKNOWN_RELEASE_INDEX),
+        FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS),
+        address(instance),
+      )
+    }
+  }
+
+  private fun createTexture(arena: Arena, device: Long, extent: MapExtent): Long {
+    val desc = arena.allocate(44)
+    desc.set(ValueLayout.JAVA_INT, 0, extent.physicalWidth)
+    desc.set(ValueLayout.JAVA_INT, 4, extent.physicalHeight)
+    desc.set(ValueLayout.JAVA_INT, 8, 1)
+    desc.set(ValueLayout.JAVA_INT, 12, 1)
+    desc.set(ValueLayout.JAVA_INT, 16, DXGI_FORMAT_R8G8B8A8_UNORM)
+    desc.set(ValueLayout.JAVA_INT, 20, 1)
+    desc.set(ValueLayout.JAVA_INT, 24, 0)
+    desc.set(ValueLayout.JAVA_INT, 28, 0)
+    desc.set(ValueLayout.JAVA_INT, 32, D3D11_BIND_RENDER_TARGET or D3D11_BIND_SHADER_RESOURCE)
+    desc.set(ValueLayout.JAVA_INT, 36, 0)
+    desc.set(
+      ValueLayout.JAVA_INT,
+      40,
+      D3D11_RESOURCE_MISC_SHARED or D3D11_RESOURCE_MISC_SHARED_NTHANDLE,
+    )
+    val textureOut = arena.allocate(ValueLayout.ADDRESS)
+    checkHResult(
+      invokeHResult(
+        comMethod(device, ID3D11_DEVICE_CREATE_TEXTURE_2D_INDEX),
+        address(device),
+        desc,
+        MemorySegment.NULL,
+        textureOut,
+      ),
+      "ID3D11Device::CreateTexture2D",
+    )
+    val texture = textureOut.get(ValueLayout.ADDRESS, 0).address()
+    check(texture != NULL) { "ID3D11Device::CreateTexture2D returned null" }
+    return texture
+  }
+
+  private fun createSharedHandle(arena: Arena, texture: Long): Long {
+    val resourceOut = arena.allocate(ValueLayout.ADDRESS)
+    checkHResult(
+      invokeHResult(
+        comMethod(texture, IUNKNOWN_QUERY_INTERFACE_INDEX),
+        address(texture),
+        iid(arena, 0x30961379, 0x4609, 0x4a41, 0x99, 0x8e, 0x54, 0xfe, 0x56, 0x7e, 0xe0, 0xc1),
+        resourceOut,
+      ),
+      "ID3D11Texture2D::QueryInterface(IDXGIResource1)",
+    )
+    val resource = resourceOut.get(ValueLayout.ADDRESS, 0).address()
+    try {
+      val handleOut = arena.allocate(ValueLayout.ADDRESS)
+      checkHResult(
+        invokeInt(
+          comMethod(resource, IDXGI_RESOURCE1_CREATE_SHARED_HANDLE_INDEX),
+          FunctionDescriptor.of(
+            ValueLayout.JAVA_INT,
+            ValueLayout.ADDRESS,
+            ValueLayout.ADDRESS,
+            ValueLayout.JAVA_INT,
+            ValueLayout.ADDRESS,
+            ValueLayout.ADDRESS,
+          ),
+          address(resource),
+          MemorySegment.NULL,
+          GENERIC_ALL,
+          MemorySegment.NULL,
+          handleOut,
+        ),
+        "IDXGIResource1::CreateSharedHandle",
+      )
+      val handle = handleOut.get(ValueLayout.ADDRESS, 0).address()
+      check(handle != NULL) { "IDXGIResource1::CreateSharedHandle returned a null handle" }
+      return handle
+    } finally {
+      release(resource)
+    }
+  }
+
+  private fun iid(
+    arena: Arena,
+    data1: Int,
+    data2: Int,
+    data3: Int,
+    vararg data4: Int,
+  ): MemorySegment {
+    val guid = arena.allocate(16)
+    guid.set(ValueLayout.JAVA_INT, 0, data1)
+    guid.set(ValueLayout.JAVA_SHORT, 4, data2.toShort())
+    guid.set(ValueLayout.JAVA_SHORT, 6, data3.toShort())
+    data4.forEachIndexed { index, value ->
+      guid.set(ValueLayout.JAVA_BYTE, 8L + index, value.toByte())
+    }
+    return guid
+  }
+
+  private fun comMethod(instance: Long, index: Int): MemorySegment {
+    val vtable = address(instance).reinterpret(Long.SIZE_BYTES.toLong()).get(ValueLayout.ADDRESS, 0)
+    return vtable
+      .reinterpret((index + 1L) * Long.SIZE_BYTES)
+      .get(ValueLayout.ADDRESS, index * Long.SIZE_BYTES.toLong())
+  }
+
+  private fun invokeHResult(function: MemorySegment, vararg args: Any): Int =
+    invokeInt(
+      function,
+      when (args.size) {
+        3 ->
+          FunctionDescriptor.of(
+            ValueLayout.JAVA_INT,
+            ValueLayout.ADDRESS,
+            ValueLayout.ADDRESS,
+            ValueLayout.ADDRESS,
+          )
+        4 ->
+          FunctionDescriptor.of(
+            ValueLayout.JAVA_INT,
+            ValueLayout.ADDRESS,
+            ValueLayout.ADDRESS,
+            ValueLayout.ADDRESS,
+            ValueLayout.ADDRESS,
+          )
+        else -> error("Unsupported HRESULT arity: ${args.size}")
+      },
+      *args,
+    )
+
+  private fun invokeInt(
+    function: MemorySegment,
+    descriptor: FunctionDescriptor,
+    vararg args: Any,
+  ): Int = linker.downcallHandle(function, descriptor).invokeWithArguments(*args) as Int
+
+  private fun address(value: Long): MemorySegment = MemorySegment.ofAddress(value)
+
+  private fun checkHResult(hr: Int, operation: String) {
+    check(hr >= 0) { "$operation failed with HRESULT 0x${hr.toUInt().toString(16)}" }
+  }
+}

--- a/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/desktop/bridge/ComposeMapHostBridgeLifecycleTest.kt
+++ b/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/desktop/bridge/ComposeMapHostBridgeLifecycleTest.kt
@@ -20,6 +20,13 @@ class ComposeMapHostBridgeLifecycleTest {
     }
   }
 
+  @Test
+  fun windows_opengl_resize_waits_for_the_first_gpu_context() {
+    VulkanOpenGlWin32MapHost(ContextlessMapHost(ComposeRenderBackend.OPENGL)).use { host ->
+      host.resize(EXTENT)
+    }
+  }
+
   private class ContextlessMapHost(override val backend: ComposeRenderBackend) : ComposeMapHost {
     override val description: String = "contextless test host"
 


### PR DESCRIPTION
**I haven't reviewed this PR yet; it was generated by Grok, but it allows MapLibre Compose to work with the Tao backend on Windows. I cannot guarantee I will have time to review it, but in any case, it can serve as a reference.**

## Description

Windows `ComposeMapHost` backends that present with ANGLE GLES (Tao, and any other EGL/D3D11 host) have no D3D12 device to share. The existing Windows consumer is `VulkanDirect3D12MapHost` and does not apply.

This adds `VulkanOpenGlWin32MapHost`:

- MapLibre still renders with Vulkan.
- The color target is a D3D11 texture allocated on **ANGLE's own** `ID3D11Device`.
- Vulkan imports the NT handle (`VK_KHR_external_memory_win32`).
- Compose samples the same allocation through `EGL_ANGLE_d3d_texture_client_buffer`.
- No CPU readback.

Also:

- Enumerate Vulkan instance/device extensions on the heap. A typical Windows ICD overflows LWJGL's 32 KiB `MemoryStack`.
- Pull LWJGL OpenGL natives on Windows (`presentsThroughOpenGl`).
- Skip WGL `GL.createCapabilities()` when the current context is ANGLE; FBO wrap uses `eglGetProcAddress`.

Linux and the D3D12 path are unchanged.

## Test plan

- [x] `:lib:maplibre-compose:compileKotlinJvm`
- [x] `:lib:maplibre-compose:jvmTest --tests ComposeMapHostBridgeLifecycleTest`
- [x] Nucleus Tao demo on Windows 11 x64 (ANGLE/D3D11): map renders, pan/zoom, no LWJGL FATAL abort

## Checklist

**To your knowledge, are you making any breaking changes?**

No. New Windows OpenGL consumer only. Existing Metal / Linux OpenGL / Windows D3D12 hosts are untouched.

**Have you tested the changes? On which platforms?**

- Desktop: Windows 11 x64, ANGLE GLES via Nucleus Tao