### PR TITLE
Make the iOS Metal UIKitView non-interactive

### DIFF
--- a/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/mlnffi/IosMlnFfiSurface.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/mlnffi/IosMlnFfiSurface.kt
@@ -79,7 +79,8 @@ internal fun IosMlnFfiSurface(
     },
     update = {},
     onRelease = { controller.surfaceDestroyed() },
-    properties = UIKitInteropProperties(isInteractive = false),
+    properties =
+      UIKitInteropProperties(isInteractive = false, isNativeAccessibilityEnabled = false),
   )
 }
 

--- a/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/mlnffi/IosMlnFfiSurface.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/mlnffi/IosMlnFfiSurface.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.viewinterop.UIKitInteropProperties
 import androidx.compose.ui.viewinterop.UIKitView
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
@@ -66,6 +67,7 @@ internal fun IosMlnFfiSurface(
     return
   }
 
+  // The Metal view only presents. Compose's mapInput modifier handles every gesture.
   UIKitView(
     modifier = modifier,
     factory = {
@@ -77,6 +79,7 @@ internal fun IosMlnFfiSurface(
     },
     update = {},
     onRelease = { controller.surfaceDestroyed() },
+    properties = UIKitInteropProperties(isInteractive = false),
   )
 }
 
@@ -85,7 +88,7 @@ internal fun IosMlnFfiSurface(
  *
  * The view keeps the layer's `contentsScale` in step with its screen and reports each settled
  * extent to the surface controller; the render session writes `drawableSize` from that extent.
- * Touch handling stays with Compose's gesture modifier, so the view accepts no touches of its own.
+ * Compose's gesture modifier owns every pointer, and this view declines UIKit hit-testing.
  */
 private class IosMetalMapView(frame: CValue<CGRect>) : UIView(frame) {
   var onLayoutChanged: ((extent: MapExtent) -> Unit)? = null


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

The iOS Metal map surface now sets `UIKitInteropProperties(isInteractive = false, isNativeAccessibilityEnabled = false)` so Compose `mapInput` receives touches immediately instead of Cooperative mode's delay.

## Validation

Matched the call to the Compose 1.11.1 two-argument constructor after iOS CI failed to compile the one-argument form; iOS compile and simulator tests were not run on this Linux agent.

## AI assistance

Cursor Grok 4.6 (Cursor cloud agent).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-29ba30fb-fa09-4c53-a83b-e35c4360b286?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-29ba30fb-fa09-4c53-a83b-e35c4360b286&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

