### PR TITLE
Fold location permission into LocationProvider

### DIFF
--- a/docs/src/content/docs/location.mdx
+++ b/docs/src/content/docs/location.mdx
@@ -107,9 +107,10 @@ on desktop.
 #### Android
 
 The default provider observes and requests Android's runtime location
-permissions. A provider created through `rememberAndroidLocationProvider` can
-launch the system permission dialog; one created through the
-`AndroidLocationProvider(context)` constructor only reports the permission.
+permissions. The permission request launches the system dialog through the
+activity that the context resolves to, so it works from a directly constructed
+provider too; with a context that cannot reach an activity, the request does
+nothing and the reported permission stays accurate.
 
 For better accuracy, use the Fused Location/Orientation Provider
 (requires Google Play Services):
@@ -120,8 +121,8 @@ val orientationProvider = rememberFusedOrientationProvider()
 ```
 
 `rememberFusedLocationProvider` delegates permission to the Android provider
-above, so it reports the permission and can launch the system dialog. The
-`FusedLocationProvider(client)` constructor keeps the always-granted default.
+above. The `FusedLocationProvider(client)` constructor keeps the always-granted
+default.
 
 Add the extension module to the Android source set:
 

--- a/docs/src/content/docs/location.mdx
+++ b/docs/src/content/docs/location.mdx
@@ -12,20 +12,20 @@ The location module provides a cross-platform way to track and visualize user
 position in MapLibre Compose.
 
 Location support is split into a few small pieces. A `LocationProvider` supplies
-foreground location updates, and `rememberLocationState` collects them according
-to permission and lifecycle state. `LocationPuck` draws the latest fix, and
-`LocationTrackingEffect` can keep the camera in sync with location changes.
+foreground location updates and carries the location permission, and
+`rememberLocationState` collects them according to permission and lifecycle
+state. `LocationPuck` draws the latest fix, and `LocationTrackingEffect` can
+keep the camera in sync with location changes.
 
 ### Overview
 
-| Component                                        | Purpose                                                                            |
-| ------------------------------------------------ | ---------------------------------------------------------------------------------- |
-| **`rememberDefaultLocationProvider`**            | Creates the platform location provider.                                            |
-| **`rememberDefaultLocationPermissionRequester`** | Observes and requests foreground location permission.                              |
-| **`rememberLocationState`**                      | Collects updates while enabled and lifecycle-active.                               |
-| **`rememberDefaultOrientationProvider`**         | Provides device orientation data from sensors.                                     |
-| **`LocationPuck`**                               | Visual indicator that displays the user's current position and bearing on the map. |
-| **`LocationTrackingEffect`**                     | Applies location changes to application or camera state.                           |
+| Component                                | Purpose                                                                            |
+| ---------------------------------------- | ---------------------------------------------------------------------------------- |
+| **`rememberDefaultLocationProvider`**    | Creates the platform location provider, including its permission handling.         |
+| **`rememberLocationState`**              | Collects updates while enabled and lifecycle-active.                               |
+| **`rememberDefaultOrientationProvider`** | Provides device orientation data from sensors.                                     |
+| **`LocationPuck`**                       | Visual indicator that displays the user's current position and bearing on the map. |
+| **`LocationTrackingEffect`**             | Applies location changes to application or camera state.                           |
 
 Android and iOS provide default location and orientation providers. Web, Linux,
 and macOS provide default location providers but no default orientation
@@ -38,9 +38,12 @@ platform location request. Cancelling collection stops that request and
 unregisters its callbacks. `rememberLocationState` collects updates only while
 `enabled` is true, permission is granted, and the lifecycle is active.
 
-`rememberLocationState` never requests permission automatically. Call
-`requestPermission` when the application is ready to present platform permission
-UI. This may be during startup or in response to an action such as a button click:
+The provider carries the permission: `LocationState.permission` mirrors
+`LocationProvider.permission`, and `LocationState.requestPermission()` delegates
+to `LocationProvider.requestPermission()`. The library never requests permission
+automatically. Call `requestPermission` when the application is ready to present
+platform permission UI. This may be during startup or in response to an action
+such as a button click:
 
 ```kotlin
 if (locationState.permission !is LocationPermission.Granted) {
@@ -85,11 +88,29 @@ indicators. If you use the Material 3 extension module, pass
 `colors = LocationPuckDefaults.colors()` for themed colors. `onClick` and
 `onLongClick` can react to interactions with the puck.
 
+### Custom providers
+
+A custom `LocationProvider` implements only `updates(request)`. `permission`
+defaults to always granted and `requestPermission()` defaults to a no-op, so a
+source where permission is not a concept, such as an external receiver or a
+network feed, needs no permission handling.
+
+A provider that wraps a real platform source can delegate permission to the
+building blocks that the default providers use: `AndroidLocationPermissionRequester`
+on Android, `IosLocationPermissionRequester` on iOS,
+`BrowserLocationPermissionRequester` on web, and
+`MacosLocationPermissionRequester` or `LinuxPortalLocationPermissionRequester`
+on desktop.
+
 ### Platform options
 
 #### Android
 
-The default permission requester uses Android's runtime location permissions.
+The default provider observes and requests Android's runtime location
+permissions. A provider created through `rememberAndroidLocationProvider` can
+launch the system permission dialog; one created through the
+`AndroidLocationProvider(context)` constructor only reports the permission.
+
 For better accuracy, use the Fused Location/Orientation Provider
 (requires Google Play Services):
 
@@ -97,6 +118,10 @@ For better accuracy, use the Fused Location/Orientation Provider
 val locationProvider = rememberFusedLocationProvider()
 val orientationProvider = rememberFusedOrientationProvider()
 ```
+
+`rememberFusedLocationProvider` delegates permission to the Android provider
+above, so it reports the permission and can launch the system dialog. The
+`FusedLocationProvider(client)` constructor keeps the always-granted default.
 
 Add the extension module to the Android source set:
 

--- a/lib/maplibre-compose-gms/src/androidMain/kotlin/org/maplibre/compose/gms/FusedLocationProvider.kt
+++ b/lib/maplibre-compose-gms/src/androidMain/kotlin/org/maplibre/compose/gms/FusedLocationProvider.kt
@@ -56,11 +56,10 @@ import org.maplibre.spatialk.units.extensions.inMeters
  * [LocationUnavailableReason.UnexpectedFailure].
  *
  * The [Context] constructor and [rememberFusedLocationProvider] with a context delegate
- * [permission] and [requestPermission] to an [AndroidLocationProvider]. A provider created by
- * [rememberFusedLocationProvider] can launch the system permission dialog; a directly constructed
- * provider only reports [permission]. The [FusedLocationProviderClient] constructor keeps the
- * default [LocationProvider.permission], which is always granted, and its [updates] still surface a
- * `SecurityException` as [LocationUnavailableReason.PermissionDenied].
+ * [permission] and [requestPermission] to an [AndroidLocationProvider]. The
+ * [FusedLocationProviderClient] constructor keeps the default [LocationProvider.permission], which
+ * is always granted, and its [updates] still surface a `SecurityException` as
+ * [LocationUnavailableReason.PermissionDenied].
  */
 public class FusedLocationProvider
 internal constructor(
@@ -76,12 +75,8 @@ internal constructor(
   public constructor(locationClient: FusedLocationProviderClient) : this(locationClient, null)
 
   /**
-   * Creates a provider with its own fused client and an unwired [AndroidLocationProvider] as its
-   * permission delegate.
-   *
-   * The provider reports [permission], but its [requestPermission] does nothing.
-   * [rememberFusedLocationProvider] creates a provider that can launch the system permission
-   * dialog.
+   * Creates a provider with its own fused client and an [AndroidLocationProvider] as its permission
+   * delegate.
    */
   public constructor(
     context: Context
@@ -157,9 +152,8 @@ internal constructor(
 }
 
 /**
- * Creates and remembers a fused provider from the current Android [context].
- *
- * The provider reports the foreground permission and can launch the system permission dialog.
+ * Creates and remembers a fused provider from the current Android [context], with permission
+ * delegated to an [AndroidLocationProvider].
  */
 @Composable
 public fun rememberFusedLocationProvider(

--- a/lib/maplibre-compose-gms/src/androidMain/kotlin/org/maplibre/compose/gms/FusedLocationProvider.kt
+++ b/lib/maplibre-compose-gms/src/androidMain/kotlin/org/maplibre/compose/gms/FusedLocationProvider.kt
@@ -19,14 +19,18 @@ import java.util.concurrent.Executors
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.tasks.await
+import org.maplibre.compose.location.AndroidLocationProvider
 import org.maplibre.compose.location.LocationAccuracy
 import org.maplibre.compose.location.LocationEvent
+import org.maplibre.compose.location.LocationPermission
 import org.maplibre.compose.location.LocationProvider
 import org.maplibre.compose.location.LocationRequest
 import org.maplibre.compose.location.LocationUnavailableReason
 import org.maplibre.compose.location.asMapLibreLocation
+import org.maplibre.compose.location.rememberAndroidLocationProvider
 import org.maplibre.compose.location.rememberLocationState
 import org.maplibre.spatialk.units.extensions.inMeters
 
@@ -51,10 +55,52 @@ import org.maplibre.spatialk.units.extensions.inMeters
  * the flow and [rememberLocationState] reports them as
  * [LocationUnavailableReason.UnexpectedFailure].
  *
- * @param locationClient Google Play Services client used for cached and live locations.
+ * The [Context] constructor and [rememberFusedLocationProvider] with a context delegate
+ * [permission] and [requestPermission] to an [AndroidLocationProvider]. A provider created by
+ * [rememberFusedLocationProvider] can launch the system permission dialog; a directly constructed
+ * provider only reports [permission]. The [FusedLocationProviderClient] constructor keeps the
+ * default [LocationProvider.permission], which is always granted, and its [updates] still surface a
+ * `SecurityException` as [LocationUnavailableReason.PermissionDenied].
  */
-public class FusedLocationProvider(private val locationClient: FusedLocationProviderClient) :
-  LocationProvider {
+public class FusedLocationProvider
+internal constructor(
+  private val locationClient: FusedLocationProviderClient,
+  private val permissionDelegate: LocationProvider?,
+) : LocationProvider {
+
+  /**
+   * Creates a provider backed by [locationClient].
+   *
+   * Permission keeps the [LocationProvider.permission] default, which is always granted.
+   */
+  public constructor(locationClient: FusedLocationProviderClient) : this(locationClient, null)
+
+  /**
+   * Creates a provider with its own fused client and an unwired [AndroidLocationProvider] as its
+   * permission delegate.
+   *
+   * The provider reports [permission], but its [requestPermission] does nothing.
+   * [rememberFusedLocationProvider] creates a provider that can launch the system permission
+   * dialog.
+   */
+  public constructor(
+    context: Context
+  ) : this(
+    LocationServices.getFusedLocationProviderClient(context),
+    AndroidLocationProvider(context),
+  )
+
+  override val permission: StateFlow<LocationPermission>
+    get() = permissionDelegate?.permission ?: super.permission
+
+  override fun requestPermission() {
+    if (permissionDelegate != null) {
+      permissionDelegate.requestPermission()
+    } else {
+      super.requestPermission()
+    }
+  }
+
   @RequiresPermission(
     anyOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION]
   )
@@ -110,16 +156,25 @@ public class FusedLocationProvider(private val locationClient: FusedLocationProv
   }
 }
 
-/** Creates and remembers a fused provider from the current Android [context]. */
+/**
+ * Creates and remembers a fused provider from the current Android [context].
+ *
+ * The provider reports the foreground permission and can launch the system permission dialog.
+ */
 @Composable
 public fun rememberFusedLocationProvider(
   context: Context = LocalContext.current
 ): FusedLocationProvider {
   val client = remember(context) { LocationServices.getFusedLocationProviderClient(context) }
-  return rememberFusedLocationProvider(client)
+  val permissionDelegate = rememberAndroidLocationProvider(context)
+  return remember(client, permissionDelegate) { FusedLocationProvider(client, permissionDelegate) }
 }
 
-/** Creates and remembers a fused provider backed by [fusedLocationProviderClient]. */
+/**
+ * Creates and remembers a fused provider backed by [fusedLocationProviderClient].
+ *
+ * Permission keeps the [LocationProvider.permission] default, which is always granted.
+ */
 @Composable
 public fun rememberFusedLocationProvider(
   fusedLocationProviderClient: FusedLocationProviderClient

--- a/lib/maplibre-compose-linux/src/main/kotlin/org/maplibre/compose/location/desktop/linux/LinuxPortalLocationBackend.kt
+++ b/lib/maplibre-compose-linux/src/main/kotlin/org/maplibre/compose/location/desktop/linux/LinuxPortalLocationBackend.kt
@@ -14,13 +14,11 @@ import kotlinx.coroutines.launch
 import org.maplibre.compose.desktop.ComposeMapHost
 import org.maplibre.compose.desktop.XdgPortalWindow
 import org.maplibre.compose.location.DesktopLocationBackend
-import org.maplibre.compose.location.DesktopLocationPermissionRequester
 import org.maplibre.compose.location.DesktopLocationProvider
 import org.maplibre.compose.location.LocationAccuracyAuthorization
 import org.maplibre.compose.location.LocationBackendAvailability
 import org.maplibre.compose.location.LocationEvent
 import org.maplibre.compose.location.LocationPermission
-import org.maplibre.compose.location.LocationPermissionRequester
 import org.maplibre.compose.location.LocationProvider
 import org.maplibre.compose.location.LocationRequest
 import org.maplibre.compose.location.LocationUnavailableReason
@@ -34,10 +32,6 @@ public class LinuxPortalLocationBackend : DesktopLocationBackend {
 
   override fun createProvider(host: ComposeMapHost?): DesktopLocationProvider =
     LinuxPortalLocationProvider(host)
-
-  override fun createPermissionRequester(
-    host: ComposeMapHost?
-  ): DesktopLocationPermissionRequester = LinuxPortalLocationPermissionRequester(host)
 }
 
 // TODO: Add a Linux orientation backend when an independent heading API is available.
@@ -56,6 +50,9 @@ internal suspend fun <T> ComposeMapHost?.withPortalParentWindow(action: suspend 
 /**
  * A desktop provider that delegates to the
  * [XDG Location portal](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Location.html).
+ *
+ * [LocationProvider.permission] and [LocationProvider.requestPermission] delegate to a
+ * [LinuxPortalLocationPermissionRequester] that shares the provider's portal.
  *
  * [LocationAccuracy.BestForNavigation] and [LocationAccuracy.High] map to
  * [`EXACT`](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Location.html#org-freedesktop-portal-location-createsession),
@@ -76,8 +73,13 @@ internal suspend fun <T> ComposeMapHost?.withPortalParentWindow(action: suspend 
  * failures map to [LocationUnavailableReason.UnexpectedFailure].
  */
 public class LinuxPortalLocationProvider
-internal constructor(private val portal: LinuxLocationPortal) : DesktopLocationProvider {
+internal constructor(
+  private val portal: LinuxLocationPortal,
+  coroutineScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
+) : DesktopLocationProvider {
   public constructor(host: ComposeMapHost? = null) : this(DbusLocationPortal(host))
+
+  private val requester = LinuxPortalLocationPermissionRequester(portal, coroutineScope)
 
   override val backendAvailability: LocationBackendAvailability =
     if (portal.available) {
@@ -85,6 +87,11 @@ internal constructor(private val portal: LinuxLocationPortal) : DesktopLocationP
     } else {
       LocationBackendAvailability.Unsupported
     }
+
+  override val permission: StateFlow<LocationPermission>
+    get() = requester.status
+
+  override fun requestPermission(): Unit = requester.requestForegroundPermission()
 
   override fun updates(request: LocationRequest): Flow<LocationEvent> = flow {
     if (!portal.available) {
@@ -95,6 +102,7 @@ internal constructor(private val portal: LinuxLocationPortal) : DesktopLocationP
   }
 
   override fun close() {
+    requester.close()
     portal.close()
   }
 }
@@ -102,23 +110,27 @@ internal constructor(private val portal: LinuxLocationPortal) : DesktopLocationP
 /**
  * Observes and requests permission through the XDG Location portal.
  *
+ * [LinuxPortalLocationProvider] delegates [LocationProvider.permission] and
+ * [LocationProvider.requestPermission] to an instance of this class. Use it directly when a custom
+ * provider needs the same portal permission behavior.
+ *
  * The portal has no permission-status query. Permission therefore remains
  * [LocationPermission.NotGranted] with `canRequest = null` until a successful
  * [`Location.Start`](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Location.html#org-freedesktop-portal-location-start)
  * response maps it to [LocationPermission.Granted] with [LocationAccuracyAuthorization.Unknown].
  * Denied and unavailable responses remain `NotGranted` with `canRequest = null`. A missing portal
- * maps [LocationPermissionRequester.backendAvailability] to
- * [LocationBackendAvailability.Unsupported].
+ * maps [backendAvailability] to [LocationBackendAvailability.Unsupported].
  */
 public class LinuxPortalLocationPermissionRequester
 internal constructor(
   private val portal: LinuxLocationPortal,
   private val coroutineScope: CoroutineScope =
     CoroutineScope(SupervisorJob() + Dispatchers.Default),
-) : DesktopLocationPermissionRequester {
+) : AutoCloseable {
   public constructor(host: ComposeMapHost? = null) : this(DbusLocationPortal(host))
 
-  override val backendAvailability: LocationBackendAvailability =
+  /** Whether the XDG Location portal is installed. */
+  public val backendAvailability: LocationBackendAvailability =
     if (portal.available) {
       LocationBackendAvailability.Available
     } else {
@@ -126,10 +138,16 @@ internal constructor(
     }
   private val mutableStatus =
     MutableStateFlow<LocationPermission>(LocationPermission.NotGranted(canRequest = null))
-  override val status: StateFlow<LocationPermission> = mutableStatus
+
+  /** Current foreground location permission. */
+  public val status: StateFlow<LocationPermission> = mutableStatus
   private val requestPending = AtomicBoolean()
 
-  override fun requestForegroundPermission() {
+  /**
+   * Starts a foreground permission request and returns immediately. The result is published to
+   * [status].
+   */
+  public fun requestForegroundPermission() {
     if (
       backendAvailability != LocationBackendAvailability.Available ||
         status.value is LocationPermission.Granted ||
@@ -153,6 +171,7 @@ internal constructor(
     }
   }
 
+  /** Cancels pending requests and closes the portal. */
   override fun close() {
     coroutineScope.cancel()
     portal.close()

--- a/lib/maplibre-compose-linux/src/test/kotlin/org/maplibre/compose/location/desktop/linux/LinuxPortalLocationProviderTest.kt
+++ b/lib/maplibre-compose-linux/src/test/kotlin/org/maplibre/compose/location/desktop/linux/LinuxPortalLocationProviderTest.kt
@@ -99,14 +99,12 @@ class LinuxPortalLocationProviderTest {
   }
 
   @Test
-  fun missingPortalMarksProviderAndRequesterUnsupported() = runTest {
+  fun missingPortalMarksProviderUnsupported() = runTest {
     val portal = FakeLinuxLocationPortal(available = false)
-    val provider = LinuxPortalLocationProvider(portal)
-    val requester = LinuxPortalLocationPermissionRequester(portal, backgroundScope)
+    val provider = LinuxPortalLocationProvider(portal, backgroundScope)
 
     assertEquals(LocationBackendAvailability.Unsupported, provider.backendAvailability)
-    assertEquals(LocationBackendAvailability.Unsupported, requester.backendAvailability)
-    requester.requestForegroundPermission()
+    provider.requestPermission()
     runCurrent()
     assertEquals(0, portal.permissionRequests)
   }
@@ -116,21 +114,21 @@ class LinuxPortalLocationProviderTest {
     val portal = FakeLinuxLocationPortal()
     val pendingResult = CompletableDeferred<PortalPermissionResult>()
     portal.permissionResult = { pendingResult.await() }
-    val requester = LinuxPortalLocationPermissionRequester(portal, backgroundScope)
+    val provider = LinuxPortalLocationProvider(portal, backgroundScope)
 
-    requester.requestForegroundPermission()
-    requester.requestForegroundPermission()
+    provider.requestPermission()
+    provider.requestPermission()
     runCurrent()
     assertEquals(1, portal.permissionRequests)
 
     pendingResult.complete(PortalPermissionResult.Granted)
     runCurrent()
     val granted = LocationPermission.Granted(LocationAccuracyAuthorization.Unknown)
-    assertEquals(granted, requester.status.value)
-    requester.requestForegroundPermission()
+    assertEquals(granted, provider.permission.value)
+    provider.requestPermission()
     assertEquals(1, portal.permissionRequests)
 
-    requester.close()
+    provider.close()
     assertTrue(portal.closed)
   }
 

--- a/lib/maplibre-compose-macos/src/main/kotlin/org/maplibre/compose/location/desktop/macos/MacosLocationBackend.kt
+++ b/lib/maplibre-compose-macos/src/main/kotlin/org/maplibre/compose/location/desktop/macos/MacosLocationBackend.kt
@@ -18,6 +18,7 @@ import org.maplibre.compose.desktop.ComposeMapHost
 import org.maplibre.compose.location.DesktopLocationBackend
 import org.maplibre.compose.location.DesktopLocationProvider
 import org.maplibre.compose.location.LocationAccuracy
+import org.maplibre.compose.location.LocationAccuracyAuthorization
 import org.maplibre.compose.location.LocationBackendAvailability
 import org.maplibre.compose.location.LocationEvent
 import org.maplibre.compose.location.LocationPermission
@@ -193,6 +194,11 @@ internal constructor(
  * distinguishes precise from approximate grants. A request calls
  * [`requestWhenInUseAuthorization()`](https://developer.apple.com/documentation/corelocation/cllocationmanager/requestwheninuseauthorization())
  * and starts location updates so macOS can present the system prompt.
+ *
+ * If the manager cannot be allocated, [status] reports [LocationPermission.Granted] at
+ * [LocationAccuracyAuthorization.Unknown] so that collection still reaches the provider's guarded
+ * update path, which retries the allocation and reports a persistent failure as
+ * [LocationUnavailableReason.UnexpectedFailure].
  */
 public class MacosLocationPermissionRequester
 internal constructor(private val client: CoreLocationClient) : AutoCloseable {
@@ -208,7 +214,9 @@ internal constructor(private val client: CoreLocationClient) : AutoCloseable {
   private val requestPending = AtomicBoolean()
 
   // Allocation is fallible and must not throw from construction, so the manager is created through
-  // manager() and retried on each access until an attempt succeeds.
+  // manager() and retried on each access until an attempt succeeds. A failed attempt reports
+  // permission as granted at unknown accuracy, so that rememberLocationState still collects updates
+  // and the provider's own guarded allocation retries or reports UnexpectedFailure.
   private var manager: CoreLocationManager? = null
 
   private fun manager(): CoreLocationManager? =
@@ -217,6 +225,7 @@ internal constructor(private val client: CoreLocationClient) : AutoCloseable {
         client.createManager().also {
           it.setDelegate(delegate)
           manager = it
+          mutableStatus.value = readPermission(it.authorizationStatus, it.accuracyAuthorization)
         }
       } catch (error: Throwable) {
         null
@@ -242,7 +251,9 @@ internal constructor(private val client: CoreLocationClient) : AutoCloseable {
     }
 
   init {
-    manager()?.let { mutableStatus.value = currentPermission() }
+    if (manager() == null) {
+      mutableStatus.value = LocationPermission.Granted(LocationAccuracyAuthorization.Unknown)
+    }
   }
 
   /**

--- a/lib/maplibre-compose-macos/src/main/kotlin/org/maplibre/compose/location/desktop/macos/MacosLocationBackend.kt
+++ b/lib/maplibre-compose-macos/src/main/kotlin/org/maplibre/compose/location/desktop/macos/MacosLocationBackend.kt
@@ -16,7 +16,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.maplibre.compose.desktop.ComposeMapHost
 import org.maplibre.compose.location.DesktopLocationBackend
-import org.maplibre.compose.location.DesktopLocationPermissionRequester
 import org.maplibre.compose.location.DesktopLocationProvider
 import org.maplibre.compose.location.LocationAccuracy
 import org.maplibre.compose.location.LocationBackendAvailability
@@ -36,15 +35,14 @@ public class MacosLocationBackend : DesktopLocationBackend {
 
   override fun createProvider(host: ComposeMapHost?): DesktopLocationProvider =
     MacosLocationProvider()
-
-  override fun createPermissionRequester(
-    host: ComposeMapHost?
-  ): DesktopLocationPermissionRequester = MacosLocationPermissionRequester()
 }
 
 /**
  * A [LocationProvider] built on
  * [`CLLocationManager`](https://developer.apple.com/documentation/corelocation/cllocationmanager).
+ *
+ * [LocationProvider.permission] and [LocationProvider.requestPermission] delegate to a
+ * [MacosLocationPermissionRequester] that shares the provider's Core Location client.
  *
  * Each collection creates a
  * [`CLLocationManager`](https://developer.apple.com/documentation/corelocation/cllocationmanager)
@@ -84,7 +82,14 @@ internal constructor(
 ) : DesktopLocationProvider {
   public constructor() : this(SystemCoreLocationClient())
 
+  private val requester = MacosLocationPermissionRequester(client)
+
   override val backendAvailability: LocationBackendAvailability = client.backendAvailability
+
+  override val permission: StateFlow<LocationPermission>
+    get() = requester.status
+
+  override fun requestPermission(): Unit = requester.requestForegroundPermission()
 
   override fun updates(request: LocationRequest): Flow<LocationEvent> = callbackFlow {
     when (val availability = backendAvailability) {
@@ -138,6 +143,7 @@ internal constructor(
     .flowOn(dispatcher)
 
   override fun close() {
+    requester.close()
     client.close()
   }
 
@@ -173,7 +179,11 @@ internal constructor(
 }
 
 /**
- * Foreground Core Location permission requester.
+ * Foreground Core Location permission holder.
+ *
+ * [MacosLocationProvider] delegates [LocationProvider.permission] and
+ * [LocationProvider.requestPermission] to an instance of this class. Use it directly when a custom
+ * provider needs the same Core Location permission behavior.
  *
  * [`CLAuthorizationStatus`](https://developer.apple.com/documentation/corelocation/clauthorizationstatus)
  * maps an authorized status to [LocationPermission.Granted], `notDetermined` to
@@ -185,13 +195,16 @@ internal constructor(
  * and starts location updates so macOS can present the system prompt.
  */
 public class MacosLocationPermissionRequester
-internal constructor(private val client: CoreLocationClient) : DesktopLocationPermissionRequester {
+internal constructor(private val client: CoreLocationClient) : AutoCloseable {
   public constructor() : this(SystemCoreLocationClient())
 
-  override val backendAvailability: LocationBackendAvailability = client.backendAvailability
+  /** Whether the process has a usable Core Location implementation. */
+  public val backendAvailability: LocationBackendAvailability = client.backendAvailability
   private val mutableStatus =
     MutableStateFlow<LocationPermission>(LocationPermission.NotGranted(canRequest = null))
-  override val status: StateFlow<LocationPermission> = mutableStatus
+
+  /** Current foreground location permission, updated when Core Location reports a change. */
+  public val status: StateFlow<LocationPermission> = mutableStatus
   private val requestPending = AtomicBoolean()
   private val manager = client.createManager()
 
@@ -219,7 +232,11 @@ internal constructor(private val client: CoreLocationClient) : DesktopLocationPe
     mutableStatus.value = currentPermission()
   }
 
-  override fun requestForegroundPermission() {
+  /**
+   * Starts a foreground permission request and returns immediately. The result is published to
+   * [status].
+   */
+  public fun requestForegroundPermission() {
     if (backendAvailability != LocationBackendAvailability.Available) return
     val current = currentPermission()
     if (current != LocationPermission.NotGranted(canRequest = true)) return
@@ -230,6 +247,7 @@ internal constructor(private val client: CoreLocationClient) : DesktopLocationPe
     manager.startUpdatingLocation()
   }
 
+  /** Releases the Core Location manager and client. */
   override fun close() {
     manager.close()
     client.close()

--- a/lib/maplibre-compose-macos/src/main/kotlin/org/maplibre/compose/location/desktop/macos/MacosLocationBackend.kt
+++ b/lib/maplibre-compose-macos/src/main/kotlin/org/maplibre/compose/location/desktop/macos/MacosLocationBackend.kt
@@ -206,14 +206,28 @@ internal constructor(private val client: CoreLocationClient) : AutoCloseable {
   /** Current foreground location permission, updated when Core Location reports a change. */
   public val status: StateFlow<LocationPermission> = mutableStatus
   private val requestPending = AtomicBoolean()
-  private val manager = client.createManager()
+
+  // Allocation is fallible and must not throw from construction, so the manager is created through
+  // manager() and retried on each access until an attempt succeeds.
+  private var manager: CoreLocationManager? = null
+
+  private fun manager(): CoreLocationManager? =
+    manager
+      ?: try {
+        client.createManager().also {
+          it.setDelegate(delegate)
+          manager = it
+        }
+      } catch (error: Throwable) {
+        null
+      }
 
   private val delegate =
     object : CoreLocationDelegate {
       override fun didUpdateLocations(locations: List<CoreLocationFix>) = Unit
 
       override fun didFailWithError(error: CoreLocationError) {
-        manager.stopUpdatingLocation()
+        manager?.stopUpdatingLocation()
         requestPending.set(false)
       }
 
@@ -221,15 +235,14 @@ internal constructor(private val client: CoreLocationClient) : AutoCloseable {
         val permission = currentPermission()
         mutableStatus.value = permission
         if (permission != LocationPermission.NotGranted(canRequest = true)) {
-          manager.stopUpdatingLocation()
+          manager?.stopUpdatingLocation()
         }
         requestPending.set(false)
       }
     }
 
   init {
-    manager.setDelegate(delegate)
-    mutableStatus.value = currentPermission()
+    manager()?.let { mutableStatus.value = currentPermission() }
   }
 
   /**
@@ -238,6 +251,7 @@ internal constructor(private val client: CoreLocationClient) : AutoCloseable {
    */
   public fun requestForegroundPermission() {
     if (backendAvailability != LocationBackendAvailability.Available) return
+    val manager = manager() ?: return
     val current = currentPermission()
     if (current != LocationPermission.NotGranted(canRequest = true)) return
     if (!requestPending.compareAndSet(false, true)) return
@@ -249,10 +263,11 @@ internal constructor(private val client: CoreLocationClient) : AutoCloseable {
 
   /** Releases the Core Location manager and client. */
   override fun close() {
-    manager.close()
+    manager?.close()
     client.close()
   }
 
   private fun currentPermission(): LocationPermission =
-    readPermission(manager.authorizationStatus, manager.accuracyAuthorization)
+    manager?.let { readPermission(it.authorizationStatus, it.accuracyAuthorization) }
+      ?: LocationPermission.NotGranted(canRequest = null)
 }

--- a/lib/maplibre-compose-macos/src/test/kotlin/org/maplibre/compose/location/desktop/macos/MacosLocationProviderTest.kt
+++ b/lib/maplibre-compose-macos/src/test/kotlin/org/maplibre/compose/location/desktop/macos/MacosLocationProviderTest.kt
@@ -285,6 +285,17 @@ class MacosLocationProviderTest {
   }
 
   @Test
+  fun managerConstructionFailureDoesNotThrowFromProviderConstruction() {
+    val client = FakeCoreLocationClient()
+    client.createFailure = IllegalStateException("native failed")
+
+    val provider = MacosLocationProvider(client, Dispatchers.Unconfined)
+
+    assertEquals(LocationPermission.NotGranted(canRequest = null), provider.permission.value)
+    provider.requestPermission()
+  }
+
+  @Test
   fun overlappingPermissionRequestsStartOneAuthorizationRequest() {
     val client = FakeCoreLocationClient()
     val provider = MacosLocationProvider(client, Dispatchers.Unconfined)

--- a/lib/maplibre-compose-macos/src/test/kotlin/org/maplibre/compose/location/desktop/macos/MacosLocationProviderTest.kt
+++ b/lib/maplibre-compose-macos/src/test/kotlin/org/maplibre/compose/location/desktop/macos/MacosLocationProviderTest.kt
@@ -285,14 +285,22 @@ class MacosLocationProviderTest {
   }
 
   @Test
-  fun managerConstructionFailureDoesNotThrowFromProviderConstruction() {
+  fun managerConstructionFailureDoesNotThrowFromProviderConstruction() = runTest {
     val client = FakeCoreLocationClient()
     client.createFailure = IllegalStateException("native failed")
 
     val provider = MacosLocationProvider(client, Dispatchers.Unconfined)
 
-    assertEquals(LocationPermission.NotGranted(canRequest = null), provider.permission.value)
+    // Permission reports granted at unknown accuracy so that collection reaches the guarded update
+    // path, which retries the allocation and reports the persistent failure.
+    assertEquals(
+      LocationPermission.Granted(LocationAccuracyAuthorization.Unknown),
+      provider.permission.value,
+    )
     provider.requestPermission()
+    val event = assertIs<LocationEvent.Unavailable>(provider.updates(LocationRequest()).first())
+    assertEquals(LocationUnavailableReason.UnexpectedFailure, event.reason)
+    assertIs<IllegalStateException>(event.cause)
   }
 
   @Test

--- a/lib/maplibre-compose-macos/src/test/kotlin/org/maplibre/compose/location/desktop/macos/MacosLocationProviderTest.kt
+++ b/lib/maplibre-compose-macos/src/test/kotlin/org/maplibre/compose/location/desktop/macos/MacosLocationProviderTest.kt
@@ -173,13 +173,15 @@ class MacosLocationProviderTest {
 
     val event = assertIs<LocationEvent.Fix>(provider.updates(LocationRequest()).first())
     assertEquals(52.0, event.location.position.value.latitude)
-    assertEquals(1, client.managers.size)
-    assertEquals(CL_LOCATION_ACCURACY_BEST, client.managers.single().desiredAccuracy)
-    assertEquals(1.0, client.managers.single().distanceFilter)
-    assertTrue(client.managers.single().closed)
-    assertFalse(client.managers.single().updating)
+    assertEquals(2, client.managers.size)
+    val manager = client.managers.last()
+    assertEquals(CL_LOCATION_ACCURACY_BEST, manager.desiredAccuracy)
+    assertEquals(1.0, manager.distanceFilter)
+    assertTrue(manager.closed)
+    assertFalse(manager.updating)
 
     provider.close()
+    assertTrue(client.managers.all { it.closed })
     assertTrue(client.closed)
   }
 
@@ -193,18 +195,19 @@ class MacosLocationProviderTest {
       .updates(LocationRequest(accuracy = LocationAccuracy.Balanced, minimumDistance = 10.meters))
       .first()
 
-    assertEquals(CL_LOCATION_ACCURACY_HUNDRED_METERS, client.managers.single().desiredAccuracy)
-    assertEquals(10.0, client.managers.single().distanceFilter)
+    assertEquals(CL_LOCATION_ACCURACY_HUNDRED_METERS, client.managers.last().desiredAccuracy)
+    assertEquals(10.0, client.managers.last().distanceFilter)
   }
 
   @Test
   fun missingLocationServicesEmitsServicesDisabled() = runTest {
     val client = FakeCoreLocationClient(locationServicesEnabled = false)
     val provider = MacosLocationProvider(client, Dispatchers.Unconfined)
+    val managersBeforeUpdates = client.managers.size
 
     val event = assertIs<LocationEvent.Unavailable>(provider.updates(LocationRequest()).first())
     assertEquals(LocationUnavailableReason.ServicesDisabled, event.reason)
-    assertEquals(0, client.managers.size)
+    assertEquals(managersBeforeUpdates, client.managers.size)
   }
 
   @Test
@@ -219,7 +222,7 @@ class MacosLocationProviderTest {
     }
 
     assertTrue(events.isEmpty())
-    client.managers.single().boundDelegate?.didUpdateLocations(listOf(sampleFix()))
+    client.managers.last().boundDelegate?.didUpdateLocations(listOf(sampleFix()))
     assertIs<LocationEvent.Fix>(events.single())
   }
 
@@ -235,7 +238,7 @@ class MacosLocationProviderTest {
     }
 
     assertIs<LocationEvent.Fix>(events.single())
-    val delegate = client.managers.single().boundDelegate
+    val delegate = client.managers.last().boundDelegate
     delegate?.didFailWithError(CoreLocationError(CL_ERROR_DOMAIN, CL_ERROR_LOCATION_UNKNOWN))
     delegate?.didUpdateLocations(listOf(sampleFix().copy(latitude = 53.0)))
 
@@ -261,7 +264,7 @@ class MacosLocationProviderTest {
     assertIs<LocationEvent.Fix>(events.single())
     client.locationServicesEnabled = false
     client.managers
-      .single()
+      .last()
       .boundDelegate
       ?.didFailWithError(CoreLocationError(CL_ERROR_DOMAIN, CL_ERROR_DENIED))
 
@@ -272,8 +275,9 @@ class MacosLocationProviderTest {
 
   @Test
   fun managerConstructionFailureIsUnexpected() = runTest {
-    val client = FakeCoreLocationClient(createFailure = IllegalStateException("native failed"))
+    val client = FakeCoreLocationClient()
     val provider = MacosLocationProvider(client, Dispatchers.Unconfined)
+    client.createFailure = IllegalStateException("native failed")
 
     val event = assertIs<LocationEvent.Unavailable>(provider.updates(LocationRequest()).first())
     assertEquals(LocationUnavailableReason.UnexpectedFailure, event.reason)
@@ -283,13 +287,13 @@ class MacosLocationProviderTest {
   @Test
   fun overlappingPermissionRequestsStartOneAuthorizationRequest() {
     val client = FakeCoreLocationClient()
-    val requester = MacosLocationPermissionRequester(client)
+    val provider = MacosLocationProvider(client, Dispatchers.Unconfined)
     val manager = client.managers.single()
 
-    assertEquals(LocationPermission.NotGranted(canRequest = true), requester.status.value)
+    assertEquals(LocationPermission.NotGranted(canRequest = true), provider.permission.value)
 
-    requester.requestForegroundPermission()
-    requester.requestForegroundPermission()
+    provider.requestPermission()
+    provider.requestPermission()
     assertEquals(1, manager.whenInUseRequests)
     assertTrue(manager.updating)
 
@@ -297,14 +301,14 @@ class MacosLocationProviderTest {
     manager.boundDelegate?.didChangeAuthorization()
     assertEquals(
       LocationPermission.Granted(LocationAccuracyAuthorization.Precise),
-      requester.status.value,
+      provider.permission.value,
     )
     assertFalse(manager.updating)
 
-    requester.requestForegroundPermission()
+    provider.requestPermission()
     assertEquals(1, manager.whenInUseRequests)
 
-    requester.close()
+    provider.close()
     assertTrue(manager.closed)
     assertTrue(client.closed)
   }
@@ -312,46 +316,44 @@ class MacosLocationProviderTest {
   @Test
   fun permissionFailureClearsPendingRequest() {
     val client = FakeCoreLocationClient()
-    val requester = MacosLocationPermissionRequester(client)
+    val provider = MacosLocationProvider(client, Dispatchers.Unconfined)
     val manager = client.managers.single()
 
-    requester.requestForegroundPermission()
+    provider.requestPermission()
     assertEquals(1, manager.whenInUseRequests)
     assertTrue(manager.updating)
 
     manager.boundDelegate?.didFailWithError(CoreLocationError(CL_ERROR_DOMAIN, CL_ERROR_DENIED))
     assertFalse(manager.updating)
 
-    requester.requestForegroundPermission()
+    provider.requestPermission()
     assertEquals(2, manager.whenInUseRequests)
     assertTrue(manager.updating)
   }
 
   @Test
-  fun missingUsageDescriptionMarksProviderAndRequesterMisconfigured() = runTest {
+  fun missingUsageDescriptionMarksProviderMisconfigured() = runTest {
     val client = FakeCoreLocationClient(hasUsageDescription = false)
     val provider = MacosLocationProvider(client, Dispatchers.Unconfined)
-    val requester = MacosLocationPermissionRequester(client)
 
     assertIs<LocationBackendAvailability.Misconfigured>(provider.backendAvailability)
-    assertIs<LocationBackendAvailability.Misconfigured>(requester.backendAvailability)
     val event = assertIs<LocationEvent.Unavailable>(provider.updates(LocationRequest()).first())
     assertEquals(LocationUnavailableReason.Misconfigured, event.reason)
-    requester.requestForegroundPermission()
+    provider.requestPermission()
     assertEquals(0, client.managers.single().whenInUseRequests)
   }
 
   @Test
   fun deniedAuthorizationCannotBeRequestedAgain() {
     val client = FakeCoreLocationClient()
-    val requester = MacosLocationPermissionRequester(client)
+    val provider = MacosLocationProvider(client, Dispatchers.Unconfined)
     val manager = client.managers.single()
 
     manager.authorizationStatus = CL_AUTHORIZATION_DENIED
     manager.boundDelegate?.didChangeAuthorization()
-    requester.requestForegroundPermission()
+    provider.requestPermission()
 
-    assertEquals(LocationPermission.NotGranted(canRequest = false), requester.status.value)
+    assertEquals(LocationPermission.NotGranted(canRequest = false), provider.permission.value)
     assertEquals(0, manager.whenInUseRequests)
   }
 
@@ -410,7 +412,6 @@ private fun sampleFix(): CoreLocationFix =
 private class FakeCoreLocationClient(
   override var locationServicesEnabled: Boolean = true,
   hasUsageDescription: Boolean = true,
-  private val createFailure: Throwable? = null,
 ) : CoreLocationClient {
   override val backendAvailability: LocationBackendAvailability =
     if (hasUsageDescription) {
@@ -421,6 +422,7 @@ private class FakeCoreLocationClient(
   val managers = mutableListOf<FakeCoreLocationManager>()
   var closed = false
   var nextLocation: CoreLocationFix? = null
+  var createFailure: Throwable? = null
 
   override fun createManager(): CoreLocationManager {
     createFailure?.let { throw it }

--- a/lib/maplibre-compose-windows/src/main/kotlin/org/maplibre/compose/location/desktop/windows/WindowsLocationBackend.kt
+++ b/lib/maplibre-compose-windows/src/main/kotlin/org/maplibre/compose/location/desktop/windows/WindowsLocationBackend.kt
@@ -2,7 +2,6 @@ package org.maplibre.compose.location.desktop.windows
 
 import org.maplibre.compose.desktop.ComposeMapHost
 import org.maplibre.compose.location.DesktopLocationBackend
-import org.maplibre.compose.location.DesktopLocationPermissionRequester
 import org.maplibre.compose.location.DesktopLocationProvider
 
 /** Scaffold for the Windows desktop location backend. */
@@ -21,8 +20,4 @@ public class WindowsLocationBackend : DesktopLocationBackend {
 
   override fun createProvider(host: ComposeMapHost?): DesktopLocationProvider =
     error("The Windows location backend is not implemented")
-
-  override fun createPermissionRequester(
-    host: ComposeMapHost?
-  ): DesktopLocationPermissionRequester = error("The Windows location backend is not implemented")
 }

--- a/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/location/AndroidLocationPermissionRequester.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/location/AndroidLocationPermissionRequester.kt
@@ -19,23 +19,34 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
 /**
- * Foreground location permission requester for Android activities.
+ * Foreground location permission building block for Android.
  *
  * Fine and coarse permission map to [LocationPermission.Granted] with precise and approximate
  * accuracy. When permission is absent,
  * [`Activity.shouldShowRequestPermissionRationale`](https://developer.android.com/reference/android/app/Activity#shouldShowRequestPermissionRationale(java.lang.String))
  * maps `true` to [LocationPermission.NotGranted] with `canRequest = true`. Android returns `false`
- * both before the first request and after a permanent denial, so both map to `canRequest = null`.
+ * both before the first request and after a permanent denial, so both map to `canRequest = null`. A
+ * [context] that cannot reach an [Activity] also maps to `canRequest = null`, because the rationale
+ * check requires an activity.
+ *
+ * Android [LocationProvider] implementations hold a requester and expose [status] and
+ * [requestForegroundPermission] through [LocationProvider.permission] and
+ * [LocationProvider.requestPermission]. A requester created by
+ * [rememberAndroidLocationPermissionRequester] launches the system permission dialog and refreshes
+ * [status] when the application resumes. A requester that a provider constructs directly reports
+ * the permission at construction time until [refresh] is called, and its
+ * [requestForegroundPermission] does nothing.
+ *
+ * @param context Any [Context]; the permission status is read from the application package.
  */
-public class AndroidLocationPermissionRequester
-internal constructor(private val activity: Activity) : LocationPermissionRequester {
+public class AndroidLocationPermissionRequester(private val context: Context) {
   private val mutableStatus = MutableStateFlow(readStatus())
-  override val status: StateFlow<LocationPermission> = mutableStatus
+  public val status: StateFlow<LocationPermission> = mutableStatus
 
   private var requestPending = false
   internal var launchRequest: () -> Unit = {}
 
-  override fun requestForegroundPermission() {
+  public fun requestForegroundPermission() {
     val current = refresh()
     if (current is LocationPermission.Granted || requestPending) return
     requestPending = true
@@ -60,26 +71,28 @@ internal constructor(private val activity: Activity) : LocationPermissionRequest
 
   private fun readStatus(): LocationPermission =
     when {
-      activity.checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION) ==
+      context.checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION) ==
         PackageManager.PERMISSION_GRANTED ->
         LocationPermission.Granted(LocationAccuracyAuthorization.Precise)
-      activity.checkSelfPermission(Manifest.permission.ACCESS_COARSE_LOCATION) ==
+      context.checkSelfPermission(Manifest.permission.ACCESS_COARSE_LOCATION) ==
         PackageManager.PERMISSION_GRANTED ->
         LocationPermission.Granted(LocationAccuracyAuthorization.Approximate)
       else ->
         LocationPermission.NotGranted(
           canRequest =
-            if (
-              activity.shouldShowRequestPermissionRationale(
-                Manifest.permission.ACCESS_FINE_LOCATION
-              ) ||
+            context.findActivityOrNull()?.let { activity ->
+              if (
                 activity.shouldShowRequestPermissionRationale(
-                  Manifest.permission.ACCESS_COARSE_LOCATION
-                )
-            ) {
-              true
-            } else {
-              null
+                  Manifest.permission.ACCESS_FINE_LOCATION
+                ) ||
+                  activity.shouldShowRequestPermissionRationale(
+                    Manifest.permission.ACCESS_COARSE_LOCATION
+                  )
+              ) {
+                true
+              } else {
+                null
+              }
             }
         )
     }
@@ -90,8 +103,7 @@ internal constructor(private val activity: Activity) : LocationPermissionRequest
 public fun rememberAndroidLocationPermissionRequester(
   context: Context = LocalContext.current
 ): AndroidLocationPermissionRequester {
-  val activity = remember(context) { context.findActivity() }
-  val requester = remember(activity) { AndroidLocationPermissionRequester(activity) }
+  val requester = remember(context) { AndroidLocationPermissionRequester(context) }
   val lifecycleOwner = LocalLifecycleOwner.current
   val launcher =
     rememberLauncherForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) {
@@ -119,13 +131,9 @@ public fun rememberAndroidLocationPermissionRequester(
   return requester
 }
 
-@Composable
-public actual fun rememberDefaultLocationPermissionRequester(): LocationPermissionRequester =
-  rememberAndroidLocationPermissionRequester()
-
-private tailrec fun Context.findActivity(): Activity =
+internal tailrec fun Context.findActivityOrNull(): Activity? =
   when (this) {
     is Activity -> this
-    is ContextWrapper -> baseContext.findActivity()
-    else -> error("Location permission requests require an Activity context")
+    is ContextWrapper -> baseContext.findActivityOrNull()
+    else -> null
   }

--- a/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/location/AndroidLocationPermissionRequester.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/location/AndroidLocationPermissionRequester.kt
@@ -5,16 +5,16 @@ import android.app.Activity
 import android.content.Context
 import android.content.ContextWrapper
 import android.content.pm.PackageManager
-import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.ComponentActivity
+import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
-import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.LifecycleOwner
+import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -31,11 +31,13 @@ import kotlinx.coroutines.flow.StateFlow
  *
  * Android [LocationProvider] implementations hold a requester and expose [status] and
  * [requestForegroundPermission] through [LocationProvider.permission] and
- * [LocationProvider.requestPermission]. A requester created by
- * [rememberAndroidLocationPermissionRequester] launches the system permission dialog and refreshes
- * [status] when the application resumes. A requester that a provider constructs directly reports
- * the permission at construction time until [refresh] is called, and its
- * [requestForegroundPermission] does nothing.
+ * [LocationProvider.requestPermission].
+ *
+ * [requestForegroundPermission] registers a launcher on the activity's result registry at request
+ * time, so a directly constructed requester is fully functional when [context] can reach a
+ * [ComponentActivity]. When it cannot, such as with a service context,
+ * [requestForegroundPermission] does nothing and [status] stays accurate. [status] refreshes when
+ * the resolved activity resumes.
  *
  * @param context Any [Context]; the permission status is read from the application package.
  */
@@ -44,23 +46,44 @@ public class AndroidLocationPermissionRequester(private val context: Context) {
   public val status: StateFlow<LocationPermission> = mutableStatus
 
   private var requestPending = false
-  internal var launchRequest: () -> Unit = {}
+
+  init {
+    (context.findActivityOrNull() as? LifecycleOwner)
+      ?.lifecycle
+      ?.addObserver(
+        LifecycleEventObserver { _, event ->
+          if (event == Lifecycle.Event.ON_RESUME) refresh()
+        }
+      )
+  }
 
   public fun requestForegroundPermission() {
     val current = refresh()
     if (current is LocationPermission.Granted || requestPending) return
+    val activity = context.findActivityOrNull() as? ComponentActivity ?: return
     requestPending = true
+    lateinit var launcher: ActivityResultLauncher<Array<String>>
+    launcher =
+      activity.activityResultRegistry.register(
+        "org.maplibre.compose.location.permission.${nextKey.getAndIncrement()}",
+        ActivityResultContracts.RequestMultiplePermissions(),
+      ) {
+        requestPending = false
+        refresh()
+        launcher.unregister()
+      }
     try {
-      launchRequest()
+      launcher.launch(
+        arrayOf(
+          Manifest.permission.ACCESS_FINE_LOCATION,
+          Manifest.permission.ACCESS_COARSE_LOCATION,
+        )
+      )
     } catch (error: Throwable) {
       requestPending = false
+      launcher.unregister()
       throw error
     }
-  }
-
-  internal fun onRequestResult() {
-    refresh()
-    requestPending = false
   }
 
   public fun refresh(): LocationPermission {
@@ -96,40 +119,18 @@ public class AndroidLocationPermissionRequester(private val context: Context) {
             }
         )
     }
+
+  private companion object {
+    private val nextKey = AtomicInteger()
+  }
 }
 
-/** Creates the permission requester used by Android location providers. */
+/** Remembers the permission requester used by Android location providers. */
 @Composable
 public fun rememberAndroidLocationPermissionRequester(
   context: Context = LocalContext.current
-): AndroidLocationPermissionRequester {
-  val requester = remember(context) { AndroidLocationPermissionRequester(context) }
-  val lifecycleOwner = LocalLifecycleOwner.current
-  val launcher =
-    rememberLauncherForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) {
-      requester.onRequestResult()
-    }
-
-  SideEffect {
-    requester.launchRequest = {
-      launcher.launch(
-        arrayOf(
-          Manifest.permission.ACCESS_FINE_LOCATION,
-          Manifest.permission.ACCESS_COARSE_LOCATION,
-        )
-      )
-    }
-  }
-  DisposableEffect(lifecycleOwner, requester) {
-    val observer = LifecycleEventObserver { _, event ->
-      if (event == Lifecycle.Event.ON_RESUME) requester.refresh()
-    }
-    lifecycleOwner.lifecycle.addObserver(observer)
-    requester.refresh()
-    onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
-  }
-  return requester
-}
+): AndroidLocationPermissionRequester =
+  remember(context) { AndroidLocationPermissionRequester(context) }
 
 internal tailrec fun Context.findActivityOrNull(): Activity? =
   when (this) {

--- a/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/location/AndroidLocationProvider.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/location/AndroidLocationProvider.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.callbackFlow
 import org.maplibre.spatialk.units.extensions.inMeters
 
@@ -49,10 +50,31 @@ import org.maplibre.spatialk.units.extensions.inMeters
  * selected provider maps to [LocationUnavailableReason.UnexpectedFailure], because this provider
  * constructs and validates every request argument itself.
  *
+ * A provider created by [rememberAndroidLocationProvider] launches the system permission dialog
+ * from [requestPermission] and refreshes [permission] when the application resumes. A directly
+ * constructed provider still reports [permission], but its [requestPermission] does nothing.
+ *
  * @param context Context used to obtain the platform [LocationManager].
+ * @param requester Permission requester that backs [permission] and [requestPermission].
  */
-public class AndroidLocationProvider(context: Context) : LocationProvider {
+public class AndroidLocationProvider
+internal constructor(context: Context, private val requester: AndroidLocationPermissionRequester) :
+  LocationProvider {
   private val context: Context = context.applicationContext
+
+  /**
+   * Creates a provider with its own permission requester.
+   *
+   * The provider reports [permission], but its [requestPermission] does nothing, because the
+   * requester is not wired to an activity result launcher. [rememberAndroidLocationProvider]
+   * creates a provider that can launch the system permission dialog.
+   */
+  public constructor(context: Context) : this(context, AndroidLocationPermissionRequester(context))
+
+  override val permission: StateFlow<LocationPermission>
+    get() = requester.status
+
+  override fun requestPermission(): Unit = requester.requestForegroundPermission()
 
   @RequiresPermission(
     anyOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION]
@@ -218,7 +240,10 @@ public actual fun rememberDefaultLocationProvider(): LocationProvider =
 @Composable
 public fun rememberAndroidLocationProvider(
   context: Context = LocalContext.current
-): AndroidLocationProvider = remember(context) { AndroidLocationProvider(context) }
+): AndroidLocationProvider {
+  val requester = rememberAndroidLocationPermissionRequester(context)
+  return remember(context, requester) { AndroidLocationProvider(context, requester) }
+}
 
 private fun Context.hasLocationPermission(): Boolean =
   checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION) ==

--- a/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/location/AndroidLocationProvider.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/location/AndroidLocationProvider.kt
@@ -50,9 +50,8 @@ import org.maplibre.spatialk.units.extensions.inMeters
  * selected provider maps to [LocationUnavailableReason.UnexpectedFailure], because this provider
  * constructs and validates every request argument itself.
  *
- * A provider created by [rememberAndroidLocationProvider] launches the system permission dialog
- * from [requestPermission] and refreshes [permission] when the application resumes. A directly
- * constructed provider still reports [permission], but its [requestPermission] does nothing.
+ * [permission] and [requestPermission] delegate to an [AndroidLocationPermissionRequester]; see its
+ * documentation for when the system permission dialog can be shown.
  *
  * @param context Context used to obtain the platform [LocationManager].
  * @param requester Permission requester that backs [permission] and [requestPermission].
@@ -62,13 +61,7 @@ internal constructor(context: Context, private val requester: AndroidLocationPer
   LocationProvider {
   private val context: Context = context.applicationContext
 
-  /**
-   * Creates a provider with its own permission requester.
-   *
-   * The provider reports [permission], but its [requestPermission] does nothing, because the
-   * requester is not wired to an activity result launcher. [rememberAndroidLocationProvider]
-   * creates a provider that can launch the system permission dialog.
-   */
+  /** Creates a provider with its own [AndroidLocationPermissionRequester]. */
   public constructor(context: Context) : this(context, AndroidLocationPermissionRequester(context))
 
   override val permission: StateFlow<LocationPermission>

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/location/LocationProvider.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/location/LocationProvider.kt
@@ -17,7 +17,9 @@ import org.maplibre.spatialk.units.extensions.meters
  *
  * If you have a more general use case, prefer using the platform APIs directly or using a more
  * powerful wrapper. In that case, you may want to provide your own [LocationProvider]
- * implementation to unify the API underneath. This is an explicitly supported use case.
+ * implementation to unify the API underneath. This is an explicitly supported use case:
+ * [permission] defaults to granted, so a source where permission is not a concept needs no
+ * permission handling.
  *
  * Each collector of [updates] starts an independent platform location request. Cancelling
  * collection must stop that request and unregister its callbacks.
@@ -28,6 +30,28 @@ public interface LocationProvider {
     get() = LocationBackendAvailability.Available
 
   /**
+   * Current foreground location permission.
+   *
+   * This value also reflects changes made outside the application when the platform reports them.
+   *
+   * The default is always [LocationPermission.Granted] at [LocationAccuracyAuthorization.Unknown].
+   * A source where permission is not a concept, such as an external receiver or a network feed,
+   * keeps the default and needs no permission handling.
+   */
+  public val permission: StateFlow<LocationPermission>
+    get() = AlwaysGrantedLocationPermission
+
+  /**
+   * Starts a foreground permission request and returns immediately.
+   *
+   * The result is published to [permission]. Calls made while a request is active must not start
+   * another platform request.
+   *
+   * The default does nothing, to match the default [permission] that is always granted.
+   */
+  public fun requestPermission(): Unit = Unit
+
+  /**
    * Returns a cold stream of foreground location updates.
    *
    * Each collector starts an independent platform location request. Cancelling collection stops
@@ -36,8 +60,11 @@ public interface LocationProvider {
   public fun updates(request: LocationRequest): Flow<LocationEvent>
 }
 
+private val AlwaysGrantedLocationPermission: StateFlow<LocationPermission> =
+  MutableStateFlow(LocationPermission.Granted(LocationAccuracyAuthorization.Unknown))
+
 /**
- * Whether a location provider or permission requester has a usable platform implementation.
+ * Whether a location implementation has a usable platform backend.
  *
  * This describes application and backend setup. It does not describe location permission, system
  * location services, or whether the next request can obtain a fix.
@@ -206,38 +233,6 @@ public sealed interface LocationPermission {
   public data class NotGranted(val canRequest: Boolean?) : LocationPermission
 }
 
-/** Observes foreground location permission and starts platform permission requests. */
-public interface LocationPermissionRequester {
-  /** Whether this requester has a usable platform implementation. */
-  public val backendAvailability: LocationBackendAvailability
-    get() = LocationBackendAvailability.Available
-
-  /**
-   * Current foreground location permission.
-   *
-   * This value also reflects changes made outside the application when the platform reports them.
-   */
-  public val status: StateFlow<LocationPermission>
-
-  /**
-   * Starts a foreground permission request and returns immediately.
-   *
-   * The result is published to [status]. Calls made while a request is active must not start
-   * another platform request.
-   */
-  public fun requestForegroundPermission()
-}
-
-internal object UnsupportedLocationPermissionRequester : LocationPermissionRequester {
-  override val backendAvailability: LocationBackendAvailability =
-    LocationBackendAvailability.Unsupported
-
-  override val status: StateFlow<LocationPermission> =
-    MutableStateFlow(LocationPermission.NotGranted(canRequest = null))
-
-  override fun requestForegroundPermission() = Unit
-}
-
 /** A provider for a target or host that has no installed location implementation. */
 public object UnsupportedLocationProvider : LocationProvider {
   override val backendAvailability: LocationBackendAvailability =
@@ -264,23 +259,3 @@ public object UnsupportedLocationProvider : LocationProvider {
  * [DesktopLocationBackend][org.maplibre.compose.location.DesktopLocationBackend].
  */
 @Composable public expect fun rememberDefaultLocationProvider(): LocationProvider
-
-/**
- * Creates and remembers the default foreground location permission requester.
- *
- * An unsupported target or host returns a requester whose
- * [LocationPermissionRequester.backendAvailability] is [LocationBackendAvailability.Unsupported]
- * instead of throwing during composition.
- *
- * See
- * [rememberAndroidLocationPermissionRequester][org.maplibre.compose.location.rememberAndroidLocationPermissionRequester],
- * [rememberBrowserLocationPermissionRequester][org.maplibre.compose.location.rememberBrowserLocationPermissionRequester],
- * [rememberIosLocationPermissionRequester][org.maplibre.compose.location.rememberIosLocationPermissionRequester],
- * [LinuxPortalLocationPermissionRequester][org.maplibre.compose.location.desktop.linux.LinuxPortalLocationPermissionRequester],
- * and
- * [MacosLocationPermissionRequester][org.maplibre.compose.location.desktop.macos.MacosLocationPermissionRequester].
- * Desktop implementations are installed through
- * [DesktopLocationBackend][org.maplibre.compose.location.DesktopLocationBackend].
- */
-@Composable
-public expect fun rememberDefaultLocationPermissionRequester(): LocationPermissionRequester

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/location/LocationState.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/location/LocationState.kt
@@ -88,13 +88,13 @@ public sealed interface LocationTrackingStatus {
  * Location updates are collected while [enabled] is `true` and the lifecycle is active. This
  * function never requests permission automatically; the application chooses when to call
  * [LocationState.requestPermission]. Stopping collection releases the platform request while
- * retaining the last measurements in [LocationState]. An unsupported or misconfigured provider or
- * permission requester is reported through [LocationState.status] before permission is requested.
+ * retaining the last measurements in [LocationState]. An unsupported or misconfigured provider is
+ * reported through [LocationState.status] before permission is requested.
  *
  * @param enabled Whether location and orientation updates should run while lifecycle-active.
- * @param provider The [LocationProvider] to use for obtaining location updates.
- * @param permissionRequester The requester used to observe and request foreground location
- *   permission.
+ * @param provider The [LocationProvider] to use for obtaining location updates and for observing
+ *   and requesting foreground location permission. A custom provider whose
+ *   [LocationProvider.permission] keeps the granted default needs no permission handling.
  * @param request Preferences for location updates.
  * @param orientationProvider The optional [OrientationProvider] to use for obtaining device
  *   orientation updates. By default, a provider that emits no orientation updates is used, meaning
@@ -111,25 +111,22 @@ public sealed interface LocationTrackingStatus {
 public fun rememberLocationState(
   enabled: Boolean = true,
   provider: LocationProvider = rememberDefaultLocationProvider(),
-  permissionRequester: LocationPermissionRequester = rememberDefaultLocationPermissionRequester(),
   request: LocationRequest = LocationRequest(),
   orientationProvider: OrientationProvider = rememberNullOrientationProvider(),
   lifecycleOwner: LifecycleOwner = LocalLifecycleOwner.current,
   minActiveState: Lifecycle.State = Lifecycle.State.STARTED,
   coroutineContext: CoroutineContext = EmptyCoroutineContext,
 ): LocationState {
-  val state =
-    remember(provider, permissionRequester) { LocationState(permissionRequester.status.value) }
-  val permission by permissionRequester.status.collectAsState()
+  val state = remember(provider) { LocationState(provider.permission.value) }
+  val permission by provider.permission.collectAsState()
   SideEffect {
     state.permission = permission
-    state.requestPermissionAction = permissionRequester::requestForegroundPermission
+    state.requestPermissionAction = provider::requestPermission
   }
 
   LaunchedEffect(
     enabled,
     provider,
-    permissionRequester,
     request,
     permission,
     state,
@@ -137,66 +134,64 @@ public fun rememberLocationState(
     minActiveState,
     coroutineContext,
   ) {
-    val backendAvailability =
-      listOf(provider.backendAvailability, permissionRequester.backendAvailability)
-    val misconfiguration =
-      backendAvailability
-        .filterIsInstance<LocationBackendAvailability.Misconfigured>()
-        .firstOrNull()
-    when {
-      misconfiguration != null -> {
+    when (val availability = provider.backendAvailability) {
+      is LocationBackendAvailability.Misconfigured -> {
         state.status =
           LocationTrackingStatus.Unavailable(
             LocationUnavailableReason.Misconfigured,
-            misconfiguration.cause,
+            availability.cause,
           )
       }
-      LocationBackendAvailability.Unsupported in backendAvailability -> {
+      LocationBackendAvailability.Unsupported -> {
         state.status = LocationTrackingStatus.Unavailable(LocationUnavailableReason.Unsupported)
       }
-      !enabled -> state.status = LocationTrackingStatus.Stopped
-      permission !is LocationPermission.Granted -> {
-        state.status = LocationTrackingStatus.WaitingForPermission
-      }
-      else -> {
-        state.status = LocationTrackingStatus.Stopped
-        lifecycleOwner.lifecycle.repeatOnLifecycle(minActiveState) {
-          try {
-            state.status = LocationTrackingStatus.Starting
-            val collectSession: suspend () -> Unit = {
-              provider
-                .updates(request)
-                .catch { error ->
-                  if (error is CancellationException) throw error
-                  emit(
-                    LocationEvent.Unavailable(
-                      LocationUnavailableReason.UnexpectedFailure,
-                      error,
-                    )
-                  )
-                }
-                .collect { event ->
-                  when (event) {
-                    is LocationEvent.Fix -> state.accept(event)
-                    is LocationEvent.Unavailable ->
-                      state.status = LocationTrackingStatus.Unavailable(event.reason, event.cause)
-                  }
-                }
-            }
-            if (coroutineContext == EmptyCoroutineContext) collectSession()
-            else withContext(coroutineContext) { collectSession() }
-            if (
-              state.status == LocationTrackingStatus.Starting ||
-                state.status == LocationTrackingStatus.Tracking
-            ) {
-              state.status = LocationTrackingStatus.Stopped
-            }
-          } catch (error: CancellationException) {
+      LocationBackendAvailability.Available ->
+        when {
+          !enabled -> state.status = LocationTrackingStatus.Stopped
+          permission !is LocationPermission.Granted -> {
+            state.status = LocationTrackingStatus.WaitingForPermission
+          }
+          else -> {
             state.status = LocationTrackingStatus.Stopped
-            throw error
+            lifecycleOwner.lifecycle.repeatOnLifecycle(minActiveState) {
+              try {
+                state.status = LocationTrackingStatus.Starting
+                val collectSession: suspend () -> Unit = {
+                  provider
+                    .updates(request)
+                    .catch { error ->
+                      if (error is CancellationException) throw error
+                      emit(
+                        LocationEvent.Unavailable(
+                          LocationUnavailableReason.UnexpectedFailure,
+                          error,
+                        )
+                      )
+                    }
+                    .collect { event ->
+                      when (event) {
+                        is LocationEvent.Fix -> state.accept(event)
+                        is LocationEvent.Unavailable ->
+                          state.status =
+                            LocationTrackingStatus.Unavailable(event.reason, event.cause)
+                      }
+                    }
+                }
+                if (coroutineContext == EmptyCoroutineContext) collectSession()
+                else withContext(coroutineContext) { collectSession() }
+                if (
+                  state.status == LocationTrackingStatus.Starting ||
+                    state.status == LocationTrackingStatus.Tracking
+                ) {
+                  state.status = LocationTrackingStatus.Stopped
+                }
+              } catch (error: CancellationException) {
+                state.status = LocationTrackingStatus.Stopped
+                throw error
+              }
+            }
           }
         }
-      }
     }
   }
 

--- a/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/location/IosLocationPermissionRequester.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/location/IosLocationPermissionRequester.kt
@@ -15,7 +15,11 @@ import platform.CoreLocation.kCLAuthorizationStatusRestricted
 import platform.darwin.NSObject
 
 /**
- * Foreground Core Location permission requester.
+ * Foreground Core Location permission holder.
+ *
+ * [IosLocationProvider] delegates [LocationProvider.permission] and
+ * [LocationProvider.requestPermission] to an instance of this class. Use it directly when a custom
+ * provider needs the same Core Location permission behavior.
  *
  * [`CLAuthorizationStatus`](https://developer.apple.com/documentation/corelocation/clauthorizationstatus)
  * maps an authorized status to [LocationPermission.Granted], `notDetermined` to
@@ -24,10 +28,12 @@ import platform.darwin.NSObject
  * [`CLLocationManager.accuracyAuthorization`](https://developer.apple.com/documentation/corelocation/cllocationmanager/accuracyauthorization)
  * distinguishes precise from approximate grants.
  */
-public class IosLocationPermissionRequester : LocationPermissionRequester {
+public class IosLocationPermissionRequester {
   private val mutableStatus =
     MutableStateFlow<LocationPermission>(LocationPermission.NotGranted(canRequest = null))
-  override val status: StateFlow<LocationPermission> = mutableStatus
+
+  /** Current foreground location permission, updated when Core Location reports a change. */
+  public val status: StateFlow<LocationPermission> = mutableStatus
   private var requestPending = false
 
   private val delegate =
@@ -45,7 +51,11 @@ public class IosLocationPermissionRequester : LocationPermissionRequester {
     mutableStatus.value = readStatus(manager)
   }
 
-  override fun requestForegroundPermission() {
+  /**
+   * Starts a foreground permission request and returns immediately. The result is published to
+   * [status].
+   */
+  public fun requestForegroundPermission() {
     val current = readStatus(manager)
     if (current != LocationPermission.NotGranted(canRequest = true) || requestPending) return
     requestPending = true
@@ -74,7 +84,3 @@ public class IosLocationPermissionRequester : LocationPermissionRequester {
 public fun rememberIosLocationPermissionRequester(): IosLocationPermissionRequester = remember {
   IosLocationPermissionRequester()
 }
-
-@Composable
-public actual fun rememberDefaultLocationPermissionRequester(): LocationPermissionRequester =
-  rememberIosLocationPermissionRequester()

--- a/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/location/IosLocationProvider.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/location/IosLocationProvider.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.flowOn
 import org.maplibre.spatialk.units.extensions.inMeters
@@ -28,6 +29,9 @@ import platform.darwin.NSObject
 /**
  * A [LocationProvider] built on
  * [`CLLocationManager`](https://developer.apple.com/documentation/corelocation/cllocationmanager).
+ *
+ * [LocationProvider.permission] and [LocationProvider.requestPermission] delegate to an
+ * [IosLocationPermissionRequester].
  *
  * Each collection creates a
  * [`CLLocationManager`](https://developer.apple.com/documentation/corelocation/cllocationmanager)
@@ -56,6 +60,13 @@ import platform.darwin.NSObject
  * [LocationUnavailableReason.UnexpectedFailure].
  */
 public class IosLocationProvider : LocationProvider {
+  private val requester = IosLocationPermissionRequester()
+
+  override val permission: StateFlow<LocationPermission>
+    get() = requester.status
+
+  override fun requestPermission(): Unit = requester.requestForegroundPermission()
+
   override fun updates(request: LocationRequest): Flow<LocationEvent> = callbackFlow {
     if (!CLLocationManager.locationServicesEnabled()) {
       trySend(LocationEvent.Unavailable(LocationUnavailableReason.ServicesDisabled))

--- a/lib/maplibre-compose/src/iosTest/kotlin/org/maplibre/compose/location/IosLocationProviderTest.kt
+++ b/lib/maplibre-compose/src/iosTest/kotlin/org/maplibre/compose/location/IosLocationProviderTest.kt
@@ -10,6 +10,14 @@ import platform.Foundation.NSError
 
 class IosLocationProviderTest {
   @Test
+  fun exposesPermissionFromItsRequester() {
+    assertEquals(
+      IosLocationPermissionRequester().status.value,
+      IosLocationProvider().permission.value,
+    )
+  }
+
+  @Test
   fun mapsCoreLocationErrorsByRecoverability() {
     assertEquals(
       LocationUnavailableReason.ServicesDisabled,

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/location/BrowserLocationProvider.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/location/BrowserLocationProvider.kt
@@ -12,6 +12,8 @@ import kotlin.time.Instant
 import kotlin.time.TimeSource
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
@@ -60,10 +62,24 @@ import web.permissions.query
  * [`TIMEOUT`](https://developer.mozilla.org/en-US/docs/Web/API/GeolocationPositionError/code#geolocationpositionerror.timeout)
  * map to [LocationUnavailableReason.TemporarilyUnavailable]. An exception thrown while starting the
  * live watch maps to [LocationUnavailableReason.UnexpectedFailure].
+ *
+ * [LocationProvider.permission] and [LocationProvider.requestPermission] delegate to a
+ * [BrowserLocationPermissionRequester] that shares the provider's boundary, so a permission denial
+ * during an active watch updates [LocationProvider.permission].
  */
 public class BrowserLocationProvider
-internal constructor(private val boundary: BrowserGeolocationBoundary) : LocationProvider {
-  public constructor() : this(BrowserGeolocation)
+internal constructor(
+  private val boundary: BrowserGeolocationBoundary,
+  coroutineScope: CoroutineScope,
+) : LocationProvider {
+  /**
+   * Creates a provider that observes permission in a coroutine scope that lives as long as the
+   * provider.
+   */
+  public constructor() :
+    this(BrowserGeolocation, CoroutineScope(SupervisorJob() + Dispatchers.Default))
+
+  private val requester = BrowserLocationPermissionRequester(boundary, coroutineScope)
 
   override val backendAvailability: LocationBackendAvailability =
     if (boundary.supported) {
@@ -71,6 +87,11 @@ internal constructor(private val boundary: BrowserGeolocationBoundary) : Locatio
     } else {
       LocationBackendAvailability.Unsupported
     }
+
+  override val permission: StateFlow<LocationPermission>
+    get() = requester.status
+
+  override fun requestPermission(): Unit = requester.requestForegroundPermission()
 
   override fun updates(request: LocationRequest): Flow<LocationEvent> = callbackFlow {
     if (!boundary.supported) {
@@ -119,7 +140,8 @@ internal constructor(private val boundary: BrowserGeolocationBoundary) : Locatio
 /** Creates and remembers the browser location provider. */
 @Composable
 public fun rememberBrowserLocationProvider(): BrowserLocationProvider {
-  return remember { BrowserLocationProvider() }
+  val scope = rememberCoroutineScope()
+  return remember(scope) { BrowserLocationProvider(BrowserGeolocation, scope) }
 }
 
 @Composable
@@ -127,26 +149,40 @@ public actual fun rememberDefaultLocationProvider(): LocationProvider =
   rememberBrowserLocationProvider()
 
 @Composable
-public actual fun rememberDefaultLocationPermissionRequester(): LocationPermissionRequester =
-  rememberBrowserLocationPermissionRequester()
-
-@Composable
 public actual fun rememberDefaultOrientationProvider(
   updateInterval: Duration
 ): OrientationProvider = NullOrientationProvider
 
-/** Observes and requests browser geolocation permission. */
-internal class BrowserLocationPermissionRequester(
+/**
+ * Observes and requests browser geolocation permission.
+ *
+ * [BrowserLocationProvider] delegates [LocationProvider.permission] and
+ * [LocationProvider.requestPermission] to an instance of this class. Construct one with a
+ * [CoroutineScope] to back a custom [LocationProvider], or use
+ * [rememberBrowserLocationPermissionRequester] to bind permission observation to the composition.
+ */
+public class BrowserLocationPermissionRequester
+internal constructor(
   private val boundary: BrowserGeolocationBoundary,
   private val coroutineScope: CoroutineScope,
-) : LocationPermissionRequester {
-  override val backendAvailability: LocationBackendAvailability =
+) {
+  /**
+   * Creates a requester whose permission observation runs in [coroutineScope]. Cancelling the scope
+   * stops the observation.
+   */
+  public constructor(coroutineScope: CoroutineScope) : this(BrowserGeolocation, coroutineScope)
+
+  /** Whether the browser has a usable Geolocation API. */
+  public val backendAvailability: LocationBackendAvailability =
     if (boundary.supported) {
       LocationBackendAvailability.Available
     } else {
       LocationBackendAvailability.Unsupported
     }
-  override val status: StateFlow<LocationPermission> = boundary.permissionState.status
+
+  /** Current foreground location permission. */
+  public val status: StateFlow<LocationPermission> = boundary.permissionState.status
+
   private var requestPending = false
 
   init {
@@ -158,7 +194,13 @@ internal class BrowserLocationPermissionRequester(
     }
   }
 
-  override fun requestForegroundPermission() {
+  /**
+   * Starts a foreground permission request and returns immediately.
+   *
+   * The result is published to [status]. Calls made while a request is active do not start another
+   * browser request.
+   */
+  public fun requestForegroundPermission() {
     val current = status.value
     if (
       !boundary.supported ||
@@ -211,11 +253,11 @@ internal class BrowserLocationPermissionRequester(
  * maps `granted` to [LocationPermission.Granted], `prompt` to [LocationPermission.NotGranted] with
  * `canRequest = true`, and `denied` to `canRequest = false`. A browser without the Permissions API
  * reports `canRequest = null` until an explicit request determines the result. A missing
- * Geolocation API maps [LocationPermissionRequester.backendAvailability] to
+ * Geolocation API maps [BrowserLocationPermissionRequester.backendAvailability] to
  * [LocationBackendAvailability.Unsupported].
  */
 @Composable
-public fun rememberBrowserLocationPermissionRequester(): LocationPermissionRequester {
+public fun rememberBrowserLocationPermissionRequester(): BrowserLocationPermissionRequester {
   val scope = rememberCoroutineScope()
   return remember(scope) { BrowserLocationPermissionRequester(BrowserGeolocation, scope) }
 }

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/location/BrowserLocationProviderTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/location/BrowserLocationProviderTest.kt
@@ -21,14 +21,12 @@ import org.maplibre.spatialk.units.extensions.inMeters
 @OptIn(ExperimentalCoroutinesApi::class)
 class BrowserLocationProviderTest {
   @Test
-  fun missingGeolocationMarksProviderAndRequesterUnsupported() = runTest {
+  fun missingGeolocationMarksProviderUnsupported() = runTest {
     val boundary = FakeBrowserGeolocationBoundary(supported = false)
-    val provider = BrowserLocationProvider(boundary)
-    val requester = BrowserLocationPermissionRequester(boundary, backgroundScope)
+    val provider = BrowserLocationProvider(boundary, backgroundScope)
 
     assertEquals(LocationBackendAvailability.Unsupported, provider.backendAvailability)
-    assertEquals(LocationBackendAvailability.Unsupported, requester.backendAvailability)
-    requester.requestForegroundPermission()
+    provider.requestPermission()
     runCurrent()
     assertEquals(emptyList(), boundary.requestedOptions)
   }
@@ -36,7 +34,7 @@ class BrowserLocationProviderTest {
   @Test
   fun watchMapsCoordinatesThrottlesUpdatesAndStopsOnCancellation() = runTest {
     val boundary = FakeBrowserGeolocationBoundary()
-    val provider = BrowserLocationProvider(boundary)
+    val provider = BrowserLocationProvider(boundary, backgroundScope)
     val events = mutableListOf<LocationEvent>()
     val request = LocationRequest(minimumInterval = 1.seconds)
 
@@ -68,7 +66,7 @@ class BrowserLocationProviderTest {
   @Test
   fun browserErrorsBecomeTypedEvents() = runTest {
     val boundary = FakeBrowserGeolocationBoundary()
-    val provider = BrowserLocationProvider(boundary)
+    val provider = BrowserLocationProvider(boundary, backgroundScope)
     val events = mutableListOf<LocationEvent>()
     runCurrent()
     backgroundScope.launch { provider.updates(LocationRequest()).collect(events::add) }
@@ -93,16 +91,15 @@ class BrowserLocationProviderTest {
   @Test
   fun watchPermissionDenialUpdatesPermissionState() = runTest {
     val boundary = FakeBrowserGeolocationBoundary()
-    val provider = BrowserLocationProvider(boundary)
-    val requester = BrowserLocationPermissionRequester(boundary, backgroundScope)
+    val provider = BrowserLocationProvider(boundary, backgroundScope)
     backgroundScope.launch { provider.updates(LocationRequest()).collect {} }
     runCurrent()
 
     boundary.send(BrowserResult.Error(BrowserError.PermissionDenied))
     runCurrent()
 
-    assertEquals(LocationPermission.NotGranted(canRequest = null), requester.status.value)
-    requester.requestForegroundPermission()
+    assertEquals(LocationPermission.NotGranted(canRequest = null), provider.permission.value)
+    provider.requestPermission()
     runCurrent()
     assertEquals(1, boundary.requestedOptions.size)
     assertEquals(1, boundary.stopCount)
@@ -111,7 +108,7 @@ class BrowserLocationProviderTest {
   @Test
   fun nonFiniteHeadingsAreNotPublishedAsCourse() = runTest {
     val boundary = FakeBrowserGeolocationBoundary()
-    val provider = BrowserLocationProvider(boundary)
+    val provider = BrowserLocationProvider(boundary, backgroundScope)
     val events = mutableListOf<LocationEvent>()
     backgroundScope.launch { provider.updates(LocationRequest()).collect(events::add) }
     runCurrent()
@@ -129,7 +126,7 @@ class BrowserLocationProviderTest {
   @Test
   fun firstFixAfterTransientErrorBypassesUpdateThrottle() = runTest {
     val boundary = FakeBrowserGeolocationBoundary()
-    val provider = BrowserLocationProvider(boundary)
+    val provider = BrowserLocationProvider(boundary, backgroundScope)
     val events = mutableListOf<LocationEvent>()
     backgroundScope.launch {
       provider.updates(LocationRequest(minimumInterval = 10.seconds)).collect(events::add)
@@ -148,27 +145,27 @@ class BrowserLocationProviderTest {
   }
 
   @Test
-  fun permissionRequesterObservesAndExplicitlyRequestsPermission() = runTest {
+  fun providerObservesAndExplicitlyRequestsPermission() = runTest {
     val boundary = FakeBrowserGeolocationBoundary()
     boundary.permission.value = BrowserPermission.Prompt
-    val requester = BrowserLocationPermissionRequester(boundary, backgroundScope)
+    val provider = BrowserLocationProvider(boundary, backgroundScope)
     runCurrent()
-    assertEquals(LocationPermission.NotGranted(canRequest = true), requester.status.value)
+    assertEquals(LocationPermission.NotGranted(canRequest = true), provider.permission.value)
 
     boundary.permission.value = BrowserPermission.Granted
     runCurrent()
     assertEquals(
       LocationPermission.Granted(LocationAccuracyAuthorization.Unknown),
-      requester.status.value,
+      provider.permission.value,
     )
 
     boundary.permission.value = BrowserPermission.Prompt
     boundary.requestPositionAction = { BrowserResult.Error(BrowserError.PermissionDenied) }
     runCurrent()
-    requester.requestForegroundPermission()
+    provider.requestPermission()
     runCurrent()
-    assertEquals(LocationPermission.NotGranted(canRequest = true), requester.status.value)
-    requester.requestForegroundPermission()
+    assertEquals(LocationPermission.NotGranted(canRequest = true), provider.permission.value)
+    provider.requestPermission()
     runCurrent()
     assertEquals(2, boundary.requestedOptions.size)
     assertEquals(listOf(1.seconds, 1.seconds), boundary.requestedOptions.map { it.timeout })
@@ -179,15 +176,15 @@ class BrowserLocationProviderTest {
     val boundary = FakeBrowserGeolocationBoundary()
     boundary.permission.value = BrowserPermission.Unknown
     boundary.requestPositionAction = { BrowserResult.Error(BrowserError.PositionUnavailable) }
-    val requester = BrowserLocationPermissionRequester(boundary, backgroundScope)
+    val provider = BrowserLocationProvider(boundary, backgroundScope)
     runCurrent()
 
-    assertEquals(LocationPermission.NotGranted(canRequest = null), requester.status.value)
-    requester.requestForegroundPermission()
+    assertEquals(LocationPermission.NotGranted(canRequest = null), provider.permission.value)
+    provider.requestPermission()
     runCurrent()
     assertEquals(
       LocationPermission.Granted(LocationAccuracyAuthorization.Unknown),
-      requester.status.value,
+      provider.permission.value,
     )
   }
 
@@ -197,11 +194,11 @@ class BrowserLocationProviderTest {
     boundary.permission.value = BrowserPermission.Prompt
     val result = CompletableDeferred<BrowserResult>()
     boundary.requestPositionAction = { result.await() }
-    val requester = BrowserLocationPermissionRequester(boundary, backgroundScope)
+    val provider = BrowserLocationProvider(boundary, backgroundScope)
     runCurrent()
 
-    requester.requestForegroundPermission()
-    requester.requestForegroundPermission()
+    provider.requestPermission()
+    provider.requestPermission()
     runCurrent()
 
     assertEquals(1, boundary.requestedOptions.size)
@@ -209,7 +206,7 @@ class BrowserLocationProviderTest {
     runCurrent()
     assertEquals(
       LocationPermission.Granted(LocationAccuracyAuthorization.Unknown),
-      requester.status.value,
+      provider.permission.value,
     )
   }
 
@@ -222,20 +219,20 @@ class BrowserLocationProviderTest {
       if (fail) error("geolocation failed")
       position(milliseconds = 0, longitude = 0.0)
     }
-    val requester = BrowserLocationPermissionRequester(boundary, backgroundScope)
+    val provider = BrowserLocationProvider(boundary, backgroundScope)
     runCurrent()
 
-    requester.requestForegroundPermission()
+    provider.requestPermission()
     runCurrent()
-    assertEquals(LocationPermission.NotGranted(canRequest = null), requester.status.value)
+    assertEquals(LocationPermission.NotGranted(canRequest = null), provider.permission.value)
 
     fail = false
-    requester.requestForegroundPermission()
+    provider.requestPermission()
     runCurrent()
     assertEquals(2, boundary.requestedOptions.size)
     assertEquals(
       LocationPermission.Granted(LocationAccuracyAuthorization.Unknown),
-      requester.status.value,
+      provider.permission.value,
     )
   }
 

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/location/DesktopLocationProvider.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/location/DesktopLocationProvider.kt
@@ -6,8 +6,6 @@ import androidx.compose.runtime.remember
 import java.util.ServiceConfigurationError
 import java.util.ServiceLoader
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.flowOf
 import org.maplibre.compose.desktop.ComposeMapHost
 import org.maplibre.compose.desktop.LocalComposeMapHostOrNull
@@ -15,12 +13,12 @@ import org.maplibre.compose.desktop.LocalComposeMapHostOrNull
 /**
  * A host-specific desktop location implementation discovered through [ServiceLoader].
  *
- * No installed or available backend maps [LocationProvider.backendAvailability] and
- * [LocationPermissionRequester.backendAvailability] to [LocationBackendAvailability.Unsupported].
- * Multiple available backends, a [ServiceConfigurationError], or an exception while checking or
- * creating a backend maps the corresponding property to
- * [LocationBackendAvailability.Misconfigured]. The selected backend documents its location-event
- * and permission mappings.
+ * A backend installs one provider that carries both location updates and permission. No installed
+ * or available backend maps [LocationProvider.backendAvailability] to
+ * [LocationBackendAvailability.Unsupported]. Multiple available backends, a
+ * [ServiceConfigurationError], or an exception while checking or creating a backend maps the
+ * property to [LocationBackendAvailability.Misconfigured]. The selected backend documents its
+ * location-event and permission mappings.
  */
 public interface DesktopLocationBackend {
   /** A stable name used in diagnostics. */
@@ -31,16 +29,10 @@ public interface DesktopLocationBackend {
 
   /** Creates a location provider for [host]. */
   public fun createProvider(host: ComposeMapHost?): DesktopLocationProvider
-
-  /** Creates a foreground permission requester and parents its UI to [host] when supported. */
-  public fun createPermissionRequester(host: ComposeMapHost?): DesktopLocationPermissionRequester
 }
 
 /** A desktop provider whose process resources can be released with [close]. */
 public interface DesktopLocationProvider : LocationProvider, AutoCloseable
-
-/** A desktop permission requester whose process resources can be released with [close]. */
-public interface DesktopLocationPermissionRequester : LocationPermissionRequester, AutoCloseable
 
 @Composable
 public actual fun rememberDefaultLocationProvider(): LocationProvider {
@@ -51,17 +43,6 @@ public actual fun rememberDefaultLocationProvider(): LocationProvider {
     }
   DisposableEffect(provider) { onDispose { provider.close() } }
   return provider
-}
-
-@Composable
-public actual fun rememberDefaultLocationPermissionRequester(): LocationPermissionRequester {
-  val host = LocalComposeMapHostOrNull.current
-  val requester =
-    remember(host) {
-      DesktopLocationBackendResolver.discoverPermissionRequester(host)
-    }
-  DisposableEffect(requester) { onDispose { requester.close() } }
-  return requester
 }
 
 internal object DesktopLocationBackendResolver {
@@ -75,20 +56,6 @@ internal object DesktopLocationBackendResolver {
       resolve(loadBackends(), host)
     } catch (error: ServiceConfigurationError) {
       UnavailableDesktopLocationProvider(LocationBackendAvailability.Misconfigured(error))
-    }
-
-  fun discoverPermissionRequester(
-    host: ComposeMapHost? = null,
-    loadBackends: () -> List<DesktopLocationBackend> = {
-      ServiceLoader.load(DesktopLocationBackend::class.java).toList()
-    },
-  ): DesktopLocationPermissionRequester =
-    try {
-      resolvePermissionRequester(loadBackends(), host)
-    } catch (error: ServiceConfigurationError) {
-      UnavailableDesktopLocationPermissionRequester(
-        LocationBackendAvailability.Misconfigured(error)
-      )
     }
 
   fun resolve(
@@ -121,41 +88,6 @@ internal object DesktopLocationBackendResolver {
         }
     }
   }
-
-  fun resolvePermissionRequester(
-    backends: List<DesktopLocationBackend>,
-    host: ComposeMapHost? = null,
-  ): DesktopLocationPermissionRequester {
-    val availableBackends =
-      try {
-        backends.filter { it.isAvailable() }
-      } catch (error: Throwable) {
-        return UnavailableDesktopLocationPermissionRequester(
-          LocationBackendAvailability.Misconfigured(error)
-        )
-      }
-    return when {
-      availableBackends.isEmpty() ->
-        UnavailableDesktopLocationPermissionRequester(LocationBackendAvailability.Unsupported)
-      availableBackends.size > 1 ->
-        UnavailableDesktopLocationPermissionRequester(
-          LocationBackendAvailability.Misconfigured(
-            IllegalStateException(
-              "Multiple desktop location backends are available: " +
-                availableBackends.joinToString { it.id }
-            )
-          )
-        )
-      else ->
-        try {
-          availableBackends.single().createPermissionRequester(host)
-        } catch (error: Throwable) {
-          UnavailableDesktopLocationPermissionRequester(
-            LocationBackendAvailability.Misconfigured(error)
-          )
-        }
-    }
-  }
 }
 
 private class UnavailableDesktopLocationProvider(
@@ -175,17 +107,6 @@ private class UnavailableDesktopLocationProvider(
           LocationEvent.Unavailable(LocationUnavailableReason.Unsupported)
       }
     )
-
-  override fun close() = Unit
-}
-
-private class UnavailableDesktopLocationPermissionRequester(
-  override val backendAvailability: LocationBackendAvailability
-) : DesktopLocationPermissionRequester {
-  override val status: StateFlow<LocationPermission> =
-    MutableStateFlow(LocationPermission.NotGranted(canRequest = null))
-
-  override fun requestForegroundPermission() = Unit
 
   override fun close() = Unit
 }

--- a/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/location/DesktopLocationBackendResolverTest.kt
+++ b/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/location/DesktopLocationBackendResolverTest.kt
@@ -5,7 +5,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertSame
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
@@ -28,12 +27,6 @@ class DesktopLocationBackendResolverTest {
         (provider.updates(LocationRequest()).first() as LocationEvent.Unavailable).reason,
       )
     }
-    val requester = DesktopLocationBackendResolver.resolvePermissionRequester(emptyList())
-    assertEquals(LocationBackendAvailability.Unsupported, requester.backendAvailability)
-    assertEquals(
-      LocationPermission.NotGranted(canRequest = null),
-      requester.status.value,
-    )
     assertEquals(0, unavailableBackend.createCalls)
   }
 
@@ -41,41 +34,25 @@ class DesktopLocationBackendResolverTest {
   fun multipleBackendsAreMisconfigured() = runTest {
     val backends = listOf(FakeBackend("first"), FakeBackend("second"))
     val provider = DesktopLocationBackendResolver.resolve(backends)
-    val requester = DesktopLocationBackendResolver.resolvePermissionRequester(backends)
 
     assertIs<LocationBackendAvailability.Misconfigured>(provider.backendAvailability)
     assertEquals(
       LocationUnavailableReason.Misconfigured,
       (provider.updates(LocationRequest()).first() as LocationEvent.Unavailable).reason,
     )
-    assertIs<LocationBackendAvailability.Misconfigured>(requester.backendAvailability)
-    assertEquals(LocationPermission.NotGranted(canRequest = null), requester.status.value)
   }
 
   @Test
   fun oneAvailableBackendCreatesProvider() {
     val expected = FakeProvider()
-    val expectedRequester = FakePermissionRequester()
     val unavailableBackend = FakeBackend("wrong-platform", available = false)
-    val availableBackend =
-      FakeBackend(
-        "current-host",
-        provider = expected,
-        permissionRequester = expectedRequester,
-      )
+    val availableBackend = FakeBackend("current-host", provider = expected)
     val provider =
       DesktopLocationBackendResolver.resolve(listOf(unavailableBackend, availableBackend))
-    val requester =
-      DesktopLocationBackendResolver.resolvePermissionRequester(
-        listOf(unavailableBackend, availableBackend)
-      )
 
     assertSame(expected, provider)
-    assertSame(expectedRequester, requester)
     assertEquals(0, unavailableBackend.createCalls)
-    assertEquals(0, unavailableBackend.createPermissionRequesterCalls)
     assertEquals(1, availableBackend.createCalls)
-    assertEquals(1, availableBackend.createPermissionRequesterCalls)
   }
 
   @Test
@@ -98,17 +75,14 @@ class DesktopLocationBackendResolverTest {
   fun serviceDiscoveryFailureBecomesMisconfiguration() = runTest {
     val failure = ServiceConfigurationError("provider constructor failed")
     val provider = DesktopLocationBackendResolver.discover(loadBackends = { throw failure })
-    val requester =
-      DesktopLocationBackendResolver.discoverPermissionRequester(loadBackends = { throw failure })
     val event = assertIs<LocationEvent.Unavailable>(provider.updates(LocationRequest()).first())
 
     assertEquals(LocationUnavailableReason.Misconfigured, event.reason)
     assertSame(failure, event.cause)
     assertSame(
       failure,
-      assertIs<LocationBackendAvailability.Misconfigured>(requester.backendAvailability).cause,
+      assertIs<LocationBackendAvailability.Misconfigured>(provider.backendAvailability).cause,
     )
-    assertEquals(LocationPermission.NotGranted(canRequest = null), requester.status.value)
   }
 }
 
@@ -116,11 +90,9 @@ private class FakeBackend(
   override val id: String,
   private val available: Boolean = true,
   private val provider: DesktopLocationProvider = FakeProvider(),
-  private val permissionRequester: DesktopLocationPermissionRequester = FakePermissionRequester(),
   private val failure: Throwable? = null,
 ) : DesktopLocationBackend {
   var createCalls = 0
-  var createPermissionRequesterCalls = 0
 
   override fun isAvailable(): Boolean = available
 
@@ -129,29 +101,10 @@ private class FakeBackend(
     failure?.let { throw it }
     return provider
   }
-
-  override fun createPermissionRequester(
-    host: ComposeMapHost?
-  ): DesktopLocationPermissionRequester {
-    createPermissionRequesterCalls += 1
-    failure?.let { throw it }
-    return permissionRequester
-  }
 }
 
 private class FakeProvider : DesktopLocationProvider {
   override fun updates(request: LocationRequest) = emptyFlow<LocationEvent>()
-
-  override fun close() = Unit
-}
-
-private class FakePermissionRequester : DesktopLocationPermissionRequester {
-  override val status =
-    MutableStateFlow<LocationPermission>(
-      LocationPermission.Granted(LocationAccuracyAuthorization.Unknown)
-    )
-
-  override fun requestForegroundPermission() = Unit
 
   override fun close() = Unit
 }

--- a/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/location/LocationStateTest.kt
+++ b/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/location/LocationStateTest.kt
@@ -35,17 +35,20 @@ import org.maplibre.spatialk.units.extensions.degrees
 @OptIn(ExperimentalCoroutinesApi::class, ExperimentalTestApi::class)
 class LocationStateTest {
   @Test
-  fun requesterMisconfigurationPrecedesPermissionAndPreventsCollection() = withMainDispatcher {
+  fun providerMisconfigurationPreventsCollection() = withMainDispatcher {
     runComposeUiTest {
       val cause = IllegalStateException("multiple backends")
-      val provider = ActiveLocationProvider(location(13.0))
+      val provider =
+        ActiveLocationProvider(
+          location(13.0),
+          backendAvailability = LocationBackendAvailability.Misconfigured(cause),
+        )
       var state: LocationState? = null
 
       setContent {
         state =
           rememberLocationState(
             provider = provider,
-            permissionRequester = MisconfiguredPermissionRequester(cause),
             lifecycleOwner = ResumedLifecycleOwner(),
           )
       }
@@ -62,51 +65,50 @@ class LocationStateTest {
   fun permissionGrantStartsAndRevocationStopsProviderUpdates() = withMainDispatcher {
     runComposeUiTest {
       val lifecycleOwner = ResumedLifecycleOwner()
-      val provider = ActiveLocationProvider(location(13.0))
-      val requester = MutablePermissionRequester()
+      val locationProvider = ActiveLocationProvider(location(13.0))
+      val provider = MutablePermissionProvider(locationProvider)
       var state: LocationState? = null
 
       setContent {
         state =
           rememberLocationState(
             provider = provider,
-            permissionRequester = requester,
             lifecycleOwner = lifecycleOwner,
           )
       }
 
       waitUntil { state?.status == LocationTrackingStatus.WaitingForPermission }
-      assertFalse(provider.active)
+      assertFalse(locationProvider.active)
       runOnIdle { state?.requestPermission() }
-      assertEquals(1, requester.requestCount)
+      assertEquals(1, provider.requestCount)
 
       runOnIdle {
-        requester.status.value = LocationPermission.Granted(LocationAccuracyAuthorization.Precise)
+        provider.permission.value =
+          LocationPermission.Granted(LocationAccuracyAuthorization.Precise)
       }
-      waitUntil { provider.active && state?.location == provider.location }
+      waitUntil { locationProvider.active && state?.location == locationProvider.location }
 
       runOnIdle {
-        requester.status.value = LocationPermission.NotGranted(canRequest = false)
+        provider.permission.value = LocationPermission.NotGranted(canRequest = false)
       }
       waitUntil {
-        !provider.active && state?.status == LocationTrackingStatus.WaitingForPermission
+        !locationProvider.active && state?.status == LocationTrackingStatus.WaitingForPermission
       }
-      assertTrue(provider.stopCount > 0)
+      assertTrue(locationProvider.stopCount > 0)
     }
   }
 
   @Test
   fun permissionGrantStartsAndRevocationStopsOrientationUpdates() = withMainDispatcher {
     runComposeUiTest {
-      val requester = MutablePermissionRequester()
+      val provider = MutablePermissionProvider(FiniteLocationProvider())
       val orientationProvider = MutableOrientationProvider()
       var state: LocationState? = null
 
       setContent {
         state =
           rememberLocationState(
-            provider = FiniteLocationProvider(),
-            permissionRequester = requester,
+            provider = provider,
             orientationProvider = orientationProvider,
             lifecycleOwner = ResumedLifecycleOwner(),
           )
@@ -116,14 +118,37 @@ class LocationStateTest {
       assertEquals(0, orientationProvider.orientation.subscriptionCount.value)
 
       runOnIdle {
-        requester.status.value = LocationPermission.Granted(LocationAccuracyAuthorization.Precise)
+        provider.permission.value =
+          LocationPermission.Granted(LocationAccuracyAuthorization.Precise)
       }
       waitUntil { orientationProvider.orientation.subscriptionCount.value == 1 }
 
       runOnIdle {
-        requester.status.value = LocationPermission.NotGranted(canRequest = false)
+        provider.permission.value = LocationPermission.NotGranted(canRequest = false)
       }
       waitUntil { orientationProvider.orientation.subscriptionCount.value == 0 }
+    }
+  }
+
+  @Test
+  fun defaultPermissionProviderCollectsWithoutPermissionWiring() = withMainDispatcher {
+    runComposeUiTest {
+      val provider = ActiveLocationProvider(location(13.0))
+      var state: LocationState? = null
+
+      setContent {
+        state =
+          rememberLocationState(
+            provider = provider,
+            lifecycleOwner = ResumedLifecycleOwner(),
+          )
+      }
+
+      waitUntil { provider.active && state?.location == provider.location }
+      assertEquals(
+        LocationPermission.Granted(LocationAccuracyAuthorization.Unknown),
+        state?.permission,
+      )
     }
   }
 
@@ -135,7 +160,6 @@ class LocationStateTest {
       setContent {
         rememberLocationState(
           provider = FiniteLocationProvider(),
-          permissionRequester = GrantedPermissionRequester,
           orientationProvider = orientationProvider,
           lifecycleOwner = ResumedLifecycleOwner(),
           coroutineContext = CoroutineName("location-updates"),
@@ -144,41 +168,6 @@ class LocationStateTest {
 
       waitUntil { orientationProvider.collectionName.isCompleted }
       assertEquals("location-updates", orientationProvider.collectionName.getCompleted())
-    }
-  }
-
-  @Test
-  fun replacingGrantedRequesterMovesLocationCollectionToNewState() = withMainDispatcher {
-    runComposeUiTest {
-      val provider = ActiveLocationProvider(location(13.0))
-      var requester by
-        mutableStateOf<LocationPermissionRequester>(
-          MutablePermissionRequester(
-            LocationPermission.Granted(LocationAccuracyAuthorization.Precise)
-          )
-        )
-      var state: LocationState? = null
-
-      setContent {
-        state =
-          rememberLocationState(
-            provider = provider,
-            permissionRequester = requester,
-            lifecycleOwner = ResumedLifecycleOwner(),
-          )
-      }
-      waitUntil { state?.location == provider.location }
-      val originalState = state
-
-      runOnIdle {
-        requester =
-          MutablePermissionRequester(
-            LocationPermission.Granted(LocationAccuracyAuthorization.Precise)
-          )
-      }
-
-      waitUntil { state !== originalState && state?.location == provider.location }
-      assertTrue(provider.stopCount > 0)
     }
   }
 
@@ -193,7 +182,6 @@ class LocationStateTest {
         state =
           rememberLocationState(
             provider = FiniteLocationProvider(expected),
-            permissionRequester = GrantedPermissionRequester,
             lifecycleOwner = lifecycleOwner,
           )
       }
@@ -217,7 +205,6 @@ class LocationStateTest {
         state =
           rememberLocationState(
             provider = provider,
-            permissionRequester = GrantedPermissionRequester,
             orientationProvider = orientationProvider,
             lifecycleOwner = lifecycleOwner,
           )
@@ -288,7 +275,11 @@ private class FiniteLocationProvider(private vararg val locations: Location) : L
     flowOf(*locations.map(LocationEvent::Fix).toTypedArray())
 }
 
-private class ActiveLocationProvider(val location: Location) : LocationProvider {
+private class ActiveLocationProvider(
+  val location: Location,
+  override val backendAvailability: LocationBackendAvailability =
+    LocationBackendAvailability.Available,
+) : LocationProvider {
   var active = false
   var stopCount = 0
 
@@ -304,32 +295,21 @@ private class ActiveLocationProvider(val location: Location) : LocationProvider 
   }
 }
 
-private class MutablePermissionRequester(
-  initialStatus: LocationPermission = LocationPermission.NotGranted(canRequest = true)
-) : LocationPermissionRequester {
-  override val status = MutableStateFlow(initialStatus)
+private class MutablePermissionProvider(
+  private val delegate: LocationProvider,
+  initialPermission: LocationPermission = LocationPermission.NotGranted(canRequest = true),
+) : LocationProvider {
+  override val backendAvailability: LocationBackendAvailability
+    get() = delegate.backendAvailability
+
+  override val permission = MutableStateFlow(initialPermission)
   var requestCount = 0
 
-  override fun requestForegroundPermission() {
+  override fun requestPermission() {
     requestCount += 1
   }
-}
 
-private class MisconfiguredPermissionRequester(cause: Throwable) : LocationPermissionRequester {
-  override val backendAvailability = LocationBackendAvailability.Misconfigured(cause)
-  override val status =
-    MutableStateFlow<LocationPermission>(LocationPermission.NotGranted(canRequest = null))
-
-  override fun requestForegroundPermission() = Unit
-}
-
-private object GrantedPermissionRequester : LocationPermissionRequester {
-  override val status =
-    MutableStateFlow<LocationPermission>(
-      LocationPermission.Granted(LocationAccuracyAuthorization.Precise)
-    )
-
-  override fun requestForegroundPermission() = Unit
+  override fun updates(request: LocationRequest): Flow<LocationEvent> = delegate.updates(request)
 }
 
 private class MutableOrientationProvider : OrientationProvider {


### PR DESCRIPTION
## Description

Folds foreground location permission into `LocationProvider` with an always-granted default and removes the `LocationPermissionRequester` interface, so a custom provider works with no permission wiring; closes #959.

## Validation

`test:desktop`, `test:android`, `test:js`, the macOS/Linux backend module tests, `build:desktop-app`, `build:docs`, and `check` all pass locally.

## AI assistance

Kimi Code CLI (Kimi), including delegated coding subagents for the platform ports.