### PR TITLE
Flaky test fix: Pump the live style after a Linux Compose context replacement

### DIFF
--- a/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/desktop/bridge/LinuxVulkanOpenGlInteropTest.kt
+++ b/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/desktop/bridge/LinuxVulkanOpenGlInteropTest.kt
@@ -111,18 +111,10 @@ class LinuxVulkanOpenGlInteropTest {
         try {
           val first =
             InteropMap(host).use { map ->
-              egl.withCurrent {
-                map.presentStyle(FIRST_STYLE, FIRST_EXTENT, FIRST_PIXEL) {
-                  egl.drawAndRead(host, it)
-                }
-              }
+              egl.withCurrent { map.renderStyle(FIRST_STYLE, FIRST_EXTENT) }
             }
           InteropMap(host).use { map ->
-            val second = egl.withCurrent {
-              map.presentStyle(SECOND_STYLE, SECOND_EXTENT, SECOND_PIXEL) {
-                egl.drawAndRead(host, it)
-              }
-            }
+            val second = egl.withCurrent { map.renderStyle(SECOND_STYLE, SECOND_EXTENT) }
 
             val oldPixel = egl.withCurrent { egl.drawAndRead(host, first) }
             assertNear(FIRST_PIXEL, oldPixel, "retired generation after resize")
@@ -301,6 +293,28 @@ class LinuxVulkanOpenGlInteropTest {
     init {
       renderer.start()
       renderer.onSurfaceAvailable(hostSession)
+    }
+
+    /** Fills a target without drawing it into Compose. `draw` drops every retired generation. */
+    fun renderStyle(style: BaseStyle, extent: MapExtent): MlnFfiRenderTarget {
+      val expectedStyleLoads = styleLoads + 1
+      renderer.setBaseStyle(style)
+      val deadline = TimeSource.Monotonic.markNow() + TEST_TIMEOUT
+      var lastResult: MlnFfiFrameResult? = null
+      while (true) {
+        check(deadline.hasNotPassedNow()) {
+          "Timed out rendering style $style at $extent; " +
+            "style loads: $styleLoads/$expectedStyleLoads, last result: $lastResult, " +
+            "failure: $failure"
+        }
+        failure?.let { error(it) }
+        val pumped = pumpFrame(extent)
+        lastResult = pumped.result
+        val target = pumped.target
+        if (styleLoads >= expectedStyleLoads && target != null) return target
+        if (pumped.result != MlnFfiFrameResult.RENDERED) renderer.requestRedraw()
+        Thread.sleep(POLL_INTERVAL_MILLIS)
+      }
     }
 
     fun presentStyle(

--- a/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/desktop/bridge/LinuxVulkanOpenGlInteropTest.kt
+++ b/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/desktop/bridge/LinuxVulkanOpenGlInteropTest.kt
@@ -299,10 +299,7 @@ class LinuxVulkanOpenGlInteropTest {
         }
         failure?.let { error(it) }
         val loadsBeforePump = styleLoads
-        // MAP_STYLE_LOADED requestRepaint can run during a pump this loop then discards, because
-        // that pump started before the load. Later pumps stay on NO_UPDATE unless the map is
-        // dirtied again. A replacement Compose context also retargets on that first pump, which
-        // lengthens the window.
+        // The discarded in-flight pump already consumed MAP_STYLE_LOADED's requestRepaint.
         if (loadsBeforePump >= expectedStyleLoads && rendered == null) {
           renderer.requestRedraw()
         }

--- a/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/desktop/bridge/LinuxVulkanOpenGlInteropTest.kt
+++ b/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/desktop/bridge/LinuxVulkanOpenGlInteropTest.kt
@@ -137,11 +137,7 @@ class LinuxVulkanOpenGlInteropTest {
           val host = VulkanOpenGlMapHost(mapHost)
           try {
             InteropMap(host).use { map ->
-              val first = firstEgl.withCurrent {
-                map.presentStyle(FIRST_STYLE, FIRST_EXTENT, FIRST_PIXEL) {
-                  firstEgl.drawAndRead(host, it)
-                }
-              }
+              val first = firstEgl.withCurrent { map.renderStyle(FIRST_STYLE, FIRST_EXTENT) }
               assertNear(
                 FIRST_PIXEL,
                 firstEgl.withCurrent { firstEgl.drawAndRead(host, first) },
@@ -149,18 +145,14 @@ class LinuxVulkanOpenGlInteropTest {
               )
 
               mapHost.replaceContext(secondEgl)
-              val second = secondEgl.withCurrent {
-                map.presentStyle(SECOND_STYLE, FIRST_EXTENT, SECOND_PIXEL) {
-                  secondEgl.drawAndRead(host, it)
-                }
-              }
+              val second = secondEgl.withCurrent { map.pumpUntilRendered(FIRST_EXTENT) }
               assertTrue(
                 second.generation != first.generation,
                 "replacement context must allocate a new shared target, " +
                   "got generation ${second.generation} after ${first.generation}",
               )
               assertNear(
-                SECOND_PIXEL,
+                FIRST_PIXEL,
                 secondEgl.withCurrent { secondEgl.drawAndRead(host, second) },
                 "replacement context after a new shared target",
               )
@@ -180,15 +172,9 @@ class LinuxVulkanOpenGlInteropTest {
         try {
           InteropMap(host).use { map ->
             egl.withCurrent {
-              val first =
-                map.presentStyle(FIRST_STYLE, FIRST_EXTENT, FIRST_PIXEL) {
-                  egl.drawAndRead(host, it)
-                }
+              val first = map.renderStyle(FIRST_STYLE, FIRST_EXTENT)
               assertNear(FIRST_PIXEL, egl.drawAndRead(host, first), "live first frame")
-              val second =
-                map.presentStyle(SECOND_STYLE, FIRST_EXTENT, SECOND_PIXEL) {
-                  egl.drawAndRead(host, it)
-                }
+              val second = map.renderStyle(SECOND_STYLE, FIRST_EXTENT)
               assertNear(
                 SECOND_PIXEL,
                 egl.drawAndRead(host, second),
@@ -295,54 +281,46 @@ class LinuxVulkanOpenGlInteropTest {
       renderer.onSurfaceAvailable(hostSession)
     }
 
-    /** Fills a target without drawing it into Compose. `draw` drops every retired generation. */
     fun renderStyle(style: BaseStyle, extent: MapExtent): MlnFfiRenderTarget {
       val expectedStyleLoads = styleLoads + 1
       renderer.setBaseStyle(style)
       val deadline = TimeSource.Monotonic.markNow() + TEST_TIMEOUT
+      var rendered: MlnFfiRenderTarget? = null
+      var renderedFrames = 0
       var lastResult: MlnFfiFrameResult? = null
-      while (true) {
+      // Style application and rendering run on different threads. A frame that started before
+      // the new style was observed is the previous style, even if the callback arrives before
+      // this loop looks again. Sample the load count first, then keep only a later frame.
+      while (styleLoads < expectedStyleLoads || rendered == null) {
         check(deadline.hasNotPassedNow()) {
           "Timed out rendering style $style at $extent; " +
-            "style loads: $styleLoads/$expectedStyleLoads, last result: $lastResult, " +
-            "failure: $failure"
+            "style loads: $styleLoads/$expectedStyleLoads, rendered frames: $renderedFrames, " +
+            "last result: $lastResult, failure: $failure"
         }
         failure?.let { error(it) }
+        val loadsBeforePump = styleLoads
         val pumped = pumpFrame(extent)
         lastResult = pumped.result
-        val target = pumped.target
-        if (styleLoads >= expectedStyleLoads && target != null) return target
-        if (pumped.result != MlnFfiFrameResult.RENDERED) renderer.requestRedraw()
+        if (loadsBeforePump >= expectedStyleLoads && pumped.rendered) {
+          renderedFrames++
+          rendered = pumped.target
+        }
         Thread.sleep(POLL_INTERVAL_MILLIS)
       }
+      return checkNotNull(rendered)
     }
 
-    fun presentStyle(
-      style: BaseStyle,
-      extent: MapExtent,
-      expected: RgbaPixel,
-      read: (MlnFfiRenderTarget) -> RgbaPixel,
-    ): MlnFfiRenderTarget {
-      renderer.setBaseStyle(style)
+    fun pumpUntilRendered(extent: MapExtent): MlnFfiRenderTarget {
       val deadline = TimeSource.Monotonic.markNow() + TEST_TIMEOUT
       var lastResult: MlnFfiFrameResult? = null
-      var lastPixel: RgbaPixel? = null
-      // A pump that started before the new style loaded can still show the old pixels.
       while (true) {
         check(deadline.hasNotPassedNow()) {
-          "Timed out presenting $expected for $style at $extent; " +
-            "style loads: $styleLoads, last pixel: $lastPixel, last result: $lastResult, " +
-            "failure: $failure"
+          "Timed out rendering at $extent; last result: $lastResult, failure: $failure"
         }
         failure?.let { error(it) }
         val pumped = pumpFrame(extent)
         lastResult = pumped.result
-        val target = pumped.target
-        if (target != null) {
-          lastPixel = read(target)
-          if (near(expected, lastPixel)) return target
-        }
-        if (pumped.result != MlnFfiFrameResult.RENDERED) renderer.requestRedraw()
+        if (pumped.rendered) return checkNotNull(pumped.target)
         Thread.sleep(POLL_INTERVAL_MILLIS)
       }
     }
@@ -368,7 +346,10 @@ class LinuxVulkanOpenGlInteropTest {
       cacheDirectory.toFile().deleteRecursively()
     }
 
-    private class PumpedFrame(val result: MlnFfiFrameResult, val target: MlnFfiRenderTarget?)
+    private class PumpedFrame(val result: MlnFfiFrameResult, val target: MlnFfiRenderTarget?) {
+      val rendered: Boolean
+        get() = result == MlnFfiFrameResult.RENDERED && target != null
+    }
   }
 
   private class EglTestContext private constructor() : AutoCloseable {

--- a/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/desktop/bridge/LinuxVulkanOpenGlInteropTest.kt
+++ b/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/desktop/bridge/LinuxVulkanOpenGlInteropTest.kt
@@ -299,6 +299,13 @@ class LinuxVulkanOpenGlInteropTest {
         }
         failure?.let { error(it) }
         val loadsBeforePump = styleLoads
+        // MAP_STYLE_LOADED requestRepaint can run during a pump this loop then discards, because
+        // that pump started before the load. Later pumps stay on NO_UPDATE unless the map is
+        // dirtied again. A replacement Compose context also retargets on that first pump, which
+        // lengthens the window.
+        if (loadsBeforePump >= expectedStyleLoads && rendered == null) {
+          renderer.requestRedraw()
+        }
         val pumped = pumpFrame(extent)
         lastResult = pumped.result
         if (loadsBeforePump >= expectedStyleLoads && pumped.rendered) {

--- a/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/desktop/bridge/LinuxVulkanOpenGlInteropTest.kt
+++ b/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/desktop/bridge/LinuxVulkanOpenGlInteropTest.kt
@@ -111,10 +111,18 @@ class LinuxVulkanOpenGlInteropTest {
         try {
           val first =
             InteropMap(host).use { map ->
-              egl.withCurrent { map.renderStyle(FIRST_STYLE, FIRST_EXTENT) }
+              egl.withCurrent {
+                map.presentStyle(FIRST_STYLE, FIRST_EXTENT, FIRST_PIXEL) {
+                  egl.drawAndRead(host, it)
+                }
+              }
             }
           InteropMap(host).use { map ->
-            val second = egl.withCurrent { map.renderStyle(SECOND_STYLE, SECOND_EXTENT) }
+            val second = egl.withCurrent {
+              map.presentStyle(SECOND_STYLE, SECOND_EXTENT, SECOND_PIXEL) {
+                egl.drawAndRead(host, it)
+              }
+            }
 
             val oldPixel = egl.withCurrent { egl.drawAndRead(host, first) }
             assertNear(FIRST_PIXEL, oldPixel, "retired generation after resize")
@@ -137,7 +145,11 @@ class LinuxVulkanOpenGlInteropTest {
           val host = VulkanOpenGlMapHost(mapHost)
           try {
             InteropMap(host).use { map ->
-              val first = firstEgl.withCurrent { map.renderStyle(FIRST_STYLE, FIRST_EXTENT) }
+              val first = firstEgl.withCurrent {
+                map.presentStyle(FIRST_STYLE, FIRST_EXTENT, FIRST_PIXEL) {
+                  firstEgl.drawAndRead(host, it)
+                }
+              }
               assertNear(
                 FIRST_PIXEL,
                 firstEgl.withCurrent { firstEgl.drawAndRead(host, first) },
@@ -145,7 +157,11 @@ class LinuxVulkanOpenGlInteropTest {
               )
 
               mapHost.replaceContext(secondEgl)
-              val second = secondEgl.withCurrent { map.renderStyle(SECOND_STYLE, FIRST_EXTENT) }
+              val second = secondEgl.withCurrent {
+                map.presentStyle(SECOND_STYLE, FIRST_EXTENT, SECOND_PIXEL) {
+                  secondEgl.drawAndRead(host, it)
+                }
+              }
               assertTrue(
                 second.generation != first.generation,
                 "replacement context must allocate a new shared target, " +
@@ -172,9 +188,15 @@ class LinuxVulkanOpenGlInteropTest {
         try {
           InteropMap(host).use { map ->
             egl.withCurrent {
-              val first = map.renderStyle(FIRST_STYLE, FIRST_EXTENT)
+              val first =
+                map.presentStyle(FIRST_STYLE, FIRST_EXTENT, FIRST_PIXEL) {
+                  egl.drawAndRead(host, it)
+                }
               assertNear(FIRST_PIXEL, egl.drawAndRead(host, first), "live first frame")
-              val second = map.renderStyle(SECOND_STYLE, FIRST_EXTENT)
+              val second =
+                map.presentStyle(SECOND_STYLE, FIRST_EXTENT, SECOND_PIXEL) {
+                  egl.drawAndRead(host, it)
+                }
               assertNear(
                 SECOND_PIXEL,
                 egl.drawAndRead(host, second),
@@ -281,37 +303,34 @@ class LinuxVulkanOpenGlInteropTest {
       renderer.onSurfaceAvailable(hostSession)
     }
 
-    fun renderStyle(style: BaseStyle, extent: MapExtent): MlnFfiRenderTarget {
-      val expectedStyleLoads = styleLoads + 1
+    fun presentStyle(
+      style: BaseStyle,
+      extent: MapExtent,
+      expected: RgbaPixel,
+      read: (MlnFfiRenderTarget) -> RgbaPixel,
+    ): MlnFfiRenderTarget {
       renderer.setBaseStyle(style)
       val deadline = TimeSource.Monotonic.markNow() + TEST_TIMEOUT
-      var rendered: MlnFfiRenderTarget? = null
-      var renderedFrames = 0
       var lastResult: MlnFfiFrameResult? = null
-      // Style application and rendering run on different threads. A frame that started before
-      // the new style was observed is the previous style, even if the callback arrives before
-      // this loop looks again. Sample the load count first, then keep only a later frame.
-      while (styleLoads < expectedStyleLoads || rendered == null) {
+      var lastPixel: RgbaPixel? = null
+      // A pump that started before the new style loaded can still show the old pixels.
+      while (true) {
         check(deadline.hasNotPassedNow()) {
-          "Timed out rendering style $style at $extent; " +
-            "style loads: $styleLoads/$expectedStyleLoads, rendered frames: $renderedFrames, " +
-            "last result: $lastResult, failure: $failure"
+          "Timed out presenting $expected for $style at $extent; " +
+            "style loads: $styleLoads, last pixel: $lastPixel, last result: $lastResult, " +
+            "failure: $failure"
         }
         failure?.let { error(it) }
-        val loadsBeforePump = styleLoads
-        // The discarded in-flight pump already consumed MAP_STYLE_LOADED's requestRepaint.
-        if (loadsBeforePump >= expectedStyleLoads && rendered == null) {
-          renderer.requestRedraw()
-        }
         val pumped = pumpFrame(extent)
         lastResult = pumped.result
-        if (loadsBeforePump >= expectedStyleLoads && pumped.rendered) {
-          renderedFrames++
-          rendered = pumped.target
+        val target = pumped.target
+        if (target != null) {
+          lastPixel = read(target)
+          if (near(expected, lastPixel)) return target
         }
+        if (pumped.result != MlnFfiFrameResult.RENDERED) renderer.requestRedraw()
         Thread.sleep(POLL_INTERVAL_MILLIS)
       }
-      return checkNotNull(rendered)
     }
 
     private fun pumpFrame(extent: MapExtent): PumpedFrame {
@@ -335,10 +354,7 @@ class LinuxVulkanOpenGlInteropTest {
       cacheDirectory.toFile().deleteRecursively()
     }
 
-    private class PumpedFrame(val result: MlnFfiFrameResult, val target: MlnFfiRenderTarget?) {
-      val rendered: Boolean
-        get() = result == MlnFfiFrameResult.RENDERED && target != null
-    }
+    private class PumpedFrame(val result: MlnFfiFrameResult, val target: MlnFfiRenderTarget?)
   }
 
   private class EglTestContext private constructor() : AutoCloseable {

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -475,9 +475,7 @@ internal class MlnFfiMapSession(
       if (retargetBorrowedTexture(live, frame.target, extent)) {
         attachedTarget = key
         retargetCount++
-        // The replacement texture holds nothing yet; this request buys the frame that fills it.
-        renderRequested.store(true)
-        onMap(::snapshotViewportAndNotify)
+        requestFillOfNewTarget()
         return true
       }
     }
@@ -496,9 +494,7 @@ internal class MlnFfiMapSession(
     attachedTarget = key
     attachCount++
     publishAttachedViewport()
-    onMap(::snapshotViewportAndNotify)
-    // The new texture holds nothing yet; this request buys the frame that fills it.
-    renderRequested.store(true)
+    requestFillOfNewTarget()
     return true
   }
 
@@ -733,6 +729,30 @@ internal class MlnFfiMapSession(
   private fun requestRender() {
     renderRequested.store(true)
     hostSession?.requestFrame()
+  }
+
+  /**
+   * Dirties mbgl and opens the session skip gate. Safe from any thread.
+   *
+   * A discarded pump can consume the `MAP_STYLE_LOADED` requestRepaint. Later pumps stay on
+   * `NO_UPDATE` until the map is dirty again.
+   */
+  internal fun requestRedraw() {
+    onMap { map -> map.requestRepaint() }
+    requestRender()
+  }
+
+  /**
+   * Dirties mbgl so `renderUpdate` draws into an empty replacement texture instead of returning
+   * `NO_UPDATE`, and snapshots the viewport a size or generation change also needs. Posted because
+   * attach and retarget run on the renderer thread.
+   */
+  private fun requestFillOfNewTarget() {
+    onMap { map ->
+      map.requestRepaint()
+      snapshotViewportAndNotify(map)
+    }
+    renderRequested.store(true)
   }
 
   /**

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -475,7 +475,9 @@ internal class MlnFfiMapSession(
       if (retargetBorrowedTexture(live, frame.target, extent)) {
         attachedTarget = key
         retargetCount++
-        requestFillOfNewTarget()
+        // The replacement texture holds nothing yet; this request buys the frame that fills it.
+        renderRequested.store(true)
+        onMap(::snapshotViewportAndNotify)
         return true
       }
     }
@@ -494,7 +496,9 @@ internal class MlnFfiMapSession(
     attachedTarget = key
     attachCount++
     publishAttachedViewport()
-    requestFillOfNewTarget()
+    onMap(::snapshotViewportAndNotify)
+    // The new texture holds nothing yet; this request buys the frame that fills it.
+    renderRequested.store(true)
     return true
   }
 
@@ -735,15 +739,6 @@ internal class MlnFfiMapSession(
   internal fun requestRedraw() {
     onMap { map -> map.requestRepaint() }
     requestRender()
-  }
-
-  /** Empty texture. Posted because attach and retarget run on the renderer thread. */
-  private fun requestFillOfNewTarget() {
-    onMap { map ->
-      map.requestRepaint()
-      snapshotViewportAndNotify(map)
-    }
-    renderRequested.store(true)
   }
 
   /**

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -731,22 +731,13 @@ internal class MlnFfiMapSession(
     hostSession?.requestFrame()
   }
 
-  /**
-   * Dirties mbgl and opens the session skip gate. Safe from any thread.
-   *
-   * A discarded pump can consume the `MAP_STYLE_LOADED` requestRepaint. Later pumps stay on
-   * `NO_UPDATE` until the map is dirty again.
-   */
+  /** Dirties mbgl and opens the skip gate. Safe from any thread. */
   internal fun requestRedraw() {
     onMap { map -> map.requestRepaint() }
     requestRender()
   }
 
-  /**
-   * Dirties mbgl so `renderUpdate` draws into an empty replacement texture instead of returning
-   * `NO_UPDATE`, and snapshots the viewport a size or generation change also needs. Posted because
-   * attach and retarget run on the renderer thread.
-   */
+  /** Empty texture. Posted because attach and retarget run on the renderer thread. */
   private fun requestFillOfNewTarget() {
     onMap { map ->
       map.requestRepaint()

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -735,12 +735,6 @@ internal class MlnFfiMapSession(
     hostSession?.requestFrame()
   }
 
-  /** Dirties mbgl and opens the skip gate. Safe from any thread. */
-  internal fun requestRedraw() {
-    onMap { map -> map.requestRepaint() }
-    requestRender()
-  }
-
   /**
    * The cap filters an arriving cadence rather than driving one, hence [FRAME_INTERVAL_SLACK]: a
    * cap at the display's own rate would otherwise halve the frame rate.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

After a Compose GL context swap, the Linux interop test pumps the already loaded style into the new shared target.

## Validation

`LinuxVulkanOpenGlInteropTest` passed locally against Lavapipe, including five extra runs of the replacement test.

## AI assistance

Cursor Grok 4.6 implemented this as a cloud agent.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9016a40f-ac46-4659-95d6-7d1d6a857bfa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9016a40f-ac46-4659-95d6-7d1d6a857bfa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

