### PR TITLE
Pass inline GeoJSON to native as UTF-8 bytes

### DIFF
--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/benchmark/BenchmarkModels.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/benchmark/BenchmarkModels.kt
@@ -120,6 +120,7 @@ val allBenchmarkScenarios: List<BenchmarkScenario> =
   listOf(
     ZoomPumpScenario,
     FlyAroundScenario,
-    GeoJsonLoadScenario,
+    GeoJsonLoadScenario(synchronousUpdate = true),
+    GeoJsonLoadScenario(synchronousUpdate = false),
     GestureTrailScenario,
   )

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/benchmark/GeoJsonLoadScenario.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/benchmark/GeoJsonLoadScenario.kt
@@ -19,10 +19,15 @@ import org.maplibre.spatialk.geojson.FeatureCollection
 import org.maplibre.spatialk.geojson.Point
 import org.maplibre.spatialk.geojson.Position
 
-internal object GeoJsonLoadScenario : BenchmarkScenario {
-  override val id = "geojson-load"
-  override val title = "GeoJSON load"
-  override val description = "Loads thousands of points, then updates them every frame."
+internal class GeoJsonLoadScenario(private val synchronousUpdate: Boolean) : BenchmarkScenario {
+  override val id = if (synchronousUpdate) "geojson-load-sync" else "geojson-load-async"
+  override val title = if (synchronousUpdate) "GeoJSON load (sync)" else "GeoJSON load (async)"
+  override val description =
+    if (synchronousUpdate) {
+      "Loads thousands of points, then updates them every frame. The next frame includes each update."
+    } else {
+      "Loads thousands of points, then updates them every frame. An update can miss the next frame."
+    }
   override val region = BenchmarkRegion
   override val minZoom = 12
   override val maxZoom = 16
@@ -34,7 +39,7 @@ internal object GeoJsonLoadScenario : BenchmarkScenario {
     val source =
       rememberGeoJsonSource(
         data = GeoJsonData.Features(data),
-        options = GeoJsonOptions(synchronousUpdate = true),
+        options = GeoJsonOptions(synchronousUpdate = synchronousUpdate),
       )
     CircleLayer(
       id = "benchmark-geojson",
@@ -89,8 +94,10 @@ internal object GeoJsonLoadScenario : BenchmarkScenario {
     return root
   }
 
-  private const val PointCount = 8_000
-  private const val Jitter = 0.0004
-  private const val SettleFrames = 30
-  private const val UpdateFrames = 90
+  private companion object {
+    const val PointCount = 8_000
+    const val Jitter = 0.0004
+    const val SettleFrames = 30
+    const val UpdateFrames = 90
+  }
 }

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/sources/GeoJsonSource.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/sources/GeoJsonSource.kt
@@ -2,8 +2,9 @@
 
 package org.maplibre.compose.sources
 
-import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import org.maplibre.compose.util.CLUSTER_ID_PROPERTY
@@ -20,21 +21,21 @@ public actual class GeoJsonSource : Source {
 
   private val options: GeoJsonOptions
 
-  // Held parsed because toJson runs again on every re-add after a style change.
-  private var data: JsonElement
+  /** UTF-8 GeoJSON for inline data. Null when [dataUrl] is set. */
+  private var inlineUtf8: ByteArray?
 
-  /** The URI form of [data], when it is one. */
+  /** The URI form of the data, when it is one. */
   private var dataUrl: String?
 
   public actual constructor(id: String, data: GeoJsonData, options: GeoJsonOptions) : super(id) {
     this.options = options
-    this.data = data.toDataJson()
+    this.inlineUtf8 = data.toInlineUtf8()
     this.dataUrl = (data as? GeoJsonData.Uri)?.uri
   }
 
   override fun toJson(): JsonObject = buildJsonObject {
     put("type", "geojson")
-    put("data", data)
+    put("data", dataJson())
     putGeoJsonOptions(options)
     // Neither is in the style spec's GeoJSON source, but MapLibre Native reads both straight off
     // the source JSON.
@@ -64,7 +65,7 @@ public actual class GeoJsonSource : Source {
   }
 
   public actual fun setData(data: GeoJsonData) {
-    this.data = data.toDataJson()
+    this.inlineUtf8 = data.toInlineUtf8()
     this.dataUrl = (data as? GeoJsonData.Uri)?.uri
     if (data is GeoJsonData.Uri) {
       mutate { map -> map.setGeoJsonSourceUrl(id, data.uri) }
@@ -79,9 +80,16 @@ public actual class GeoJsonSource : Source {
     }
   }
 
+  /**
+   * Style JSON for reads and error messages. Native install uses [inlineUtf8] directly, so this
+   * parse runs only when something asks for the descriptor.
+   */
+  private fun dataJson() =
+    dataUrl?.let { JsonPrimitive(it) } ?: Json.parseToJsonElement(inlineUtf8!!.decodeToString())
+
   /** Prepared with the options the source was added with; a mismatch is rejected at install. */
   private fun prepareData(): GeoJsonSourceDataHandle =
-    GeoJsonSourceDataHandle.create(data.toJsonBytes(), options.toFfiOptions())
+    GeoJsonSourceDataHandle.create(inlineUtf8!!, options.toFfiOptions())
 
   public actual fun isCluster(feature: Feature<*, JsonObject?>): Boolean {
     return CLUSTER_ID_PROPERTY in feature.properties.orEmpty()

--- a/lib/maplibre-compose/src/nextCommonMain/kotlin/org/maplibre/compose/sources/SourceJson.kt
+++ b/lib/maplibre-compose/src/nextCommonMain/kotlin/org/maplibre/compose/sources/SourceJson.kt
@@ -45,6 +45,14 @@ internal fun GeoJsonData.toDataJson(): JsonElement =
     is GeoJsonData.Features -> Json.parseToJsonElement(geoJson.toJson())
   }
 
+/** UTF-8 GeoJSON for an inline value, or null when the data is a URL. */
+internal fun GeoJsonData.toInlineUtf8(): ByteArray? =
+  when (this) {
+    is GeoJsonData.Uri -> null
+    is GeoJsonData.JsonString -> json.encodeToByteArray()
+    is GeoJsonData.Features -> geoJson.toJson().encodeToByteArray()
+  }
+
 /**
  * `minzoom` and `synchronousUpdate` are deliberately absent: the spec has no place for them here
  * and GL JS rejects the whole source over an unknown key, so each backend that honours one writes

--- a/lib/maplibre-compose/src/nextCommonTest/kotlin/org/maplibre/compose/sources/SourceJsonTest.kt
+++ b/lib/maplibre-compose/src/nextCommonTest/kotlin/org/maplibre/compose/sources/SourceJsonTest.kt
@@ -10,6 +10,8 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.maplibre.spatialk.geojson.BoundingBox
 import org.maplibre.spatialk.geojson.Position
+import org.maplibre.spatialk.geojson.dsl.featureCollectionOf
+import org.maplibre.spatialk.geojson.toJson
 
 class SourceJsonTest {
 
@@ -75,6 +77,26 @@ class SourceJsonTest {
       (json["tiles"] as JsonArray).map { it.jsonPrimitive.content },
     )
     assertEquals("512", json["tileSize"]?.jsonPrimitive?.content, "tileSize, not tilesize")
+  }
+
+  @Test
+  fun inline_utf8_is_the_feature_json_bytes() {
+    val collection = featureCollectionOf()
+    assertEquals(
+      collection.toJson(),
+      GeoJsonData.Features(collection).toInlineUtf8()!!.decodeToString(),
+    )
+  }
+
+  @Test
+  fun inline_utf8_keeps_a_json_string_verbatim() {
+    val json = """{"type":"Point","coordinates":[1,2]}"""
+    assertEquals(json, GeoJsonData.JsonString(json).toInlineUtf8()!!.decodeToString())
+  }
+
+  @Test
+  fun a_uri_has_no_inline_utf8() {
+    assertNull(GeoJsonData.Uri("https://example.invalid/data.geojson").toInlineUtf8())
   }
 
   @Test


### PR DESCRIPTION
## Description

Pass inline GeoJSON to native as UTF-8 bytes instead of a JsonElement round trip, and split the load benchmark into sync and async, stacked on #844.

## Validation

Installed the demo on a Galaxy Z Fold (SM-F966U1); sync GeoJSON load beat main, and async occasionally aborted in native (`maplibre/maplibre-native-ffi#644`).

## AI assistance

Cursor Grok 4.6 in the Cursor CLI.