### PR TITLE
Acquire Vulkan writes in the Linux GL presenter

### DIFF
--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/bridge/VulkanOpenGlMapHost.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/bridge/VulkanOpenGlMapHost.kt
@@ -129,6 +129,8 @@ internal class VulkanOpenGlMapHost(private val gpuHost: ComposeMapHost) : MlnFfi
   private var generation = 0L
   private var currentExtent = MapExtent.Empty
 
+  @Volatile private var acquireProducerWrites = false
+
   override val backends: RenderBackendPair =
     RenderBackendPair(MapRenderBackend.VULKAN, ComposeRenderBackend.OPENGL)
 
@@ -159,6 +161,7 @@ internal class VulkanOpenGlMapHost(private val gpuHost: ComposeMapHost) : MlnFfi
 
   override fun completeProducerAccess(frame: MlnFfiMapFrame) {
     rendererThread.run { vulkan?.waitIdle() }
+    acquireProducerWrites = true
   }
 
   override fun <T> withProducerAccess(frame: MlnFfiMapFrame, action: () -> T): T =
@@ -172,6 +175,12 @@ internal class VulkanOpenGlMapHost(private val gpuHost: ComposeMapHost) : MlnFfi
     if (target !is VulkanImageTarget) return false
     return gpuHost.withOpenGlContextOrNull { context ->
       frameCompletion.prepare(context.skiaContext, ::abandonContext)
+      if (acquireProducerWrites) {
+        // EXT_memory_object does not make Vulkan's waitIdle visible to this context. glFinish
+        // acquires those writes.
+        glFinish()
+        acquireProducerWrites = false
+      }
       val sharedTexture =
         if (target.generation == generation) texture else retiredTextures[target.generation]
       val imported = sharedTexture?.imported ?: return@withOpenGlContextOrNull false
@@ -236,6 +245,7 @@ internal class VulkanOpenGlMapHost(private val gpuHost: ComposeMapHost) : MlnFfi
   /** Drops OpenGL names that cannot be used or deleted in the replacement context. */
   private fun abandonContext() {
     presenter.abandon()
+    acquireProducerWrites = false
     // Keep the Vulkan allocation and device alive: MapLibre's render session still refers to both
     // until the next producer frame retargets it.
     texture?.let { retiredTextures[generation] = it }

--- a/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/desktop/bridge/LinuxVulkanOpenGlInteropTest.kt
+++ b/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/desktop/bridge/LinuxVulkanOpenGlInteropTest.kt
@@ -146,6 +146,11 @@ class LinuxVulkanOpenGlInteropTest {
 
               mapHost.replaceContext(secondEgl)
               val second = secondEgl.withCurrent { map.renderStyle(SECOND_STYLE, FIRST_EXTENT) }
+              assertTrue(
+                second.generation != first.generation,
+                "replacement context must allocate a new shared target, " +
+                  "got generation ${second.generation} after ${first.generation}",
+              )
               assertNear(
                 SECOND_PIXEL,
                 secondEgl.withCurrent { secondEgl.drawAndRead(host, second) },
@@ -169,9 +174,12 @@ class LinuxVulkanOpenGlInteropTest {
             egl.withCurrent {
               val first = map.renderStyle(FIRST_STYLE, FIRST_EXTENT)
               assertNear(FIRST_PIXEL, egl.drawAndRead(host, first), "live first frame")
-              map.presentStyle(SECOND_STYLE, FIRST_EXTENT, SECOND_PIXEL) { target ->
-                egl.drawAndRead(host, target)
-              }
+              val second = map.renderStyle(SECOND_STYLE, FIRST_EXTENT)
+              assertNear(
+                SECOND_PIXEL,
+                egl.drawAndRead(host, second),
+                "live second frame after reuse",
+              )
             }
           }
         } finally {
@@ -280,8 +288,9 @@ class LinuxVulkanOpenGlInteropTest {
       var rendered: MlnFfiRenderTarget? = null
       var renderedFrames = 0
       var lastResult: MlnFfiFrameResult? = null
-      // Style callbacks and rendering happen on different threads, so wait for both facts
-      // without requiring either to be observed first.
+      // Style application and rendering run on different threads. A frame that started before
+      // the new style was observed is the previous style, even if the callback arrives before
+      // this loop looks again. Sample the load count first, then keep only a later frame.
       while (styleLoads < expectedStyleLoads || rendered == null) {
         check(deadline.hasNotPassedNow()) {
           "Timed out rendering style $style at $extent; " +
@@ -289,39 +298,16 @@ class LinuxVulkanOpenGlInteropTest {
             "last result: $lastResult, failure: $failure"
         }
         failure?.let { error(it) }
+        val loadsBeforePump = styleLoads
         val pumped = pumpFrame(extent)
         lastResult = pumped.result
-        if (pumped.rendered) {
+        if (loadsBeforePump >= expectedStyleLoads && pumped.rendered) {
           renderedFrames++
           rendered = pumped.target
         }
         Thread.sleep(POLL_INTERVAL_MILLIS)
       }
       return checkNotNull(rendered)
-    }
-
-    fun presentStyle(
-      style: BaseStyle,
-      extent: MapExtent,
-      expected: RgbaPixel,
-      read: (MlnFfiRenderTarget) -> RgbaPixel,
-    ): MlnFfiRenderTarget {
-      var target = renderStyle(style, extent)
-      var actual = read(target)
-      val deadline = TimeSource.Monotonic.markNow() + TEST_TIMEOUT
-      while (!near(expected, actual)) {
-        check(deadline.hasNotPassedNow()) {
-          "Timed out presenting $expected at $extent, last read $actual"
-        }
-        renderer.onSurfaceChanged(extent)
-        val pumped = pumpFrame(extent)
-        if (pumped.rendered) {
-          target = checkNotNull(pumped.target)
-          actual = read(target)
-        }
-        Thread.sleep(POLL_INTERVAL_MILLIS)
-      }
-      return target
     }
 
     private fun pumpFrame(extent: MapExtent): PumpedFrame {

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -621,6 +621,11 @@ internal class MlnFfiMapSession(
         callbacks.onStyleChanged(this, MlnFfiStyle(binding, ::imageScale))
         styleLoadUnreported = true
         reportedUrlAttribution.clear()
+        // The callback is the signal that the new style is loaded. A producer frame that
+        // started before this event can still hold the previous style, so schedule one that
+        // starts afterward. MAP_RENDER_UPDATE_AVAILABLE does not always follow this event,
+        // especially after a retarget that already consumed the last render request.
+        requestRender()
       }
 
       // mbgl only delivers onDidFinishLoadingMap once a frame has seen the new style as not yet

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -621,10 +621,10 @@ internal class MlnFfiMapSession(
         callbacks.onStyleChanged(this, MlnFfiStyle(binding, ::imageScale))
         styleLoadUnreported = true
         reportedUrlAttribution.clear()
-        // The callback is the signal that the new style is loaded. A producer frame that
-        // started before this event can still hold the previous style, so schedule one that
-        // starts afterward. MAP_RENDER_UPDATE_AVAILABLE does not always follow this event,
-        // especially after a retarget that already consumed the last render request.
+        // A producer frame that started before this callback can still hold the previous style.
+        // requestRepaint dirties mbgl so the next renderUpdate draws instead of returning
+        // NO_UPDATE; requestRender lets that draw through the session skip gate.
+        loop?.map?.requestRepaint()
         requestRender()
       }
 

--- a/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/map/MlnFfiMapRepaintTest.kt
+++ b/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/map/MlnFfiMapRepaintTest.kt
@@ -21,10 +21,21 @@ import org.maplibre.spatialk.geojson.dsl.featureCollectionOf
  * Proves that a style change actually redraws, not just that it reaches MapLibre.
  *
  * `addSource`, `removeSource`, and `removeImage` publish no render update on their own, so the
- * style binding requests a repaint for them. Each test settles first, because a frame still in
- * flight would render the mutation by accident.
+ * style binding requests a repaint for them. A base style load can finish during a frame that
+ * started beforehand, so `MAP_STYLE_LOADED` also requests a repaint. Each test settles first,
+ * because a frame still in flight would render the mutation by accident.
  */
 class MlnFfiMapRepaintTest {
+
+  @Test
+  fun replacing_the_base_style_after_the_map_settles_redraws() {
+    BridgeMapFixture.create().use { fixture ->
+      fixture.loadEmptyStyle()
+      fixture.assertRedrawsAfter("replacing the base style") {
+        fixture.session.setBaseStyle(COLORED_BACKGROUND)
+      }
+    }
+  }
 
   @Test
   fun adding_a_layer_after_the_map_settles_redraws() {
@@ -107,5 +118,14 @@ class MlnFfiMapRepaintTest {
     val REDRAW_TIMEOUT: Duration = 30.seconds
 
     val POLL_WINDOW: Duration = 50.milliseconds
+
+    val COLORED_BACKGROUND =
+      BaseStyle.Json(
+        """
+        {"version":8,"sources":{},"layers":[
+          {"id":"background","type":"background","paint":{"background-color":"#ff0000"}}
+        ]}
+        """
+      )
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Ubuntu `LinuxVulkanOpenGlInteropTest` failed because a frame rendered before the new style, because Vulkan `waitIdle` does not publish `EXT_memory_object` writes into Compose's GL context, and because `MAP_STYLE_LOADED` did not dirty mbgl, so the next `renderUpdate` returned `NO_UPDATE` after a retarget consumed the last real draw.

## Validation

`LinuxVulkanOpenGlInteropTest` passed 5 consecutive `jvmTest` runs on this x64 lavapipe host, and `MlnFfiMapRepaintTest` including `replacing_the_base_style_after_the_map_settles_redraws` passed; ubuntu-24.04 and ubuntu-24.04-arm both timed out the replacement-context case before `requestRepaint`.

## AI assistance

Cursor Grok 4.6 implemented this as a cloud agent.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f9ec2778-9c7c-4664-9aec-cb6908f083df?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f9ec2778-9c7c-4664-9aec-cb6908f083df&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

