### PR TITLE
Retain native feature state across render sessions

### DIFF
--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/sources/GeoJsonSource.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/sources/GeoJsonSource.kt
@@ -48,8 +48,6 @@ public expect class GeoJsonSource : Source {
    * [feature.state][org.maplibre.compose.expressions.dsl.Feature.state]. Keys already on the
    * feature and absent from [state] stay as they are. [featureId] is matched as text: a GeoJSON
    * `id` of `7` is `"7"`.
-   *
-   * A call before the first frame is ignored on the native platforms.
    */
   public fun setFeatureState(featureId: String, state: JsonObject)
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/sources/VectorSource.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/sources/VectorSource.kt
@@ -9,12 +9,7 @@ import org.maplibre.compose.expressions.value.BooleanValue
 import org.maplibre.spatialk.geojson.Feature
 import org.maplibre.spatialk.geojson.Geometry
 
-/**
- * A map data source of tiled vector data.
- *
- * Feature-state mutation is available on desktop, Android, and the browser. The methods throw
- * [UnsupportedOperationException] on iOS.
- */
+/** A map data source of tiled vector data. */
 public expect class VectorSource : Source {
 
   /**
@@ -54,8 +49,6 @@ public expect class VectorSource : Source {
    * [feature.state][org.maplibre.compose.expressions.dsl.Feature.state]. Keys already on the
    * feature and absent from [state] stay as they are. [featureId] is matched as text: a feature
    * `id` of `7` is `"7"`.
-   *
-   * A call before the first frame is ignored on desktop.
    */
   public fun setFeatureState(sourceLayerId: String, featureId: String, state: JsonObject)
 

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -48,6 +48,7 @@ import org.maplibre.compose.mlnffi.currentMlnFfiThreadName
 import org.maplibre.compose.mlnffi.withLock
 import org.maplibre.compose.resource.MlnFfiResourceProvider
 import org.maplibre.compose.resource.MlnFfiResourceProviderFactory
+import org.maplibre.compose.sources.MlnFfiFeatureStateStore
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.compose.style.MlnFfiStyle
 import org.maplibre.compose.style.MlnFfiStyleBinding
@@ -161,6 +162,12 @@ internal class MlnFfiMapSession(
   /** Renderer-thread state. */
   private var renderSession: RenderSessionHandle? = null
 
+  /** Renderer-thread state; the FFI creates its renderer during the first successful render. */
+  private var renderSessionReady = false
+
+  /** Any thread may publish style or source state that the next rendered update must receive. */
+  private val featureStateReplayPending = AtomicBoolean(false)
+
   @Volatile private var hostSession: MlnFfiMapHostSession? = null
 
   private data class TargetKey(val generation: Long, val extent: MapExtent)
@@ -228,6 +235,8 @@ internal class MlnFfiMapSession(
   private inner class SessionStyleBinding : MlnFfiStyleBinding {
     @Volatile private var loaded = true
 
+    override val featureStateStore = MlnFfiFeatureStateStore()
+
     override val isLoaded: Boolean
       get() = loaded && !closed
 
@@ -239,6 +248,7 @@ internal class MlnFfiMapSession(
     }
 
     override fun reportSourceChanged(sourceId: String) {
+      featureStateReplayPending.store(true)
       reportedUrlAttribution.remove(sourceId)
       callbacks.onSourceChanged(this@MlnFfiMapSession, sourceId)
     }
@@ -262,6 +272,7 @@ internal class MlnFfiMapSession(
     override fun <T> withRenderSession(action: (RenderSessionHandle) -> T): T? {
       if (!isLoaded) return null
       return withRendererAccess {
+        if (!renderSessionReady) return@withRendererAccess null
         val session = renderSession
         if (session == null) {
           logger?.d { "Ignoring a render session call: no session is attached yet" }
@@ -340,6 +351,12 @@ internal class MlnFfiMapSession(
       } catch (error: NativeErrorException) {
         throw MlnFfiRecoverableFrameException("The MapLibre render session failed", error)
       }
+    if (update.result == RenderResult.RENDERED) {
+      renderSessionReady = true
+      if (featureStateReplayPending.compareAndSet(true, false)) {
+        if (styleBinding?.featureStateStore?.replay(session) == true) requestRender()
+      }
+    }
     when (update.result) {
       RenderResult.NO_UPDATE,
       RenderResult.SIZE_PENDING -> return MlnFfiFrameResult.SKIPPED
@@ -438,6 +455,7 @@ internal class MlnFfiMapSession(
   private fun closeRenderSession() {
     val handle = renderSession
     renderSession = null
+    renderSessionReady = false
     attachedTarget = null
     if (handle == null) return
 
@@ -497,6 +515,8 @@ internal class MlnFfiMapSession(
         logger?.e(error) { "Failed to attach a render session to the host target" }
         throw error
       }
+    renderSessionReady = false
+    featureStateReplayPending.store(true)
     attachedTarget = key
     attachCount++
     publishAttachedViewport()
@@ -622,6 +642,7 @@ internal class MlnFfiMapSession(
         // Descriptors holding the previous binding must not write into a style that is gone.
         styleBinding?.unload()
         val binding = SessionStyleBinding().also { styleBinding = it }
+        featureStateReplayPending.store(true)
         callbacks.onStyleChanged(this, MlnFfiStyle(binding, ::imageScale))
         styleLoadUnreported = true
         reportedUrlAttribution.clear()

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/sources/FeatureState.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/sources/FeatureState.kt
@@ -1,11 +1,83 @@
 package org.maplibre.compose.sources
 
 import kotlinx.serialization.json.JsonObject
+import org.maplibre.compose.mlnffi.MlnFfiLock
+import org.maplibre.compose.mlnffi.withLock
 import org.maplibre.compose.style.MlnFfiStyleBinding
 import org.maplibre.compose.util.toJsonBytes
-import org.maplibre.compose.util.toJsonElement
 import org.maplibre.nativeffi.query.FeatureStateSelector
 import org.maplibre.nativeffi.render.RenderSessionHandle
+
+/** The feature identity that MapLibre Native uses for state. */
+private data class FeatureStateKey(
+  val sourceId: String,
+  val sourceLayerId: String?,
+  val featureId: String,
+)
+
+/**
+ * The feature state that belongs to one loaded style.
+ *
+ * MapLibre Native stores these values on its renderer. This copy accepts operations while no
+ * renderer exists and restores the values whenever the renderer is replaced.
+ */
+internal class MlnFfiFeatureStateStore {
+  private val lock = MlnFfiLock()
+  private val states = mutableMapOf<FeatureStateKey, JsonObject>()
+
+  fun set(sourceId: String, sourceLayerId: String?, featureId: String, state: JsonObject) {
+    lock.withLock {
+      val key = FeatureStateKey(sourceId, sourceLayerId, featureId)
+      val merged = JsonObject(states[key].orEmpty() + state)
+      if (merged.isEmpty()) states.remove(key) else states[key] = merged
+    }
+  }
+
+  fun get(sourceId: String, sourceLayerId: String?, featureId: String): JsonObject =
+    lock.withLock { states[FeatureStateKey(sourceId, sourceLayerId, featureId)] }
+      ?: JsonObject(emptyMap())
+
+  fun remove(
+    sourceId: String,
+    sourceLayerId: String?,
+    featureId: String,
+    stateKey: String?,
+  ) {
+    lock.withLock {
+      val key = FeatureStateKey(sourceId, sourceLayerId, featureId)
+      if (stateKey == null) {
+        states.remove(key)
+      } else {
+        val remaining = states[key].orEmpty() - stateKey
+        if (remaining.isEmpty()) states.remove(key) else states[key] = JsonObject(remaining)
+      }
+    }
+  }
+
+  fun reset(sourceId: String, sourceLayerId: String?) {
+    lock.withLock {
+      states.keys.removeAll { key ->
+        key.sourceId == sourceId && (sourceLayerId == null || key.sourceLayerId == sourceLayerId)
+      }
+    }
+  }
+
+  fun forgetSource(sourceId: String) {
+    lock.withLock { states.keys.removeAll { key -> key.sourceId == sourceId } }
+  }
+
+  /** Restores a snapshot, so native calls run without holding [lock]. */
+  fun replay(session: RenderSessionHandle): Boolean {
+    val snapshot = lock.withLock { states.toList() }
+    snapshot.forEach { (key, state) ->
+      session.setFeatureState(
+        featureStateSelector(key.sourceId, key.sourceLayerId, key.featureId),
+        state.toJsonBytes(),
+      )
+    }
+    return snapshot.isNotEmpty()
+  }
+}
 
 internal fun MlnFfiStyleBinding.setFeatureState(
   sourceId: String,
@@ -13,7 +85,9 @@ internal fun MlnFfiStyleBinding.setFeatureState(
   state: JsonObject,
   sourceLayerId: String? = null,
 ) {
-  mutateFeatureState { session ->
+  val store = liveFeatureStateStore() ?: return
+  store.set(sourceId, sourceLayerId, featureId, state)
+  mutateLiveFeatureState { session ->
     session.setFeatureState(
       featureStateSelector(sourceId, sourceLayerId, featureId),
       state.toJsonBytes(),
@@ -26,11 +100,7 @@ internal fun MlnFfiStyleBinding.getFeatureState(
   featureId: String,
   sourceLayerId: String? = null,
 ): JsonObject =
-  withRenderSession { session ->
-    val bytes = session.getFeatureState(featureStateSelector(sourceId, sourceLayerId, featureId))
-    if (bytes.isEmpty()) JsonObject(emptyMap())
-    else bytes.toJsonElement() as? JsonObject ?: JsonObject(emptyMap())
-  } ?: JsonObject(emptyMap())
+  liveFeatureStateStore()?.get(sourceId, sourceLayerId, featureId) ?: JsonObject(emptyMap())
 
 internal fun MlnFfiStyleBinding.removeFeatureState(
   sourceId: String,
@@ -38,7 +108,9 @@ internal fun MlnFfiStyleBinding.removeFeatureState(
   stateKey: String? = null,
   sourceLayerId: String? = null,
 ) {
-  mutateFeatureState { session ->
+  val store = liveFeatureStateStore() ?: return
+  store.remove(sourceId, sourceLayerId, featureId, stateKey)
+  mutateLiveFeatureState { session ->
     session.removeFeatureState(featureStateSelector(sourceId, sourceLayerId, featureId, stateKey))
   }
 }
@@ -47,13 +119,24 @@ internal fun MlnFfiStyleBinding.resetFeatureStates(
   sourceId: String,
   sourceLayerId: String? = null,
 ) {
-  mutateFeatureState { session ->
+  val store = liveFeatureStateStore() ?: return
+  store.reset(sourceId, sourceLayerId)
+  mutateLiveFeatureState { session ->
     session.removeFeatureState(featureStateSelector(sourceId, sourceLayerId))
   }
 }
 
-/** Feature-state writes live on the render session; the map still has to be asked to draw. */
-private fun MlnFfiStyleBinding.mutateFeatureState(action: (RenderSessionHandle) -> Unit) {
+internal fun MlnFfiStyleBinding.forgetFeatureStates(sourceId: String) {
+  featureStateStore?.forgetSource(sourceId)
+}
+
+private fun MlnFfiStyleBinding.liveFeatureStateStore(): MlnFfiFeatureStateStore? =
+  featureStateStore?.takeIf {
+    isLoaded
+  }
+
+/** The retained copy is already updated; apply it to the renderer when one is ready. */
+private fun MlnFfiStyleBinding.mutateLiveFeatureState(action: (RenderSessionHandle) -> Unit) {
   withRenderSession(action) ?: return
   mutateMap {}
 }

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/sources/Source.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/sources/Source.kt
@@ -128,6 +128,7 @@ public actual sealed class Source(internal actual val id: String) {
     val current = binding
     current.mutateMap { map ->
       map.removeStyleSource(id)
+      current.forgetFeatureStates(id)
       current.reportSourceChanged(id)
     }
     binding = MlnFfiStyleBinding.UNLOADED

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/style/MlnFfiStyleBinding.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/style/MlnFfiStyleBinding.kt
@@ -3,6 +3,7 @@ package org.maplibre.compose.style
 import co.touchlab.kermit.Logger
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
+import org.maplibre.compose.sources.MlnFfiFeatureStateStore
 import org.maplibre.compose.sources.Source
 import org.maplibre.compose.util.toJsonBytes
 import org.maplibre.compose.util.toJsonElement
@@ -15,6 +16,9 @@ import org.maplibre.nativeffi.render.RenderSessionHandle
  * the session supplies that hop.
  */
 internal interface MlnFfiStyleBinding : StyleBinding {
+  /** Feature state retained for this loaded style. */
+  val featureStateStore: MlnFfiFeatureStateStore?
+
   /** Null if the style has unloaded; reads should then fall back to the descriptor. */
   fun <T> readMap(action: (MapHandle) -> T): T?
 
@@ -29,8 +33,8 @@ internal interface MlnFfiStyleBinding : StyleBinding {
   fun <T> mutateMap(abandon: () -> Unit, action: (MapHandle) -> T): T?
 
   /**
-   * Null when the style has unloaded or no session is attached yet — a session exists only between
-   * the first frame and teardown. The handle must not escape [action].
+   * Null when the style has unloaded or no renderer is ready. The renderer exists after the first
+   * successful frame and until teardown. The handle must not escape [action].
    */
   fun <T> withRenderSession(action: (RenderSessionHandle) -> T): T?
 
@@ -93,6 +97,8 @@ internal interface MlnFfiStyleBinding : StyleBinding {
     /** A binding for a descriptor that has never been added to a style. */
     val UNLOADED: MlnFfiStyleBinding =
       object : MlnFfiStyleBinding {
+        override val featureStateStore: MlnFfiFeatureStateStore? = null
+
         override val isLoaded: Boolean = false
 
         override val logger: Logger? = null

--- a/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/mlnffi/BridgeMapFixture.kt
+++ b/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/mlnffi/BridgeMapFixture.kt
@@ -223,6 +223,21 @@ private constructor(
     }
   }
 
+  /**
+   * Loads [style] while leaving the render session unattached until the caller requests a frame.
+   */
+  fun loadStyleBeforeRendering(style: BaseStyle, timeout: Duration = 60.seconds) {
+    val styleLoadsBefore = events.count { it == STYLE_LOADED }
+    session.setBaseStyle(style)
+    val deadline = TimeSource.Monotonic.markNow() + timeout
+    while (events.count { it == STYLE_LOADED } <= styleLoadsBefore || this.style == null) {
+      check(deadline.hasNotPassedNow()) {
+        "Timed out waiting for style $style to load before rendering. Errors: $errors"
+      }
+      parkForTest(POLL_INTERVAL_MILLIS)
+    }
+  }
+
   override fun close() {
     runCatching { session.close() }
     runCatching { driver.close() }

--- a/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/sources/MlnFfiFeatureStateLifecycleTest.kt
+++ b/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/sources/MlnFfiFeatureStateLifecycleTest.kt
@@ -1,0 +1,231 @@
+package org.maplibre.compose.sources
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import org.maplibre.compose.camera.CameraPosition
+import org.maplibre.compose.expressions.ast.ExpressionContext
+import org.maplibre.compose.expressions.dsl.all
+import org.maplibre.compose.expressions.dsl.asBoolean
+import org.maplibre.compose.expressions.dsl.condition
+import org.maplibre.compose.expressions.dsl.const
+import org.maplibre.compose.expressions.dsl.feature
+import org.maplibre.compose.expressions.dsl.switch
+import org.maplibre.compose.expressions.value.BooleanValue
+import org.maplibre.compose.layers.CircleLayer
+import org.maplibre.compose.mlnffi.BridgeMapFixture
+import org.maplibre.compose.style.BaseStyle
+import org.maplibre.compose.style.Style
+import org.maplibre.compose.testing.RgbaPixel
+import org.maplibre.compose.util.toJsonElement
+import org.maplibre.nativeffi.query.FeatureStateSelector
+import org.maplibre.spatialk.geojson.Geometry
+import org.maplibre.spatialk.geojson.Point
+import org.maplibre.spatialk.geojson.Position
+import org.maplibre.spatialk.geojson.dsl.addFeature
+import org.maplibre.spatialk.geojson.dsl.buildFeatureCollection
+
+class MlnFfiFeatureStateLifecycleTest {
+
+  @Test
+  fun state_written_before_the_first_frame_reaches_the_renderer() {
+    BridgeMapFixture.create().use { fixture ->
+      fixture.loadStyleBeforeRendering(BLACK_STYLE)
+      assertEquals(0, fixture.attachCount)
+      fixture.session.setCameraPosition(CameraPosition(target = Position(0.0, 0.0), zoom = 1.0))
+      val style = assertNotNull(fixture.style)
+      val source = attachPointSource(style)
+      attachStateLayer(style, source, "selected")
+
+      source.setFeatureState("1", state("selected"))
+      assertTrue(source.getFeatureState("1")["selected"]?.jsonPrimitive?.boolean == true)
+
+      fixture.pumpUntilPixel("the retained state to color the circle", RED)
+      assertEquals(1, fixture.attachCount)
+    }
+  }
+
+  @Test
+  fun state_survives_surface_loss_and_accepts_detached_mutations() {
+    BridgeMapFixture.create().use { fixture ->
+      fixture.loadStyle(BLACK_STYLE)
+      fixture.session.setCameraPosition(CameraPosition(target = Position(0.0, 0.0), zoom = 1.0))
+      val style = assertNotNull(fixture.style)
+      val source = attachPointSource(style)
+      attachStateLayer(style, source, "persistent", "detached")
+      fixture.pumpUntilPixel("the default circle", BLUE)
+
+      source.setFeatureState("1", state("persistent", "discarded"))
+      fixture.loseSurface()
+      source.setFeatureState("1", state("detached"))
+      source.removeFeatureState("1", "discarded")
+      val retained = source.getFeatureState("1")
+      assertTrue(retained["persistent"]?.jsonPrimitive?.boolean == true)
+      assertTrue(retained["detached"]?.jsonPrimitive?.boolean == true)
+      assertFalse("discarded" in retained)
+
+      fixture.restoreSurface()
+      fixture.pumpUntilPixel("state from both renderer lifetimes to color the circle", RED)
+
+      fixture.loseSurface()
+      source.resetFeatureStates()
+      assertEquals(JsonObject(emptyMap()), source.getFeatureState("1"))
+      fixture.restoreSurface()
+      fixture.pumpUntilPixel("the reset state to restore the default circle", BLUE)
+    }
+  }
+
+  @Test
+  fun vector_layers_replay_independently_after_surface_loss() {
+    BridgeMapFixture.create().use { fixture ->
+      fixture.loadStyle(BaseStyle.Empty)
+      val style = assertNotNull(fixture.style)
+      val source =
+        VectorSource(
+          id = "vector",
+          tiles = listOf("https://example.invalid/{z}/{x}/{y}.pbf"),
+          options = TileSetOptions(),
+        )
+      style.addSource(source)
+      source.setFeatureState("kept", "1", state("selected"))
+      source.setFeatureState("reset", "1", state("selected"))
+
+      fixture.loseSurface()
+      source.resetFeatureStates("reset")
+      assertTrue(source.getFeatureState("kept", "1")["selected"]?.jsonPrimitive?.boolean == true)
+      assertEquals(JsonObject(emptyMap()), source.getFeatureState("reset", "1"))
+
+      fixture.restoreSurface()
+      fixture.pumpUntilRendered()
+      assertTrue(
+        nativeFeatureState(source, "kept", "1")["selected"]?.jsonPrimitive?.boolean == true
+      )
+      assertEquals(JsonObject(emptyMap()), nativeFeatureState(source, "reset", "1"))
+    }
+  }
+
+  @Test
+  fun removing_a_source_forgets_its_retained_state() {
+    BridgeMapFixture.create().use { fixture ->
+      fixture.loadStyle(BaseStyle.Empty)
+      val style = assertNotNull(fixture.style)
+      val source = attachPointSource(style)
+      source.setFeatureState("1", state("selected"))
+
+      style.removeSource(source)
+      style.addSource(source)
+
+      assertEquals(JsonObject(emptyMap()), source.getFeatureState("1"))
+    }
+  }
+
+  @Test
+  fun replacing_the_style_discards_its_retained_state() {
+    BridgeMapFixture.create().use { fixture ->
+      fixture.loadStyle(BaseStyle.Empty)
+      val first = attachPointSource(assertNotNull(fixture.style))
+      first.setFeatureState("1", state("selected"))
+
+      fixture.loadStyle(BLACK_STYLE)
+      val replacement = attachPointSource(assertNotNull(fixture.style))
+
+      assertEquals(JsonObject(emptyMap()), first.getFeatureState("1"))
+      assertEquals(JsonObject(emptyMap()), replacement.getFeatureState("1"))
+    }
+  }
+
+  private fun attachPointSource(style: Style): GeoJsonSource {
+    val source =
+      GeoJsonSource(
+        id = "points",
+        data =
+          GeoJsonData.Features(
+            buildFeatureCollection<Geometry, JsonObject?> {
+              addFeature(geometry = Point(Position(0.0, 0.0))) { setId(1) }
+            }
+          ),
+        options = GeoJsonOptions(),
+      )
+    style.addSource(source)
+    return source
+  }
+
+  private fun attachStateLayer(style: Style, source: GeoJsonSource, vararg requiredKeys: String) {
+    val layer = CircleLayer("circles", source)
+    layer.setCircleRadius(const(48.dp).compile(ExpressionContext.None))
+    layer.setCircleColor(
+      switch(
+          condition(
+            test =
+              all(
+                *requiredKeys
+                  .map { key -> feature.state<BooleanValue>(key).asBoolean(const(false)) }
+                  .toTypedArray()
+              ),
+            output = const(Color.Red),
+          ),
+          fallback = const(Color.Blue),
+        )
+        .compile(ExpressionContext.None)
+    )
+    style.addLayer(layer)
+  }
+
+  private fun BridgeMapFixture.pumpUntilPixel(description: String, expected: RgbaPixel) {
+    pumpUntil(description) { hasRendered && readPixel(CENTER, CENTER).isNear(expected) }
+  }
+
+  private fun nativeFeatureState(
+    source: VectorSource,
+    sourceLayerId: String,
+    featureId: String,
+  ): JsonObject {
+    val bytes =
+      assertNotNull(
+        source.binding.withRenderSession { session ->
+          session.getFeatureState(
+            FeatureStateSelector(source.id).apply {
+              this.sourceLayerId = sourceLayerId
+              this.featureId = featureId
+            }
+          )
+        }
+      )
+    return assertIs<JsonObject>(bytes.toJsonElement())
+  }
+
+  private fun state(vararg keys: String): JsonObject = buildJsonObject {
+    keys.forEach { key -> put(key, true) }
+  }
+
+  private companion object {
+    const val CENTER = 256
+
+    val RED = RgbaPixel(red = 255, green = 0, blue = 0, alpha = 255)
+    val BLUE = RgbaPixel(red = 0, green = 0, blue = 255, alpha = 255)
+
+    val BLACK_STYLE =
+      BaseStyle.Json(
+        """
+        {
+          "version": 8,
+          "sources": {},
+          "layers": [
+            { "id": "bg", "type": "background", "paint": { "background-color": "#000000" } }
+          ]
+        }
+        """
+          .trimIndent()
+      )
+  }
+}


### PR DESCRIPTION
## Description

Retains feature state per loaded native style and replays it after renderer attachment or replacement, which fixes #995.

## Validation

Passed `mise run check`, the desktop test suite, targeted feature-state lifecycle tests, Android API 36 device tests (348/348), and the iOS simulator suite.

## AI assistance

Codex (GPT-5.6 Sol) implemented the lifecycle fix, added its tests, and ran the validation.