### PR TITLE
Document that an application can supply its own location source

### DIFF
--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Location.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Location.kt
@@ -3,11 +3,18 @@
 package org.maplibre.compose.docsnippets
 
 import androidx.compose.runtime.Composable
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.camera.rememberCameraState
+import org.maplibre.compose.location.Location
+import org.maplibre.compose.location.LocationEvent
+import org.maplibre.compose.location.LocationProvider
 import org.maplibre.compose.location.LocationPuck
+import org.maplibre.compose.location.LocationRequest
 import org.maplibre.compose.location.LocationTrackingEffect
+import org.maplibre.compose.location.LocationUnavailableReason
 import org.maplibre.compose.location.mostAccurateBearing
 import org.maplibre.compose.location.rememberDefaultLocationProvider
 import org.maplibre.compose.location.rememberDefaultOrientationProvider
@@ -46,3 +53,12 @@ fun Location() {
   }
   // #endregion puck
 }
+
+// #region custom-provider
+class ReplayLocationProvider(private val locations: List<Location>) : LocationProvider {
+  override fun updates(request: LocationRequest): Flow<LocationEvent> = flow {
+    locations.forEach { emit(LocationEvent.Fix(it)) }
+    emit(LocationEvent.Unavailable(LocationUnavailableReason.TemporarilyUnavailable))
+  }
+}
+// #endregion custom-provider

--- a/docs/src/content/docs/location.mdx
+++ b/docs/src/content/docs/location.mdx
@@ -90,10 +90,26 @@ indicators. If you use the Material 3 extension module, pass
 
 ### Custom providers
 
+An application implements `LocationProvider` for any source that is not the
+operating system's location API. That includes a serial or Bluetooth GNSS
+receiver, a vehicle bus, a network feed, a recorded-track replay, and a
+simulator.
+
 A custom `LocationProvider` implements only `updates(request)`. `permission`
 defaults to always granted and `requestPermission()` defaults to a no-op, so a
 source where permission is not a concept, such as an external receiver or a
 network feed, needs no permission handling.
+
+Emit `LocationEvent.Unavailable` when the fix is lost. A single physical
+device shares one flow rather than opening a new request per collector.
+
+Fill `Location.course` with movement direction. Desktop's default orientation
+provider is `NullOrientationProvider`. The puck and camera use that course.
+
+Unlike a wall-clock instant, `Location.timestamp` is a `TimeMark`. A source
+with its own clock marks receipt of the fix.
+
+<Code code={region(location, "custom-provider")} lang="kotlin" />
 
 A provider that wraps a real platform source can delegate permission to the
 building blocks that the default providers use: `AndroidLocationPermissionRequester`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Documents that an application can implement `LocationProvider` itself for non-OS sources, and closes #960.

## Validation

`./gradlew :demo-app:common:compileKotlinJvm` compiled the snippet, and `dprint check` passed on the changed files.

## AI assistance

Cursor Grok 4.6 (Cursor Cloud Agent).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-93407544-607a-4c6b-939f-d8e72167b4a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-93407544-607a-4c6b-939f-d8e72167b4a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

