### PR TITLE
Expose tile LOD controls on MapOptions

### DIFF
--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoMap.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoMap.kt
@@ -70,6 +70,7 @@ fun DemoMap(state: DemoAppState, sheetInsets: WindowInsets = WindowInsets(0)) {
         MapOptions(
           renderOptions = state.settings.renderOptions,
           gestureOptions = state.settings.gestureOptions,
+          tileLodOptions = state.settings.tileLodOptions,
         ),
       onFrame = { state.frameRateState.record() },
       contentWindowInsets = insets,

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoPanel.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoPanel.kt
@@ -138,6 +138,7 @@ fun DemoPanel(state: DemoAppState, modifier: Modifier = Modifier) {
     }
     composable("settings/rendering") {
       SettingsSubScreen("Rendering", onBack = { navController.popBackStack() }) {
+        TileLodSettingsItems(state.settings)
         RenderSettingsItems(state.settings)
       }
     }
@@ -232,7 +233,7 @@ private fun StyleSelector(state: DemoAppState) {
 private fun SettingsScreen(onBack: () -> Unit, onOpen: (route: String) -> Unit) {
   SettingsSubScreen("Settings", onBack) {
     SubmenuRow("Gestures", "Which inputs move the camera") { onOpen("gestures") }
-    SubmenuRow("Rendering", "Frame rate cap and debug views") { onOpen("rendering") }
+    SubmenuRow("Rendering", "Frame rate cap, tile detail, and debug views") { onOpen("rendering") }
     SubmenuRow("Interface", "Map controls and diagnostic overlays") { onOpen("interface") }
   }
 }

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoSettings.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoSettings.kt
@@ -6,14 +6,18 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import org.maplibre.compose.demoapp.design.SectionHeader
+import org.maplibre.compose.demoapp.design.SegmentedRow
 import org.maplibre.compose.map.GestureOptions
 import org.maplibre.compose.map.RenderOptions
+import org.maplibre.compose.map.TileLodOptions
 
 /** App-wide diagnostics and toggles, available regardless of which demo is open. */
 @Stable
 class DemoSettings {
   var gestureOptions by mutableStateOf(GestureOptions.Standard)
   var renderOptions by mutableStateOf(RenderOptions.Standard)
+  var tileLodOptions by mutableStateOf(TileLodOptions.Standard)
   var showFpsOverlay by mutableStateOf(false)
   var showCameraOverlay by mutableStateOf(false)
   var useMaterial3Controls by mutableStateOf(true)
@@ -32,3 +36,24 @@ class DemoSettings {
  * and where supported the texture-versus-surface choice — as settings list items.
  */
 @Composable expect fun RenderSettingsItems(settings: DemoSettings)
+
+/** Presets for [TileLodOptions], shared because every platform exposes the same three. */
+@Composable
+fun TileLodSettingsItems(settings: DemoSettings) {
+  SectionHeader("Tile level of detail")
+  SegmentedRow(
+    label = "When the camera is pitched",
+    options =
+      listOf(TileLodOptions.Standard, TileLodOptions.Performance, TileLodOptions.HighDetail),
+    selected = settings.tileLodOptions,
+    optionLabel = {
+      when (it) {
+        TileLodOptions.Standard -> "Standard"
+        TileLodOptions.Performance -> "Fewer"
+        TileLodOptions.HighDetail -> "More"
+        else -> "Custom"
+      }
+    },
+    onSelect = { settings.tileLodOptions = it },
+  )
+}

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapAdapter.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapAdapter.kt
@@ -59,6 +59,8 @@ internal interface MapAdapter {
 
   fun setGestureSettings(value: GestureOptions)
 
+  fun setTileLodSettings(value: TileLodOptions)
+
   fun positionFromScreenLocation(offset: DpOffset): Position
 
   fun screenLocationFromPosition(position: Position): DpOffset

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapOptions.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapOptions.kt
@@ -12,4 +12,5 @@ import androidx.compose.runtime.Immutable
 public data class MapOptions(
   val renderOptions: RenderOptions = RenderOptions.Standard,
   val gestureOptions: GestureOptions = GestureOptions.Standard,
+  val tileLodOptions: TileLodOptions = TileLodOptions.Standard,
 )

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MaplibreMap.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MaplibreMap.kt
@@ -262,6 +262,7 @@ public fun MaplibreMap(
         map.setMaxPitch(pitchRange.endInclusive.toDouble())
         map.setRenderSettings(options.renderOptions)
         map.setGestureSettings(options.gestureOptions)
+        map.setTileLodSettings(options.tileLodOptions)
         map.setCameraBoundingBox(boundingBox)
       },
       onReset = {

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/TileLodOptions.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/TileLodOptions.kt
@@ -1,0 +1,25 @@
+package org.maplibre.compose.map
+
+import androidx.compose.runtime.Immutable
+
+/**
+ * How the map chooses tile zoom when the camera is pitched.
+ *
+ * At high pitch, farther ground covers more of the screen. The map can fetch coarser tiles toward
+ * the horizon so it requests fewer of them. [Standard] is each backend's own default. [Performance]
+ * fetches fewer tiles; [HighDetail] keeps more detail. The knobs behind those presets differ by
+ * platform, so a custom configuration is written in expect/actual code.
+ */
+@Immutable
+public expect class TileLodOptions {
+  public companion object Companion {
+    /** Each backend's own default tile cover. */
+    public val Standard: TileLodOptions
+
+    /** Fewer tiles when the camera is pitched, at the cost of coarser tiles toward the horizon. */
+    public val Performance: TileLodOptions
+
+    /** More tiles when the camera is pitched, keeping more detail toward the horizon. */
+    public val HighDetail: TileLodOptions
+  }
+}

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsModule.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsModule.kt
@@ -70,6 +70,8 @@ internal external class MaplibreMap(options: MapOptions) {
 
   fun setMaxPitch(maxPitch: Double)
 
+  fun setSourceTileLodParams(maxZoomLevelsOnScreen: Double, tileCountMaxMinRatio: Double)
+
   fun project(lngLat: LngLat): Point
 
   fun unproject(point: Point): LngLat

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
@@ -118,6 +118,7 @@ internal class GlJsMapSession(
   private var lentContext: WebGL2RenderingContext? = null
 
   private var maximumFps: Int? = null
+  private var tileLodOptions: TileLodOptions = TileLodOptions.Standard
   private var lastRenderTime = TimeSource.Monotonic.markNow()
   private var lastFrameTime = TimeSource.Monotonic.markNow()
   private var hasRenderedAFrame = false
@@ -314,6 +315,7 @@ internal class GlJsMapSession(
       styleBinding?.unload()
       val binding = GlJsStyleBinding(map, logger).also { styleBinding = it }
       callbacks.onStyleChanged(this, GlJsStyle(binding) { appliedExtent.scaleFactor.toFloat() })
+      applyTileLod(map)
       if (!hasLoadedInitialStyle) {
         hasLoadedInitialStyle = true
         runPending(pendingInitialStyleActions, map)
@@ -327,6 +329,7 @@ internal class GlJsMapSession(
     map.subscribe("sourcedata") { event ->
       reportLoadedOnceStyleIsReady(map)
       if (event.sourceDataType == "metadata") {
+        applyTileLod(map)
         event.sourceId?.let { callbacks.onSourceChanged(this, it) }
       }
     }
@@ -573,6 +576,24 @@ internal class GlJsMapSession(
 
   override fun setGestureSettings(value: GestureOptions) {
     // Gestures are implemented in Compose, so the host's input handling reads these.
+  }
+
+  override fun setTileLodSettings(value: TileLodOptions) {
+    if (value == tileLodOptions) return
+    tileLodOptions = value
+    onMap(::applyTileLod)
+  }
+
+  /**
+   * GL JS stores these parameters on each source. A style load or a source added later would
+   * otherwise keep MapLibre's own defaults.
+   */
+  private fun applyTileLod(map: MaplibreMap) {
+    if (!map.isStyleLoaded()) return
+    map.setSourceTileLodParams(
+      tileLodOptions.maxZoomLevelsOnScreen,
+      tileLodOptions.tileCountMaxMinRatio,
+    )
   }
 
   override fun positionFromScreenLocation(offset: DpOffset): Position =

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/TileLodOptions.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/TileLodOptions.kt
@@ -1,0 +1,28 @@
+package org.maplibre.compose.map
+
+import androidx.compose.runtime.Immutable
+
+/**
+ * MapLibre GL JS tile cover when the camera is pitched. These parameters have no effect at pitch 0,
+ * and the largest effect when the horizon is on screen.
+ *
+ * @param maxZoomLevelsOnScreen Cap on distinct zooms when the horizon is on screen. Increasing it
+ *   makes zoom decay faster toward the horizon.
+ * @param tileCountMaxMinRatio Cap on tiles at high pitch versus pitch 0. Increasing it allows more
+ *   tiles when pitched; if the ratio would be exceeded, zoom is reduced uniformly.
+ */
+@Immutable
+public actual data class TileLodOptions(
+  val maxZoomLevelsOnScreen: Double = 9.314,
+  val tileCountMaxMinRatio: Double = 3.0,
+) {
+  public actual companion object Companion {
+    public actual val Standard: TileLodOptions = TileLodOptions()
+
+    public actual val Performance: TileLodOptions =
+      TileLodOptions(maxZoomLevelsOnScreen = 11.0, tileCountMaxMinRatio = 1.5)
+
+    public actual val HighDetail: TileLodOptions =
+      TileLodOptions(maxZoomLevelsOnScreen = 4.0, tileCountMaxMinRatio = 8.0)
+  }
+}

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -14,6 +14,7 @@ import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.concurrent.atomics.incrementAndFetch
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
+import kotlin.math.PI
 import kotlin.math.round
 import kotlin.time.Duration
 import kotlin.time.DurationUnit
@@ -76,6 +77,8 @@ import org.maplibre.nativeffi.geo.ScreenPoint
 import org.maplibre.nativeffi.map.DebugOption
 import org.maplibre.nativeffi.map.MapHandle
 import org.maplibre.nativeffi.map.MapProjectionHandle
+import org.maplibre.nativeffi.map.TileLodMode as FfiTileLodMode
+import org.maplibre.nativeffi.map.TileOptions
 import org.maplibre.nativeffi.query.RenderedQueryGeometry
 import org.maplibre.nativeffi.render.MetalBorrowedTextureDescriptor
 import org.maplibre.nativeffi.render.MetalContextDescriptor
@@ -270,6 +273,7 @@ internal class MlnFfiMapSession(
   }
 
   @Volatile private var maximumFps: Int? = null
+  private var tileLodOptions: TileLodOptions = TileLodOptions.Standard
   private var lastRenderTime = TimeSource.Monotonic.markNow()
 
   private val frameTimer = TimeSource.Monotonic
@@ -1176,6 +1180,15 @@ internal class MlnFfiMapSession(
     // handling rather than pushed into the map.
   }
 
+  override fun setTileLodSettings(value: TileLodOptions) {
+    if (value == tileLodOptions) return
+    tileLodOptions = value
+    configureMap { map -> map.tileOptions = value.toFfi() }
+  }
+
+  /** Test seam: runs [action] on the owner thread and waits for it. */
+  internal fun <T> readMap(action: (MapHandle) -> T): T? = runOnMap(action)
+
   override fun positionFromScreenLocation(offset: DpOffset): Position =
     withSnapshotProjection { it.latLngForPixel(offset.toScreenPoint()).toPosition() }
       ?: Position(0.0, 0.0)
@@ -1466,3 +1479,18 @@ private fun WglContextHandles.toFfi() =
     getProcAddress = NativePointer.ofAddress(getProcAddress.address),
     ownership = ownership,
   )
+
+private fun TileLodOptions.toFfi(): TileOptions =
+  TileOptions().also {
+    it.lodMode = mode.toFfi()
+    it.lodMinRadius = minRadius
+    it.lodScale = scale
+    it.lodPitchThreshold = pitchThreshold * PI / 180.0
+    it.lodZoomShift = zoomShift
+  }
+
+private fun TileLodMode.toFfi(): FfiTileLodMode =
+  when (this) {
+    TileLodMode.Default -> FfiTileLodMode.DEFAULT
+    TileLodMode.Distance -> FfiTileLodMode.DISTANCE
+  }

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/TileLodMode.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/TileLodMode.kt
@@ -1,0 +1,22 @@
+package org.maplibre.compose.map
+
+/**
+ * How MapLibre Native picks a zoom for each tile when the camera is pitched.
+ *
+ * [Default] keeps the finest tiles at the centre of the screen. [Distance] keeps them nearest the
+ * camera, so the foreground is denser than the horizon.
+ */
+public enum class TileLodMode {
+  /**
+   * Finest tiles at the screen centre, then coarser tiles outside [TileLodOptions.minRadius].
+   * [TileLodOptions.scale], [TileLodOptions.pitchThreshold], and [TileLodOptions.zoomShift] all
+   * apply.
+   */
+  Default,
+
+  /**
+   * Finest tiles nearest the camera. [TileLodOptions.scale] and [TileLodOptions.pitchThreshold]
+   * apply; [TileLodOptions.minRadius] and [TileLodOptions.zoomShift] do not.
+   */
+  Distance,
+}

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/TileLodOptions.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/TileLodOptions.kt
@@ -1,0 +1,36 @@
+package org.maplibre.compose.map
+
+import androidx.compose.runtime.Immutable
+
+/**
+ * MapLibre Native tile cover when the camera is pitched.
+ *
+ * @param mode Which tile-cover algorithm to use.
+ * @param minRadius Radius, in tile units, around the view point that always uses the finest zoom.
+ *   Must be greater than 1. Ignored when [mode] is [TileLodMode.Distance].
+ * @param scale Scale on camera distance. Values greater than 1 coarsen tiles farther from the
+ *   camera.
+ * @param pitchThreshold Camera pitch in degrees from nadir, matching
+ *   [org.maplibre.compose.camera.CameraPosition.tilt], above which level-of-detail reduction runs.
+ *   0 always reduces; 180 never reduces.
+ * @param zoomShift Added to the zoom used for level-of-detail. `-1` cuts the tile count by about
+ *   four. Ignored when [mode] is [TileLodMode.Distance].
+ */
+@Immutable
+public actual data class TileLodOptions(
+  val mode: TileLodMode = TileLodMode.Default,
+  val minRadius: Double = 3.0,
+  val scale: Double = 1.0,
+  val pitchThreshold: Double = 60.0,
+  val zoomShift: Double = 0.0,
+) {
+  public actual companion object Companion {
+    public actual val Standard: TileLodOptions = TileLodOptions()
+
+    public actual val Performance: TileLodOptions =
+      TileLodOptions(minRadius = 2.0, scale = 1.5, pitchThreshold = 45.0, zoomShift = -1.0)
+
+    public actual val HighDetail: TileLodOptions =
+      TileLodOptions(minRadius = 5.0, pitchThreshold = 85.0)
+  }
+}

--- a/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/map/MlnFfiTileLodTest.kt
+++ b/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/map/MlnFfiTileLodTest.kt
@@ -1,0 +1,74 @@
+package org.maplibre.compose.map
+
+import kotlin.math.PI
+import kotlin.math.abs
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import org.maplibre.compose.mlnffi.BridgeMapFixture
+import org.maplibre.compose.style.BaseStyle
+import org.maplibre.nativeffi.map.TileLodMode as FfiTileLodMode
+
+class MlnFfiTileLodTest {
+
+  @Test
+  fun performance_options_reach_the_map_and_leave_prefetch_alone() {
+    BridgeMapFixture.create().use { fixture ->
+      fixture.loadStyle(BaseStyle.Empty)
+
+      fixture.session.readMap { map ->
+        map.tileOptions = map.tileOptions.also { it.prefetchZoomDelta = PREFETCH }
+      }
+      fixture.session.setTileLodSettings(TileLodOptions.Performance)
+      val applied = assertNotNull(fixture.session.readMap { it.tileOptions })
+
+      assertEquals(FfiTileLodMode.DEFAULT, applied.lodMode)
+      assertEquals(2.0, assertNotNull(applied.lodMinRadius))
+      assertEquals(1.5, assertNotNull(applied.lodScale))
+      assertAngleDegrees(45.0, applied.lodPitchThreshold)
+      assertEquals(-1.0, assertNotNull(applied.lodZoomShift))
+      assertEquals(PREFETCH, applied.prefetchZoomDelta)
+    }
+  }
+
+  @Test
+  fun distance_mode_and_a_return_to_standard_both_round_trip() {
+    BridgeMapFixture.create().use { fixture ->
+      fixture.loadStyle(BaseStyle.Empty)
+
+      fixture.session.setTileLodSettings(
+        TileLodOptions(
+          mode = TileLodMode.Distance,
+          minRadius = 4.0,
+          scale = 2.0,
+          pitchThreshold = 30.0,
+          zoomShift = 1.0,
+        )
+      )
+      val appliedDistance = assertNotNull(fixture.session.readMap { it.tileOptions })
+
+      assertEquals(FfiTileLodMode.DISTANCE, appliedDistance.lodMode)
+      assertEquals(2.0, assertNotNull(appliedDistance.lodScale))
+      assertAngleDegrees(30.0, appliedDistance.lodPitchThreshold)
+
+      fixture.session.setTileLodSettings(TileLodOptions.Standard)
+      val appliedStandard = assertNotNull(fixture.session.readMap { it.tileOptions })
+
+      assertEquals(FfiTileLodMode.DEFAULT, appliedStandard.lodMode)
+      assertEquals(3.0, assertNotNull(appliedStandard.lodMinRadius))
+      assertEquals(1.0, assertNotNull(appliedStandard.lodScale))
+      assertAngleDegrees(60.0, appliedStandard.lodPitchThreshold)
+      assertEquals(0.0, assertNotNull(appliedStandard.lodZoomShift))
+    }
+  }
+
+  private companion object {
+    const val PREFETCH = 7
+
+    fun assertAngleDegrees(expected: Double, radians: Double?) {
+      val actual = assertNotNull(radians) * 180.0 / PI
+      assertTrue(abs(expected - actual) <= 1e-6, "expected $expected°, was $actual°")
+    }
+  }
+}

--- a/lib/maplibre-compose/src/nextCommonTest/kotlin/org/maplibre/compose/map/MapTileLodTest.kt
+++ b/lib/maplibre-compose/src/nextCommonTest/kotlin/org/maplibre/compose/map/MapTileLodTest.kt
@@ -1,0 +1,41 @@
+package org.maplibre.compose.map
+
+import kotlin.test.Test
+import org.maplibre.compose.style.BaseStyle
+import org.maplibre.compose.testing.MapTestResult
+import org.maplibre.compose.testing.createMapFixture
+import org.maplibre.compose.testing.runMapTest
+
+class MapTileLodTest {
+
+  @Test
+  fun every_preset_can_be_applied_to_a_loaded_map(): MapTestResult = runMapTest {
+    createMapFixture().use { fixture ->
+      fixture.loadStyle(TILED_STYLE)
+      fixture.session.setTileLodSettings(TileLodOptions.Performance)
+      fixture.session.setTileLodSettings(TileLodOptions.HighDetail)
+      fixture.session.setTileLodSettings(TileLodOptions.Standard)
+      fixture.settle()
+    }
+  }
+
+  private companion object {
+    val TILED_STYLE =
+      BaseStyle.Json(
+        """
+        {
+          "version": 8,
+          "sources": {
+            "tiles": {
+              "type": "raster",
+              "tiles": ["https://example.invalid/{z}/{x}/{y}.png"],
+              "tileSize": 256
+            }
+          },
+          "layers": [{"id": "tiles", "type": "raster", "source": "tiles"}]
+        }
+        """
+          .trimIndent()
+      )
+  }
+}


### PR DESCRIPTION
resolve #408 

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Adds platform-specific `TileLodOptions` on `MapOptions` so Native and GL JS keep their own tile LOD knobs, with Standard / Performance / HighDetail presets and a demo toggle.

## Validation

JS `MapTileLodTest` passed in headless Chrome; Native `MlnFfiTileLodTest` compiled but could not run here because this VM has no Vulkan GPU.

## AI assistance

Cursor Grok 4.6 cloud agent implemented the change from the Tile LOD API recommendation.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cf9f5564-48cd-42e6-8d3d-08dfb5bae001?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf9f5564-48cd-42e6-8d3d-08dfb5bae001&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

