### PR TITLE
Expose the native location indicator layer

### DIFF
--- a/.agents/docs/COMMON_API_GAPS.md
+++ b/.agents/docs/COMMON_API_GAPS.md
@@ -104,20 +104,6 @@ Design question: the callback boundary. MapLibre calls back on its own worker
 threads to ask for a tile, which has to become something safe and idiomatic to
 implement from Kotlin.
 
-## Location indicator layer
-
-MapLibre's built-in user-location puck — a style layer with a position, bearing,
-and accuracy radius, rendered by the map rather than composed over it.
-
-- FFI: `addLocationIndicatorLayer`, `setLocationIndicatorLocation`,
-  `setLocationIndicatorBearing`, `setLocationIndicatorAccuracyRadius`,
-  `setLocationIndicatorImageName`
-
-Worth weighing against drawing the puck as ordinary layers from
-`org.maplibre.compose.location`, which is portable and already how the demo does
-it. The native indicator's advantage is that it interpolates and renders in the
-same frame as the map.
-
 ## Projection mode
 
 Switching between Mercator and globe projections.

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/LocationDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/LocationDemo.kt
@@ -53,6 +53,7 @@ object LocationDemo : Demo {
 
   private var follow by mutableStateOf(true)
   private var usePlayServices by mutableStateOf(true)
+  private var useNativeIndicator by mutableStateOf(false)
   private var lastFix by mutableStateOf<Position?>(null)
   private var panelLocationState by mutableStateOf<LocationState?>(null)
 
@@ -95,13 +96,17 @@ object LocationDemo : Demo {
       }
     }
 
-    LocationPuck(
-      idPrefix = "user",
-      location = location,
-      bearing = locationState.mostAccurateBearing(),
-      cameraState = cameraState,
-      colors = LocationPuckDefaults.colors(),
-    )
+    if (useNativeIndicator) {
+      NativeLocationIndicator(location = location, bearing = locationState.mostAccurateBearing())
+    } else {
+      LocationPuck(
+        idPrefix = "user",
+        location = location,
+        bearing = locationState.mostAccurateBearing(),
+        cameraState = cameraState,
+        colors = LocationPuckDefaults.colors(),
+      )
+    }
   }
 
   @Composable
@@ -113,6 +118,9 @@ object LocationDemo : Demo {
       modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
     )
     SwitchRow("Follow me", follow) { follow = it }
+    if (isNativeLocationIndicatorAvailable) {
+      SwitchRow("Native indicator", useNativeIndicator) { useNativeIndicator = it }
+    }
     LocationEngineRow(usePlayServices) { usePlayServices = it }
   }
 }

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/NativeLocationIndicator.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/NativeLocationIndicator.kt
@@ -1,0 +1,21 @@
+package org.maplibre.compose.demoapp.demos
+
+import androidx.compose.runtime.Composable
+import org.maplibre.compose.location.BearingWithAccuracy
+import org.maplibre.compose.location.Location
+import org.maplibre.compose.util.MaplibreComposable
+
+/**
+ * Whether this platform draws the location indicator with MapLibre Native's built-in layer. The
+ * browser runs MapLibre GL JS, which has no such layer.
+ */
+expect val isNativeLocationIndicatorAvailable: Boolean
+
+/**
+ * Draws the user's location with MapLibre Native's location indicator layer, the map-rendered
+ * alternative to the [LocationPuck][org.maplibre.compose.location.LocationPuck] composable. Draws
+ * nothing on platforms where [isNativeLocationIndicatorAvailable] is false.
+ */
+@Composable
+@MaplibreComposable
+expect fun NativeLocationIndicator(location: Location?, bearing: BearingWithAccuracy?)

--- a/demo-app/common/src/jsMain/kotlin/org/maplibre/compose/demoapp/demos/NativeLocationIndicator.js.kt
+++ b/demo-app/common/src/jsMain/kotlin/org/maplibre/compose/demoapp/demos/NativeLocationIndicator.js.kt
@@ -1,0 +1,12 @@
+package org.maplibre.compose.demoapp.demos
+
+import androidx.compose.runtime.Composable
+import org.maplibre.compose.location.BearingWithAccuracy
+import org.maplibre.compose.location.Location
+import org.maplibre.compose.util.MaplibreComposable
+
+actual val isNativeLocationIndicatorAvailable: Boolean = false
+
+@Composable
+@MaplibreComposable
+actual fun NativeLocationIndicator(location: Location?, bearing: BearingWithAccuracy?) {}

--- a/demo-app/common/src/mlnFfiShared/kotlin/org/maplibre/compose/demoapp/demos/NativeLocationIndicator.kt
+++ b/demo-app/common/src/mlnFfiShared/kotlin/org/maplibre/compose/demoapp/demos/NativeLocationIndicator.kt
@@ -1,0 +1,78 @@
+package org.maplibre.compose.demoapp.demos
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import org.maplibre.compose.expressions.dsl.const
+import org.maplibre.compose.expressions.dsl.image
+import org.maplibre.compose.expressions.dsl.nil
+import org.maplibre.compose.layers.LocationIndicatorLayer
+import org.maplibre.compose.location.BearingWithAccuracy
+import org.maplibre.compose.location.Location
+import org.maplibre.compose.material3.LocationPuckDefaults
+import org.maplibre.compose.util.MaplibreComposable
+import org.maplibre.spatialk.units.Bearing
+import org.maplibre.spatialk.units.extensions.inDegrees
+import org.maplibre.spatialk.units.extensions.inMeters
+
+actual val isNativeLocationIndicatorAvailable: Boolean = true
+
+@Composable
+@MaplibreComposable
+actual fun NativeLocationIndicator(location: Location?, bearing: BearingWithAccuracy?) {
+  if (location == null) return
+
+  val colors = LocationPuckDefaults.colors()
+  val dot =
+    remember(colors) { DotPainter(colors.dotFillColorCurrentLocation, colors.dotStrokeColor) }
+  val arrow = remember(colors) { ArrowPainter(colors.bearingColor) }
+
+  LocationIndicatorLayer(
+    id = "native-location-indicator",
+    location = location.position.value,
+    bearing = const(bearing?.let { (it.value - Bearing.North).inDegrees.toFloat() } ?: 0f),
+    accuracyRadius = const(location.position.accuracy?.inMeters?.toFloat() ?: 0f),
+    accuracyRadiusColor = const(colors.accuracyFillColor),
+    accuracyRadiusBorderColor = const(colors.accuracyStrokeColor),
+    topImage = image(dot, size = DpSize(24.dp, 24.dp)),
+    bearingImage = if (bearing != null) image(arrow, size = DpSize(56.dp, 56.dp)) else nil(),
+  )
+}
+
+/** The location dot: a filled circle with a stroke, sized by the canvas it is drawn into. */
+private class DotPainter(private val fill: Color, private val stroke: Color) : Painter() {
+  override val intrinsicSize: Size = Size.Unspecified
+
+  override fun DrawScope.onDraw() {
+    val strokeWidth = size.minDimension / 8f
+    val radius = (size.minDimension - strokeWidth) / 2f
+    drawCircle(fill, radius = radius)
+    drawCircle(stroke, radius = radius, style = Stroke(strokeWidth))
+  }
+}
+
+/**
+ * The bearing arrow: a triangle at the top of the canvas. The layer rotates the whole image around
+ * its center, so the empty middle leaves room for the dot.
+ */
+private class ArrowPainter(private val color: Color) : Painter() {
+  override val intrinsicSize: Size = Size.Unspecified
+
+  override fun DrawScope.onDraw() {
+    val path =
+      Path().apply {
+        moveTo(size.width / 2f, 0f)
+        lineTo(size.width * 0.65f, size.height * 0.25f)
+        lineTo(size.width * 0.35f, size.height * 0.25f)
+        close()
+      }
+    drawPath(path, color)
+  }
+}

--- a/demo-app/common/src/mlnFfiShared/kotlin/org/maplibre/compose/demoapp/demos/NativeLocationIndicator.kt
+++ b/demo-app/common/src/mlnFfiShared/kotlin/org/maplibre/compose/demoapp/demos/NativeLocationIndicator.kt
@@ -1,7 +1,11 @@
 package org.maplibre.compose.demoapp.demos
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
@@ -10,6 +14,9 @@ import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.delay
 import org.maplibre.compose.expressions.dsl.const
 import org.maplibre.compose.expressions.dsl.image
 import org.maplibre.compose.expressions.dsl.nil
@@ -29,21 +36,40 @@ actual val isNativeLocationIndicatorAvailable: Boolean = true
 actual fun NativeLocationIndicator(location: Location?, bearing: BearingWithAccuracy?) {
   if (location == null) return
 
+  val isOld = rememberIsLocationOld(location)
   val colors = LocationPuckDefaults.colors()
-  val dot =
-    remember(colors) { DotPainter(colors.dotFillColorCurrentLocation, colors.dotStrokeColor) }
+  val dotFill = if (isOld) colors.dotFillColorOldLocation else colors.dotFillColorCurrentLocation
+  val dot = remember(dotFill, colors) { DotPainter(dotFill, colors.dotStrokeColor) }
   val arrow = remember(colors) { ArrowPainter(colors.bearingColor) }
 
   LocationIndicatorLayer(
     id = "native-location-indicator",
     location = location.position.value,
     bearing = const(bearing?.let { (it.value - Bearing.North).inDegrees.toFloat() } ?: 0f),
-    accuracyRadius = const(location.position.accuracy?.inMeters?.toFloat() ?: 0f),
+    accuracyRadius =
+      const(if (isOld) 0f else location.position.accuracy?.inMeters?.toFloat() ?: 0f),
     accuracyRadiusColor = const(colors.accuracyFillColor),
     accuracyRadiusBorderColor = const(colors.accuracyStrokeColor),
     topImage = image(dot, size = DpSize(24.dp, 24.dp)),
     bearingImage = if (bearing != null) image(arrow, size = DpSize(56.dp, 56.dp)) else nil(),
   )
+}
+
+/**
+ * Whether [location] is older than the same 30-second threshold [LocationPuck]
+ * [org.maplibre.compose.location.LocationPuck] uses to mark a retained fix as stale.
+ */
+@Composable
+private fun rememberIsLocationOld(location: Location): Boolean {
+  val threshold = 30.seconds
+  var isOld by remember(location) { mutableStateOf(location.timestamp.elapsedNow() > threshold) }
+  LaunchedEffect(location) {
+    if (isOld) return@LaunchedEffect
+    val remaining = threshold - location.timestamp.elapsedNow()
+    if (remaining > Duration.ZERO) delay(remaining)
+    isOld = true
+  }
+  return isOld
 }
 
 /** The location dot: a filled circle with a stroke, sized by the canvas it is drawn into. */

--- a/docs/src/content/docs/roadmap.md
+++ b/docs/src/content/docs/roadmap.md
@@ -111,9 +111,9 @@ Publishing those handles is also the answer to
 **Status:** Needs Exploration 🔍
 
 MapLibre Native can do a number of things MapLibre Compose has no cross-platform
-API for, among them style light, the location indicator layer, alternative
-projections, style transition options, HTTP header transforms, supplying missing
-style images on demand, resource transforms, merging offline databases, and
+API for, among them style light, alternative projections, style transition
+options, HTTP header transforms, supplying missing style images on demand,
+resource transforms, merging offline databases, and
 [static map snapshots](https://github.com/maplibre/maplibre-compose/issues/28).
 The inventory is in
 [`COMMON_API_GAPS.md`](https://github.com/maplibre/maplibre-compose/blob/main/.agents/docs/COMMON_API_GAPS.md).

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/layers/LocationIndicatorLayerComposable.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/layers/LocationIndicatorLayerComposable.kt
@@ -1,0 +1,113 @@
+package org.maplibre.compose.layers
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import org.maplibre.compose.expressions.ast.Expression
+import org.maplibre.compose.expressions.dsl.const
+import org.maplibre.compose.expressions.dsl.image
+import org.maplibre.compose.expressions.dsl.nil
+import org.maplibre.compose.expressions.value.ColorValue
+import org.maplibre.compose.expressions.value.FloatValue
+import org.maplibre.compose.expressions.value.ImageValue
+import org.maplibre.compose.util.MaplibreComposable
+import org.maplibre.spatialk.geojson.Position
+
+/**
+ * A layer that MapLibre Native renders as a location indicator: images for the position, bearing,
+ * and shadow, and a circle for the position accuracy.
+ *
+ * This layer draws no images until at least one of [topImage], [bearingImage], or [shadowImage] is
+ * set. Unlike other layers, it takes its position from [location] rather than from a source.
+ *
+ * MapLibre Native animates changes to [location], [bearing], and [accuracyRadius] with the style's
+ * transition options, so a location update moves the indicator smoothly.
+ *
+ * This layer is available on Android, desktop, and iOS. MapLibre GL JS has no location indicator
+ * layer, so the browser platform draws a location marker with [LocationPuck]
+ * [org.maplibre.compose.location.LocationPuck] instead.
+ *
+ * @param id Unique layer name.
+ * @param location The position to draw the indicator at.
+ * @param minZoom The minimum zoom level for the layer. At zoom levels less than this, the layer
+ *   will be hidden. A value in the range of `[0..24]`.
+ * @param maxZoom The maximum zoom level for the layer. At zoom levels equal to or greater than
+ *   this, the layer will be hidden. A value in the range of `[0..24]`.
+ * @param visible Whether the layer should be displayed.
+ * @param bearing The bearing of the indicator in degrees clockwise from north. Rotates
+ *   [bearingImage].
+ * @param accuracyRadius The position accuracy in meters, drawn as a circle under the indicator.
+ * @param accuracyRadiusColor The fill color of the accuracy circle.
+ * @param accuracyRadiusBorderColor The color of the accuracy circle's border.
+ * @param topImage The image drawn on top, typically the location dot. See [image].
+ * @param bearingImage The image drawn under [topImage] and rotated by [bearing], typically an
+ *   arrow.
+ * @param shadowImage The image drawn under the others, typically a shadow.
+ * @param topImageSize A scale factor for [topImage].
+ * @param bearingImageSize A scale factor for [bearingImage].
+ * @param shadowImageSize A scale factor for [shadowImage].
+ * @param imageTiltDisplacement The displacement of the images off the indicator's center when the
+ *   map is pitched, in pixels, which fakes a height above the map.
+ * @param perspectiveCompensation How much to compensate the perspective shrinking of the images
+ *   when the map is pitched. `0` draws them shrunk with distance like map features; `1` keeps their
+ *   screen size.
+ */
+@Composable
+@MaplibreComposable
+public fun LocationIndicatorLayer(
+  id: String,
+  location: Position,
+  minZoom: Float = 0.0f,
+  maxZoom: Float = 24.0f,
+  visible: Boolean = true,
+  bearing: Expression<FloatValue> = const(0f),
+  accuracyRadius: Expression<FloatValue> = const(0f),
+  accuracyRadiusColor: Expression<ColorValue> = const(Color.White),
+  accuracyRadiusBorderColor: Expression<ColorValue> = const(Color.White),
+  topImage: Expression<ImageValue> = nil(),
+  bearingImage: Expression<ImageValue> = nil(),
+  shadowImage: Expression<ImageValue> = nil(),
+  topImageSize: Expression<FloatValue> = const(1f),
+  bearingImageSize: Expression<FloatValue> = const(1f),
+  shadowImageSize: Expression<FloatValue> = const(1f),
+  imageTiltDisplacement: Expression<FloatValue> = const(0f),
+  perspectiveCompensation: Expression<FloatValue> = const(0.85f),
+) {
+  val compile = rememberPropertyCompiler()
+
+  val compiledBearing = compile(bearing)
+  val compiledAccuracyRadius = compile(accuracyRadius)
+  val compiledAccuracyRadiusColor = compile(accuracyRadiusColor)
+  val compiledAccuracyRadiusBorderColor = compile(accuracyRadiusBorderColor)
+  val compiledTopImage = compile(topImage)
+  val compiledBearingImage = compile(bearingImage)
+  val compiledShadowImage = compile(shadowImage)
+  val compiledTopImageSize = compile(topImageSize)
+  val compiledBearingImageSize = compile(bearingImageSize)
+  val compiledShadowImageSize = compile(shadowImageSize)
+  val compiledImageTiltDisplacement = compile(imageTiltDisplacement)
+  val compiledPerspectiveCompensation = compile(perspectiveCompensation)
+
+  LayerNode(
+    factory = { LocationIndicatorLayer(id = id) },
+    update = {
+      set(minZoom) { layer.minZoom = it }
+      set(maxZoom) { layer.maxZoom = it }
+      set(visible) { layer.visible = it }
+      set(compiledTopImage) { layer.setTopImage(it) }
+      set(compiledBearingImage) { layer.setBearingImage(it) }
+      set(compiledShadowImage) { layer.setShadowImage(it) }
+      set(location) { layer.setLocation(it) }
+      set(compiledBearing) { layer.setBearing(it) }
+      set(compiledAccuracyRadius) { layer.setAccuracyRadius(it) }
+      set(compiledAccuracyRadiusColor) { layer.setAccuracyRadiusColor(it) }
+      set(compiledAccuracyRadiusBorderColor) { layer.setAccuracyRadiusBorderColor(it) }
+      set(compiledTopImageSize) { layer.setTopImageSize(it) }
+      set(compiledBearingImageSize) { layer.setBearingImageSize(it) }
+      set(compiledShadowImageSize) { layer.setShadowImageSize(it) }
+      set(compiledImageTiltDisplacement) { layer.setImageTiltDisplacement(it) }
+      set(compiledPerspectiveCompensation) { layer.setPerspectiveCompensation(it) }
+    },
+    onClick = null,
+    onLongClick = null,
+  )
+}

--- a/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/layers/LocationIndicatorLayerTest.kt
+++ b/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/layers/LocationIndicatorLayerTest.kt
@@ -5,6 +5,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.doubleOrNull
 import org.maplibre.compose.expressions.ast.ExpressionContext
@@ -40,8 +41,22 @@ class LocationIndicatorLayerTest {
       layer.setPerspectiveCompensation(const(0.9f).compile(ExpressionContext.None))
       style.addLayer(layer)
 
+      // The renderer evaluates the layer only when a frame is drawn, and image properties that
+      // arrive as expressions abort it there rather than at addLayer.
+      it.pumpUntilRendered()
+      repeat(3) { _ -> it.frame() }
+
       layer.onMap { map ->
         assertTrue(map.styleLayerExists("indicator"), "the layer should have been added")
+        // A constant image reads back as an object naming it; an expression would read back as an
+        // ["image", ...] array, which the renderer cannot take.
+        assertEquals(
+          JsonPrimitive("top-icon"),
+          (map.layerProperty("indicator", "top-image")?.toJsonElement() as? JsonObject)?.get(
+            "name"
+          ),
+          "the image should be written as a plain name, which the renderer reads as a constant",
+        )
         assertEquals(
           JsonArray(listOf(JsonPrimitive(48.0), JsonPrimitive(11.0), JsonPrimitive(0.0))),
           map.layerProperty("indicator", "location")?.toJsonElement(),

--- a/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/layers/LocationIndicatorLayerTest.kt
+++ b/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/layers/LocationIndicatorLayerTest.kt
@@ -1,0 +1,74 @@
+package org.maplibre.compose.layers
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.doubleOrNull
+import org.maplibre.compose.expressions.ast.ExpressionContext
+import org.maplibre.compose.expressions.dsl.const
+import org.maplibre.compose.expressions.dsl.image
+import org.maplibre.compose.mlnffi.BridgeMapFixture
+import org.maplibre.compose.style.BaseStyle
+import org.maplibre.compose.style.MlnFfiStyle
+import org.maplibre.compose.util.onMap
+import org.maplibre.compose.util.toJsonElement
+import org.maplibre.spatialk.geojson.Position
+
+class LocationIndicatorLayerTest {
+
+  @Test
+  fun location_indicator_properties_reach_maplibre() {
+    val fixture = BridgeMapFixture.create()
+    fixture.use {
+      it.loadStyle(BaseStyle.Empty)
+      val style = assertNotNull(it.style as? MlnFfiStyle, "Errors: ${it.errors}")
+
+      val layer = LocationIndicatorLayer("indicator")
+      layer.setTopImage(image("top-icon").compile(ExpressionContext.None))
+      layer.setBearingImage(image("bearing-icon").compile(ExpressionContext.None))
+      layer.setShadowImage(image("shadow-icon").compile(ExpressionContext.None))
+      layer.setLocation(Position(longitude = 11.0, latitude = 48.0))
+      layer.setBearing(const(45f).compile(ExpressionContext.None))
+      layer.setAccuracyRadius(const(20f).compile(ExpressionContext.None))
+      layer.setTopImageSize(const(0.5f).compile(ExpressionContext.None))
+      layer.setBearingImageSize(const(0.25f).compile(ExpressionContext.None))
+      layer.setShadowImageSize(const(0.75f).compile(ExpressionContext.None))
+      layer.setImageTiltDisplacement(const(4f).compile(ExpressionContext.None))
+      layer.setPerspectiveCompensation(const(0.9f).compile(ExpressionContext.None))
+      style.addLayer(layer)
+
+      layer.onMap { map ->
+        assertTrue(map.styleLayerExists("indicator"), "the layer should have been added")
+        assertEquals(
+          JsonArray(listOf(JsonPrimitive(48.0), JsonPrimitive(11.0), JsonPrimitive(0.0))),
+          map.layerProperty("indicator", "location")?.toJsonElement(),
+          "the location should read back as [latitude, longitude, altitude]",
+        )
+        assertEquals(
+          45.0,
+          (map.layerProperty("indicator", "bearing")?.toJsonElement() as? JsonPrimitive)
+            ?.doubleOrNull,
+        )
+        assertEquals(
+          20.0,
+          (map.layerProperty("indicator", "accuracy-radius")?.toJsonElement() as? JsonPrimitive)
+            ?.doubleOrNull,
+        )
+      }
+
+      // A property set on the live layer takes effect too.
+      layer.setLocation(Position(longitude = -122.0, latitude = 37.0, altitude = 10.0))
+      layer.onMap { map ->
+        assertEquals(
+          JsonArray(listOf(JsonPrimitive(37.0), JsonPrimitive(-122.0), JsonPrimitive(10.0))),
+          map.layerProperty("indicator", "location")?.toJsonElement(),
+        )
+      }
+
+      assertEquals(emptyList(), it.errors, "the map should report nothing")
+    }
+  }
+}

--- a/lib/maplibre-compose/src/nextCommonMain/kotlin/org/maplibre/compose/layers/LocationIndicatorLayer.kt
+++ b/lib/maplibre-compose/src/nextCommonMain/kotlin/org/maplibre/compose/layers/LocationIndicatorLayer.kt
@@ -1,11 +1,13 @@
 package org.maplibre.compose.layers
 
 import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonPrimitive
 import org.maplibre.compose.expressions.ast.CompiledExpression
 import org.maplibre.compose.expressions.value.ColorValue
 import org.maplibre.compose.expressions.value.FloatValue
 import org.maplibre.compose.expressions.value.ImageValue
+import org.maplibre.compose.util.toStyleJson
 import org.maplibre.spatialk.geojson.Position
 
 internal class LocationIndicatorLayer(id: String) : Layer(id) {
@@ -13,15 +15,39 @@ internal class LocationIndicatorLayer(id: String) : Layer(id) {
   override val type: String = "location-indicator"
 
   fun setTopImage(topImage: CompiledExpression<ImageValue>) {
-    setLayoutProperty("top-image", topImage)
+    setImageProperty("top-image", topImage)
   }
 
   fun setBearingImage(bearingImage: CompiledExpression<ImageValue>) {
-    setLayoutProperty("bearing-image", bearingImage)
+    setImageProperty("bearing-image", bearingImage)
   }
 
   fun setShadowImage(shadowImage: CompiledExpression<ImageValue>) {
-    setLayoutProperty("shadow-image", shadowImage)
+    setImageProperty("shadow-image", shadowImage)
+  }
+
+  /**
+   * MapLibre Native reads this layer's image properties with `asConstant()`, and an expression —
+   * even the constant `["image", name]` wrapper the DSL compiles to — aborts the renderer with
+   * `bad_variant_access` on the first frame. Only a plain image name is safe to write.
+   */
+  private fun setImageProperty(name: String, image: CompiledExpression<ImageValue>) {
+    when (val json = image.toStyleJson()) {
+      is JsonNull,
+      is JsonPrimitive -> setLayoutProperty(name, json)
+      is JsonArray ->
+        if (
+          json.size == 2 &&
+            (json[0] as? JsonPrimitive)?.content == "image" &&
+            json[1] is JsonPrimitive
+        ) {
+          setLayoutProperty(name, json[1])
+        } else {
+          skipUnsupportedProperty(name, image, "MapLibre Native reads only a constant image here")
+        }
+      else ->
+        skipUnsupportedProperty(name, image, "MapLibre Native reads only a constant image here")
+    }
   }
 
   fun setLocation(location: Position) {

--- a/lib/maplibre-compose/src/nextCommonMain/kotlin/org/maplibre/compose/layers/LocationIndicatorLayer.kt
+++ b/lib/maplibre-compose/src/nextCommonMain/kotlin/org/maplibre/compose/layers/LocationIndicatorLayer.kt
@@ -1,0 +1,76 @@
+package org.maplibre.compose.layers
+
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonPrimitive
+import org.maplibre.compose.expressions.ast.CompiledExpression
+import org.maplibre.compose.expressions.value.ColorValue
+import org.maplibre.compose.expressions.value.FloatValue
+import org.maplibre.compose.expressions.value.ImageValue
+import org.maplibre.spatialk.geojson.Position
+
+internal class LocationIndicatorLayer(id: String) : Layer(id) {
+
+  override val type: String = "location-indicator"
+
+  fun setTopImage(topImage: CompiledExpression<ImageValue>) {
+    setLayoutProperty("top-image", topImage)
+  }
+
+  fun setBearingImage(bearingImage: CompiledExpression<ImageValue>) {
+    setLayoutProperty("bearing-image", bearingImage)
+  }
+
+  fun setShadowImage(shadowImage: CompiledExpression<ImageValue>) {
+    setLayoutProperty("shadow-image", shadowImage)
+  }
+
+  fun setLocation(location: Position) {
+    // The style property reads [latitude, longitude, altitude], unlike GeoJSON positions.
+    setPaintProperty(
+      "location",
+      JsonArray(
+        listOf(
+          JsonPrimitive(location.latitude),
+          JsonPrimitive(location.longitude),
+          JsonPrimitive(location.altitude ?: 0.0),
+        )
+      ),
+    )
+  }
+
+  fun setBearing(bearing: CompiledExpression<FloatValue>) {
+    setPaintProperty("bearing", bearing)
+  }
+
+  fun setAccuracyRadius(accuracyRadius: CompiledExpression<FloatValue>) {
+    setPaintProperty("accuracy-radius", accuracyRadius)
+  }
+
+  fun setAccuracyRadiusColor(accuracyRadiusColor: CompiledExpression<ColorValue>) {
+    setPaintProperty("accuracy-radius-color", accuracyRadiusColor)
+  }
+
+  fun setAccuracyRadiusBorderColor(accuracyRadiusBorderColor: CompiledExpression<ColorValue>) {
+    setPaintProperty("accuracy-radius-border-color", accuracyRadiusBorderColor)
+  }
+
+  fun setTopImageSize(topImageSize: CompiledExpression<FloatValue>) {
+    setPaintProperty("top-image-size", topImageSize)
+  }
+
+  fun setBearingImageSize(bearingImageSize: CompiledExpression<FloatValue>) {
+    setPaintProperty("bearing-image-size", bearingImageSize)
+  }
+
+  fun setShadowImageSize(shadowImageSize: CompiledExpression<FloatValue>) {
+    setPaintProperty("shadow-image-size", shadowImageSize)
+  }
+
+  fun setImageTiltDisplacement(imageTiltDisplacement: CompiledExpression<FloatValue>) {
+    setPaintProperty("image-tilt-displacement", imageTiltDisplacement)
+  }
+
+  fun setPerspectiveCompensation(perspectiveCompensation: CompiledExpression<FloatValue>) {
+    setPaintProperty("perspective-compensation", perspectiveCompensation)
+  }
+}


### PR DESCRIPTION
## Description

Adds a `LocationIndicatorLayer` composable on the mln-ffi platforms (Android, desktop, iOS), backed by the core's `location-indicator` style layer, with a "Native indicator" toggle on the My location demo. Closes #760.

## Validation

Added a property round-trip test in `mlnFfiSharedTest` (passing on desktop against real MapLibre Native; CI runs it on Android host and iOS), and compiled all targets including the demo app.

## AI assistance

Written by Claude Fable 5 via Claude Code