### PR TITLE
Apply default MapLibre.configure on the first map

### DIFF
--- a/demo-app/android/src/main/kotlin/org/maplibre/compose/demoapp/MainActivity.kt
+++ b/demo-app/android/src/main/kotlin/org/maplibre/compose/demoapp/MainActivity.kt
@@ -4,13 +4,11 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import org.maplibre.compose.android.MapLibre
 
 class MainActivity : ComponentActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     enableEdgeToEdge()
-    MapLibre.configure(applicationContext)
     setContent { DemoApp() }
   }
 }

--- a/demo-app/common/src/iosMain/kotlin/org/maplibre/compose/demoapp/MainViewController.kt
+++ b/demo-app/common/src/iosMain/kotlin/org/maplibre/compose/demoapp/MainViewController.kt
@@ -1,11 +1,7 @@
 package org.maplibre.compose.demoapp
 
 import androidx.compose.ui.window.ComposeUIViewController
-import org.maplibre.compose.ios.MapLibre
 import platform.UIKit.UIViewController
 
 @Suppress("unused", "FunctionName") // called in Swift
-fun MainViewController(): UIViewController {
-  MapLibre.configure()
-  return ComposeUIViewController { DemoApp() }
-}
+fun MainViewController(): UIViewController = ComposeUIViewController { DemoApp() }

--- a/demo-app/common/src/jsMain/kotlin/org/maplibre/compose/demoapp/main.kt
+++ b/demo-app/common/src/jsMain/kotlin/org/maplibre/compose/demoapp/main.kt
@@ -11,7 +11,7 @@ fun main() {
   onWasmReady {
     // Must run before Compose builds its renderer, which creates the GPU context maps composite
     // into.
-    MapLibre.initialize()
+    MapLibre.configure()
     ComposeViewport(document.body!!) { DemoApp() }
   }
 }

--- a/demo-app/desktop/src/main/kotlin/org/maplibre/compose/demoapp/Main.kt
+++ b/demo-app/desktop/src/main/kotlin/org/maplibre/compose/demoapp/Main.kt
@@ -1,13 +1,11 @@
 package org.maplibre.compose.demoapp
 
 import androidx.compose.ui.window.singleWindowApplication
-import org.maplibre.compose.desktop.MapLibre
 import org.maplibre.compose.desktop.ProvideMapHost
 import org.maplibre.compose.desktop.rememberAwtComposeMapHost
 
 // #region main
 fun main() {
-  MapLibre.configure(applicationId = "org.maplibre.compose.demoapp")
   singleWindowApplication {
     ProvideMapHost(host = rememberAwtComposeMapHost(window)) { DemoApp() }
   }

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -73,38 +73,11 @@ commonMain.dependencies {
 
 ## Set up Android
 
-The first map uses the application's private cache directory for the ambient
-cache and offline-region database. Call `MapLibre.configure` before composing a
-map to choose another file or cache budget:
-
-```kotlin title="MainActivity.kt"
-MapLibre.configure(
-  applicationContext,
-  AndroidRuntimeOptions(
-    cacheFile = androidCacheFile(applicationContext),
-    maximumCacheSizeBytes = 512L * 1024L * 1024L,
-  ),
-)
-```
-
-Import `MapLibre` from `org.maplibre.compose.android`.
+Maps use the application's private cache directory.
 
 ## Set up iOS
 
-The first map uses the application's caches directory for the ambient cache and
-offline-region database. Call `MapLibre.configure` before composing a map to
-choose another file or cache budget:
-
-```kotlin title="MainViewController.kt"
-MapLibre.configure(
-  IosRuntimeOptions(
-    cacheFile = iosCacheFile(),
-    maximumCacheSizeBytes = 512L * 1024L * 1024L,
-  ),
-)
-```
-
-Import `MapLibre` from `org.maplibre.compose.ios`.
+Maps use the application's caches directory.
 
 The runtime's system libraries link when Xcode links your app, not when Gradle
 builds the framework. Add them to your iOS app target's **Other Linker Flags**:
@@ -168,13 +141,10 @@ sourceSets {
 }
 ```
 
-Provide each AWT window's GPU context. The first map names its cache after the
-package of the process `main` class; pass `applicationId` to pin a name that
-survives moving `main`:
+Provide each AWT window's GPU context:
 
 ```kotlin title="Main.kt"
 fun main() {
-  MapLibre.configure(applicationId = "com.example.myapp")
   singleWindowApplication {
     ProvideMapHost(host = rememberAwtComposeMapHost(window)) {
       App()

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -73,36 +73,38 @@ commonMain.dependencies {
 
 ## Set up Android
 
-Configure MapLibre once during application startup, before composing a map or
-using the offline APIs:
+The first map uses the application's private cache directory for the ambient
+cache and offline-region database. Call `MapLibre.configure` before composing a
+map to choose another file or cache budget:
 
 ```kotlin title="MainActivity.kt"
-override fun onCreate(savedInstanceState: Bundle?) {
-  super.onCreate(savedInstanceState)
-  MapLibre.configure(applicationContext)
-  setContent { App() }
-}
+MapLibre.configure(
+  applicationContext,
+  AndroidRuntimeOptions(
+    cacheFile = androidCacheFile(applicationContext),
+    maximumCacheSizeBytes = 512L * 1024L * 1024L,
+  ),
+)
 ```
 
-Import `MapLibre` from `org.maplibre.compose.android`. By default its ambient
-cache and offline-region database live in the application's private cache
-directory; pass `AndroidRuntimeOptions` to choose another file or cache budget.
+Import `MapLibre` from `org.maplibre.compose.android`.
 
 ## Set up iOS
 
-Configure MapLibre once during application startup, before composing a map or
-using the offline APIs:
+The first map uses the application's caches directory for the ambient cache and
+offline-region database. Call `MapLibre.configure` before composing a map to
+choose another file or cache budget:
 
 ```kotlin title="MainViewController.kt"
-fun MainViewController(): UIViewController {
-  MapLibre.configure()
-  return ComposeUIViewController { App() }
-}
+MapLibre.configure(
+  IosRuntimeOptions(
+    cacheFile = iosCacheFile(),
+    maximumCacheSizeBytes = 512L * 1024L * 1024L,
+  ),
+)
 ```
 
-Import `MapLibre` from `org.maplibre.compose.ios`. By default its ambient
-cache and offline-region database live in the application's caches directory;
-pass `IosRuntimeOptions` to choose another file or cache budget.
+Import `MapLibre` from `org.maplibre.compose.ios`.
 
 The runtime's system libraries link when Xcode links your app, not when Gradle
 builds the framework. Add them to your iOS app target's **Other Linker Flags**:
@@ -133,12 +135,12 @@ kotlin {
 }
 ```
 
-Initialize MapLibre inside `onWasmReady`, before Compose starts.
+Configure MapLibre inside `onWasmReady`, before Compose starts.
 
 ```kotlin title="main.kt"
 fun main() {
   onWasmReady {
-    MapLibre.initialize()
+    MapLibre.configure()
     ComposeViewport(document.body!!) { App() }
   }
 }
@@ -166,7 +168,9 @@ sourceSets {
 }
 ```
 
-Configure MapLibre once, then provide each AWT window's GPU context:
+Provide each AWT window's GPU context. The first map names its cache after the
+package of the process `main` class; pass `applicationId` to pin a name that
+survives moving `main`:
 
 ```kotlin title="Main.kt"
 fun main() {

--- a/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/android/MapLibre.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/android/MapLibre.kt
@@ -4,14 +4,14 @@ import android.content.Context
 import org.maplibre.compose.mlnffi.AndroidMlnFfiPlatform
 import org.maplibre.compose.mlnffi.MlnFfiApplication
 
-/** Process-wide entry point for configuring MapLibre Compose on Android. */
+/** Android configuration for MapLibre Compose. */
 public object MapLibre {
   /**
-   * Installs [options] for every map and offline operation in this process.
+   * Sets the cache file and ambient cache budget for every map and offline operation in this
+   * process.
    *
-   * The first map or offline manager uses [androidCacheFile] and MapLibre's cache budget. Call this
-   * beforehand to choose another file or budget. The first call wins. Repeating the same normalized
-   * configuration is a no-op; a conflicting call throws [IllegalStateException].
+   * Defaults to [androidCacheFile] and MapLibre's cache budget. A conflicting call throws
+   * [IllegalStateException].
    */
   public fun configure(
     context: Context,

--- a/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/android/MapLibre.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/android/MapLibre.kt
@@ -9,9 +9,9 @@ public object MapLibre {
   /**
    * Installs [options] for every map and offline operation in this process.
    *
-   * Call this once from application startup, before composing a map or using offline APIs. The
-   * first call wins. Repeating the same normalized configuration is a no-op; a conflicting call
-   * throws [IllegalStateException].
+   * The first map or offline manager uses [androidCacheFile] and MapLibre's cache budget. Call this
+   * beforehand to choose another file or budget. The first call wins. Repeating the same normalized
+   * configuration is a no-op; a conflicting call throws [IllegalStateException].
    */
   public fun configure(
     context: Context,

--- a/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/map/AndroidMapView.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/map/AndroidMapView.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.Modifier
 import co.touchlab.kermit.Logger
 import org.maplibre.compose.mlnffi.AndroidMapSurfaceKind
 import org.maplibre.compose.mlnffi.AndroidMlnFfiSurface
+import org.maplibre.compose.mlnffi.EnsureMlnFfiConfigured
 import org.maplibre.compose.mlnffi.MapRenderBackend
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.compose.style.SafeStyle
@@ -22,6 +23,7 @@ internal actual fun ComposableMapView(
   callbacks: MapAdapter.Callbacks,
   options: MapOptions,
 ) {
+  EnsureMlnFfiConfigured()
   val runtimeBackends = remember { loadRuntimeBackends(logger) }
   val surfaceKind =
     when (options.renderOptions.preferredRenderMode) {

--- a/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/mlnffi/EnsureMlnFfiConfigured.android.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/mlnffi/EnsureMlnFfiConfigured.android.kt
@@ -1,0 +1,11 @@
+package org.maplibre.compose.mlnffi
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+import org.maplibre.compose.android.MapLibre
+
+@Composable
+internal actual fun EnsureMlnFfiConfigured() {
+  val context = LocalContext.current
+  MlnFfiApplication.ensureConfigured { MapLibre.configure(context) }
+}

--- a/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/mlnffi/EnsureMlnFfiConfigured.android.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/mlnffi/EnsureMlnFfiConfigured.android.kt
@@ -2,10 +2,15 @@ package org.maplibre.compose.mlnffi
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
-import org.maplibre.compose.android.MapLibre
+import org.maplibre.compose.android.AndroidRuntimeOptions
+import org.maplibre.compose.android.androidCacheFile
+import org.maplibre.compose.android.toMlnFfiRuntimeOptions
 
 @Composable
 internal actual fun EnsureMlnFfiConfigured() {
   val context = LocalContext.current
-  MlnFfiApplication.ensureConfigured { MapLibre.configure(context) }
+  AndroidMlnFfiPlatform.initialize(context)
+  MlnFfiApplication.ensureConfigured {
+    AndroidRuntimeOptions(androidCacheFile(context)).toMlnFfiRuntimeOptions()
+  }
 }

--- a/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/ios/MapLibre.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/ios/MapLibre.kt
@@ -7,9 +7,9 @@ public object MapLibre {
   /**
    * Installs [options] for every map and offline operation in this process.
    *
-   * Call this once from application startup, before composing a map or using offline APIs. The
-   * first call wins. Repeating the same normalized configuration is a no-op; a conflicting call
-   * throws [IllegalStateException].
+   * The first map or offline manager uses [iosCacheFile] and MapLibre's cache budget. Call this
+   * beforehand to choose another file or budget. The first call wins. Repeating the same normalized
+   * configuration is a no-op; a conflicting call throws [IllegalStateException].
    */
   public fun configure(options: IosRuntimeOptions = IosRuntimeOptions(iosCacheFile())) {
     MlnFfiApplication.configure(options.toMlnFfiRuntimeOptions())

--- a/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/ios/MapLibre.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/ios/MapLibre.kt
@@ -2,14 +2,14 @@ package org.maplibre.compose.ios
 
 import org.maplibre.compose.mlnffi.MlnFfiApplication
 
-/** Process-wide entry point for configuring MapLibre Compose on iOS. */
+/** iOS configuration for MapLibre Compose. */
 public object MapLibre {
   /**
-   * Installs [options] for every map and offline operation in this process.
+   * Sets the cache file and ambient cache budget for every map and offline operation in this
+   * process.
    *
-   * The first map or offline manager uses [iosCacheFile] and MapLibre's cache budget. Call this
-   * beforehand to choose another file or budget. The first call wins. Repeating the same normalized
-   * configuration is a no-op; a conflicting call throws [IllegalStateException].
+   * Defaults to [iosCacheFile] and MapLibre's cache budget. A conflicting call throws
+   * [IllegalStateException].
    */
   public fun configure(options: IosRuntimeOptions = IosRuntimeOptions(iosCacheFile())) {
     MlnFfiApplication.configure(options.toMlnFfiRuntimeOptions())

--- a/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/mlnffi/EnsureMlnFfiConfigured.ios.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/mlnffi/EnsureMlnFfiConfigured.ios.kt
@@ -1,9 +1,13 @@
 package org.maplibre.compose.mlnffi
 
 import androidx.compose.runtime.Composable
-import org.maplibre.compose.ios.MapLibre
+import org.maplibre.compose.ios.IosRuntimeOptions
+import org.maplibre.compose.ios.iosCacheFile
+import org.maplibre.compose.ios.toMlnFfiRuntimeOptions
 
 @Composable
 internal actual fun EnsureMlnFfiConfigured() {
-  MlnFfiApplication.ensureConfigured { MapLibre.configure() }
+  MlnFfiApplication.ensureConfigured {
+    IosRuntimeOptions(iosCacheFile()).toMlnFfiRuntimeOptions()
+  }
 }

--- a/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/mlnffi/EnsureMlnFfiConfigured.ios.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/mlnffi/EnsureMlnFfiConfigured.ios.kt
@@ -1,0 +1,9 @@
+package org.maplibre.compose.mlnffi
+
+import androidx.compose.runtime.Composable
+import org.maplibre.compose.ios.MapLibre
+
+@Composable
+internal actual fun EnsureMlnFfiConfigured() {
+  MlnFfiApplication.ensureConfigured { MapLibre.configure() }
+}

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/browser/MapLibre.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/browser/MapLibre.kt
@@ -4,27 +4,15 @@ import org.maplibre.compose.gljs.DEFAULT_WORKER_URL
 import org.maplibre.compose.gljs.GlJsRuntime
 import org.maplibre.compose.gljs.SkikoGpuBridge
 
-/** Process-wide entry point for configuring MapLibre Compose in the browser. */
+/** Browser configuration for MapLibre Compose. */
 public object MapLibre {
   /**
-   * Prepares the page to composite maps, and must be called before Compose starts.
+   * Records Compose's GPU context and sets the MapLibre GL JS worker URL. Call this inside
+   * `onWasmReady`, before Compose starts.
    *
-   * ```kt
-   * fun main() {
-   *   onWasmReady {
-   *     MapLibre.configure()
-   *     ComposeViewport(document.body!!) { App() }
-   *   }
-   * }
-   * ```
+   * [workerUrl] defaults to the bundled MapLibre GL JS worker on jsDelivr. Later calls are ignored.
    *
-   * By default the MapLibre GL JS 6 worker is loaded from the jsDelivr CDN at the same version as
-   * the bundled library, so no bundler setup is needed. Pass [workerUrl] to self-host the worker or
-   * pin a different version.
-   *
-   * Repeat calls are ignored.
-   *
-   * @throws IllegalStateException if skiko is not loaded yet. Call this inside `onWasmReady`.
+   * @throws IllegalStateException if skiko has not published its exports yet.
    */
   public fun configure(workerUrl: String = DEFAULT_WORKER_URL) {
     check(SkikoGpuBridge.install()) {

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/browser/MapLibre.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/browser/MapLibre.kt
@@ -12,7 +12,7 @@ public object MapLibre {
    * ```kt
    * fun main() {
    *   onWasmReady {
-   *     MapLibre.initialize()
+   *     MapLibre.configure()
    *     ComposeViewport(document.body!!) { App() }
    *   }
    * }
@@ -26,11 +26,16 @@ public object MapLibre {
    *
    * @throws IllegalStateException if skiko is not loaded yet. Call this inside `onWasmReady`.
    */
-  public fun initialize(workerUrl: String = DEFAULT_WORKER_URL) {
+  public fun configure(workerUrl: String = DEFAULT_WORKER_URL) {
     check(SkikoGpuBridge.install()) {
-      "MapLibre.initialize() ran before skiko finished loading, so Compose's graphics context " +
+      "MapLibre.configure() ran before skiko finished loading, so Compose's graphics context " +
         "cannot be reached. Call it inside onWasmReady, immediately before ComposeViewport."
     }
     GlJsRuntime.pointAtWorker(workerUrl)
+  }
+
+  @Deprecated("Renamed to configure", ReplaceWith("configure(workerUrl)"))
+  public fun initialize(workerUrl: String = DEFAULT_WORKER_URL) {
+    configure(workerUrl)
   }
 }

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/SkikoGpuBridge.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/SkikoGpuBridge.kt
@@ -16,7 +16,7 @@ private const val GL_STATES = 0xffff
  * before Compose builds its renderer. A second `DirectContext.makeGL()` corrupts Compose's
  * rendering, so the existing one has to be caught as it is created.
  *
- * TODO: retire this, and [org.maplibre.compose.browser.MapLibre.initialize] with it, once
+ * TODO: retire this, and [org.maplibre.compose.browser.MapLibre.configure] with it, once
  *   [JetBrains/skiko#1219](https://github.com/JetBrains/skiko/pull/1219) or an equivalent lands.
  */
 internal object SkikoGpuBridge {

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserGpu.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserGpu.kt
@@ -56,7 +56,7 @@ private fun createGpu(): BrowserGpu {
   registry.makeContextCurrent(handle)
 
   // The hook has to be installed before the context is made.
-  MapLibre.initialize(workerUrl = LOCAL_WORKER_URL)
+  MapLibre.configure(workerUrl = LOCAL_WORKER_URL)
   val skia = DirectContext.makeGL()
   check(SkikoGpuBridge.isReady) { SkikoGpuBridge.diagnostic() }
 

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/ApplicationId.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/ApplicationId.kt
@@ -17,9 +17,7 @@ internal fun applicationIdFromClassName(className: String): String? {
   return pkg.takeIf { it.isNotEmpty() && APPLICATION_ID.matches(it) }
 }
 
-internal fun mainClassName(): String? =
-  mainClassNameFromStackTraces(Thread.getAllStackTraces())
-    ?: mainClassNameFromJavaCommand(System.getProperty("sun.java.command"))
+internal fun mainClassName(): String? = mainClassNameFromStackTraces(Thread.getAllStackTraces())
 
 internal fun mainClassNameFromStackTraces(traces: Map<Thread, Array<StackTraceElement>>): String? {
   val preferred = traces.entries.firstOrNull { it.key.name == "main" }
@@ -42,13 +40,6 @@ internal fun mainClassNameFromFrames(frames: List<StackTraceElement>): String? =
     .asReversed()
     .firstOrNull { frame -> frame.methodName == "main" && isApplicationClass(frame.className) }
     ?.className
-
-internal fun mainClassNameFromJavaCommand(command: String?): String? {
-  val token = command?.trim()?.substringBefore(' ')?.takeIf { it.isNotEmpty() } ?: return null
-  if ('/' in token || '\\' in token) return null
-  if (token.endsWith(".jar", ignoreCase = true)) return null
-  return token.takeIf(::isApplicationClass)
-}
 
 internal fun isApplicationClass(className: String): Boolean = LAUNCHER_PREFIXES.none {
   className.startsWith(it)

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/ApplicationId.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/ApplicationId.kt
@@ -1,0 +1,77 @@
+package org.maplibre.compose.desktop
+
+/**
+ * Derives the desktop cache namespace from the process `main` class.
+ *
+ * The package of that class is the default [MapLibre.configure] `applicationId`. Callers that move
+ * `main` or share a package across apps should pass `applicationId` explicitly.
+ */
+internal fun inferredApplicationId(): String {
+  val className = mainClassName()
+  val id = className?.let(::applicationIdFromClassName)
+  return id
+    ?: throw IllegalStateException(
+      "Could not infer applicationId from the process main class" +
+        (className?.let { " '$it'" } ?: "") +
+        ". Pass one explicitly: MapLibre.configure(applicationId = \"com.example.myapp\")."
+    )
+}
+
+internal fun applicationIdFromClassName(className: String): String? {
+  val pkg = className.substringBeforeLast('.', missingDelimiterValue = "")
+  return pkg.takeIf { it.isNotEmpty() && APPLICATION_ID.matches(it) }
+}
+
+internal fun mainClassName(): String? =
+  mainClassNameFromStackTraces(Thread.getAllStackTraces())
+    ?: mainClassNameFromJavaCommand(System.getProperty("sun.java.command"))
+
+internal fun mainClassNameFromStackTraces(traces: Map<Thread, Array<StackTraceElement>>): String? {
+  val preferred = traces.entries.firstOrNull { it.key.name == "main" }
+  val stacks = buildList {
+    if (preferred != null) add(preferred.value)
+    for ((thread, frames) in traces) {
+      if (thread !== preferred?.key) add(frames)
+    }
+  }
+  for (frames in stacks) {
+    mainClassNameFromFrames(frames.asList())?.let {
+      return it
+    }
+  }
+  return null
+}
+
+internal fun mainClassNameFromFrames(frames: List<StackTraceElement>): String? =
+  frames
+    .asReversed()
+    .firstOrNull { frame -> frame.methodName == "main" && isApplicationClass(frame.className) }
+    ?.className
+
+internal fun mainClassNameFromJavaCommand(command: String?): String? {
+  val token = command?.trim()?.substringBefore(' ')?.takeIf { it.isNotEmpty() } ?: return null
+  if ('/' in token || '\\' in token) return null
+  if (token.endsWith(".jar", ignoreCase = true)) return null
+  return token.takeIf(::isApplicationClass)
+}
+
+internal fun isApplicationClass(className: String): Boolean = LAUNCHER_PREFIXES.none {
+  className.startsWith(it)
+}
+
+internal val APPLICATION_ID = Regex("[A-Za-z0-9_-]+(?:\\.[A-Za-z0-9_-]+)*")
+
+private val LAUNCHER_PREFIXES =
+  arrayOf(
+    "java.",
+    "javax.",
+    "jdk.",
+    "sun.",
+    "com.sun.",
+    "kotlin.",
+    "kotlinx.",
+    "org.junit.",
+    "org.gradle.",
+    "worker.org.gradle.",
+    "com.intellij.rt.",
+  )

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/ApplicationId.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/ApplicationId.kt
@@ -1,11 +1,6 @@
 package org.maplibre.compose.desktop
 
-/**
- * Derives the desktop cache namespace from the process `main` class.
- *
- * The package of that class is the default [MapLibre.configure] `applicationId`. Callers that move
- * `main` or share a package across apps should pass `applicationId` explicitly.
- */
+/** Package of the process `main` class, used as the default [MapLibre.configure] applicationId. */
 internal fun inferredApplicationId(): String {
   val className = mainClassName()
   val id = className?.let(::applicationIdFromClassName)

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/MapLibre.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/MapLibre.kt
@@ -10,8 +10,10 @@ public object MapLibre {
   /**
    * Configures every map and offline operation in this process.
    *
-   * The first call wins. Repeating the same normalized configuration is a no-op; a conflicting call
-   * throws [IllegalStateException].
+   * The first map or offline manager infers [applicationId] from the package of the process `main`
+   * class. Call this beforehand to pin a name that survives moving `main`, or to set a cache
+   * budget. The first call wins. Repeating the same normalized configuration is a no-op; a
+   * conflicting call throws [IllegalStateException].
    *
    * @param applicationId Stable reverse-domain application identifier, such as `com.example.myapp`.
    *   MapLibre uses it to isolate the application's cache in the current operating system's
@@ -19,7 +21,10 @@ public object MapLibre {
    * @param maximumCacheSizeBytes Maximum ambient cache size in bytes, or null for MapLibre's own
    *   default. Offline regions are not ambient and are not evicted to satisfy this limit.
    */
-  public fun configure(applicationId: String, maximumCacheSizeBytes: Long? = null) {
+  public fun configure(
+    applicationId: String = inferredApplicationId(),
+    maximumCacheSizeBytes: Long? = null,
+  ) {
     require(APPLICATION_ID.matches(applicationId)) {
       "applicationId must contain only nonempty dot-separated letters, digits, underscores, or hyphens"
     }
@@ -53,5 +58,3 @@ internal fun desktopCachePath(applicationId: String): Path {
 
 internal fun absoluteEnvironmentPath(value: String?): Path? =
   value?.takeIf { it.isNotBlank() }?.let(Paths::get)?.takeIf(Path::isAbsolute)
-
-private val APPLICATION_ID = Regex("[A-Za-z0-9_-]+(?:\\.[A-Za-z0-9_-]+)*")

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/MapLibre.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/MapLibre.kt
@@ -5,21 +5,17 @@ import java.nio.file.Paths
 import org.maplibre.compose.mlnffi.MlnFfiApplication
 import org.maplibre.compose.mlnffi.MlnFfiRuntimeOptions
 
-/** Process-wide entry point for configuring MapLibre Compose on desktop. */
+/** Desktop configuration for MapLibre Compose. */
 public object MapLibre {
   /**
-   * Configures every map and offline operation in this process.
+   * Sets the cache location and ambient cache budget for every map and offline operation in this
+   * process.
    *
-   * The first map or offline manager infers [applicationId] from the package of the process `main`
-   * class. Call this beforehand to pin a name that survives moving `main`, or to set a cache
-   * budget. The first call wins. Repeating the same normalized configuration is a no-op; a
-   * conflicting call throws [IllegalStateException].
+   * [applicationId] defaults to the package of the process `main` class. [maximumCacheSizeBytes]
+   * defaults to MapLibre's cache budget. A conflicting call throws [IllegalStateException].
    *
-   * @param applicationId Stable reverse-domain application identifier, such as `com.example.myapp`.
-   *   MapLibre uses it to isolate the application's cache in the current operating system's
-   *   per-user cache directory.
-   * @param maximumCacheSizeBytes Maximum ambient cache size in bytes, or null for MapLibre's own
-   *   default. Offline regions are not ambient and are not evicted to satisfy this limit.
+   * @param applicationId Reverse-domain name for the cache directory, such as `com.example.myapp`.
+   * @param maximumCacheSizeBytes Ambient cache size in bytes, or null for MapLibre's default.
    */
   public fun configure(
     applicationId: String = inferredApplicationId(),
@@ -36,10 +32,8 @@ public object MapLibre {
 }
 
 /**
- * Returns the conventional desktop cache database path for [applicationId].
- *
- * [applicationId] is used only as a filesystem namespace and should be a stable reverse-domain
- * identifier such as `com.example.myapp`.
+ * Cache database path for [applicationId] in the current operating system's per-user cache
+ * directory.
  */
 internal fun desktopCachePath(applicationId: String): Path {
   val os = System.getProperty("os.name")?.lowercase().orEmpty()

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/MapLibre.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/MapLibre.kt
@@ -21,14 +21,19 @@ public object MapLibre {
     applicationId: String = inferredApplicationId(),
     maximumCacheSizeBytes: Long? = null,
   ) {
-    require(APPLICATION_ID.matches(applicationId)) {
-      "applicationId must contain only nonempty dot-separated letters, digits, underscores, or hyphens"
-    }
-    val cachePath = desktopCachePath(applicationId)
-    MlnFfiApplication.configure(
-      MlnFfiRuntimeOptions(kotlinx.io.files.Path(cachePath.toString()), maximumCacheSizeBytes)
-    )
+    MlnFfiApplication.configure(desktopRuntimeOptions(applicationId, maximumCacheSizeBytes))
   }
+}
+
+internal fun desktopRuntimeOptions(
+  applicationId: String = inferredApplicationId(),
+  maximumCacheSizeBytes: Long? = null,
+): MlnFfiRuntimeOptions {
+  require(APPLICATION_ID.matches(applicationId)) {
+    "applicationId must contain only nonempty dot-separated letters, digits, underscores, or hyphens"
+  }
+  val cachePath = desktopCachePath(applicationId)
+  return MlnFfiRuntimeOptions(kotlinx.io.files.Path(cachePath.toString()), maximumCacheSizeBytes)
 }
 
 /**

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/mlnffi/EnsureMlnFfiConfigured.desktop.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/mlnffi/EnsureMlnFfiConfigured.desktop.kt
@@ -1,0 +1,9 @@
+package org.maplibre.compose.mlnffi
+
+import androidx.compose.runtime.Composable
+import org.maplibre.compose.desktop.MapLibre
+
+@Composable
+internal actual fun EnsureMlnFfiConfigured() {
+  MlnFfiApplication.ensureConfigured { MapLibre.configure() }
+}

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/mlnffi/EnsureMlnFfiConfigured.desktop.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/mlnffi/EnsureMlnFfiConfigured.desktop.kt
@@ -1,9 +1,9 @@
 package org.maplibre.compose.mlnffi
 
 import androidx.compose.runtime.Composable
-import org.maplibre.compose.desktop.MapLibre
+import org.maplibre.compose.desktop.desktopRuntimeOptions
 
 @Composable
 internal actual fun EnsureMlnFfiConfigured() {
-  MlnFfiApplication.ensureConfigured { MapLibre.configure() }
+  MlnFfiApplication.ensureConfigured { desktopRuntimeOptions() }
 }

--- a/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/desktop/MapLibreConfigurationTest.kt
+++ b/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/desktop/MapLibreConfigurationTest.kt
@@ -141,18 +141,4 @@ class MapLibreConfigurationTest {
 
     assertEquals("org.maplibre.compose.demoapp.MainKt", mainClassNameFromStackTraces(traces))
   }
-
-  @Test
-  fun java_command_yields_the_main_class() {
-    assertEquals(
-      "org.maplibre.compose.demoapp.MainKt",
-      mainClassNameFromJavaCommand("org.maplibre.compose.demoapp.MainKt --foo"),
-    )
-    assertNull(mainClassNameFromJavaCommand("app.jar"))
-    assertNull(mainClassNameFromJavaCommand("/opt/app/app.jar"))
-    assertNull(mainClassNameFromJavaCommand("""C:\opt\app.jar"""))
-    assertNull(mainClassNameFromJavaCommand("org.gradle.wrapper.GradleWrapperMain"))
-    assertNull(mainClassNameFromJavaCommand(null))
-    assertNull(mainClassNameFromJavaCommand("  "))
-  }
 }

--- a/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/desktop/MapLibreConfigurationTest.kt
+++ b/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/desktop/MapLibreConfigurationTest.kt
@@ -91,7 +91,7 @@ class MapLibreConfigurationTest {
     )
     assertEquals("com.example.app", applicationIdFromClassName("com.example.app.DesktopApp"))
     assertNull(applicationIdFromClassName("MainKt"))
-    assertNull(applicationIdFromClassName("com.example.app/MainKt"))
+    assertNull(applicationIdFromClassName("com/example/app.MainKt"))
   }
 
   @Test

--- a/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/desktop/MapLibreConfigurationTest.kt
+++ b/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/desktop/MapLibreConfigurationTest.kt
@@ -75,7 +75,7 @@ class MapLibreConfigurationTest {
   fun default_configuration_does_not_replace_an_existing_one() {
     try {
       MapLibre.configure("com.example.first")
-      MlnFfiApplication.ensureConfigured { MapLibre.configure("com.example.second") }
+      MlnFfiApplication.ensureConfigured { desktopRuntimeOptions("com.example.second") }
       val installed = MlnFfiApplication.options.cacheFile.toString()
       assertTrue(installed.contains("com.example.first"))
     } finally {

--- a/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/desktop/MapLibreConfigurationTest.kt
+++ b/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/desktop/MapLibreConfigurationTest.kt
@@ -6,6 +6,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 import org.maplibre.compose.mlnffi.MlnFfiApplication
 
 class MapLibreConfigurationTest {
@@ -68,5 +69,90 @@ class MapLibreConfigurationTest {
     } finally {
       MlnFfiApplication.resetForTest()
     }
+  }
+
+  @Test
+  fun default_configuration_does_not_replace_an_existing_one() {
+    try {
+      MapLibre.configure("com.example.first")
+      MlnFfiApplication.ensureConfigured { MapLibre.configure("com.example.second") }
+      val installed = MlnFfiApplication.options.cacheFile.toString()
+      assertTrue(installed.contains("com.example.first"))
+    } finally {
+      MlnFfiApplication.resetForTest()
+    }
+  }
+
+  @Test
+  fun application_id_is_the_main_class_package() {
+    assertEquals(
+      "org.maplibre.compose.demoapp",
+      applicationIdFromClassName("org.maplibre.compose.demoapp.MainKt"),
+    )
+    assertEquals("com.example.app", applicationIdFromClassName("com.example.app.DesktopApp"))
+    assertNull(applicationIdFromClassName("MainKt"))
+    assertNull(applicationIdFromClassName("com.example.app/MainKt"))
+  }
+
+  @Test
+  fun stack_walk_uses_the_process_entry_main() {
+    val frames =
+      listOf(
+        StackTraceElement("java.lang.Object", "wait", "Object.java", 1),
+        StackTraceElement(
+          "androidx.compose.ui.window.Application_desktopKt",
+          "application",
+          null,
+          1,
+        ),
+        StackTraceElement("org.maplibre.compose.demoapp.MainKt", "main", "Main.kt", 9),
+        StackTraceElement(
+          "com.intellij.rt.execution.application.AppMainV2",
+          "main",
+          "AppMainV2.java",
+          50,
+        ),
+      )
+
+    assertEquals("org.maplibre.compose.demoapp.MainKt", mainClassNameFromFrames(frames))
+    assertEquals(
+      "org.maplibre.compose.demoapp",
+      applicationIdFromClassName(mainClassNameFromFrames(frames)!!),
+    )
+  }
+
+  @Test
+  fun stack_walk_prefers_the_thread_named_main() {
+    val appMain =
+      arrayOf(
+        StackTraceElement("java.lang.Object", "wait", "Object.java", 1),
+        StackTraceElement("org.maplibre.compose.demoapp.MainKt", "main", "Main.kt", 9),
+      )
+    val workerMain =
+      arrayOf(
+        StackTraceElement(
+          "org.junit.platform.console.ConsoleLauncher",
+          "main",
+          "ConsoleLauncher.java",
+          1,
+        )
+      )
+    val traces = mapOf(Thread({}, "main") to appMain, Thread({}, "Test worker") to workerMain)
+
+    assertEquals("org.maplibre.compose.demoapp.MainKt", mainClassNameFromStackTraces(traces))
+  }
+
+  @Test
+  fun java_command_yields_the_main_class() {
+    assertEquals(
+      "org.maplibre.compose.demoapp.MainKt",
+      mainClassNameFromJavaCommand("org.maplibre.compose.demoapp.MainKt --foo"),
+    )
+    assertNull(mainClassNameFromJavaCommand("app.jar"))
+    assertNull(mainClassNameFromJavaCommand("/opt/app/app.jar"))
+    assertNull(mainClassNameFromJavaCommand("""C:\opt\app.jar"""))
+    assertNull(mainClassNameFromJavaCommand("org.gradle.wrapper.GradleWrapperMain"))
+    assertNull(mainClassNameFromJavaCommand(null))
+    assertNull(mainClassNameFromJavaCommand("  "))
   }
 }

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/MlnFfiMapView.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/MlnFfiMapView.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
 import co.touchlab.kermit.Logger
+import org.maplibre.compose.mlnffi.EnsureMlnFfiConfigured
 import org.maplibre.compose.mlnffi.MapRenderBackend
 import org.maplibre.compose.mlnffi.MlnFfiApplication
 import org.maplibre.compose.mlnffi.MlnFfiMapHostFactory
@@ -77,6 +78,7 @@ internal fun MlnFfiMapView(
   callbacks: MapAdapter.Callbacks,
   options: MapOptions,
 ) {
+  EnsureMlnFfiConfigured()
   val applicationOptions = MlnFfiApplication.options
   val layoutDirection = LocalLayoutDirection.current
   val density = LocalDensity.current

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/mlnffi/EnsureMlnFfiConfigured.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/mlnffi/EnsureMlnFfiConfigured.kt
@@ -1,0 +1,10 @@
+package org.maplibre.compose.mlnffi
+
+import androidx.compose.runtime.Composable
+
+/**
+ * Installs the platform default [MlnFfiApplication] configuration if the caller has not already
+ * called `MapLibre.configure`. Must run during composition, before anything reads
+ * [MlnFfiApplication.options].
+ */
+@Composable internal expect fun EnsureMlnFfiConfigured()

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/mlnffi/EnsureMlnFfiConfigured.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/mlnffi/EnsureMlnFfiConfigured.kt
@@ -2,9 +2,5 @@ package org.maplibre.compose.mlnffi
 
 import androidx.compose.runtime.Composable
 
-/**
- * Installs the platform default [MlnFfiApplication] configuration if the caller has not already
- * called `MapLibre.configure`. Must run during composition, before anything reads
- * [MlnFfiApplication.options].
- */
+/** Applies the platform default configuration when [MlnFfiApplication] has none. */
 @Composable internal expect fun EnsureMlnFfiConfigured()

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/mlnffi/MlnFfiRuntimeOptions.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/mlnffi/MlnFfiRuntimeOptions.kt
@@ -47,11 +47,7 @@ internal object MlnFfiApplication {
   val isConfigured: Boolean
     get() = state != null
 
-  /**
-   * Runs [installDefault] only when nothing has installed a configuration yet. [installDefault]
-   * should call [configure]; a concurrent caller that already configured a different value still
-   * throws from that call.
-   */
+  /** Runs [installDefault] when no configuration is set. */
   fun ensureConfigured(installDefault: () -> Unit) {
     if (isConfigured) return
     installDefault()

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/mlnffi/MlnFfiRuntimeOptions.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/mlnffi/MlnFfiRuntimeOptions.kt
@@ -47,10 +47,14 @@ internal object MlnFfiApplication {
   val isConfigured: Boolean
     get() = state != null
 
-  /** Runs [installDefault] when no configuration is set. */
-  fun ensureConfigured(installDefault: () -> Unit) {
+  /** Installs [defaultOptions] when no configuration is set. */
+  fun ensureConfigured(defaultOptions: () -> MlnFfiRuntimeOptions) {
     if (isConfigured) return
-    installDefault()
+    lock.withLock {
+      if (state != null) return
+      val options = defaultOptions().normalized()
+      state = State(options, MlnFfiOfflineManager(options))
+    }
   }
 
   val options: MlnFfiRuntimeOptions

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/mlnffi/MlnFfiRuntimeOptions.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/mlnffi/MlnFfiRuntimeOptions.kt
@@ -44,6 +44,19 @@ internal object MlnFfiApplication {
     }
   }
 
+  val isConfigured: Boolean
+    get() = state != null
+
+  /**
+   * Runs [installDefault] only when nothing has installed a configuration yet. [installDefault]
+   * should call [configure]; a concurrent caller that already configured a different value still
+   * throws from that call.
+   */
+  fun ensureConfigured(installDefault: () -> Unit) {
+    if (isConfigured) return
+    installDefault()
+  }
+
   val options: MlnFfiRuntimeOptions
     get() = requireState().options
 
@@ -52,7 +65,8 @@ internal object MlnFfiApplication {
 
   private fun requireState(): State =
     checkNotNull(state) {
-      "MapLibre is not configured. Call MapLibre.configure(...) before opening a map."
+      "MapLibre is not configured. Compose a map, call rememberOfflineManager, or call " +
+        "MapLibre.configure(...) first."
     }
 
   /**

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/offline/MlnFfiOfflineManager.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/offline/MlnFfiOfflineManager.kt
@@ -12,6 +12,7 @@ import kotlin.coroutines.resumeWithException
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import org.maplibre.compose.mlnffi.EnsureMlnFfiConfigured
 import org.maplibre.compose.mlnffi.MlnFfiApplication
 import org.maplibre.compose.mlnffi.MlnFfiGate
 import org.maplibre.compose.mlnffi.MlnFfiRuntimeOptions
@@ -28,6 +29,7 @@ import org.maplibre.nativeffi.runtime.RuntimeHandle
 
 @Composable
 public actual fun rememberOfflineManager(): OfflineManager {
+  EnsureMlnFfiConfigured()
   val density = LocalDensity.current.density
   val manager = MlnFfiApplication.offlineManager
   // Packs record the density they were created at; a downloaded raster tile cannot be rescaled.


### PR DESCRIPTION
resolve #994 

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

The first map now installs platform cache defaults, desktop infers `applicationId` from the `main` class package, and the browser entry point is renamed from `initialize()` to `configure()`.

## Validation

`MapLibreConfigurationTest` passed on desktop JVM (11 tests); JS and desktop Kotlin compiled; Android SDK is not present in this environment so Android was not compiled here.

## AI assistance

Cursor Grok 4.6 cloud agent.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b5faa521-3f9e-4d70-9ed9-3d14009040bd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b5faa521-3f9e-4d70-9ed9-3d14009040bd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

