### PR TITLE
Add the my location demo

### DIFF
--- a/demo-app/common/build.gradle.kts
+++ b/demo-app/common/build.gradle.kts
@@ -108,6 +108,9 @@ kotlin {
         implementation(libs.androidx.activity.compose)
         implementation(libs.kotlinx.coroutines.android)
         implementation(libs.ktor.client.okhttp)
+        implementation(project(":lib:maplibre-compose-gms")) {
+          exclude(group = "org.maplibre.gl", module = "android-sdk")
+        }
 
         project.properties["demoAppMaplibreAndroidFlavor"].let { flavor ->
           when (flavor) {

--- a/demo-app/common/src/androidMain/kotlin/org/maplibre/compose/demoapp/demos/LocationEngine.android.kt
+++ b/demo-app/common/src/androidMain/kotlin/org/maplibre/compose/demoapp/demos/LocationEngine.android.kt
@@ -1,0 +1,23 @@
+package org.maplibre.compose.demoapp.demos
+
+import androidx.compose.runtime.Composable
+import org.maplibre.compose.demoapp.design.SwitchRow
+import org.maplibre.compose.gms.rememberFusedLocationProvider
+import org.maplibre.compose.gms.rememberFusedOrientationProvider
+import org.maplibre.compose.location.LocationProvider
+import org.maplibre.compose.location.OrientationProvider
+import org.maplibre.compose.location.rememberDefaultLocationProvider
+import org.maplibre.compose.location.rememberDefaultOrientationProvider
+
+@Composable
+internal actual fun rememberDemoLocationProvider(usePlayServices: Boolean): LocationProvider =
+  if (usePlayServices) rememberFusedLocationProvider() else rememberDefaultLocationProvider()
+
+@Composable
+internal actual fun rememberDemoOrientationProvider(usePlayServices: Boolean): OrientationProvider =
+  if (usePlayServices) rememberFusedOrientationProvider() else rememberDefaultOrientationProvider()
+
+@Composable
+internal actual fun LocationEngineRow(usePlayServices: Boolean, onChange: (Boolean) -> Unit) {
+  SwitchRow("Google Play Services", usePlayServices, onChange)
+}

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/Demo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/Demo.kt
@@ -7,14 +7,16 @@ import org.maplibre.compose.camera.CameraState
 import org.maplibre.compose.demoapp.demos.CastelloPlanDemo
 import org.maplibre.compose.demoapp.demos.DataVizDemo
 import org.maplibre.compose.demoapp.demos.LiveTrackingDemo
+import org.maplibre.compose.demoapp.demos.LocationDemo
 import org.maplibre.compose.demoapp.demos.Manhattan3dDemo
 import org.maplibre.compose.util.MaplibreComposable
 import org.maplibre.spatialk.geojson.BoundingBox
 import org.maplibre.spatialk.geojson.Position
 
 /**
- * A demo lives at a real place in the world. Selecting it flies the camera to [region] and composes
- * [MapContent] into the shared map. Each demo owns its state internally.
+ * A demo lives at a real place in the world. Selecting it composes [MapContent] into the shared map
+ * and, when [fliesOnSelect] is true, flies the camera to [region] or [camera]. Each demo owns its
+ * state internally.
  */
 interface Demo {
   val name: String
@@ -36,6 +38,13 @@ interface Demo {
   val showsPointerPin: Boolean
     get() = true
 
+  /**
+   * Whether the shell flies to [region] or [camera] when this demo is selected. A demo that drives
+   * the camera from live data turns this off.
+   */
+  val fliesOnSelect: Boolean
+    get() = true
+
   @MaplibreComposable @Composable fun MapContent(cameraState: CameraState) {}
 
   /** Controls shown in the sheet or side panel while this demo is selected. */
@@ -54,4 +63,6 @@ internal expect val extraDemos: List<Demo>
 
 /** Demos appear in the shell in this order. */
 val allDemos: List<Demo> =
-  listOf(Manhattan3dDemo, CastelloPlanDemo, DataVizDemo, LiveTrackingDemo) + extraDemos
+  listOf(Manhattan3dDemo, CastelloPlanDemo, DataVizDemo, LiveTrackingDemo) +
+    extraDemos +
+    listOf(LocationDemo)

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoMap.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoMap.kt
@@ -57,7 +57,7 @@ fun DemoMap(state: DemoAppState, sheetInsets: WindowInsets = WindowInsets(0)) {
   LaunchedEffect(state.selectedDemo) {
     val demo = state.selectedDemo ?: return@LaunchedEffect
     demo.preferredStyle?.let { state.selectedStyle = it }
-    state.cameraState.flyToDemo(demo)
+    if (demo.fliesOnSelect) state.cameraState.flyToDemo(demo)
   }
 
   Box(Modifier.fillMaxSize()) {

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/LocationDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/LocationDemo.kt
@@ -9,8 +9,10 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.flow.drop
 import org.maplibre.compose.camera.CameraMoveReason
 import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.camera.CameraState
@@ -68,8 +70,13 @@ object LocationDemo : Demo {
     }
     LaunchedEffect(locationState) { locationState.requestPermission() }
 
-    LaunchedEffect(cameraState.moveReason) {
-      if (cameraState.moveReason == CameraMoveReason.GESTURE) follow = false
+    // Skip the move reason a previous demo left on the shared camera.
+    LaunchedEffect(cameraState) {
+      snapshotFlow { cameraState.moveReason to cameraState.position }
+        .drop(1)
+        .collect { (reason, _) ->
+          if (reason == CameraMoveReason.GESTURE) follow = false
+        }
     }
 
     val location = locationState.location

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/LocationDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/LocationDemo.kt
@@ -1,0 +1,126 @@
+package org.maplibre.compose.demoapp.demos
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import org.maplibre.compose.camera.CameraMoveReason
+import org.maplibre.compose.camera.CameraPosition
+import org.maplibre.compose.camera.CameraState
+import org.maplibre.compose.demoapp.Demo
+import org.maplibre.compose.demoapp.DemoFlightDuration
+import org.maplibre.compose.demoapp.OpenFreeMap
+import org.maplibre.compose.demoapp.design.SwitchRow
+import org.maplibre.compose.location.LocationPuck
+import org.maplibre.compose.location.LocationState
+import org.maplibre.compose.location.LocationTrackingEffect
+import org.maplibre.compose.location.LocationTrackingStatus
+import org.maplibre.compose.location.LocationUnavailableReason
+import org.maplibre.compose.location.mostAccurateBearing
+import org.maplibre.compose.location.rememberLocationState
+import org.maplibre.compose.material3.LocationPuckDefaults
+import org.maplibre.spatialk.geojson.BoundingBox
+import org.maplibre.spatialk.geojson.Position
+
+object LocationDemo : Demo {
+  override val name = "My location"
+  override val description =
+    "The location puck, device heading, and a camera-follow toggle on the real device."
+  override val preferredStyle = OpenFreeMap.Liberty
+  override val fliesOnSelect = false
+  override val showsPointerPin
+    get() = lastFix != null
+
+  override val region: BoundingBox
+    get() {
+      val p = lastFix ?: Position(longitude = 0.0, latitude = 0.0)
+      val delta = 0.005
+      return BoundingBox(
+        west = p.longitude - delta,
+        south = p.latitude - delta,
+        east = p.longitude + delta,
+        north = p.latitude + delta,
+      )
+    }
+
+  private var follow by mutableStateOf(true)
+  private var usePlayServices by mutableStateOf(true)
+  private var lastFix by mutableStateOf<Position?>(null)
+  private var panelLocationState by mutableStateOf<LocationState?>(null)
+
+  @Composable
+  override fun MapContent(cameraState: CameraState) {
+    val locationState =
+      rememberLocationState(
+        provider = rememberDemoLocationProvider(usePlayServices),
+        orientationProvider = rememberDemoOrientationProvider(usePlayServices),
+      )
+    DisposableEffect(locationState) {
+      panelLocationState = locationState
+      onDispose { if (panelLocationState === locationState) panelLocationState = null }
+    }
+    LaunchedEffect(locationState) { locationState.requestPermission() }
+
+    LaunchedEffect(cameraState.moveReason) {
+      if (cameraState.moveReason == CameraMoveReason.GESTURE) follow = false
+    }
+
+    val location = locationState.location
+    LaunchedEffect(location) { location?.position?.value?.let { lastFix = it } }
+
+    LocationTrackingEffect(locationState = locationState, enabled = follow) {
+      if (previousLocation == null) {
+        cameraState.animateTo(
+          CameraPosition(target = currentLocation.position.value, zoom = 16.0),
+          duration = DemoFlightDuration,
+        )
+      } else {
+        cameraState.updateFromLocation()
+      }
+    }
+
+    LocationPuck(
+      idPrefix = "user",
+      location = location,
+      bearing = locationState.mostAccurateBearing(),
+      cameraState = cameraState,
+      colors = LocationPuckDefaults.colors(),
+    )
+  }
+
+  @Composable
+  override fun Panel() {
+    Text(
+      text = panelLocationState?.statusMessage() ?: "Starting location",
+      style = MaterialTheme.typography.bodyMedium,
+      color = MaterialTheme.colorScheme.onSurfaceVariant,
+      modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+    )
+    SwitchRow("Follow me", follow) { follow = it }
+    LocationEngineRow(usePlayServices) { usePlayServices = it }
+  }
+}
+
+private fun LocationState.statusMessage(): String =
+  when (val status = this.status) {
+    LocationTrackingStatus.Stopped -> "Location is off"
+    LocationTrackingStatus.WaitingForPermission -> "Waiting for location permission"
+    LocationTrackingStatus.Starting -> "Finding your location"
+    LocationTrackingStatus.Tracking -> "Tracking your location"
+    is LocationTrackingStatus.Unavailable ->
+      when (status.reason) {
+        LocationUnavailableReason.ServicesDisabled -> "Location services are turned off"
+        LocationUnavailableReason.TemporarilyUnavailable -> "Location is temporarily unavailable"
+        LocationUnavailableReason.Unsupported -> "Location is not available on this device"
+        LocationUnavailableReason.Misconfigured -> "Location is misconfigured on this device"
+        LocationUnavailableReason.PermissionDenied -> "Location permission was denied"
+        LocationUnavailableReason.UnexpectedFailure -> "Location failed"
+      }
+  }

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/LocationDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/LocationDemo.kt
@@ -12,7 +12,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import kotlinx.coroutines.flow.drop
 import org.maplibre.compose.camera.CameraMoveReason
 import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.camera.CameraState
@@ -70,12 +69,15 @@ object LocationDemo : Demo {
     }
     LaunchedEffect(locationState) { locationState.requestPermission() }
 
-    // Skip the move reason a previous demo left on the shared camera.
     LaunchedEffect(cameraState) {
-      snapshotFlow { cameraState.moveReason to cameraState.position }
-        .drop(1)
-        .collect { (reason, _) ->
-          if (reason == CameraMoveReason.GESTURE) follow = false
+      var previous = cameraState.moveReason
+      snapshotFlow { cameraState.moveReason }
+        .collect { reason ->
+          // Follow moves the camera programmatically; a pan is the GESTURE that interrupts it.
+          if (previous != CameraMoveReason.GESTURE && reason == CameraMoveReason.GESTURE) {
+            follow = false
+          }
+          previous = reason
         }
     }
 

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/LocationEngine.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/LocationEngine.kt
@@ -1,0 +1,18 @@
+package org.maplibre.compose.demoapp.demos
+
+import androidx.compose.runtime.Composable
+import org.maplibre.compose.location.LocationProvider
+import org.maplibre.compose.location.OrientationProvider
+
+/**
+ * Platform location and orientation used by [LocationDemo]. Android can switch to Play Services.
+ */
+@Composable
+internal expect fun rememberDemoLocationProvider(usePlayServices: Boolean): LocationProvider
+
+@Composable
+internal expect fun rememberDemoOrientationProvider(usePlayServices: Boolean): OrientationProvider
+
+/** Android-only switch between Play Services and the platform location engine. */
+@Composable
+internal expect fun LocationEngineRow(usePlayServices: Boolean, onChange: (Boolean) -> Unit)

--- a/demo-app/common/src/iosMain/kotlin/org/maplibre/compose/demoapp/demos/LocationEngine.ios.kt
+++ b/demo-app/common/src/iosMain/kotlin/org/maplibre/compose/demoapp/demos/LocationEngine.ios.kt
@@ -1,0 +1,18 @@
+package org.maplibre.compose.demoapp.demos
+
+import androidx.compose.runtime.Composable
+import org.maplibre.compose.location.LocationProvider
+import org.maplibre.compose.location.OrientationProvider
+import org.maplibre.compose.location.rememberDefaultLocationProvider
+import org.maplibre.compose.location.rememberDefaultOrientationProvider
+
+@Composable
+internal actual fun rememberDemoLocationProvider(usePlayServices: Boolean): LocationProvider =
+  rememberDefaultLocationProvider()
+
+@Composable
+internal actual fun rememberDemoOrientationProvider(usePlayServices: Boolean): OrientationProvider =
+  rememberDefaultOrientationProvider()
+
+@Composable
+internal actual fun LocationEngineRow(usePlayServices: Boolean, onChange: (Boolean) -> Unit) {}

--- a/demo-app/common/src/jsMain/kotlin/org/maplibre/compose/demoapp/demos/LocationEngine.js.kt
+++ b/demo-app/common/src/jsMain/kotlin/org/maplibre/compose/demoapp/demos/LocationEngine.js.kt
@@ -1,0 +1,18 @@
+package org.maplibre.compose.demoapp.demos
+
+import androidx.compose.runtime.Composable
+import org.maplibre.compose.location.LocationProvider
+import org.maplibre.compose.location.OrientationProvider
+import org.maplibre.compose.location.rememberDefaultLocationProvider
+import org.maplibre.compose.location.rememberDefaultOrientationProvider
+
+@Composable
+internal actual fun rememberDemoLocationProvider(usePlayServices: Boolean): LocationProvider =
+  rememberDefaultLocationProvider()
+
+@Composable
+internal actual fun rememberDemoOrientationProvider(usePlayServices: Boolean): OrientationProvider =
+  rememberDefaultOrientationProvider()
+
+@Composable
+internal actual fun LocationEngineRow(usePlayServices: Boolean, onChange: (Boolean) -> Unit) {}

--- a/demo-app/common/src/jvmMain/kotlin/org/maplibre/compose/demoapp/demos/LocationEngine.jvm.kt
+++ b/demo-app/common/src/jvmMain/kotlin/org/maplibre/compose/demoapp/demos/LocationEngine.jvm.kt
@@ -1,0 +1,18 @@
+package org.maplibre.compose.demoapp.demos
+
+import androidx.compose.runtime.Composable
+import org.maplibre.compose.location.LocationProvider
+import org.maplibre.compose.location.OrientationProvider
+import org.maplibre.compose.location.rememberDefaultLocationProvider
+import org.maplibre.compose.location.rememberDefaultOrientationProvider
+
+@Composable
+internal actual fun rememberDemoLocationProvider(usePlayServices: Boolean): LocationProvider =
+  rememberDefaultLocationProvider()
+
+@Composable
+internal actual fun rememberDemoOrientationProvider(usePlayServices: Boolean): OrientationProvider =
+  rememberDefaultOrientationProvider()
+
+@Composable
+internal actual fun LocationEngineRow(usePlayServices: Boolean, onChange: (Boolean) -> Unit) {}

--- a/demo-app/ios/iosApp/Info.plist
+++ b/demo-app/ios/iosApp/Info.plist
@@ -23,7 +23,7 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>Example</string>
+	<string>The My location demo draws your position on the map.</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Adds a My location demo that requests permission when opened, draws the puck with device heading, and offers a Play Services engine switch on Android.

## Test plan

Compiled `:demo-app:common:compileKotlinJvm` and `compileKotlinJs`; grant location on a device to confirm the puck, follow toggle, and Android engine switch.

## Checklist

**To your knowledge, are you making any breaking changes?**

No.

**Have you tested the changes? On which platforms?**

- Desktop: JVM compile of the demo-app common module
- Web: JS compile of the demo-app common module

## AI assistance

- **Tools:** Cursor
- **Context:** Demo 6 from the demo app redesign plan, stacked on the transit network PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-20f3455e-33ee-4d41-a04a-2bfceb706427?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-20f3455e-33ee-4d41-a04a-2bfceb706427&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

