### PR TITLE
Print full test exceptions and upload reports on CI failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,17 @@ jobs:
       - uses: ./.github/actions/setup-ci-deps
         with:
           android-emulator: ${{ matrix.api-level }}
-      - run: mise run test:android
+      - id: android-host-tests
+        run: mise run test:android
+      - name: Upload Android host test reports
+        if: ${{ failure() && steps.android-host-tests.outcome == 'failure' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          if-no-files-found: warn
+          name: android-${{ matrix.api-level }}-host-test-reports
+          path: |
+            **/build/reports/tests
+            **/build/test-results
       - id: android-device-tests
         run: mise run test:android:device ${{ matrix.api-level }}
       - name: Capture Android emulator diagnostics
@@ -94,7 +104,17 @@ jobs:
       - uses: ./.github/actions/setup-ci-deps
         with:
           save-toolchains: "true"
-      - run: mise run test:ios
+      - id: ios-tests
+        run: mise run test:ios
+      - name: Upload iOS test reports
+        if: ${{ failure() && steps.ios-tests.outcome == 'failure' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          if-no-files-found: warn
+          name: ios-test-reports
+          path: |
+            **/build/reports/tests
+            **/build/test-results
 
   ios-device:
     timeout-minutes: 45
@@ -116,7 +136,17 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-ci-deps
-      - run: mise run test:js
+      - id: js-tests
+        run: mise run test:js
+      - name: Upload JS test reports
+        if: ${{ failure() && steps.js-tests.outcome == 'failure' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          if-no-files-found: warn
+          name: js-test-reports
+          path: |
+            **/build/reports/tests
+            **/build/test-results
 
   desktop:
     strategy:
@@ -153,7 +183,17 @@ jobs:
       - uses: ./.github/actions/setup-ci-deps
         with:
           save-toolchains: ${{ matrix.save_toolchains }}
-      - run: mise run test:desktop
+      - id: desktop-tests
+        run: mise run test:desktop
+      - name: Upload desktop test reports
+        if: ${{ failure() && steps.desktop-tests.outcome == 'failure' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          if-no-files-found: warn
+          name: ${{ matrix.artifact_name }}-test-reports
+          path: |
+            **/build/reports/tests
+            **/build/test-results
       - run: mise run build:desktop-app
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/buildSrc/src/main/kotlin/module-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/module-conventions.gradle.kts
@@ -1,3 +1,4 @@
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 group = "org.maplibre.compose"
@@ -17,7 +18,11 @@ tasks
   .withType<KotlinCompilationTask<*>>()
   .configureEach { compilerOptions { allWarningsAsErrors = false } }
 
-tasks.withType<AbstractTestTask>().configureEach { failOnNoDiscoveredTests = false }
+tasks.withType<AbstractTestTask>().configureEach {
+  failOnNoDiscoveredTests = false
+  // SHORT prints "Type at File:line" and drops the message. CI needs the message.
+  testLogging { exceptionFormat = TestExceptionFormat.FULL }
+}
 
 // Desktop tests may load the MapLibre Native FFI runtime, which needs native access.
 tasks.withType<Test>().configureEach {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Failed Gradle tests print the exception message in the log, and CI uploads the HTML and XML reports when a test step fails.

## Validation

A JVM `check()` failure now logs `IllegalStateException: CI_PROBE_EXCEPTION_MESSAGE` instead of `Type at File:line`; actionlint and action-pins passed on commit.

## AI assistance

Cursor Grok 4.6 implemented this as a cloud agent.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-25d56b23-3c2f-4543-80f2-6df546ebc020?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-25d56b23-3c2f-4543-80f2-6df546ebc020&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

