### PR TITLE
Prepare remembered GeoJSON on a worker

### DIFF
--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/sources/GeoJsonSource.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/sources/GeoJsonSource.kt
@@ -2,13 +2,16 @@ package org.maplibre.compose.sources
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.key
 import kotlinx.serialization.json.JsonObject
 import org.maplibre.compose.expressions.ast.Expression
 import org.maplibre.compose.expressions.value.ExpressionValue
+import org.maplibre.compose.style.LocalStyleNode
 import org.maplibre.spatialk.geojson.Feature
 import org.maplibre.spatialk.geojson.FeatureCollection
 import org.maplibre.spatialk.geojson.GeoJsonObject
+import org.maplibre.spatialk.geojson.Geometry
 
 /**
  * A map data source consisting of geojson data.
@@ -158,8 +161,23 @@ public fun rememberGeoJsonSource(
   options: GeoJsonOptions = GeoJsonOptions(),
 ): GeoJsonSource =
   key(options) {
-    rememberUserSource(
-      factory = { GeoJsonSource(id = it, data = data, options = options) },
-      update = { setData(data) },
-    )
+    val node = LocalStyleNode.current
+    val source =
+      rememberUserSource(
+        factory = { GeoJsonSource(id = it, data = EmptyInlineGeoJson, options = options) },
+        update = {},
+      )
+    LaunchedEffect(source, data, node.style.isUnloaded) {
+      if (!node.style.isUnloaded) source.publishData(data)
+    }
+    source
   }
+
+private val EmptyInlineGeoJson: GeoJsonData =
+  GeoJsonData.Features(FeatureCollection<Geometry, JsonObject?>(emptyList()))
+
+/**
+ * Replaces the source's data. Native platforms that parse and index inline GeoJSON do that work on
+ * a worker; iOS and the browser apply it on the caller.
+ */
+internal expect suspend fun GeoJsonSource.publishData(data: GeoJsonData)

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/sources/GeoJsonSource.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/sources/GeoJsonSource.kt
@@ -178,6 +178,7 @@ private val EmptyInlineGeoJson: GeoJsonData =
 
 /**
  * Replaces the source's data. Native platforms that parse and index inline GeoJSON do that work on
- * a worker; iOS and the browser apply it on the caller.
+ * a worker; iOS and the browser apply it on the caller. When two publications overlap, the later
+ * call is the data the source keeps.
  */
 internal expect suspend fun GeoJsonSource.publishData(data: GeoJsonData)

--- a/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/sources/GeoJsonSource.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/sources/GeoJsonSource.kt
@@ -130,3 +130,7 @@ public actual class GeoJsonSource : Source {
     featureStateUnavailable()
   }
 }
+
+internal actual suspend fun GeoJsonSource.publishData(data: GeoJsonData) {
+  setData(data)
+}

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/sources/GeoJsonSource.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/sources/GeoJsonSource.kt
@@ -110,3 +110,7 @@ public actual class GeoJsonSource : Source {
     const val NO_EXPANSION_ZOOM = 0.0
   }
 }
+
+internal actual suspend fun GeoJsonSource.publishData(data: GeoJsonData) {
+  setData(data)
+}

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/sources/GeoJsonSource.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/sources/GeoJsonSource.kt
@@ -2,6 +2,9 @@
 
 package org.maplibre.compose.sources
 
+import kotlin.concurrent.Volatile
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
@@ -20,15 +23,17 @@ import org.maplibre.spatialk.geojson.Geometry
 public actual class GeoJsonSource : Source {
 
   private val options: GeoJsonOptions
+  private val ffiOptions: GeoJsonSourceOptions
 
   /** UTF-8 GeoJSON for inline data. Null when [dataUrl] is set. */
-  private var inlineUtf8: ByteArray?
+  @Volatile private var inlineUtf8: ByteArray?
 
   /** The URI form of the data, when it is one. */
-  private var dataUrl: String?
+  @Volatile private var dataUrl: String?
 
   public actual constructor(id: String, data: GeoJsonData, options: GeoJsonOptions) : super(id) {
     this.options = options
+    this.ffiOptions = options.toFfiOptions()
     this.inlineUtf8 = data.toInlineUtf8()
     this.dataUrl = (data as? GeoJsonData.Uri)?.uri
   }
@@ -52,7 +57,7 @@ public actual class GeoJsonSource : Source {
     val url = dataUrl
     if (url != null) {
       prepared?.close()
-      map.addGeoJsonSourceUrl(id, url, options.toFfiOptions())
+      map.addGeoJsonSourceUrl(id, url, ffiOptions)
     } else {
       val handle =
         (prepared as? GeoJsonSourceDataHandle)
@@ -70,10 +75,9 @@ public actual class GeoJsonSource : Source {
     if (data is GeoJsonData.Uri) {
       mutate { map -> map.setGeoJsonSourceUrl(id, data.uri) }
     } else {
-      // Prepared outside the lambda so the map's owner thread does not parse or index the data.
-      // mutateMap waits until the owner thread has used the handle, so closing it afterward is
-      // safe. synchronousTiling is independent of this: it only changes where viewport tiles are
-      // sliced after the cheap install, on the owner thread (true) or a worker (false).
+      // Parse and index on the caller; [publishData] runs this on a worker. mutateMap waits until
+      // the owner thread has installed the handle. synchronousTiling only changes where viewport
+      // tiles are sliced after that install: during the next render (true) or on a worker (false).
       prepareData().use { prepared ->
         mutate { map -> map.setGeoJsonSourceData(id, prepared) }
       }
@@ -89,7 +93,7 @@ public actual class GeoJsonSource : Source {
 
   /** Prepared with the options the source was added with; a mismatch is rejected at install. */
   private fun prepareData(): GeoJsonSourceDataHandle =
-    GeoJsonSourceDataHandle.create(inlineUtf8!!, options.toFfiOptions())
+    GeoJsonSourceDataHandle.create(inlineUtf8!!, ffiOptions)
 
   public actual fun isCluster(feature: Feature<*, JsonObject?>): Boolean {
     return CLUSTER_ID_PROPERTY in feature.properties.orEmpty()
@@ -210,8 +214,7 @@ private fun GeoJsonOptions.toFfiOptions(): GeoJsonSourceOptions =
     it.clusterMaxZoom = clusterMaxZoom.toDouble()
     it.clusterMinPoints = clusterMinPoints
     it.lineMetrics = lineMetrics
-    // Viewport tile slicing during the update pass on the owner thread, not JSON parse. Parse and
-    // index happen in [GeoJsonSourceDataHandle.create], which the caller runs off that thread.
+    // Viewport tiles are sliced during the next render when true, or on a worker when false.
     it.synchronousTiling = synchronousUpdate
     it.clusterProperties = clusterPropertiesBytes()
   }
@@ -219,4 +222,8 @@ private fun GeoJsonOptions.toFfiOptions(): GeoJsonSourceOptions =
 private fun GeoJsonOptions.clusterPropertiesBytes(): ByteArray? {
   if (clusterProperties.isEmpty()) return null
   return buildJsonObject { putClusterProperties(clusterProperties) }.toJsonBytes()
+}
+
+internal actual suspend fun GeoJsonSource.publishData(data: GeoJsonData) {
+  withContext(Dispatchers.Default) { setData(data) }
 }

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/sources/GeoJsonSource.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/sources/GeoJsonSource.kt
@@ -31,6 +31,14 @@ public actual class GeoJsonSource : Source {
   /** The URI form of the data, when it is one. */
   @Volatile private var dataUrl: String?
 
+  /**
+   * Incremented at the start of every [setData] and [publishData]. Only the current generation
+   * installs after a parse.
+   */
+  @Volatile private var publishGeneration = 0
+
+  private val installLock = Any()
+
   public actual constructor(id: String, data: GeoJsonData, options: GeoJsonOptions) : super(id) {
     this.options = options
     this.ffiOptions = options.toFfiOptions()
@@ -70,18 +78,46 @@ public actual class GeoJsonSource : Source {
   }
 
   public actual fun setData(data: GeoJsonData) {
-    this.inlineUtf8 = data.toInlineUtf8()
-    this.dataUrl = (data as? GeoJsonData.Uri)?.uri
+    applyData(data, nextPublishGeneration())
+  }
+
+  private fun nextPublishGeneration(): Int = synchronized(installLock) { ++publishGeneration }
+
+  /**
+   * Parses the [data] argument, then installs it when [generation] is still current. mutateMap
+   * waits until the owner thread has used the handle, so closing it afterward is safe.
+   */
+  private fun applyData(data: GeoJsonData, generation: Int) {
     if (data is GeoJsonData.Uri) {
-      mutate { map -> map.setGeoJsonSourceUrl(id, data.uri) }
-    } else {
-      // Parse and index on the caller; [publishData] runs this on a worker. mutateMap waits until
-      // the owner thread has installed the handle. synchronousTiling only changes where viewport
-      // tiles are sliced after that install: during the next render (true) or on a worker (false).
-      prepareData().use { prepared ->
+      installIfCurrent(generation) {
+        inlineUtf8 = null
+        dataUrl = data.uri
+        mutate { map -> map.setGeoJsonSourceUrl(id, data.uri) }
+      }
+      return
+    }
+    val utf8 = data.toInlineUtf8()!!
+    if (generation != publishGeneration) return
+    GeoJsonSourceDataHandle.create(utf8, ffiOptions).use { prepared ->
+      installIfCurrent(generation) {
+        inlineUtf8 = utf8
+        dataUrl = null
         mutate { map -> map.setGeoJsonSourceData(id, prepared) }
       }
     }
+  }
+
+  private inline fun installIfCurrent(generation: Int, install: () -> Unit) {
+    synchronized(installLock) {
+      if (generation != publishGeneration) return
+      install()
+    }
+  }
+
+  /** Parses and indexes on Default. [applyData] installs only the current generation. */
+  internal suspend fun publishPreparedData(data: GeoJsonData) {
+    val generation = nextPublishGeneration()
+    withContext(Dispatchers.Default) { applyData(data, generation) }
   }
 
   /**
@@ -225,5 +261,5 @@ private fun GeoJsonOptions.clusterPropertiesBytes(): ByteArray? {
 }
 
 internal actual suspend fun GeoJsonSource.publishData(data: GeoJsonData) {
-  withContext(Dispatchers.Default) { setData(data) }
+  publishPreparedData(data)
 }

--- a/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/sources/GeoJsonSourceAttachTest.kt
+++ b/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/sources/GeoJsonSourceAttachTest.kt
@@ -105,7 +105,7 @@ class GeoJsonSourceAttachTest {
       assertEquals(1, features.size, source.toJson().toString())
       val coordinates =
         ((features.single() as JsonObject)["geometry"] as JsonObject)["coordinates"] as JsonArray
-      assertEquals(9.0, coordinates[0].jsonPrimitive.double)
+      assertEquals(9.0, coordinates[0].jsonPrimitive.content.toDouble())
       assertEquals(emptyList(), fixture.errors, "the map should report nothing")
     }
   }

--- a/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/sources/GeoJsonSourceAttachTest.kt
+++ b/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/sources/GeoJsonSourceAttachTest.kt
@@ -11,7 +11,13 @@ import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import org.maplibre.compose.mlnffi.BridgeMapFixture
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.compose.style.MlnFfiStyle
@@ -73,9 +79,47 @@ class GeoJsonSourceAttachTest {
     }
   }
 
+  /**
+   * A newer one-point payload remains after a slower older parse finishes. `publishData` parses on
+   * Default without a suspend point, and the older worker runs to completion.
+   */
+  @Test
+  fun a_newer_publish_keeps_its_data_when_an_older_parse_finishes_later() = runBlocking {
+    BridgeMapFixture.create().use { fixture ->
+      fixture.loadStyle(BaseStyle.Empty)
+      fixture.pumpUntilRendered()
+      val style = assertIs<MlnFfiStyle>(fixture.style, "Errors: ${fixture.errors}")
+      val source = GeoJsonSource(SOURCE_ID, GeoJsonData.Features(pointAt(0.0)), GeoJsonOptions())
+      style.addSource(source)
+
+      val older = GeoJsonData.Features(manyPoints(longitude = 2.0, count = 4_000))
+      val newer = GeoJsonData.Features(pointAt(longitude = 9.0))
+      val olderJob =
+        launch(Dispatchers.Default, start = CoroutineStart.UNDISPATCHED) {
+          source.publishData(older)
+        }
+      source.publishData(newer)
+      olderJob.join()
+
+      val features = (source.toJson()["data"] as JsonObject)["features"] as JsonArray
+      assertEquals(1, features.size, source.toJson().toString())
+      val coordinates =
+        ((features.single() as JsonObject)["geometry"] as JsonObject)["coordinates"] as JsonArray
+      assertEquals(9.0, coordinates[0].jsonPrimitive.double)
+      assertEquals(emptyList(), fixture.errors, "the map should report nothing")
+    }
+  }
+
   private fun pointAt(longitude: Double): FeatureCollection<Geometry, JsonObject?> =
     buildFeatureCollection {
       addFeature(geometry = Point(Position(longitude = longitude, latitude = 0.0)))
+    }
+
+  private fun manyPoints(longitude: Double, count: Int): FeatureCollection<Geometry, JsonObject?> =
+    buildFeatureCollection {
+      repeat(count) { index ->
+        addFeature(geometry = Point(Position(longitude = longitude, latitude = index * 0.0001)))
+      }
     }
 
   private companion object {


### PR DESCRIPTION
## Description

`rememberGeoJsonSource` prepares inline GeoJSON on a worker so Compose Main does not parse or index updates, stacked on #981.

## Validation

Installed as a second app on a Galaxy Z Fold (SM-F966U1); not yet run through the GeoJSON load benchmark.

## AI assistance

Cursor Grok 4.6 in the Cursor CLI.