### PR TITLE
Add a --release flag to the iOS demo task

### DIFF
--- a/.mise/bin/run-ios-demo
+++ b/.mise/bin/run-ios-demo
@@ -12,16 +12,20 @@ fi
 # mise passes usage values as environment variables; the arguments are for
 # running this script outside of mise.
 target="simulator"
+configuration="Debug"
 requested=""
 for arg in "$@"; do
-  if [[ "$arg" == "--device" ]]; then
-    target="device"
-  else
-    requested="$arg"
-  fi
+  case "$arg" in
+    --device) target="device" ;;
+    --release) configuration="Release" ;;
+    *) requested="$arg" ;;
+  esac
 done
 if [[ "${usage_device:-}" == "true" ]]; then
   target="device"
+fi
+if [[ "${usage_release:-}" == "true" ]]; then
+  configuration="Release"
 fi
 if [[ -z "$requested" && -n "${usage_udid:-}" ]]; then
   requested="$usage_udid"
@@ -122,10 +126,10 @@ if [[ "$target" == "simulator" ]]; then
   fi
   ensure_simulator_booted "$udid"
 
-  xcodebuild -project "$project" -scheme iosApp -configuration Debug \
+  xcodebuild -project "$project" -scheme iosApp -configuration "$configuration" \
     -destination "id=$udid" -derivedDataPath "$derived_data" build
 
-  app="$(app_bundle Debug-iphonesimulator)"
+  app="$(app_bundle "$configuration"-iphonesimulator)"
   [[ -n "$app" ]] || {
     echo "No app bundle under $derived_data." >&2
     exit 1
@@ -148,11 +152,11 @@ udid="$(pick_id "iOS device" "$devices")"
 # Signing needs no setup here: the project carries a DEVELOPMENT_TEAM.
 # Build for a generic device rather than for "id=$udid": xcodebuild identifies a
 # device by its ECID, devicectl by a CoreDevice UUID, and the two do not match.
-xcodebuild -project "$project" -scheme iosApp -configuration Debug \
+xcodebuild -project "$project" -scheme iosApp -configuration "$configuration" \
   -destination "generic/platform=iOS" -derivedDataPath "$derived_data" \
   -allowProvisioningUpdates build
 
-app="$(app_bundle Debug-iphoneos)"
+app="$(app_bundle "$configuration"-iphoneos)"
 [[ -n "$app" ]] || {
   echo "No app bundle under $derived_data." >&2
   exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ per `./gradlew` invocation. Two together can fail in ways neither does alone.
 - `mise run demo:desktop-glfw`
 - `mise run demo:android` (prompts when several devices are connected)
 - `mise run demo:ios` (pass `--device` for a connected iPhone; prompts when
-  several are ready)
+  several are ready; `--release` builds the optimized framework)
 - `mise run demo:js`
 
 ### Formatting and linting

--- a/mise.toml
+++ b/mise.toml
@@ -194,6 +194,7 @@ run = "./gradlew :demo-app:common:jsBrowserDevelopmentRun"
 description = "Run the demo app on an iOS simulator or a connected iPhone."
 usage = '''
 flag "--device" help="Run on a connected iPhone instead of a simulator."
+flag "--release" help="Build the Release configuration, with the optimized Kotlin/Native binary."
 arg "[udid]" help="Device or simulator UDID. Prompts when several are ready."
 '''
 # The device prompt needs the real terminal; mise otherwise pipes stdio.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Adds `--release` to `mise run demo:ios` so the demo can use the optimized Kotlin/Native binary, extracted from #985.

## Validation

`bash -n` and argument-parse cases passed; this Linux host cannot launch the iOS demo.

## AI assistance

Cursor Grok 4.6 as a Cursor Cloud agent.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e0fb2e6d-715e-4f7f-88e3-8aeed5cd5d3a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e0fb2e6d-715e-4f7f-88e3-8aeed5cd5d3a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

