### PR TITLE
Install streamed GeoJSON publications instead of dropping superseded parses

### DIFF
--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/sources/GeoJsonSource.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/sources/GeoJsonSource.kt
@@ -178,7 +178,8 @@ private val EmptyInlineGeoJson: GeoJsonData =
 
 /**
  * Replaces the source's data. Native platforms that parse and index inline GeoJSON do that work on
- * a worker; iOS and the browser apply it on the caller. When two publications overlap, the later
- * call is the data the source keeps.
+ * a worker; iOS and the browser apply it on the caller. Publications that outpace the parse
+ * conflate to the newest data, and when two publications overlap, the later call is the data the
+ * source keeps.
  */
 internal expect suspend fun GeoJsonSource.publishData(data: GeoJsonData)

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/sources/GeoJsonSource.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/sources/GeoJsonSource.kt
@@ -35,17 +35,17 @@ public actual class GeoJsonSource : Source {
   @Volatile private var dataUrl: String?
 
   /** Bumped at the start of every [setData] and [publishPreparedData]; orders data by call. */
-  @Volatile private var dataGeneration = 0
+  @Volatile private var dataGeneration = 0L
 
   /** The generation of the data last installed. Guarded by [installLock]. */
-  @Volatile private var installedGeneration = 0
+  @Volatile private var installedGeneration = 0L
 
   private val installLock = Any()
 
   /** The newest published data not yet claimed by a parse. Guarded by [installLock]. */
   private var pendingPublish: PendingPublish? = null
 
-  private class PendingPublish(val generation: Int, val data: GeoJsonData)
+  private class PendingPublish(val generation: Long, val data: GeoJsonData)
 
   /** Serializes parses, so a burst of publications conflates into parses of the newest data. */
   private val publishMutex = Mutex()
@@ -92,7 +92,7 @@ public actual class GeoJsonSource : Source {
     applyData(data, nextDataGeneration(discardPending = true))
   }
 
-  private fun nextDataGeneration(discardPending: Boolean = false): Int =
+  private fun nextDataGeneration(discardPending: Boolean = false): Long =
     synchronized(installLock) {
       // A synchronous setData supersedes a publication that no parse has claimed yet.
       if (discardPending) pendingPublish = null
@@ -103,7 +103,7 @@ public actual class GeoJsonSource : Source {
    * Parses the [data] argument, then installs it when no newer data has installed. mutateMap waits
    * until the owner thread has used the handle, so closing it afterward is safe.
    */
-  private fun applyData(data: GeoJsonData, generation: Int) {
+  private fun applyData(data: GeoJsonData, generation: Long) {
     if (data is GeoJsonData.Uri) {
       installIfNewest(generation) {
         inlineUtf8 = null
@@ -127,7 +127,7 @@ public actual class GeoJsonSource : Source {
    * Installs [generation]'s data unless newer data has already installed. A newer publication that
    * has not parsed yet does not block this install: its own parse follows and overwrites this one.
    */
-  private inline fun installIfNewest(generation: Int, install: () -> Unit) {
+  private inline fun installIfNewest(generation: Long, install: () -> Unit) {
     synchronized(installLock) {
       if (generation <= installedGeneration) return
       install()
@@ -139,8 +139,20 @@ public actual class GeoJsonSource : Source {
    * Claims the newest pending publication and parses it on Default. Publications that arrive faster
    * than a parse conflate: each parse works on the newest data rather than every publication paying
    * for a parse of its own.
+   *
+   * A URI has no parse, so it installs without waiting for [publishMutex]. When an in-flight inline
+   * parse finishes, [installIfNewest] keeps the URI.
    */
   internal suspend fun publishPreparedData(data: GeoJsonData) {
+    if (data is GeoJsonData.Uri) {
+      val generation =
+        synchronized(installLock) {
+          pendingPublish = null
+          ++dataGeneration
+        }
+      withContext(NonCancellable) { applyData(data, generation) }
+      return
+    }
     synchronized(installLock) { pendingPublish = PendingPublish(++dataGeneration, data) }
     publishMutex.withLock {
       val pending = synchronized(installLock) { pendingPublish.also { pendingPublish = null } }

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/sources/GeoJsonSource.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/sources/GeoJsonSource.kt
@@ -4,6 +4,9 @@ package org.maplibre.compose.sources
 
 import kotlin.concurrent.Volatile
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
@@ -31,13 +34,21 @@ public actual class GeoJsonSource : Source {
   /** The URI form of the data, when it is one. */
   @Volatile private var dataUrl: String?
 
-  /**
-   * Incremented at the start of every [setData] and [publishData]. Only the current generation
-   * installs after a parse.
-   */
-  @Volatile private var publishGeneration = 0
+  /** Bumped at the start of every [setData] and [publishPreparedData]; orders data by call. */
+  @Volatile private var dataGeneration = 0
+
+  /** The generation of the data last installed. Guarded by [installLock]. */
+  @Volatile private var installedGeneration = 0
 
   private val installLock = Any()
+
+  /** The newest published data not yet claimed by a parse. Guarded by [installLock]. */
+  private var pendingPublish: PendingPublish? = null
+
+  private class PendingPublish(val generation: Int, val data: GeoJsonData)
+
+  /** Serializes parses, so a burst of publications conflates into parses of the newest data. */
+  private val publishMutex = Mutex()
 
   public actual constructor(id: String, data: GeoJsonData, options: GeoJsonOptions) : super(id) {
     this.options = options
@@ -78,18 +89,23 @@ public actual class GeoJsonSource : Source {
   }
 
   public actual fun setData(data: GeoJsonData) {
-    applyData(data, nextPublishGeneration())
+    applyData(data, nextDataGeneration(discardPending = true))
   }
 
-  private fun nextPublishGeneration(): Int = synchronized(installLock) { ++publishGeneration }
+  private fun nextDataGeneration(discardPending: Boolean = false): Int =
+    synchronized(installLock) {
+      // A synchronous setData supersedes a publication that no parse has claimed yet.
+      if (discardPending) pendingPublish = null
+      ++dataGeneration
+    }
 
   /**
-   * Parses the [data] argument, then installs it when [generation] is still current. mutateMap
-   * waits until the owner thread has used the handle, so closing it afterward is safe.
+   * Parses the [data] argument, then installs it when no newer data has installed. mutateMap waits
+   * until the owner thread has used the handle, so closing it afterward is safe.
    */
   private fun applyData(data: GeoJsonData, generation: Int) {
     if (data is GeoJsonData.Uri) {
-      installIfCurrent(generation) {
+      installIfNewest(generation) {
         inlineUtf8 = null
         dataUrl = data.uri
         mutate { map -> map.setGeoJsonSourceUrl(id, data.uri) }
@@ -97,9 +113,9 @@ public actual class GeoJsonSource : Source {
       return
     }
     val utf8 = data.toInlineUtf8()!!
-    if (generation != publishGeneration) return
+    if (generation <= installedGeneration) return
     GeoJsonSourceDataHandle.create(utf8, ffiOptions).use { prepared ->
-      installIfCurrent(generation) {
+      installIfNewest(generation) {
         inlineUtf8 = utf8
         dataUrl = null
         mutate { map -> map.setGeoJsonSourceData(id, prepared) }
@@ -107,17 +123,36 @@ public actual class GeoJsonSource : Source {
     }
   }
 
-  private inline fun installIfCurrent(generation: Int, install: () -> Unit) {
+  /**
+   * Installs [generation]'s data unless newer data has already installed. A newer publication that
+   * has not parsed yet does not block this install: its own parse follows and overwrites this one.
+   */
+  private inline fun installIfNewest(generation: Int, install: () -> Unit) {
     synchronized(installLock) {
-      if (generation != publishGeneration) return
+      if (generation <= installedGeneration) return
       install()
+      installedGeneration = generation
     }
   }
 
-  /** Parses and indexes on Default. [applyData] installs only the current generation. */
+  /**
+   * Claims the newest pending publication and parses it on Default. Publications that arrive faster
+   * than a parse conflate: each parse works on the newest data rather than every publication paying
+   * for a parse of its own.
+   */
   internal suspend fun publishPreparedData(data: GeoJsonData) {
-    val generation = nextPublishGeneration()
-    withContext(Dispatchers.Default) { applyData(data, generation) }
+    synchronized(installLock) { pendingPublish = PendingPublish(++dataGeneration, data) }
+    publishMutex.withLock {
+      val pending = synchronized(installLock) { pendingPublish.also { pendingPublish = null } }
+      // Null when a sibling's parse already claimed this publication's data.
+      if (pending != null) {
+        // The effect that published this data may already be cancelled by a newer publication,
+        // but this coroutine claimed the pending data; abandoning the parse here would lose it.
+        withContext(NonCancellable + Dispatchers.Default) {
+          applyData(pending.data, pending.generation)
+        }
+      }
+    }
   }
 
   /**

--- a/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/sources/GeoJsonSourceAttachTest.kt
+++ b/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/sources/GeoJsonSourceAttachTest.kt
@@ -1,6 +1,7 @@
 package org.maplibre.compose.sources
 
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.concurrent.thread
@@ -13,6 +14,7 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.io.buffered
@@ -120,6 +122,9 @@ class GeoJsonSourceAttachTest {
   /**
    * A URI has no parse, so it installs without waiting for an in-flight inline parse. When the
    * older parse finishes, the URI remains.
+   *
+   * The inline job starts on a worker that is not Default, so `withContext(Default)` inside the
+   * parse suspends instead of finishing before `launch` returns.
    */
   @Test
   fun a_uri_publish_installs_while_an_inline_parse_is_still_running() = runBlocking {
@@ -131,6 +136,7 @@ class GeoJsonSourceAttachTest {
       style.addSource(source)
 
       val cache = FfiTestPlatform.createCacheFile()
+      val executor = Executors.newSingleThreadExecutor()
       try {
         val file = Path(requireNotNull(cache.parent), "points.geojson")
         SystemFileSystem.sink(file).buffered().use {
@@ -138,15 +144,18 @@ class GeoJsonSourceAttachTest {
         }
         val url = fileUrlOf(file)
         val olderJob =
-          launch(Dispatchers.Default, start = CoroutineStart.UNDISPATCHED) {
+          launch(executor.asCoroutineDispatcher(), start = CoroutineStart.UNDISPATCHED) {
             source.publishData(GeoJsonData.Features(manyPoints(longitude = 2.0, count = 8_000)))
           }
+        val featuresBeforeUri = (source.toJson()["data"] as JsonObject)["features"] as JsonArray
+        assertEquals(1, featuresBeforeUri.size, source.toJson().toString())
         source.publishData(GeoJsonData.Uri(url))
         assertEquals(JsonPrimitive(url), source.toJson()["data"], source.toJson().toString())
         olderJob.join()
         assertEquals(JsonPrimitive(url), source.toJson()["data"], source.toJson().toString())
         assertEquals(emptyList(), fixture.errors, "the map should report nothing")
       } finally {
+        executor.shutdown()
         FfiTestPlatform.deleteCacheFile(cache)
       }
     }

--- a/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/sources/GeoJsonSourceAttachTest.kt
+++ b/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/sources/GeoJsonSourceAttachTest.kt
@@ -15,10 +15,17 @@ import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.io.buffered
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+import kotlinx.io.writeString
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.jsonPrimitive
 import org.maplibre.compose.mlnffi.BridgeMapFixture
+import org.maplibre.compose.mlnffi.FfiTestPlatform
+import org.maplibre.compose.mlnffi.fileUrlOf
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.compose.style.MlnFfiStyle
 import org.maplibre.spatialk.geojson.FeatureCollection
@@ -107,6 +114,42 @@ class GeoJsonSourceAttachTest {
         ((features.single() as JsonObject)["geometry"] as JsonObject)["coordinates"] as JsonArray
       assertEquals(9.0, coordinates[0].jsonPrimitive.content.toDouble())
       assertEquals(emptyList(), fixture.errors, "the map should report nothing")
+    }
+  }
+
+  /**
+   * A URI has no parse, so it installs without waiting for an in-flight inline parse. When the
+   * older parse finishes, the URI remains.
+   */
+  @Test
+  fun a_uri_publish_installs_while_an_inline_parse_is_still_running() = runBlocking {
+    BridgeMapFixture.create().use { fixture ->
+      fixture.loadStyle(BaseStyle.Empty)
+      fixture.pumpUntilRendered()
+      val style = assertIs<MlnFfiStyle>(fixture.style, "Errors: ${fixture.errors}")
+      val source = GeoJsonSource(SOURCE_ID, GeoJsonData.Features(pointAt(0.0)), GeoJsonOptions())
+      style.addSource(source)
+
+      val cache = FfiTestPlatform.createCacheFile()
+      try {
+        val file = Path(requireNotNull(cache.parent), "points.geojson")
+        SystemFileSystem.sink(file).buffered().use {
+          it.writeString("""{"type":"FeatureCollection","features":[]}""")
+        }
+        val url = fileUrlOf(file)
+        val olderJob =
+          launch(Dispatchers.Default, start = CoroutineStart.UNDISPATCHED) {
+            source.publishData(GeoJsonData.Features(manyPoints(longitude = 2.0, count = 8_000)))
+          }
+        source.publishData(GeoJsonData.Uri(url))
+        assertEquals(JsonPrimitive(url), source.toJson()["data"], source.toJson().toString())
+        assertTrue(olderJob.isActive, "the URI should install without waiting for the inline parse")
+        olderJob.join()
+        assertEquals(JsonPrimitive(url), source.toJson()["data"], source.toJson().toString())
+        assertEquals(emptyList(), fixture.errors, "the map should report nothing")
+      } finally {
+        FfiTestPlatform.deleteCacheFile(cache)
+      }
     }
   }
 

--- a/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/sources/GeoJsonSourceAttachTest.kt
+++ b/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/sources/GeoJsonSourceAttachTest.kt
@@ -143,7 +143,6 @@ class GeoJsonSourceAttachTest {
           }
         source.publishData(GeoJsonData.Uri(url))
         assertEquals(JsonPrimitive(url), source.toJson()["data"], source.toJson().toString())
-        assertTrue(olderJob.isActive, "the URI should install without waiting for the inline parse")
         olderJob.join()
         assertEquals(JsonPrimitive(url), source.toJson()["data"], source.toJson().toString())
         assertEquals(emptyList(), fixture.errors, "the map should report nothing")

--- a/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/sources/GeoJsonSourceUpdateTest.kt
+++ b/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/sources/GeoJsonSourceUpdateTest.kt
@@ -1,0 +1,242 @@
+package org.maplibre.compose.sources
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import kotlin.concurrent.atomics.AtomicBoolean
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+import kotlin.math.abs
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeSource
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.double
+import kotlinx.serialization.json.jsonPrimitive
+import org.maplibre.compose.camera.CameraPosition
+import org.maplibre.compose.expressions.ast.ExpressionContext
+import org.maplibre.compose.expressions.dsl.const
+import org.maplibre.compose.layers.CircleLayer
+import org.maplibre.compose.mlnffi.BridgeMapFixture
+import org.maplibre.compose.style.BaseStyle
+import org.maplibre.compose.style.MlnFfiStyle
+import org.maplibre.compose.testing.RgbaPixel
+import org.maplibre.spatialk.geojson.FeatureCollection
+import org.maplibre.spatialk.geojson.Geometry
+import org.maplibre.spatialk.geojson.Point
+import org.maplibre.spatialk.geojson.Position
+import org.maplibre.spatialk.geojson.dsl.addFeature
+import org.maplibre.spatialk.geojson.dsl.buildFeatureCollection
+
+/**
+ * Renders one point at the screen center, then replaces the source's data with a point far
+ * offscreen. The center pixel must return to the background, which only happens when the update
+ * reaches native, native re-tiles, and a frame presents the result.
+ */
+class GeoJsonSourceUpdateTest {
+
+  @Test
+  fun setData_moves_a_rendered_point() =
+    assertUpdateMovesPoint(synchronousUpdate = false) { source, data ->
+      source.setData(GeoJsonData.Features(data))
+    }
+
+  @Test
+  fun setData_moves_a_rendered_point_with_synchronous_tiling() =
+    assertUpdateMovesPoint(synchronousUpdate = true) { source, data ->
+      source.setData(GeoJsonData.Features(data))
+    }
+
+  @Test
+  fun publishData_moves_a_rendered_point() =
+    assertUpdateMovesPoint(synchronousUpdate = false) { source, data ->
+      source.publishData(GeoJsonData.Features(data))
+    }
+
+  @Test
+  fun publishData_moves_a_rendered_point_with_synchronous_tiling() =
+    assertUpdateMovesPoint(synchronousUpdate = true) { source, data ->
+      source.publishData(GeoJsonData.Features(data))
+    }
+
+  @Test
+  fun setData_moves_a_rendered_point_when_frames_are_on_demand() =
+    assertUpdateMovesPoint(synchronousUpdate = false, onDemand = true) { source, data ->
+      source.setData(GeoJsonData.Features(data))
+    }
+
+  @Test
+  fun publishData_moves_a_rendered_point_when_frames_are_on_demand() =
+    assertUpdateMovesPoint(synchronousUpdate = false, onDemand = true) { source, data ->
+      source.publishData(GeoJsonData.Features(data))
+    }
+
+  /**
+   * The GeoJSON benchmark publishes every frame, each from a fresh coroutine (a LaunchedEffect
+   * relaunch on the main dispatcher, so the generation ticks at frame rate while parses run on a
+   * worker). A stream that outpaces the parse must still install, conflated to the newest data.
+   */
+  @OptIn(ExperimentalAtomicApi::class)
+  @Test
+  fun rapid_publishes_install_during_the_stream() = runBlocking {
+    BridgeMapFixture.create().use { fixture ->
+      fixture.loadStyle(BaseStyle.Empty)
+      val style = assertIs<MlnFfiStyle>(fixture.style, "Errors: ${fixture.errors}")
+      val source = GeoJsonSource(SOURCE_ID, GeoJsonData.Features(manyPoints(0.0)), GeoJsonOptions())
+      style.addSource(source)
+
+      val sawInstall = AtomicBoolean(false)
+      val poller =
+        launch(Dispatchers.Default) {
+          while (isActive) {
+            if (installedBatch(source) != 0.0) {
+              sawInstall.store(true)
+              break
+            }
+            delay(POLL_INTERVAL_MILLIS)
+          }
+        }
+      // Launched on the test's event loop, standing in for the main dispatcher: publications
+      // tick at frame rate regardless of how backed up the parse workers are.
+      val publisher = launch {
+        var batch = 1
+        while (isActive) {
+          val batchNumber = batch++
+          launch { source.publishData(GeoJsonData.Features(manyPoints(batchNumber.toDouble()))) }
+          delay(FRAME_INTERVAL_MILLIS)
+        }
+      }
+      try {
+        val deadline = TimeSource.Monotonic.markNow() + STREAM_TIMEOUT
+        while (!sawInstall.load()) {
+          check(deadline.hasNotPassedNow()) {
+            "No publication installed while updates streamed every ${FRAME_INTERVAL_MILLIS}ms"
+          }
+          delay(POLL_INTERVAL_MILLIS)
+        }
+      } finally {
+        publisher.cancelAndJoin()
+        poller.cancelAndJoin()
+      }
+    }
+  }
+
+  /** The batch number the installed data was published with; every feature shares it. */
+  private fun installedBatch(source: GeoJsonSource): Double {
+    val features = (source.toJson()["data"] as JsonObject)["features"] as JsonArray
+    val first = features.firstOrNull() as? JsonObject ?: return Double.NaN
+    val coordinates = (first["geometry"] as JsonObject)["coordinates"] as JsonArray
+    return coordinates[0].jsonPrimitive.double
+  }
+
+  private fun manyPoints(longitude: Double): FeatureCollection<Geometry, JsonObject?> =
+    buildFeatureCollection {
+      repeat(STREAM_POINT_COUNT) { index ->
+        addFeature(geometry = Point(Position(longitude, latitude = index * 0.0001)))
+      }
+    }
+
+  private fun assertUpdateMovesPoint(
+    synchronousUpdate: Boolean,
+    onDemand: Boolean = false,
+    update: suspend (GeoJsonSource, FeatureCollection<Geometry, JsonObject?>) -> Unit,
+  ) = runBlocking {
+    BridgeMapFixture.create().use { fixture ->
+      fixture.loadStyle(STYLE)
+      val style = assertIs<MlnFfiStyle>(fixture.style, "Errors: ${fixture.errors}")
+      fixture.session.setCameraPosition(CameraPosition(target = ORIGIN, zoom = 14.0))
+
+      val source =
+        GeoJsonSource(
+          SOURCE_ID,
+          GeoJsonData.Features(pointAt(ORIGIN)),
+          GeoJsonOptions(synchronousUpdate = synchronousUpdate),
+        )
+      style.addSource(source)
+      val layer = CircleLayer(LAYER_ID, source)
+      layer.setCircleRadius(const(16.dp).compile(ExpressionContext.None))
+      layer.setCircleColor(const(Color.Black))
+      layer.setCircleOpacity(const(1.0f))
+      style.addLayer(layer)
+
+      val extent = BridgeMapFixture.DEFAULT_EXTENT
+      val centerX = extent.physicalWidth / 2
+      val centerY = extent.physicalHeight / 2
+
+      fixture.pumpUntil("the initial point to render", PUMP_TIMEOUT) {
+        fixture.hasRendered && fixture.readPixel(centerX, centerY).isNear(CIRCLE)
+      }
+
+      update(source, pointAt(FAR_AWAY))
+
+      if (onDemand) {
+        // The real hosts draw only the frames the session asks for. An unconditional pump would
+        // mask an update that never turns into a frame request.
+        fixture.settle()
+        assertTrue(
+          fixture.readPixel(centerX, centerY).isNear(BACKGROUND),
+          "the update did not render without pumping: ${fixture.errors}",
+        )
+      } else {
+        fixture.pumpUntil("the update to render", PUMP_TIMEOUT) {
+          fixture.hasRendered && fixture.readPixel(centerX, centerY).isNear(BACKGROUND)
+        }
+      }
+      assertEquals(emptyList(), fixture.errors, "the map should report nothing")
+    }
+  }
+
+  private fun pointAt(position: Position): FeatureCollection<Geometry, JsonObject?> =
+    buildFeatureCollection {
+      addFeature(geometry = Point(position))
+    }
+
+  private fun RgbaPixel.isNear(expected: RgbaPixel): Boolean =
+    listOf(
+        abs(expected.red - red),
+        abs(expected.green - green),
+        abs(expected.blue - blue),
+        abs(expected.alpha - alpha),
+      )
+      .all { it <= CHANNEL_TOLERANCE }
+
+  private companion object {
+    const val SOURCE_ID = "points"
+    const val LAYER_ID = "points-layer"
+    const val CHANNEL_TOLERANCE = 2
+
+    /** Matches the GeoJSON benchmark: 8000 points, one publication per frame. */
+    const val STREAM_POINT_COUNT = 8_000
+
+    const val FRAME_INTERVAL_MILLIS = 16L
+    const val POLL_INTERVAL_MILLIS = 250L
+
+    val STREAM_TIMEOUT = 30.seconds
+    val PUMP_TIMEOUT = 30.seconds
+
+    val ORIGIN = Position(longitude = 0.0, latitude = 0.0)
+
+    /** At zoom 14 this is far beyond the viewport. */
+    val FAR_AWAY = Position(longitude = 5.0, latitude = 5.0)
+
+    val BACKGROUND = RgbaPixel(red = 0x33, green = 0x66, blue = 0x99, alpha = 0xff)
+    val CIRCLE = RgbaPixel(red = 0x00, green = 0x00, blue = 0x00, alpha = 0xff)
+
+    val STYLE =
+      BaseStyle.Json(
+        """
+        {"version":8,"sources":{},"layers":[
+          {"id":"background","type":"background","paint":{"background-color":"#336699"}}
+        ]}
+        """
+      )
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Publications that outpace a GeoJSON parse now conflate to the newest data and still install, extracted from #985.

## Validation

Desktop JVM GeoJSON attach and update tests passed, including a URI publication overlapped with an in-flight inline parse.

## AI assistance

Cursor Grok 4.6 as a Cursor Cloud agent.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e0fb2e6d-715e-4f7f-88e3-8aeed5cd5d3a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e0fb2e6d-715e-4f7f-88e3-8aeed5cd5d3a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

