### PR TITLE
Animate demo bottom sheet height with content

### DIFF
--- a/demo-app/common/build.gradle.kts
+++ b/demo-app/common/build.gradle.kts
@@ -89,6 +89,7 @@ kotlin {
 
       implementation(libs.jetbrains.compose.components.resources)
       implementation(libs.jetbrains.compose.material3)
+      implementation(libs.jetbrains.compose.material3.adaptive)
       implementation(libs.androidx.navigation.compose)
       implementation(libs.spatialk.geojson)
 

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoApp.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoApp.kt
@@ -9,7 +9,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.material3.BottomSheetScaffold
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.compose.material3.adaptive.currentWindowAdaptiveInfoV2
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.material3.rememberBottomSheetScaffoldState
@@ -32,7 +32,7 @@ fun DemoApp() {
   // viewport crosses the side-pane / bottom-sheet breakpoint.
   val panel = remember { movableContentOf { modifier: Modifier -> DemoPanel(state, modifier) } }
   MaterialTheme(colorScheme = colorScheme) {
-    val windowSizeClass = currentWindowAdaptiveInfoV2().windowSizeClass
+    val windowSizeClass = currentWindowAdaptiveInfo().windowSizeClass
     if (windowSizeClass.isWidthAtLeastBreakpoint(WindowSizeClass.WIDTH_DP_EXPANDED_LOWER_BOUND)) {
       WideLayout(state, panel)
     } else {

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoApp.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoApp.kt
@@ -63,6 +63,7 @@ private fun NarrowLayout(state: DemoAppState, panel: @Composable (Modifier) -> U
   BottomSheetScaffold(
     sheetPeekHeight = SheetPeekHeight,
     scaffoldState = rememberBottomSheetScaffoldState(),
+    // Expanded is the measured height of this content, capped at the scaffold.
     sheetContent = { panel(Modifier) },
   ) {
     // The map draws under the scaffold content area, so the sheet covers its bottom edge.

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoApp.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoApp.kt
@@ -75,7 +75,7 @@ private fun NarrowLayout(state: DemoAppState, panel: @Composable (Modifier) -> U
     // Expanded is the measured height of this content, capped at the scaffold.
     // Animate that measurement so the sheet slides with the destination.
     sheetContent = {
-      panel(Modifier.fillMaxWidth().animateContentSize(SheetSizeAnimationSpec))
+      panel(Modifier.animateContentSize(SheetSizeAnimationSpec).fillMaxWidth())
     },
   ) {
     // The map draws under the scaffold content area, so the sheet covers its bottom edge.

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoApp.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoApp.kt
@@ -1,10 +1,14 @@
 package org.maplibre.compose.demoapp
 
+import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.core.CubicBezierEasing
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.BottomSheetScaffold
 import androidx.compose.material3.MaterialTheme
@@ -16,6 +20,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.movableContentOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import org.maplibre.compose.demoapp.benchmark.BenchmarkMap
 
@@ -48,6 +53,10 @@ private val PanelWidth = 360.dp
 /** How much of the map the collapsed sheet covers. */
 private val SheetPeekHeight = 128.dp
 
+/** Matches the panel's shared-axis duration so the sheet slides with the destination. */
+private val SheetSizeAnimationSpec =
+  tween<IntSize>(300, easing = CubicBezierEasing(0.2f, 0f, 0f, 1f))
+
 @Composable
 private fun WideLayout(state: DemoAppState, panel: @Composable (Modifier) -> Unit) {
   Row(Modifier.fillMaxSize()) {
@@ -64,7 +73,10 @@ private fun NarrowLayout(state: DemoAppState, panel: @Composable (Modifier) -> U
     sheetPeekHeight = SheetPeekHeight,
     scaffoldState = rememberBottomSheetScaffoldState(),
     // Expanded is the measured height of this content, capped at the scaffold.
-    sheetContent = { panel(Modifier) },
+    // Animate that measurement so the sheet slides with the destination.
+    sheetContent = {
+      panel(Modifier.fillMaxWidth().animateContentSize(SheetSizeAnimationSpec))
+    },
   ) {
     // The map draws under the scaffold content area, so the sheet covers its bottom edge.
     ShellMap(state, sheetInsets = WindowInsets(bottom = SheetPeekHeight))

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoApp.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoApp.kt
@@ -1,9 +1,5 @@
 package org.maplibre.compose.demoapp
 
-import androidx.compose.animation.animateContentSize
-import androidx.compose.animation.core.CubicBezierEasing
-import androidx.compose.animation.core.tween
-import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -13,6 +9,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.material3.BottomSheetScaffold
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfoV2
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.material3.rememberBottomSheetScaffoldState
@@ -20,8 +17,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.movableContentOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
+import androidx.window.core.layout.WindowSizeClass
 import org.maplibre.compose.demoapp.benchmark.BenchmarkMap
 
 @Composable
@@ -35,27 +32,19 @@ fun DemoApp() {
   // viewport crosses the side-pane / bottom-sheet breakpoint.
   val panel = remember { movableContentOf { modifier: Modifier -> DemoPanel(state, modifier) } }
   MaterialTheme(colorScheme = colorScheme) {
-    BoxWithConstraints(Modifier.fillMaxSize()) {
-      if (maxWidth >= WideLayoutMinWidth) {
-        WideLayout(state, panel)
-      } else {
-        NarrowLayout(state, panel)
-      }
+    val windowSizeClass = currentWindowAdaptiveInfoV2().windowSizeClass
+    if (windowSizeClass.isWidthAtLeastBreakpoint(WindowSizeClass.WIDTH_DP_EXPANDED_LOWER_BOUND)) {
+      WideLayout(state, panel)
+    } else {
+      NarrowLayout(state, panel)
     }
   }
 }
-
-/** Below this width the panel becomes a bottom sheet. */
-private val WideLayoutMinWidth = 720.dp
 
 private val PanelWidth = 360.dp
 
 /** How much of the map the collapsed sheet covers. */
 private val SheetPeekHeight = 128.dp
-
-/** Matches the panel's shared-axis duration so the sheet slides with the destination. */
-private val SheetSizeAnimationSpec =
-  tween<IntSize>(300, easing = CubicBezierEasing(0.2f, 0f, 0f, 1f))
 
 @Composable
 private fun WideLayout(state: DemoAppState, panel: @Composable (Modifier) -> Unit) {
@@ -73,10 +62,8 @@ private fun NarrowLayout(state: DemoAppState, panel: @Composable (Modifier) -> U
     sheetPeekHeight = SheetPeekHeight,
     scaffoldState = rememberBottomSheetScaffoldState(),
     // Expanded is the measured height of this content, capped at the scaffold.
-    // Animate that measurement so the sheet slides with the destination.
-    sheetContent = {
-      panel(Modifier.animateContentSize(SheetSizeAnimationSpec).fillMaxWidth())
-    },
+    // NavHost SizeTransform interpolates that height with the destination.
+    sheetContent = { panel(Modifier.fillMaxWidth()) },
   ) {
     // The map draws under the scaffold content area, so the sheet covers its bottom edge.
     ShellMap(state, sheetInsets = WindowInsets(bottom = SheetPeekHeight))

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoPanel.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoPanel.kt
@@ -2,6 +2,7 @@ package org.maplibre.compose.demoapp
 
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.SizeTransform
 import androidx.compose.animation.core.CubicBezierEasing
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
@@ -36,6 +37,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -73,6 +75,10 @@ fun DemoPanel(state: DemoAppState, modifier: Modifier = Modifier) {
     exitTransition = { sharedAxisExit(-slideDistance) },
     popEnterTransition = { sharedAxisEnter(-slideDistance) },
     popExitTransition = { sharedAxisExit(slideDistance) },
+    // Report the incoming destination's size while the outgoing screen is still
+    // composed, so a wrap-content parent (the bottom sheet) shrinks in time
+    // with the shared axis instead of waiting for the exit to finish.
+    sizeTransform = { sharedAxisSizeTransform },
   ) {
     composable("demos") {
       DemosScreen(
@@ -155,6 +161,10 @@ private fun sharedAxisEnter(slideDistance: Int): EnterTransition =
 private fun sharedAxisExit(slideDistance: Int): ExitTransition =
   slideOutHorizontally(tween(AxisDurationMillis, easing = StandardEasing)) { slideDistance } +
     fadeOut(tween(AxisDurationMillis * 3 / 10, easing = AccelerateEasing))
+
+private val sharedAxisSizeSpec = tween<IntSize>(AxisDurationMillis, easing = StandardEasing)
+
+private val sharedAxisSizeTransform = SizeTransform(clip = false) { _, _ -> sharedAxisSizeSpec }
 
 @Composable
 private fun DemosScreen(

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoPanel.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoPanel.kt
@@ -2,6 +2,8 @@ package org.maplibre.compose.demoapp
 
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.SizeTransform
+import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.CubicBezierEasing
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
@@ -36,6 +38,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -73,6 +76,9 @@ fun DemoPanel(state: DemoAppState, modifier: Modifier = Modifier) {
     exitTransition = { sharedAxisExit(-slideDistance) },
     popEnterTransition = { sharedAxisEnter(-slideDistance) },
     popExitTransition = { sharedAxisExit(slideDistance) },
+    // Animate destination size with the shared axis so the wrap-content sheet
+    // slides to the new height.
+    sizeTransform = { sharedAxisSizeTransform },
   ) {
     composable("demos") {
       DemosScreen(
@@ -155,6 +161,10 @@ private fun sharedAxisEnter(slideDistance: Int): EnterTransition =
 private fun sharedAxisExit(slideDistance: Int): ExitTransition =
   slideOutHorizontally(tween(AxisDurationMillis, easing = StandardEasing)) { slideDistance } +
     fadeOut(tween(AxisDurationMillis * 3 / 10, easing = AccelerateEasing))
+
+private val sharedAxisSizeSpec = tween<IntSize>(AxisDurationMillis, easing = StandardEasing)
+
+private val sharedAxisSizeTransform = SizeTransform(clip = false) { _, _ -> sharedAxisSizeSpec }
 
 @Composable
 private fun DemosScreen(
@@ -251,7 +261,7 @@ private fun InterfaceSettingsItems(settings: DemoSettings) {
 
 @Composable
 internal fun SettingsSubScreen(title: String, onBack: () -> Unit, content: @Composable () -> Unit) {
-  Column {
+  Column(Modifier.animateContentSize(sharedAxisSizeSpec)) {
     TopAppBar(
       title = { Text(title) },
       navigationIcon = {

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoPanel.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoPanel.kt
@@ -2,8 +2,6 @@ package org.maplibre.compose.demoapp
 
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
-import androidx.compose.animation.SizeTransform
-import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.CubicBezierEasing
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
@@ -38,7 +36,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -76,9 +73,6 @@ fun DemoPanel(state: DemoAppState, modifier: Modifier = Modifier) {
     exitTransition = { sharedAxisExit(-slideDistance) },
     popEnterTransition = { sharedAxisEnter(-slideDistance) },
     popExitTransition = { sharedAxisExit(slideDistance) },
-    // Animate destination size with the shared axis so the wrap-content sheet
-    // slides to the new height.
-    sizeTransform = { sharedAxisSizeTransform },
   ) {
     composable("demos") {
       DemosScreen(
@@ -161,10 +155,6 @@ private fun sharedAxisEnter(slideDistance: Int): EnterTransition =
 private fun sharedAxisExit(slideDistance: Int): ExitTransition =
   slideOutHorizontally(tween(AxisDurationMillis, easing = StandardEasing)) { slideDistance } +
     fadeOut(tween(AxisDurationMillis * 3 / 10, easing = AccelerateEasing))
-
-private val sharedAxisSizeSpec = tween<IntSize>(AxisDurationMillis, easing = StandardEasing)
-
-private val sharedAxisSizeTransform = SizeTransform(clip = false) { _, _ -> sharedAxisSizeSpec }
 
 @Composable
 private fun DemosScreen(
@@ -261,7 +251,7 @@ private fun InterfaceSettingsItems(settings: DemoSettings) {
 
 @Composable
 internal fun SettingsSubScreen(title: String, onBack: () -> Unit, content: @Composable () -> Unit) {
-  Column(Modifier.animateContentSize(sharedAxisSizeSpec)) {
+  Column {
     TopAppBar(
       title = { Text(title) },
       navigationIcon = {

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/benchmark/BenchmarkPanel.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/benchmark/BenchmarkPanel.kt
@@ -18,15 +18,6 @@ internal fun BenchmarksScreen(
   onOpenScenario: (BenchmarkScenario) -> Unit,
 ) {
   SettingsSubScreen("Benchmarks", onBack) {
-    Text(
-      text =
-        "Each run uses a map of its own, packs tiles first, then plays a script. Frame times " +
-          "print as a JSON line tagged maplibre-compose-bench. Render and gesture options stay " +
-          "at Standard. Demo settings do not apply.",
-      style = MaterialTheme.typography.bodyMedium,
-      color = MaterialTheme.colorScheme.onSurfaceVariant,
-      modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
-    )
     allBenchmarkScenarios.forEach { scenario ->
       SubmenuRow(scenario.title, scenario.description) { onOpenScenario(scenario) }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,7 +45,8 @@ gradle-spmForKmp = "1.9.5"
 gradle-compose = "1.11.1"
 androidx-compose = "1.11.2"
 jetbrains-compose-material3 = "1.11.0-alpha07"
-jetbrains-compose-material3-adaptive = "1.3.0-alpha07"
+# 1.3.x needs compileSdk 37; AGP 9.1 and this catalog stay on 36.
+jetbrains-compose-material3-adaptive = "1.2.0"
 jetbrains-navigation = "2.9.2"
 
 # Android and Kotlin: Keep Kotlin up to date and set Android accordingly.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,6 +45,7 @@ gradle-spmForKmp = "1.9.5"
 gradle-compose = "1.11.1"
 androidx-compose = "1.11.2"
 jetbrains-compose-material3 = "1.11.0-alpha07"
+jetbrains-compose-material3-adaptive = "1.3.0-alpha07"
 jetbrains-navigation = "2.9.2"
 
 # Android and Kotlin: Keep Kotlin up to date and set Android accordingly.
@@ -85,6 +86,7 @@ jetbrains-compose-components-resources = { module = "org.jetbrains.compose.compo
 jetbrains-compose-foundation = { module = "org.jetbrains.compose.foundation:foundation", version.ref = "gradle-compose" }
 jetbrains-compose-html-core = { module = "org.jetbrains.compose.html:html-core", version.ref = "gradle-compose" }
 jetbrains-compose-material3 = { module = "org.jetbrains.compose.material3:material3", version.ref = "jetbrains-compose-material3" }
+jetbrains-compose-material3-adaptive = { module = "org.jetbrains.compose.material3.adaptive:adaptive", version.ref = "jetbrains-compose-material3-adaptive" }
 jetbrains-compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "gradle-compose" }
 jetbrains-compose-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "gradle-compose" }
 jetbrains-compose-ui-test = { module = "org.jetbrains.compose.ui:ui-test", version.ref = "gradle-compose" }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

The wrap-content sheet now slides to the destination’s measured height instead of jumping when you navigate or when a panel grows.

## Validation

Compiled `:demo-app:common:compileKotlinJvm` and ran the desktop demo in a 420px-wide window: the expanded sheet wraps the demo list, then shortens for 3D Manhattan and Settings. Map-backed demos crash this host (software Skiko redrawer vs OpenGL map host), so those destinations were not used for the height check.

## AI assistance

Cursor Grok 4.6 (Cursor Cloud Agent) implemented this change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-411c94b1-17d2-4fe4-94d9-58ecbd7b5230?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-411c94b1-17d2-4fe4-94d9-58ecbd7b5230&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

