### PR TITLE
Fix android-sdk-root on bash 3.2 with no SDK vars set

### DIFF
--- a/.mise/bin/android-sdk-root
+++ b/.mise/bin/android-sdk-root
@@ -28,7 +28,9 @@ if [[ -n "${ANDROID_SDK_ROOT:-}" ]]; then
   candidates+=("$ANDROID_SDK_ROOT")
 fi
 
-for candidate in "${candidates[@]}"; do
+# ${candidates[@]+...} keeps bash 3.2 (macOS) from failing on an empty array
+# under `set -u`; plain "${candidates[@]}" errors before the message below.
+for candidate in ${candidates[@]+"${candidates[@]}"}; do
   if [[ -d "$candidate" ]]; then
     printf '%s\n' "$candidate"
     exit 0


### PR DESCRIPTION
## Description

Uses `${candidates[@]+...}` when iterating the SDK candidates so macOS bash 3.2 no longer fails on the empty array under `set -u` when no SDK environment variables are set.

## AI assistance

Prepared with Kimi Code CLI.