### PR TITLE
Document declaring an image source before its image exists

### DIFF
--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/sources/ImageSource.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/sources/ImageSource.kt
@@ -41,12 +41,8 @@ public fun rememberImageSource(position: PositionQuad, uri: String): ImageSource
 /**
  * Remember a new [ImageSource] from the given [bitmap].
  *
- * Pass a placeholder [ImageBitmap] and the best-known [PositionQuad] to declare the source before
- * the real image is ready. A transparent 1×1 bitmap is a typical placeholder. When the real image
- * and corners arrive, recomposition updates the same remembered source in place through
- * [ImageSource.setImage] and [ImageSource.setBounds]. Declaring the source once and updating it is
- * cheaper than wrapping the layer in `if (image != null)`. Use the layer's `visible` to show or
- * hide an overlay that is already in the style.
+ * Recomposition updates this source in place through [ImageSource.setImage] and
+ * [ImageSource.setBounds].
  */
 @Composable
 public fun rememberImageSource(position: PositionQuad, bitmap: ImageBitmap): ImageSource =

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/sources/ImageSource.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/sources/ImageSource.kt
@@ -22,7 +22,12 @@ public expect class ImageSource : Source {
   public fun setUri(uri: String)
 }
 
-/** Remember a new [ImageSource] from the given [uri]. */
+/**
+ * Remember a new [ImageSource] from the given [uri].
+ *
+ * Recomposition updates this source in place through [ImageSource.setUri] and
+ * [ImageSource.setBounds].
+ */
 @Composable
 public fun rememberImageSource(position: PositionQuad, uri: String): ImageSource =
   rememberUserSource(
@@ -33,7 +38,16 @@ public fun rememberImageSource(position: PositionQuad, uri: String): ImageSource
     },
   )
 
-/** Remember a new [ImageSource] from the given [bitmap]. */
+/**
+ * Remember a new [ImageSource] from the given [bitmap].
+ *
+ * Pass a placeholder [ImageBitmap] and the best-known [PositionQuad] to declare the source before
+ * the real image is ready. A transparent 1×1 bitmap is a typical placeholder. When the real image
+ * and corners arrive, recomposition updates the same remembered source in place through
+ * [ImageSource.setImage] and [ImageSource.setBounds]. Declaring the source once and updating it is
+ * cheaper than wrapping the layer in `if (image != null)`. Use the layer's `visible` to show or
+ * hide an overlay that is already in the style.
+ */
 @Composable
 public fun rememberImageSource(position: PositionQuad, bitmap: ImageBitmap): ImageSource =
   rememberUserSource(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Documents the placeholder-bitmap pattern on `rememberImageSource` so a source can be declared before its image and corners exist. Closes #957.

## Validation

Read the KDoc against #957; this change is documentation only.

## AI assistance

Cursor Grok 4.6 in Cursor Cloud Agent.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-93407544-607a-4c6b-939f-d8e72167b4a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-93407544-607a-4c6b-939f-d8e72167b4a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

