### PR TITLE
Expose the viewport as observable state on CameraState

### DIFF
--- a/demo-app/common/src/androidMain/kotlin/org/maplibre/compose/docsnippets/Interaction.kt
+++ b/demo-app/common/src/androidMain/kotlin/org/maplibre/compose/docsnippets/Interaction.kt
@@ -62,7 +62,7 @@ fun Interaction() {
     cameraState = camera,
     onMapClick = { pos, offset ->
       scope.launch {
-        val features = camera.projection?.queryRenderedFeatures(offset)
+        val features = camera.viewport?.queryRenderedFeatures(offset)
         if (!features.isNullOrEmpty()) {
           println("Clicked on ${features[0].toJson()}")
         }

--- a/demo-app/common/src/androidMain/kotlin/org/maplibre/compose/docsnippets/Interaction.kt
+++ b/demo-app/common/src/androidMain/kotlin/org/maplibre/compose/docsnippets/Interaction.kt
@@ -62,8 +62,8 @@ fun Interaction() {
     cameraState = camera,
     onMapClick = { pos, offset ->
       scope.launch {
-        val features = camera.viewport?.queryRenderedFeatures(offset)
-        if (!features.isNullOrEmpty()) {
+        val features = camera.queryRenderedFeatures(offset)
+        if (features.isNotEmpty()) {
           println("Clicked on ${features[0].toJson()}")
         }
       }

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/benchmark/BenchmarkMap.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/benchmark/BenchmarkMap.kt
@@ -171,10 +171,9 @@ internal fun BenchmarkMap(state: DemoAppState, sheetInsets: WindowInsets = Windo
               session.pointerPx = Offset(change.position.x, change.position.y)
             }
             if (change.pressed && session.pin == null && scenario.usesGestures) {
-              val viewport = cameraState.viewport
-              if (viewport != null) {
+              if (cameraState.viewport != null) {
                 session.pin =
-                  viewport.positionFromScreenLocation(
+                  cameraState.positionFromScreenLocation(
                     with(density) { DpOffset(change.position.x.toDp(), change.position.y.toDp()) }
                   )
               }
@@ -236,7 +235,8 @@ internal fun BenchmarkMap(state: DemoAppState, sheetInsets: WindowInsets = Windo
 
 private fun samplePin(session: BenchmarkSession) {
   val pin = session.pin ?: return
-  val projected = session.cameraState.viewport?.screenLocationFromPosition(pin) ?: return
+  if (session.cameraState.viewport == null) return
+  val projected = session.cameraState.screenLocationFromPosition(pin)
   val px = with(session.density) { Offset(projected.x.toPx(), projected.y.toPx()) }
   session.gestures.onMapProjection(px.x.toDouble(), px.y.toDouble())
 }
@@ -244,7 +244,10 @@ private fun samplePin(session: BenchmarkSession) {
 private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawTrail(session: BenchmarkSession) {
   val composePoint = session.pointerPx
   val pin = session.pin
-  val projected = pin?.let { session.cameraState.viewport?.screenLocationFromPosition(it) }
+  val projected =
+    pin
+      ?.takeIf { session.cameraState.viewport != null }
+      ?.let { session.cameraState.screenLocationFromPosition(it) }
   val mapPoint = projected?.let { with(session.density) { Offset(it.x.toPx(), it.y.toPx()) } }
   if (composePoint != null) {
     val arm = 12.dp.toPx()

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/benchmark/BenchmarkMap.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/benchmark/BenchmarkMap.kt
@@ -171,12 +171,10 @@ internal fun BenchmarkMap(state: DemoAppState, sheetInsets: WindowInsets = Windo
               session.pointerPx = Offset(change.position.x, change.position.y)
             }
             if (change.pressed && session.pin == null && scenario.usesGestures) {
-              if (cameraState.viewport != null) {
-                session.pin =
-                  cameraState.positionFromScreenLocation(
-                    with(density) { DpOffset(change.position.x.toDp(), change.position.y.toDp()) }
-                  )
-              }
+              session.pin =
+                cameraState.positionFromScreenLocation(
+                  with(density) { DpOffset(change.position.x.toDp(), change.position.y.toDp()) }
+                )
             }
             session.gestures.onPointer(x, y, change.pressed)
             if (!change.pressed && scenario.usesGestures) {
@@ -235,8 +233,7 @@ internal fun BenchmarkMap(state: DemoAppState, sheetInsets: WindowInsets = Windo
 
 private fun samplePin(session: BenchmarkSession) {
   val pin = session.pin ?: return
-  if (session.cameraState.viewport == null) return
-  val projected = session.cameraState.screenLocationFromPosition(pin)
+  val projected = session.cameraState.screenLocationFromPosition(pin) ?: return
   val px = with(session.density) { Offset(projected.x.toPx(), projected.y.toPx()) }
   session.gestures.onMapProjection(px.x.toDouble(), px.y.toDouble())
 }
@@ -244,10 +241,7 @@ private fun samplePin(session: BenchmarkSession) {
 private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawTrail(session: BenchmarkSession) {
   val composePoint = session.pointerPx
   val pin = session.pin
-  val projected =
-    pin
-      ?.takeIf { session.cameraState.viewport != null }
-      ?.let { session.cameraState.screenLocationFromPosition(it) }
+  val projected = pin?.let { session.cameraState.screenLocationFromPosition(it) }
   val mapPoint = projected?.let { with(session.density) { Offset(it.x.toPx(), it.y.toPx()) } }
   if (composePoint != null) {
     val arm = 12.dp.toPx()

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/benchmark/BenchmarkMap.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/benchmark/BenchmarkMap.kt
@@ -171,10 +171,10 @@ internal fun BenchmarkMap(state: DemoAppState, sheetInsets: WindowInsets = Windo
               session.pointerPx = Offset(change.position.x, change.position.y)
             }
             if (change.pressed && session.pin == null && scenario.usesGestures) {
-              val projection = cameraState.projection
-              if (projection != null) {
+              val viewport = cameraState.viewport
+              if (viewport != null) {
                 session.pin =
-                  projection.positionFromScreenLocation(
+                  viewport.positionFromScreenLocation(
                     with(density) { DpOffset(change.position.x.toDp(), change.position.y.toDp()) }
                   )
               }
@@ -236,7 +236,7 @@ internal fun BenchmarkMap(state: DemoAppState, sheetInsets: WindowInsets = Windo
 
 private fun samplePin(session: BenchmarkSession) {
   val pin = session.pin ?: return
-  val projected = session.cameraState.projection?.screenLocationFromPosition(pin) ?: return
+  val projected = session.cameraState.viewport?.screenLocationFromPosition(pin) ?: return
   val px = with(session.density) { Offset(projected.x.toPx(), projected.y.toPx()) }
   session.gestures.onMapProjection(px.x.toDouble(), px.y.toDouble())
 }
@@ -244,7 +244,7 @@ private fun samplePin(session: BenchmarkSession) {
 private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawTrail(session: BenchmarkSession) {
   val composePoint = session.pointerPx
   val pin = session.pin
-  val projected = pin?.let { session.cameraState.projection?.screenLocationFromPosition(it) }
+  val projected = pin?.let { session.cameraState.viewport?.screenLocationFromPosition(it) }
   val mapPoint = projected?.let { with(session.density) { Offset(it.x.toPx(), it.y.toPx()) } }
   if (composePoint != null) {
     val arm = 12.dp.toPx()

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Material3.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Material3.kt
@@ -24,7 +24,7 @@ fun Material3() {
     overlay =
       MapOverlay {
         ScaleBar(
-          cameraState.metersPerDpAtTarget,
+          cameraState.viewport?.metersPerDpAtTarget ?: 0.0,
           modifier = Modifier.align(Alignment.TopStart),
         ) // (1)!
         CompassButton(cameraState, modifier = Modifier.align(Alignment.TopEnd))

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/org/maplibre/compose/material3/MapOverlay.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/org/maplibre/compose/material3/MapOverlay.kt
@@ -10,7 +10,7 @@ import org.maplibre.compose.overlay.MaplibreLogo
 
 private val Material3Overlay = MapOverlay {
   DisappearingScaleBar(
-    metersPerDp = cameraState.metersPerDpAtTarget,
+    metersPerDp = cameraState.viewport?.metersPerDpAtTarget ?: 0.0,
     zoom = cameraState.position.zoom,
     modifier = Modifier.align(Alignment.TopStart),
   )

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/org/maplibre/compose/material3/PointerPinButton.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/org/maplibre/compose/material3/PointerPinButton.kt
@@ -86,9 +86,9 @@ public fun PointerPinButton(
   interactionSource: MutableInteractionSource? = null,
   content: @Composable (BoxScope.() -> Unit),
 ) {
-  val projection = cameraState.projection
+  val viewport = cameraState.viewport
   val dpTarget =
-    remember(targetPosition, projection) { projection?.screenLocationFromPosition(targetPosition) }
+    remember(targetPosition, viewport) { viewport?.screenLocationFromPosition(targetPosition) }
   val target = dpTarget?.toOffset() ?: return
   var area by remember { mutableStateOf<Rect?>(null) }
 

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/org/maplibre/compose/material3/PointerPinButton.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/org/maplibre/compose/material3/PointerPinButton.kt
@@ -86,11 +86,10 @@ public fun PointerPinButton(
   interactionSource: MutableInteractionSource? = null,
   content: @Composable (BoxScope.() -> Unit),
 ) {
+  // The viewport read recomputes the conversion when the transform changes.
   val viewport = cameraState.viewport
   val dpTarget =
-    remember(targetPosition, viewport) {
-      if (viewport == null) null else cameraState.screenLocationFromPosition(targetPosition)
-    }
+    remember(targetPosition, viewport) { cameraState.screenLocationFromPosition(targetPosition) }
   val target = dpTarget?.toOffset() ?: return
   var area by remember { mutableStateOf<Rect?>(null) }
 

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/org/maplibre/compose/material3/PointerPinButton.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/org/maplibre/compose/material3/PointerPinButton.kt
@@ -88,7 +88,9 @@ public fun PointerPinButton(
 ) {
   val viewport = cameraState.viewport
   val dpTarget =
-    remember(targetPosition, viewport) { viewport?.screenLocationFromPosition(targetPosition) }
+    remember(targetPosition, viewport) {
+      if (viewport == null) null else cameraState.screenLocationFromPosition(targetPosition)
+    }
   val target = dpTarget?.toOffset() ?: return
   var area by remember { mutableStateOf<Rect?>(null) }
 

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/org/maplibre/compose/material3/ScaleBar.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/org/maplibre/compose/material3/ScaleBar.kt
@@ -30,7 +30,7 @@ import org.maplibre.compose.overlay.ScaleBarMeasures
  *
  * @param metersPerDp how many meters are displayed in one device independent pixel (dp), i.e. the
  *   scale. See
- *   [CameraState.metersPerDpAtTarget][org.maplibre.compose.camera.CameraState.metersPerDpAtTarget]
+ *   [Viewport.metersPerDpAtTarget][org.maplibre.compose.camera.Viewport.metersPerDpAtTarget]
  * @param modifier the [Modifier] to be applied to this layout node
  * @param measures which measures to show on the scale bar. The default follows the system settings,
  *   or otherwise the user's locale.
@@ -76,7 +76,7 @@ public fun ScaleBar(
  *
  * @param metersPerDp how many meters are displayed in one device independent pixel (dp), i.e. the
  *   scale. See
- *   [CameraState.metersPerDpAtTarget][org.maplibre.compose.camera.CameraState.metersPerDpAtTarget]
+ *   [Viewport.metersPerDpAtTarget][org.maplibre.compose.camera.Viewport.metersPerDpAtTarget]
  * @param zoom zoom level of the map
  * @param modifier the [Modifier] to be applied to this layout node
  * @param measures which measures to show on the scale bar. The default follows the system settings,

--- a/lib/maplibre-compose/src/androidJvmSharedTest/kotlin/org/maplibre/compose/map/MlnFfiMapInputTest.kt
+++ b/lib/maplibre-compose/src/androidJvmSharedTest/kotlin/org/maplibre/compose/map/MlnFfiMapInputTest.kt
@@ -92,7 +92,7 @@ class MlnFfiMapInputTest {
         onRoot().performMouseInput { moveTo(center) }
         mainClock.advanceTimeByFrame()
         // waitForIdle() would wait until overlay layout stops invalidating, which follows
-        // CameraState.projection replacements through the rest of this native ease.
+        // CameraState.viewport replacements through the rest of this native ease.
         assertTrue(camera.isCameraMoving, "a hover cancelled the keyboard pan")
       } finally {
         mainClock.autoAdvance = true
@@ -991,7 +991,7 @@ class MlnFfiMapInputTest {
       }
     }
 
-    cameraState.awaitProjection()
+    cameraState.awaitViewport()
     cameraState.position = initialPosition
     waitUntil(timeoutMillis = TIMEOUT) { frames.load() > 0 }
     waitUntil(timeoutMillis = TIMEOUT) {

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/CameraState.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/CameraState.kt
@@ -2,7 +2,6 @@ package org.maplibre.compose.camera
 
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableDoubleStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.snapshotFlow
@@ -21,10 +20,9 @@ public fun rememberCameraState(firstPosition: CameraPosition = CameraPosition())
 /** Use this class to access information about the map in relation to the camera. */
 public class CameraState(firstPosition: CameraPosition) {
   internal val mapState = mutableStateOf<MapAdapter?>(null)
-  internal val projectionState = mutableStateOf<CameraProjection?>(null)
+  internal val viewportState = mutableStateOf<Viewport?>(null)
   internal val positionState = mutableStateOf(firstPosition)
   internal val moveReasonState = mutableStateOf(CameraMoveReason.NONE)
-  internal val metersPerDpAtTargetState = mutableDoubleStateOf(0.0)
   internal val isCameraMovingState = mutableStateOf(false)
 
   internal var map: MapAdapter?
@@ -37,18 +35,23 @@ public class CameraState(firstPosition: CameraPosition) {
         // apply deferred state
         map.setCameraPosition(position)
 
-        // initialize imperative API
-        projectionState.value = CameraProjection(map)
+        // usually null until the map reports its first viewport
+        viewportState.value = map.getViewport()
       }
     }
 
   /**
-   * Converts between geographic positions and the map's current screen. Null until this state is
-   * attached to a map. A composition that reads this property redraws after a camera move or a
-   * viewport resize, because the instance is replaced when either changes.
+   * What the map shows right now: the size of the map composable, the visible area, and conversions
+   * between geographic positions and screen locations. Null until the map has rendered its first
+   * viewport. A composition that reads this property recomposes after a camera move or a resize of
+   * the map composable, because the instance is replaced once the map has adopted either change.
    */
-  public val projection: CameraProjection?
-    get() = projectionState.value
+  public val viewport: Viewport?
+    get() = viewportState.value
+
+  @Deprecated("Renamed to viewport", ReplaceWith("viewport"))
+  public val projection: Viewport?
+    get() = viewport
 
   /** how the camera is oriented towards the map */
   // if the map is not yet initialized, we store the value to apply it later
@@ -63,9 +66,12 @@ public class CameraState(firstPosition: CameraPosition) {
   public val moveReason: CameraMoveReason
     get() = moveReasonState.value
 
-  /** meters per dp at the target position. Zero when the map is not initialized yet. */
+  @Deprecated(
+    "The value is a property of the viewport now",
+    ReplaceWith("viewport?.metersPerDpAtTarget ?: 0.0"),
+  )
   public val metersPerDpAtTarget: Double
-    get() = metersPerDpAtTargetState.value
+    get() = viewport?.metersPerDpAtTarget ?: 0.0
 
   /** whether the camera is currently moving */
   public val isCameraMoving: Boolean
@@ -75,10 +81,13 @@ public class CameraState(firstPosition: CameraPosition) {
     return snapshotFlow { map }.first { it != null }!!
   }
 
-  /** Suspends until the CameraState has been attached to the map. */
-  public suspend fun awaitProjection(): CameraProjection {
-    return snapshotFlow { projection }.first { it != null }!!
+  /** Suspends until the map this state is attached to has rendered its first viewport. */
+  public suspend fun awaitViewport(): Viewport {
+    return snapshotFlow { viewport }.first { it != null }!!
   }
+
+  @Deprecated("Renamed to awaitViewport", ReplaceWith("awaitViewport()"))
+  public suspend fun awaitProjection(): Viewport = awaitViewport()
 
   /** Animates the camera towards the [finalPosition] in [duration] time. */
   public suspend fun animateTo(

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/CameraState.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/CameraState.kt
@@ -48,6 +48,9 @@ public class CameraState(firstPosition: CameraPosition) {
 
         // usually null until the map reports its first viewport
         viewportState.value = map.getViewport()
+      } else if (map == null) {
+        // a snapshot kept past detachment would report a viewport no map is showing
+        viewportState.value = null
       }
     }
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/CameraState.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/CameraState.kt
@@ -61,34 +61,33 @@ public class CameraState(firstPosition: CameraPosition) {
     get() = viewportState.value
 
   /**
-   * Returns an offset from the top-left corner of the map composable that corresponds to the given
-   * [position]. This works for positions that are off-screen, too.
+   * Returns the offset from the top-left corner of the map composable that corresponds to the given
+   * [position], or null while the map has no [viewport]. This works for positions that are
+   * off-screen, too.
    *
-   * The map answers for its current transform; [DpOffset.Zero] before this state is attached to a
-   * map with a viewport, so gate on [viewport] when that matters. To recompose when the answer
-   * changes, read [viewport] as well: this function is not snapshot state.
+   * The answer describes the transform that the map has at the time of the call. To recompose when
+   * the transform changes, read [viewport].
    */
-  public fun screenLocationFromPosition(position: Position): DpOffset {
-    return map?.screenLocationFromPosition(position) ?: DpOffset.Zero
+  public fun screenLocationFromPosition(position: Position): DpOffset? {
+    return map?.screenLocationFromPosition(position)
   }
 
   /**
-   * Returns a position that corresponds to the given [offset] from the top-left corner of the map
-   * composable.
+   * Returns the position that corresponds to the given [offset] from the top-left corner of the map
+   * composable, or null while the map has no [viewport].
    *
-   * The map answers for its current transform; position zero before this state is attached to a map
-   * with a viewport, so gate on [viewport] when that matters. To recompose when the answer changes,
-   * read [viewport] as well: this function is not snapshot state.
+   * The answer describes the transform that the map has at the time of the call. To recompose when
+   * the transform changes, read [viewport].
    */
-  public fun positionFromScreenLocation(offset: DpOffset): Position {
-    return map?.positionFromScreenLocation(offset) ?: Position(0.0, 0.0)
+  public fun positionFromScreenLocation(offset: DpOffset): Position? {
+    return map?.positionFromScreenLocation(offset)
   }
 
   /**
    * Returns a list of features that are rendered at the given [offset] from the top-left corner of
    * the map composable, optionally limited to layers with the given [layerIds] and filtered by the
    * given [predicate]. The result is sorted by render order, i.e. the feature in front is first in
-   * the list. Empty before this state is attached to a map.
+   * the list. The list is empty while this state is not attached to a map.
    *
    * @param offset position from the top-left corner of the map composable to query for
    * @param layerIds the ids of the layers to limit the query to. If not specified, features in
@@ -107,8 +106,8 @@ public class CameraState(firstPosition: CameraPosition) {
   /**
    * Returns a list of features whose rendered geometry intersect with the given [rect], optionally
    * limited to layers with the given [layerIds] and filtered by the given [predicate]. The result
-   * is sorted by render order, i.e. the feature in front is first in the list. Empty before this
-   * state is attached to a map.
+   * is sorted by render order, i.e. the feature in front is first in the list. The list is empty
+   * while this state is not attached to a map.
    *
    * @param rect rectangle to intersect with rendered geometry
    * @param layerIds the ids of the layers to limit the query to. If not specified, features in

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/CameraState.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/CameraState.kt
@@ -49,10 +49,6 @@ public class CameraState(firstPosition: CameraPosition) {
   public val viewport: Viewport?
     get() = viewportState.value
 
-  @Deprecated("Renamed to viewport", ReplaceWith("viewport"))
-  public val projection: Viewport?
-    get() = viewport
-
   /** how the camera is oriented towards the map */
   // if the map is not yet initialized, we store the value to apply it later
   public var position: CameraPosition
@@ -66,13 +62,6 @@ public class CameraState(firstPosition: CameraPosition) {
   public val moveReason: CameraMoveReason
     get() = moveReasonState.value
 
-  @Deprecated(
-    "The value is a property of the viewport now",
-    ReplaceWith("viewport?.metersPerDpAtTarget ?: 0.0"),
-  )
-  public val metersPerDpAtTarget: Double
-    get() = viewport?.metersPerDpAtTarget ?: 0.0
-
   /** whether the camera is currently moving */
   public val isCameraMoving: Boolean
     get() = isCameraMovingState.value
@@ -85,9 +74,6 @@ public class CameraState(firstPosition: CameraPosition) {
   public suspend fun awaitViewport(): Viewport {
     return snapshotFlow { viewport }.first { it != null }!!
   }
-
-  @Deprecated("Renamed to awaitViewport", ReplaceWith("awaitViewport()"))
-  public suspend fun awaitProjection(): Viewport = awaitViewport()
 
   /** Animates the camera towards the [finalPosition] in [duration] time. */
   public suspend fun animateTo(

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/CameraState.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/CameraState.kt
@@ -5,12 +5,23 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.DpRect
 import androidx.compose.ui.unit.dp
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.flow.first
+import kotlinx.serialization.json.JsonObject
+import org.maplibre.compose.expressions.ast.CompiledExpression
+import org.maplibre.compose.expressions.ast.Expression
+import org.maplibre.compose.expressions.ast.ExpressionContext
+import org.maplibre.compose.expressions.dsl.const
+import org.maplibre.compose.expressions.value.BooleanValue
 import org.maplibre.compose.map.MapAdapter
 import org.maplibre.spatialk.geojson.BoundingBox
+import org.maplibre.spatialk.geojson.Feature
+import org.maplibre.spatialk.geojson.Geometry
+import org.maplibre.spatialk.geojson.Position
 
 /** Remember a new [CameraState] in the initial state as given in [firstPosition]. */
 @Composable
@@ -41,13 +52,83 @@ public class CameraState(firstPosition: CameraPosition) {
     }
 
   /**
-   * What the map shows right now: the size of the map composable, the visible area, and conversions
-   * between geographic positions and screen locations. Null until the map has rendered its first
-   * viewport. A composition that reads this property recomposes after a camera move or a resize of
-   * the map composable, because the instance is replaced once the map has adopted either change.
+   * What the map shows right now: the size of the map composable and the visible area. Null until
+   * the map has rendered its first viewport. A composition that reads this property recomposes
+   * after a camera move or a resize of the map composable, because the instance is replaced once
+   * the map has adopted either change.
    */
   public val viewport: Viewport?
     get() = viewportState.value
+
+  /**
+   * Returns an offset from the top-left corner of the map composable that corresponds to the given
+   * [position]. This works for positions that are off-screen, too.
+   *
+   * The map answers for its current transform; [DpOffset.Zero] before this state is attached to a
+   * map with a viewport, so gate on [viewport] when that matters. To recompose when the answer
+   * changes, read [viewport] as well: this function is not snapshot state.
+   */
+  public fun screenLocationFromPosition(position: Position): DpOffset {
+    return map?.screenLocationFromPosition(position) ?: DpOffset.Zero
+  }
+
+  /**
+   * Returns a position that corresponds to the given [offset] from the top-left corner of the map
+   * composable.
+   *
+   * The map answers for its current transform; position zero before this state is attached to a map
+   * with a viewport, so gate on [viewport] when that matters. To recompose when the answer changes,
+   * read [viewport] as well: this function is not snapshot state.
+   */
+  public fun positionFromScreenLocation(offset: DpOffset): Position {
+    return map?.positionFromScreenLocation(offset) ?: Position(0.0, 0.0)
+  }
+
+  /**
+   * Returns a list of features that are rendered at the given [offset] from the top-left corner of
+   * the map composable, optionally limited to layers with the given [layerIds] and filtered by the
+   * given [predicate]. The result is sorted by render order, i.e. the feature in front is first in
+   * the list. Empty before this state is attached to a map.
+   *
+   * @param offset position from the top-left corner of the map composable to query for
+   * @param layerIds the ids of the layers to limit the query to. If not specified, features in
+   *   *any* layer are returned
+   * @param predicate expression that has to evaluate to true for a feature to be included in the
+   *   result
+   */
+  public suspend fun queryRenderedFeatures(
+    offset: DpOffset,
+    layerIds: Set<String>? = null,
+    predicate: Expression<BooleanValue> = const(true),
+  ): List<Feature<Geometry, JsonObject?>> {
+    return map?.queryRenderedFeatures(offset, layerIds, predicate.compileOrNull()) ?: emptyList()
+  }
+
+  /**
+   * Returns a list of features whose rendered geometry intersect with the given [rect], optionally
+   * limited to layers with the given [layerIds] and filtered by the given [predicate]. The result
+   * is sorted by render order, i.e. the feature in front is first in the list. Empty before this
+   * state is attached to a map.
+   *
+   * @param rect rectangle to intersect with rendered geometry
+   * @param layerIds the ids of the layers to limit the query to. If not specified, features in
+   *   *any* layer are returned
+   * @param predicate expression that has to evaluate to true for a feature to be included in the
+   *   result
+   */
+  public suspend fun queryRenderedFeatures(
+    rect: DpRect,
+    layerIds: Set<String>? = null,
+    predicate: Expression<BooleanValue> = const(true),
+  ): List<Feature<Geometry, JsonObject?>> {
+    return map?.queryRenderedFeatures(rect, layerIds, predicate.compileOrNull()) ?: emptyList()
+  }
+
+  private fun Expression<BooleanValue>.compileOrNull(): CompiledExpression<BooleanValue>? =
+    takeUnless {
+      it == const(true)
+    }
+    ?.compile(ExpressionContext.None)
 
   /** how the camera is oriented towards the map */
   // if the map is not yet initialized, we store the value to apply it later

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/Viewport.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/Viewport.kt
@@ -1,24 +1,12 @@
 package org.maplibre.compose.camera
 
 import androidx.compose.runtime.Immutable
-import androidx.compose.ui.unit.DpOffset
-import androidx.compose.ui.unit.DpRect
 import androidx.compose.ui.unit.DpSize
-import kotlinx.serialization.json.JsonObject
-import org.maplibre.compose.expressions.ast.Expression
-import org.maplibre.compose.expressions.ast.ExpressionContext
-import org.maplibre.compose.expressions.dsl.const
-import org.maplibre.compose.expressions.value.BooleanValue
-import org.maplibre.compose.map.MapAdapter
 import org.maplibre.compose.util.VisibleRegion
 import org.maplibre.spatialk.geojson.BoundingBox
-import org.maplibre.spatialk.geojson.Feature
-import org.maplibre.spatialk.geojson.Geometry
-import org.maplibre.spatialk.geojson.Position
 
 /**
- * What the map shows right now: the size of the map composable, the visible area, and conversions
- * between geographic positions and screen locations.
+ * What the map shows right now: the size of the map composable and the visible area.
  *
  * Read a current instance from [CameraState.viewport]. The instance is immutable; a new one
  * replaces it when the map has adopted a new camera or a new size, so a composition that reads any
@@ -49,70 +37,4 @@ internal constructor(
 
   /** Meters per dp at the camera's target position. */
   public val metersPerDpAtTarget: Double,
-  internal val map: MapAdapter,
-) {
-  /**
-   * Returns an offset from the top-left corner of the map composable that corresponds to the given
-   * [position]. This works for positions that are off-screen, too.
-   *
-   * Always convert through the latest [CameraState.viewport]: an instance kept around after the
-   * camera moved converts with the map's current transform, not the one it was created at.
-   */
-  public fun screenLocationFromPosition(position: Position): DpOffset {
-    return map.screenLocationFromPosition(position)
-  }
-
-  /**
-   * Returns a position that corresponds to the given [offset] from the top-left corner of the map
-   * composable.
-   *
-   * Always convert through the latest [CameraState.viewport]: an instance kept around after the
-   * camera moved converts with the map's current transform, not the one it was created at.
-   */
-  public fun positionFromScreenLocation(offset: DpOffset): Position {
-    return map.positionFromScreenLocation(offset)
-  }
-
-  /**
-   * Returns a list of features that are rendered at the given [offset] from the top-left corner of
-   * the map composable, optionally limited to layers with the given [layerIds] and filtered by the
-   * given [predicate]. The result is sorted by render order, i.e. the feature in front is first in
-   * the list.
-   *
-   * @param offset position from the top-left corner of the map composable to query for
-   * @param layerIds the ids of the layers to limit the query to. If not specified, features in
-   *   *any* layer are returned
-   * @param predicate expression that has to evaluate to true for a feature to be included in the
-   *   result
-   */
-  public suspend fun queryRenderedFeatures(
-    offset: DpOffset,
-    layerIds: Set<String>? = null,
-    predicate: Expression<BooleanValue> = const(true),
-  ): List<Feature<Geometry, JsonObject?>> {
-    val predicateOrNull =
-      predicate.takeUnless { it == const(true) }?.compile(ExpressionContext.None)
-    return map.queryRenderedFeatures(offset, layerIds, predicateOrNull)
-  }
-
-  /**
-   * Returns a list of features whose rendered geometry intersect with the given [rect], optionally
-   * limited to layers with the given [layerIds] and filtered by the given [predicate]. The result
-   * is sorted by render order, i.e. the feature in front is first in the list.
-   *
-   * @param rect rectangle to intersect with rendered geometry
-   * @param layerIds the ids of the layers to limit the query to. If not specified, features in
-   *   *any* layer are returned
-   * @param predicate expression that has to evaluate to true for a feature to be included in the
-   *   result
-   */
-  public suspend fun queryRenderedFeatures(
-    rect: DpRect,
-    layerIds: Set<String>? = null,
-    predicate: Expression<BooleanValue> = const(true),
-  ): List<Feature<Geometry, JsonObject?>> {
-    val predicateOrNull =
-      predicate.takeUnless { it == const(true) }?.compile(ExpressionContext.None)
-    return map.queryRenderedFeatures(rect, layerIds, predicateOrNull)
-  }
-}
+)

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/Viewport.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/Viewport.kt
@@ -1,7 +1,9 @@
 package org.maplibre.compose.camera
 
+import androidx.compose.runtime.Immutable
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.DpRect
+import androidx.compose.ui.unit.DpSize
 import kotlinx.serialization.json.JsonObject
 import org.maplibre.compose.expressions.ast.Expression
 import org.maplibre.compose.expressions.ast.ExpressionContext
@@ -15,15 +17,46 @@ import org.maplibre.spatialk.geojson.Geometry
 import org.maplibre.spatialk.geojson.Position
 
 /**
- * Converts coordinates and queries what is visible on the map's current transform.
+ * What the map shows right now: the size of the map composable, the visible area, and conversions
+ * between geographic positions and screen locations.
  *
- * Read a current instance from [CameraState.projection]. That property is replaced when the camera
- * or the viewport changes.
+ * Read a current instance from [CameraState.viewport]. The instance is immutable; a new one
+ * replaces it when the map has adopted a new camera or a new size, so a composition that reads any
+ * of its properties recomposes exactly when the answers change. All properties of one instance
+ * describe the same rendered transform, so they are consistent with each other.
  */
-public class CameraProjection internal constructor(internal val map: MapAdapter) {
+@Immutable
+public class Viewport
+internal constructor(
+  /** The size of the map composable this viewport was computed for. */
+  public val size: DpSize,
+
+  /**
+   * The smallest bounding box that contains the currently visible area.
+   *
+   * Note that the bounding box is always a north-aligned rectangle. I.e. if the map is rotated or
+   * tilted, the returned bounding box will always be larger than the actually visible area. See
+   * [visibleRegion].
+   */
+  public val visibleBoundingBox: BoundingBox,
+
+  /**
+   * The currently visible area, which is a four-sided polygon spanned by the four points each at
+   * one corner of the map composable. If the camera has tilt (pitch), this polygon is a trapezoid
+   * instead of a rectangle.
+   */
+  public val visibleRegion: VisibleRegion,
+
+  /** Meters per dp at the camera's target position. */
+  public val metersPerDpAtTarget: Double,
+  internal val map: MapAdapter,
+) {
   /**
    * Returns an offset from the top-left corner of the map composable that corresponds to the given
    * [position]. This works for positions that are off-screen, too.
+   *
+   * The conversion answers for the map's current transform, which on a retained old instance may be
+   * newer than the transform the properties above describe.
    */
   public fun screenLocationFromPosition(position: Position): DpOffset {
     return map.screenLocationFromPosition(position)
@@ -32,6 +65,9 @@ public class CameraProjection internal constructor(internal val map: MapAdapter)
   /**
    * Returns a position that corresponds to the given [offset] from the top-left corner of the map
    * composable.
+   *
+   * The conversion answers for the map's current transform, which on a retained old instance may be
+   * newer than the transform the properties above describe.
    */
   public fun positionFromScreenLocation(offset: DpOffset): Position {
     return map.positionFromScreenLocation(offset)
@@ -80,25 +116,18 @@ public class CameraProjection internal constructor(internal val map: MapAdapter)
     return map.queryRenderedFeatures(rect, layerIds, predicateOrNull)
   }
 
-  /**
-   * Returns the smallest bounding box that contains the currently visible area.
-   *
-   * Note that the bounding box is always a north-aligned rectangle. I.e. if the map is rotated or
-   * tilted, the returned bounding box will always be larger than the actually visible area. See
-   * [queryVisibleRegion].
-   */
-  public fun queryVisibleBoundingBox(): BoundingBox {
-    // TODO at some point, this should be refactored to State, just like the camera position
-    return map.getVisibleBoundingBox()
-  }
+  @Deprecated(
+    "The visible bounding box is a property of the viewport now",
+    ReplaceWith("visibleBoundingBox"),
+  )
+  public fun queryVisibleBoundingBox(): BoundingBox = visibleBoundingBox
 
-  /**
-   * Returns the currently visible area, which is a four-sided polygon spanned by the four points
-   * each at one corner of the map composable. If the camera has tilt (pitch), this polygon is a
-   * trapezoid instead of a rectangle.
-   */
-  public fun queryVisibleRegion(): VisibleRegion {
-    // TODO at some point, this should be refactored to State, just like the camera position
-    return map.getVisibleRegion()
-  }
+  @Deprecated(
+    "The visible region is a property of the viewport now",
+    ReplaceWith("visibleRegion"),
+  )
+  public fun queryVisibleRegion(): VisibleRegion = visibleRegion
 }
+
+@Deprecated("Renamed to Viewport", ReplaceWith("Viewport"))
+public typealias CameraProjection = Viewport

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/Viewport.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/Viewport.kt
@@ -55,8 +55,8 @@ internal constructor(
    * Returns an offset from the top-left corner of the map composable that corresponds to the given
    * [position]. This works for positions that are off-screen, too.
    *
-   * The conversion answers for the map's current transform, which on a retained old instance may be
-   * newer than the transform the properties above describe.
+   * Always convert through the latest [CameraState.viewport]: an instance kept around after the
+   * camera moved converts with the map's current transform, not the one it was created at.
    */
   public fun screenLocationFromPosition(position: Position): DpOffset {
     return map.screenLocationFromPosition(position)
@@ -66,8 +66,8 @@ internal constructor(
    * Returns a position that corresponds to the given [offset] from the top-left corner of the map
    * composable.
    *
-   * The conversion answers for the map's current transform, which on a retained old instance may be
-   * newer than the transform the properties above describe.
+   * Always convert through the latest [CameraState.viewport]: an instance kept around after the
+   * camera moved converts with the map's current transform, not the one it was created at.
    */
   public fun positionFromScreenLocation(offset: DpOffset): Position {
     return map.positionFromScreenLocation(offset)
@@ -115,19 +115,4 @@ internal constructor(
       predicate.takeUnless { it == const(true) }?.compile(ExpressionContext.None)
     return map.queryRenderedFeatures(rect, layerIds, predicateOrNull)
   }
-
-  @Deprecated(
-    "The visible bounding box is a property of the viewport now",
-    ReplaceWith("visibleBoundingBox"),
-  )
-  public fun queryVisibleBoundingBox(): BoundingBox = visibleBoundingBox
-
-  @Deprecated(
-    "The visible region is a property of the viewport now",
-    ReplaceWith("visibleRegion"),
-  )
-  public fun queryVisibleRegion(): VisibleRegion = visibleRegion
 }
-
-@Deprecated("Renamed to Viewport", ReplaceWith("Viewport"))
-public typealias CameraProjection = Viewport

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/location/LocationPuck.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/location/LocationPuck.kt
@@ -71,9 +71,10 @@ import org.maplibre.spatialk.units.extensions.inMeters
  *   [timestamp][Location.timestamp] determines whether it is styled as old.
  * @param bearing The bearing of the location puck, which determines the rotation of the bearing
  *   indicator. Defaults to `location.course`, which is the direction of travel.
- * @param cameraState The [CameraState] of the map, used only for [CameraState.metersPerDpAtTarget]
- *   to correctly draw the accuracy circle. The camera state is not modified by this composable; if
- *   you want the camera to track the current location, use [LocationTrackingEffect].
+ * @param cameraState The [CameraState] of the map, used only for
+ *   [Viewport.metersPerDpAtTarget][org.maplibre.compose.camera.Viewport.metersPerDpAtTarget] to
+ *   correctly draw the accuracy circle. The camera state is not modified by this composable; if you
+ *   want the camera to track the current location, use [LocationTrackingEffect].
  * @param oldLocationThreshold Locations with a [timestamp][Location.timestamp] older than this will
  *   be considered old and will be styled differently.
  * @param accuracyThreshold A circle showing the accuracy range will be drawn when
@@ -119,7 +120,9 @@ public fun LocationPuck(
       switch(
         condition(test = isOldLocation, output = const(0.dp)),
         fallback =
-          (feature["accuracy"].asNumber() / const(cameraState.metersPerDpAtTarget.toFloat())).dp,
+          (feature["accuracy"].asNumber() /
+              const((cameraState.viewport?.metersPerDpAtTarget ?: 0.0).toFloat()))
+            .dp,
       ),
     color = const(colors.accuracyFillColor),
     strokeColor = const(colors.accuracyStrokeColor),

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapAdapter.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapAdapter.kt
@@ -7,6 +7,7 @@ import kotlin.time.Duration
 import kotlinx.serialization.json.JsonObject
 import org.maplibre.compose.camera.CameraMoveReason
 import org.maplibre.compose.camera.CameraPosition
+import org.maplibre.compose.camera.Viewport
 import org.maplibre.compose.expressions.ast.CompiledExpression
 import org.maplibre.compose.expressions.value.BooleanValue
 import org.maplibre.compose.style.BaseStyle
@@ -54,6 +55,13 @@ internal interface MapAdapter {
   fun getVisibleBoundingBox(): BoundingBox
 
   fun getVisibleRegion(): VisibleRegion
+
+  /**
+   * The viewport the map last adopted, with every property read from the same transform, or null
+   * before the map has one. Implementations answer from where the map's size actually lands, so a
+   * read made from [Callbacks.onCameraMoved] already describes a finished resize.
+   */
+  fun getViewport(): Viewport?
 
   fun setRenderSettings(value: RenderOptions)
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapAdapter.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapAdapter.kt
@@ -69,9 +69,11 @@ internal interface MapAdapter {
 
   fun setTileLodSettings(value: TileLodOptions)
 
-  fun positionFromScreenLocation(offset: DpOffset): Position
+  /** Null while the map has no viewport to convert with. */
+  fun positionFromScreenLocation(offset: DpOffset): Position?
 
-  fun screenLocationFromPosition(position: Position): DpOffset
+  /** Null while the map has no viewport to convert with. */
+  fun screenLocationFromPosition(position: Position): DpOffset?
 
   suspend fun queryRenderedFeatures(
     offset: DpOffset,

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MaplibreMap.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MaplibreMap.kt
@@ -20,7 +20,6 @@ import androidx.compose.ui.unit.DpOffset
 import co.touchlab.kermit.Logger
 import kotlinx.coroutines.launch
 import org.maplibre.compose.camera.CameraMoveReason
-import org.maplibre.compose.camera.CameraProjection
 import org.maplibre.compose.camera.CameraState
 import org.maplibre.compose.camera.rememberCameraState
 import org.maplibre.compose.overlay.MapOverlay
@@ -154,8 +153,7 @@ public fun MaplibreMap(
           rememberedStyle?.unload()
           val safeStyle = style?.let { SafeStyle(it, currentLogger) }
           rememberedStyle = safeStyle
-          cameraState.metersPerDpAtTargetState.value =
-            map.metersPerDpAtLatitude(map.getCameraPosition().target.latitude)
+          if (cameraState.map === map) cameraState.viewportState.value = map.getViewport()
         }
 
         override fun onMapFailLoading(reason: String?) {
@@ -180,11 +178,9 @@ public fun MaplibreMap(
         override fun onCameraMoved(map: MapAdapter) {
           if (cameraState.map !== map) return
           cameraState.positionState.value = map.getCameraPosition()
-          cameraState.metersPerDpAtTargetState.value =
-            map.metersPerDpAtLatitude(map.getCameraPosition().target.latitude)
-          // A new instance so a composition that reads CameraState.projection redraws when the
+          // A new instance so a composition that reads CameraState.viewport redraws when the
           // transform changes without the camera position changing, which is what a resize does.
-          cameraState.projectionState.value = CameraProjection(map)
+          cameraState.viewportState.value = map.getViewport()
         }
 
         override fun onCameraMoveEnded(map: MapAdapter) {

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/DisappearingScaleBar.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/DisappearingScaleBar.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.delay
  *
  * @param metersPerDp how many meters are displayed in one device independent pixel (dp), i.e. the
  *   scale. See
- *   [CameraState.metersPerDpAtTarget][org.maplibre.compose.camera.CameraState.metersPerDpAtTarget]
+ *   [Viewport.metersPerDpAtTarget][org.maplibre.compose.camera.Viewport.metersPerDpAtTarget]
  * @param zoom zoom level of the map
  * @param modifier the [Modifier] to be applied to this layout node
  * @param measures which measures to show on the scale bar. The default follows the system settings,

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/MapOverlay.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/MapOverlay.kt
@@ -154,14 +154,15 @@ internal fun MapOverlayHost(
     layout(width, height) {
       val hasPlacedAt = measurables.any { it.parentData is OverlayChildData.PlacedAt }
       // Aligned children stay put when the camera moves. Reading the viewport here would
-      // invalidate this layout on every frame of a camera ease.
+      // invalidate this layout on every frame of a camera ease, so it is read only when a child
+      // needs placing; the read is also what re-runs this layout when the transform changes.
       val viewport = if (hasPlacedAt) cameraState.viewport else null
       measurables.forEachIndexed { index, measurable ->
         val placeable = placeables[index]
         when (val child = measurable.parentData as? OverlayChildData) {
           is OverlayChildData.PlacedAt -> {
             if (viewport == null || width == 0 || height == 0) return@forEachIndexed
-            val screen = viewport.screenLocationFromPosition(child.position)
+            val screen = cameraState.screenLocationFromPosition(child.position)
             val aligned =
               child.alignment.align(
                 size = IntSize(placeable.width, placeable.height),

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/MapOverlay.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/MapOverlay.kt
@@ -94,7 +94,7 @@ public class MapOverlay(
      */
     public val Default: MapOverlay = MapOverlay {
       DisappearingScaleBar(
-        metersPerDp = cameraState.metersPerDpAtTarget,
+        metersPerDp = cameraState.viewport?.metersPerDpAtTarget ?: 0.0,
         zoom = cameraState.position.zoom,
         modifier = Modifier.align(Alignment.TopStart),
       )
@@ -153,15 +153,15 @@ internal fun MapOverlayHost(
     }
     layout(width, height) {
       val hasPlacedAt = measurables.any { it.parentData is OverlayChildData.PlacedAt }
-      // Aligned children stay put when the camera moves. Reading projection here would
+      // Aligned children stay put when the camera moves. Reading the viewport here would
       // invalidate this layout on every frame of a camera ease.
-      val projection = if (hasPlacedAt) cameraState.projection else null
+      val viewport = if (hasPlacedAt) cameraState.viewport else null
       measurables.forEachIndexed { index, measurable ->
         val placeable = placeables[index]
         when (val child = measurable.parentData as? OverlayChildData) {
           is OverlayChildData.PlacedAt -> {
-            if (projection == null || width == 0 || height == 0) return@forEachIndexed
-            val screen = projection.screenLocationFromPosition(child.position)
+            if (viewport == null || width == 0 || height == 0) return@forEachIndexed
+            val screen = viewport.screenLocationFromPosition(child.position)
             val aligned =
               child.alignment.align(
                 size = IntSize(placeable.width, placeable.height),

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/MapOverlay.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/MapOverlay.kt
@@ -162,7 +162,8 @@ internal fun MapOverlayHost(
         when (val child = measurable.parentData as? OverlayChildData) {
           is OverlayChildData.PlacedAt -> {
             if (viewport == null || width == 0 || height == 0) return@forEachIndexed
-            val screen = cameraState.screenLocationFromPosition(child.position)
+            val screen =
+              cameraState.screenLocationFromPosition(child.position) ?: return@forEachIndexed
             val aligned =
               child.alignment.align(
                 size = IntSize(placeable.width, placeable.height),

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/ScaleBar.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/ScaleBar.kt
@@ -38,7 +38,7 @@ import org.maplibre.spatialk.units.extensions.meters
  *
  * @param metersPerDp how many meters are displayed in one device independent pixel (dp), i.e. the
  *   scale. See
- *   [CameraState.metersPerDpAtTarget][org.maplibre.compose.camera.CameraState.metersPerDpAtTarget]
+ *   [Viewport.metersPerDpAtTarget][org.maplibre.compose.camera.Viewport.metersPerDpAtTarget]
  * @param modifier the [Modifier] to be applied to this layout node
  * @param measures which measures to show on the scale bar. The default follows the system settings,
  *   or otherwise the user's locale.

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
@@ -614,13 +614,11 @@ internal class GlJsMapSession(
     )
   }
 
-  override fun positionFromScreenLocation(offset: DpOffset): Position =
-    withMap(Position(0.0, 0.0)) { map ->
-      map.unprojectAt(offset.x.value.toDouble(), offset.y.value.toDouble())
-    }
+  override fun positionFromScreenLocation(offset: DpOffset): Position? =
+    withMap(null) { map -> map.unprojectAt(offset.x.value.toDouble(), offset.y.value.toDouble()) }
 
-  override fun screenLocationFromPosition(position: Position): DpOffset =
-    withMap(DpOffset.Zero) { map -> map.project(position.toLngLat()).toDpOffset() }
+  override fun screenLocationFromPosition(position: Position): DpOffset? =
+    withMap(null) { map -> map.project(position.toLngLat()).toDpOffset() }
 
   override suspend fun queryRenderedFeatures(
     offset: DpOffset,

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
@@ -579,7 +579,6 @@ internal class GlJsMapSession(
         visibleBoundingBox = getVisibleBoundingBox(),
         visibleRegion = getVisibleRegion(),
         metersPerDpAtTarget = metersPerDpAtLatitude(camera.zoom, camera.target.latitude),
-        map = this,
       )
     }
 

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
@@ -3,7 +3,9 @@ package org.maplibre.compose.map
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.DpRect
+import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
 import co.touchlab.kermit.Logger
 import js.objects.unsafeJso
 import kotlin.coroutines.resume
@@ -16,6 +18,7 @@ import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.serialization.json.JsonObject
 import org.maplibre.compose.camera.CameraMoveReason
 import org.maplibre.compose.camera.CameraPosition
+import org.maplibre.compose.camera.Viewport
 import org.maplibre.compose.expressions.ast.CompiledExpression
 import org.maplibre.compose.expressions.value.BooleanValue
 import org.maplibre.compose.gljs.DEFAULT_WORKER_URL
@@ -561,6 +564,22 @@ internal class GlJsMapSession(
         farRight = map.unprojectAt(width, 0.0),
         nearLeft = map.unprojectAt(0.0, height),
         nearRight = map.unprojectAt(width, height),
+      )
+    }
+
+  override fun getViewport(): Viewport? =
+    withMap(null as Viewport?) { map ->
+      // GL JS adopts a resize synchronously in applyExtent, so the applied extent, the bounds, and
+      // the transform the conversions read all describe the same viewport here.
+      val extent = appliedExtent
+      if (extent.isEmpty) return@withMap null
+      val camera = getCameraPosition()
+      Viewport(
+        size = DpSize(extent.width.dp, extent.height.dp),
+        visibleBoundingBox = getVisibleBoundingBox(),
+        visibleRegion = getVisibleRegion(),
+        metersPerDpAtTarget = metersPerDpAtLatitude(camera.zoom, camera.target.latitude),
+        map = this,
       )
     }
 

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserMapLifecycleTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserMapLifecycleTest.kt
@@ -87,12 +87,12 @@ class BrowserMapLifecycleTest {
       }
     }
     waitUntilMap("the first map to load") { loads >= 1 }
-    val firstProjection = cameraState.projection
+    val firstViewport = cameraState.viewport
 
     density = Density(2f)
     waitUntilMap("the replacement map to load at the new density") { loads >= 2 }
 
-    assertNotSame(firstProjection, cameraState.projection, "the camera should attach to a new map")
+    assertNotSame(firstViewport, cameraState.viewport, "the camera should attach to a new map")
     assertEquals(expectedCamera.target, cameraState.position.target, "camera target")
     assertEquals(expectedCamera.zoom, cameraState.position.zoom, 0.001, "camera zoom")
   }

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -1144,6 +1144,9 @@ internal class MlnFfiMapSession(
   override fun getVisibleRegion(): VisibleRegion = mirroredViewport.visibleRegion
 
   override fun getViewport(): Viewport? {
+    // The map bootstraps at a 1x1 extent, so the mirror describes a real viewport only once a
+    // render target has attached with the composable's dimensions.
+    if (!stateLock.withLock { hasAttachedViewport }) return null
     // One read so every property comes from the same publish.
     val mirror = mirroredViewport
     if (mirror.size == DpSize.Zero) return null

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -5,7 +5,9 @@ package org.maplibre.compose.map
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.DpRect
+import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
 import co.touchlab.kermit.Logger
 import kotlin.concurrent.Volatile
 import kotlin.concurrent.atomics.AtomicBoolean
@@ -25,6 +27,7 @@ import kotlinx.io.files.Path
 import kotlinx.serialization.json.JsonObject
 import org.maplibre.compose.camera.CameraMoveReason
 import org.maplibre.compose.camera.CameraPosition
+import org.maplibre.compose.camera.Viewport
 import org.maplibre.compose.expressions.ast.CompiledExpression
 import org.maplibre.compose.expressions.value.BooleanValue
 import org.maplibre.compose.mlnffi.EglContextHandles
@@ -881,6 +884,7 @@ internal class MlnFfiMapSession(
    */
   private data class MirroredViewport(
     val camera: CameraPosition = CameraPosition(),
+    val size: DpSize = DpSize.Zero,
     val visibleRegion: VisibleRegion =
       VisibleRegion(Position(0.0, 0.0), Position(0.0, 0.0), Position(0.0, 0.0), Position(0.0, 0.0)),
     val boundingBox: BoundingBox = BoundingBox(Position(0.0, 0.0), Position(0.0, 0.0)),
@@ -897,7 +901,7 @@ internal class MlnFfiMapSession(
 
   /**
    * A resize changes the projection without a camera event, so Compose overlays that key on
-   * [org.maplibre.compose.camera.CameraState.projection] would keep the previous screen locations
+   * [org.maplibre.compose.camera.CameraState.viewport] would keep the previous screen locations
    * unless this reports the new snapshot.
    */
   private fun snapshotViewportAndNotify(map: MapHandle) {
@@ -928,6 +932,7 @@ internal class MlnFfiMapSession(
     publishViewport(
       MirroredViewport(
         camera = map.camera.toCameraPosition(),
+        size = DpSize(size.width.dp, size.height.dp),
         visibleRegion = visibleRegion,
         boundingBox =
           BoundingBox(
@@ -1137,6 +1142,20 @@ internal class MlnFfiMapSession(
   override fun getVisibleBoundingBox(): BoundingBox = mirroredViewport.boundingBox
 
   override fun getVisibleRegion(): VisibleRegion = mirroredViewport.visibleRegion
+
+  override fun getViewport(): Viewport? {
+    // One read so every property comes from the same publish.
+    val mirror = mirroredViewport
+    if (mirror.size == DpSize.Zero) return null
+    return Viewport(
+      size = mirror.size,
+      visibleBoundingBox = mirror.boundingBox,
+      visibleRegion = mirror.visibleRegion,
+      metersPerDpAtTarget =
+        metersPerDpAtLatitude(mirror.camera.zoom, mirror.camera.target.latitude),
+      map = this,
+    )
+  }
 
   /**
    * The map's corners as positions, ordered top-left, top-right, bottom-left, bottom-right.

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -1153,7 +1153,6 @@ internal class MlnFfiMapSession(
       visibleRegion = mirror.visibleRegion,
       metersPerDpAtTarget =
         metersPerDpAtLatitude(mirror.camera.zoom, mirror.camera.target.latitude),
-      map = this,
     )
   }
 

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -1207,12 +1207,13 @@ internal class MlnFfiMapSession(
   /** Test seam: runs [action] on the owner thread and waits for it. */
   internal fun <T> readMap(action: (MapHandle) -> T): T? = runOnMap(action)
 
-  override fun positionFromScreenLocation(offset: DpOffset): Position =
-    withSnapshotProjection { it.latLngForPixel(offset.toScreenPoint()).toPosition() }
-      ?: Position(0.0, 0.0)
+  override fun positionFromScreenLocation(offset: DpOffset): Position? = withSnapshotProjection {
+    it.latLngForPixel(offset.toScreenPoint()).toPosition()
+  }
 
-  override fun screenLocationFromPosition(position: Position): DpOffset =
-    withSnapshotProjection { it.pixelForLatLng(position.toLatLng()).toDpOffset() } ?: DpOffset.Zero
+  override fun screenLocationFromPosition(position: Position): DpOffset? = withSnapshotProjection {
+    it.pixelForLatLng(position.toLatLng()).toDpOffset()
+  }
 
   /**
    * Runs [block] on the snapshot's frozen projection. Holds [projectionLock] for the call so the

--- a/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/map/MlnFfiProjectionTest.kt
+++ b/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/map/MlnFfiProjectionTest.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import kotlin.math.abs
 import kotlin.test.Test
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineScope
@@ -44,7 +45,7 @@ class MlnFfiProjectionTest {
 
       val roundTrip =
         fixture.session.screenLocationFromPosition(
-          fixture.session.positionFromScreenLocation(SCREEN_CENTER)
+          assertNotNull(fixture.session.positionFromScreenLocation(SCREEN_CENTER))
         )
       assertTrue(
         roundTrip.isNear(SCREEN_CENTER),
@@ -96,7 +97,7 @@ class MlnFfiProjectionTest {
       }
 
       repeat(200) {
-        val unprojected = fixture.session.positionFromScreenLocation(SCREEN_CENTER)
+        val unprojected = assertNotNull(fixture.session.positionFromScreenLocation(SCREEN_CENTER))
         val projected = fixture.session.screenLocationFromPosition(unprojected)
         assertTrue(
           projected.isNear(SCREEN_CENTER),
@@ -109,8 +110,9 @@ class MlnFfiProjectionTest {
     }
   }
 
-  private fun DpOffset.isNear(other: DpOffset): Boolean =
-    abs(x.value - other.x.value) <= PIXEL_TOLERANCE &&
+  private fun DpOffset?.isNear(other: DpOffset): Boolean =
+    this != null &&
+      abs(x.value - other.x.value) <= PIXEL_TOLERANCE &&
       abs(y.value - other.y.value) <= PIXEL_TOLERANCE
 
   private companion object {

--- a/lib/maplibre-compose/src/nextCommonTest/kotlin/org/maplibre/compose/map/MapVisibleAreaTest.kt
+++ b/lib/maplibre-compose/src/nextCommonTest/kotlin/org/maplibre/compose/map/MapVisibleAreaTest.kt
@@ -2,9 +2,9 @@ package org.maplibre.compose.map
 
 import kotlin.math.abs
 import kotlin.test.Test
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import org.maplibre.compose.camera.CameraPosition
-import org.maplibre.compose.camera.CameraProjection
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.compose.testing.MapTestResult
 import org.maplibre.compose.testing.createMapFixture
@@ -117,15 +117,19 @@ class MapVisibleAreaTest {
   }
 
   @Test
-  fun the_projection_query_matches_the_session(): MapTestResult = runMapTest {
+  fun the_viewport_matches_the_session(): MapTestResult = runMapTest {
     createMapFixture().use {
       it.session.setBaseStyle(BaseStyle.Empty)
       it.awaitMapReady()
       it.session.setCameraPosition(ROTATED_CAMERA)
       it.pumpUntil("the camera to rotate") { it.session.hasNativeCamera(ROTATED_CAMERA) }
 
-      val projection = CameraProjection(it.session)
-      assertNear(it.session.getVisibleBoundingBox(), projection.queryVisibleBoundingBox())
+      val viewport = assertNotNull(it.session.getViewport())
+      assertNear(it.session.getVisibleBoundingBox(), viewport.visibleBoundingBox)
+      assertTrue(
+        viewport.size.width.value > 0f && viewport.size.height.value > 0f,
+        "the viewport should carry the map's size, was ${viewport.size}",
+      )
     }
   }
 


### PR DESCRIPTION
## Description

Replaces `CameraProjection` with an immutable `Viewport` snapshot on `CameraState.viewport` — size, visible bounding box, visible region, meters per dp, and coordinate conversions — replaced only once the map has adopted a new camera or size, so a resize reports exactly when the new answers exist (fixes #954).

## Validation

Desktop and Android host tests, `mise run check`, and JS compilation pass locally; browser tests deferred to CI (no Chrome on this machine).

## AI assistance

Claude Fable 5 via Claude Code.