### PR TITLE
Add ColorReliefLayer

### DIFF
--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/dsl/inputs.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/dsl/inputs.kt
@@ -18,3 +18,9 @@ public fun zoom(): Expression<FloatValue> = FunctionCall.of("zoom").cast()
  * [HeatmapLayer][org.maplibre.compose.layers.HeatmapLayer].
  */
 public fun heatmapDensity(): Expression<FloatValue> = FunctionCall.of("heatmap-density").cast()
+
+/**
+ * Gets the elevation of a pixel in meters. Can only be used in the expression for the `color`
+ * parameter in a [ColorReliefLayer][org.maplibre.compose.layers.ColorReliefLayer].
+ */
+public fun elevation(): Expression<FloatValue> = FunctionCall.of("elevation").cast()

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/ColorReliefLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/ColorReliefLayer.kt
@@ -36,6 +36,8 @@ public fun ColorReliefLayer(
   color: Expression<ColorValue> = LayerDefaults.ColorReliefColors,
   opacity: Expression<FloatValue> = const(1f),
 ) {
+  // The style spec also defines `resampling`, but MapLibre Native refuses the whole layer when the
+  // property is present, so it is not exposed until Native accepts it.
   val compile = rememberPropertyCompiler()
 
   val compiledColor = compile(color)

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/ColorReliefLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/ColorReliefLayer.kt
@@ -4,8 +4,10 @@ import androidx.compose.runtime.Composable
 import org.maplibre.compose.expressions.ast.CompiledExpression
 import org.maplibre.compose.expressions.ast.Expression
 import org.maplibre.compose.expressions.dsl.const
+import org.maplibre.compose.expressions.dsl.nil
 import org.maplibre.compose.expressions.value.ColorValue
 import org.maplibre.compose.expressions.value.FloatValue
+import org.maplibre.compose.expressions.value.RasterResampling
 import org.maplibre.compose.sources.Source
 import org.maplibre.compose.sources.SourceReferenceEffect
 import org.maplibre.compose.util.MaplibreComposable
@@ -24,6 +26,10 @@ import org.maplibre.compose.util.MaplibreComposable
  * @param color Defines the color of each pixel based on its elevation. Should be an expression that
  *   uses [elevation][org.maplibre.compose.expressions.dsl.elevation] as input.
  * @param opacity The global opacity at which the color relief layer will be drawn.
+ * @param resampling The resampling/interpolation method to use for overscaling, also known as
+ *   texture magnification filter.
+ *
+ *   **Note**: This property is not supported on native platforms yet.
  */
 @Composable
 @MaplibreComposable
@@ -35,13 +41,13 @@ public fun ColorReliefLayer(
   visible: Boolean = true,
   color: Expression<ColorValue> = LayerDefaults.ColorReliefColors,
   opacity: Expression<FloatValue> = const(1f),
+  resampling: Expression<RasterResampling> = nil(),
 ) {
-  // The style spec also defines `resampling`, but MapLibre Native refuses the whole layer when the
-  // property is present, so it is not exposed until Native accepts it.
   val compile = rememberPropertyCompiler()
 
   val compiledColor = compile(color)
   val compiledOpacity = compile(opacity)
+  val compiledResampling = compile(resampling)
 
   SourceReferenceEffect(source)
   LayerNode(
@@ -52,6 +58,7 @@ public fun ColorReliefLayer(
       set(visible) { layer.visible = it }
       set(compiledColor) { layer.setColorReliefColor(it) }
       set(compiledOpacity) { layer.setColorReliefOpacity(it) }
+      set(compiledResampling) { layer.setResampling(it) }
     },
     onClick = null,
     onLongClick = null,
@@ -64,4 +71,6 @@ internal expect class ColorReliefLayer(id: String, source: Source) : Layer {
   fun setColorReliefColor(color: CompiledExpression<ColorValue>)
 
   fun setColorReliefOpacity(opacity: CompiledExpression<FloatValue>)
+
+  fun setResampling(resampling: CompiledExpression<RasterResampling>)
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/ColorReliefLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/ColorReliefLayer.kt
@@ -1,0 +1,65 @@
+package org.maplibre.compose.layers
+
+import androidx.compose.runtime.Composable
+import org.maplibre.compose.expressions.ast.CompiledExpression
+import org.maplibre.compose.expressions.ast.Expression
+import org.maplibre.compose.expressions.dsl.const
+import org.maplibre.compose.expressions.value.ColorValue
+import org.maplibre.compose.expressions.value.FloatValue
+import org.maplibre.compose.sources.Source
+import org.maplibre.compose.sources.SourceReferenceEffect
+import org.maplibre.compose.util.MaplibreComposable
+
+/**
+ * Client-side elevation coloring (hypsometric tinting) based on DEM data. The implementation
+ * supports Mapbox Terrain RGB, Mapzen Terrarium tiles and custom encodings.
+ *
+ * @param id Unique layer name.
+ * @param source Raster DEM data source for this layer.
+ * @param minZoom The minimum zoom level for the layer. At zoom levels less than this, the layer
+ *   will be hidden. A value in the range of `[0..24]`.
+ * @param maxZoom The maximum zoom level for the layer. At zoom levels equal to or greater than
+ *   this, the layer will be hidden. A value in the range of `[0..24]`.
+ * @param visible Whether the layer should be displayed.
+ * @param color Defines the color of each pixel based on its elevation. Should be an expression that
+ *   uses [elevation][org.maplibre.compose.expressions.dsl.elevation] as input.
+ * @param opacity The global opacity at which the color relief layer will be drawn.
+ */
+@Composable
+@MaplibreComposable
+public fun ColorReliefLayer(
+  id: String,
+  source: Source,
+  minZoom: Float = 0.0f,
+  maxZoom: Float = 24.0f,
+  visible: Boolean = true,
+  color: Expression<ColorValue> = LayerDefaults.ColorReliefColors,
+  opacity: Expression<FloatValue> = const(1f),
+) {
+  val compile = rememberPropertyCompiler()
+
+  val compiledColor = compile(color)
+  val compiledOpacity = compile(opacity)
+
+  SourceReferenceEffect(source)
+  LayerNode(
+    factory = { ColorReliefLayer(id = id, source = source) },
+    update = {
+      set(minZoom) { layer.minZoom = it }
+      set(maxZoom) { layer.maxZoom = it }
+      set(visible) { layer.visible = it }
+      set(compiledColor) { layer.setColorReliefColor(it) }
+      set(compiledOpacity) { layer.setColorReliefOpacity(it) }
+    },
+    onClick = null,
+    onLongClick = null,
+  )
+}
+
+internal expect class ColorReliefLayer(id: String, source: Source) : Layer {
+  val source: Source
+
+  fun setColorReliefColor(color: CompiledExpression<ColorValue>)
+
+  fun setColorReliefOpacity(opacity: CompiledExpression<FloatValue>)
+}

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/ColorReliefLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/ColorReliefLayer.kt
@@ -13,7 +13,8 @@ import org.maplibre.compose.sources.SourceReferenceEffect
 import org.maplibre.compose.util.MaplibreComposable
 
 /**
- * Client-side elevation coloring (hypsometric tinting) based on DEM data. The implementation
+ * Client-side elevation coloring ([hypsometric
+ * tinting](https://en.wikipedia.org/wiki/Hypsometric_tints)) based on DEM data. The implementation
  * supports Mapbox Terrain RGB, Mapzen Terrarium tiles and custom encodings.
  *
  * @param id Unique layer name.

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/LayerDefaults.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/LayerDefaults.kt
@@ -3,6 +3,7 @@ package org.maplibre.compose.layers
 import androidx.compose.ui.graphics.Color
 import org.maplibre.compose.expressions.ast.Expression
 import org.maplibre.compose.expressions.dsl.const
+import org.maplibre.compose.expressions.dsl.elevation
 import org.maplibre.compose.expressions.dsl.heatmapDensity
 import org.maplibre.compose.expressions.dsl.interpolate
 import org.maplibre.compose.expressions.dsl.linear
@@ -21,6 +22,16 @@ public object LayerDefaults {
       0.5 to const(Color(0xFF00FF00)), // lime
       0.7 to const(Color(0xFFFFFF00)), // yellow
       1 to const(Color(0xFFFF0000)), // red
+    )
+
+  public val ColorReliefColors: Expression<ColorValue> =
+    interpolate(
+      linear(),
+      elevation(),
+      0 to const(Color(0xFF00801E)), // green lowlands
+      1500 to const(Color(0xFFF0E68C)), // khaki foothills
+      3000 to const(Color(0xFF8B5A2B)), // brown mountains
+      4500 to const(Color(0xFFFFFFFF)), // white peaks
     )
 
   public val FontNames: Expression<ListValue<StringValue>> =

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MaplibreMap.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MaplibreMap.kt
@@ -95,6 +95,7 @@ import org.maplibre.spatialk.geojson.Position
  * [layer](https://maplibre.org/maplibre-style-spec/layers/) definition(s), which define how that
  * data is rendered, see:
  * - [BackgroundLayer][org.maplibre.compose.layers.BackgroundLayer]
+ * - [ColorReliefLayer][org.maplibre.compose.layers.ColorReliefLayer]
  * - [LineLayer][org.maplibre.compose.layers.LineLayer]
  * - [FillExtrusionLayer][org.maplibre.compose.layers.FillExtrusionLayer]
  * - [FillLayer][org.maplibre.compose.layers.FillLayer]

--- a/lib/maplibre-compose/src/nextCommonMain/kotlin/org/maplibre/compose/layers/ColorReliefLayer.kt
+++ b/lib/maplibre-compose/src/nextCommonMain/kotlin/org/maplibre/compose/layers/ColorReliefLayer.kt
@@ -3,6 +3,7 @@ package org.maplibre.compose.layers
 import org.maplibre.compose.expressions.ast.CompiledExpression
 import org.maplibre.compose.expressions.value.ColorValue
 import org.maplibre.compose.expressions.value.FloatValue
+import org.maplibre.compose.expressions.value.RasterResampling
 import org.maplibre.compose.sources.Source
 
 internal actual class ColorReliefLayer actual constructor(id: String, actual val source: Source) :
@@ -21,5 +22,14 @@ internal actual class ColorReliefLayer actual constructor(id: String, actual val
 
   actual fun setColorReliefOpacity(opacity: CompiledExpression<FloatValue>) {
     setPaintProperty("color-relief-opacity", opacity)
+  }
+
+  /** TODO: write this property once MapLibre Native implements `resampling` on color-relief. */
+  actual fun setResampling(resampling: CompiledExpression<RasterResampling>) {
+    skipUnsupportedProperty(
+      "resampling",
+      resampling,
+      "MapLibre Native does not implement it on color-relief layers.",
+    )
   }
 }

--- a/lib/maplibre-compose/src/nextCommonMain/kotlin/org/maplibre/compose/layers/ColorReliefLayer.kt
+++ b/lib/maplibre-compose/src/nextCommonMain/kotlin/org/maplibre/compose/layers/ColorReliefLayer.kt
@@ -1,0 +1,25 @@
+package org.maplibre.compose.layers
+
+import org.maplibre.compose.expressions.ast.CompiledExpression
+import org.maplibre.compose.expressions.value.ColorValue
+import org.maplibre.compose.expressions.value.FloatValue
+import org.maplibre.compose.sources.Source
+
+internal actual class ColorReliefLayer actual constructor(id: String, actual val source: Source) :
+  Layer(id) {
+
+  override val type: String = "color-relief"
+
+  override val sourceId: String = source.id
+
+  override val sourceDescriptor: Source
+    get() = source
+
+  actual fun setColorReliefColor(color: CompiledExpression<ColorValue>) {
+    setPaintProperty("color-relief-color", color)
+  }
+
+  actual fun setColorReliefOpacity(opacity: CompiledExpression<FloatValue>) {
+    setPaintProperty("color-relief-opacity", opacity)
+  }
+}

--- a/lib/maplibre-compose/src/nextCommonTest/kotlin/org/maplibre/compose/layers/LayerPropertyRoundTripTest.kt
+++ b/lib/maplibre-compose/src/nextCommonTest/kotlin/org/maplibre/compose/layers/LayerPropertyRoundTripTest.kt
@@ -20,6 +20,7 @@ import org.maplibre.compose.expressions.ast.Expression
 import org.maplibre.compose.expressions.ast.ExpressionContext
 import org.maplibre.compose.expressions.dsl.Feature
 import org.maplibre.compose.expressions.dsl.const
+import org.maplibre.compose.expressions.dsl.elevation
 import org.maplibre.compose.expressions.dsl.format
 import org.maplibre.compose.expressions.dsl.heatmapDensity
 import org.maplibre.compose.expressions.dsl.image
@@ -150,6 +151,22 @@ class LayerPropertyRoundTripTest {
         )
       style.addSource(source)
       ({ id -> HillshadeLayer(id, source) })
+    }
+  }
+
+  @Test
+  fun color_relief_layer_properties_reach_maplibre(): MapTestResult = runMapTest {
+    assertPropertiesRoundTrip(COLOR_RELIEF_CASES) { style ->
+      val source =
+        RasterDemSource(
+          id = "dem",
+          tiles = listOf(TILE_TEMPLATE),
+          options = TileSetOptions(),
+          tileSize = 256,
+          demEncoding = RasterDemEncoding.Terrarium,
+        )
+      style.addSource(source)
+      ({ id -> ColorReliefLayer(id, source) })
     }
   }
 
@@ -449,6 +466,23 @@ class LayerPropertyRoundTripTest {
         ) {
           it.setHillshadeAccentColor(const(Color.Cyan).c())
         },
+      )
+
+    val COLOR_RELIEF_CASES =
+      listOf<Case<ColorReliefLayer>>(
+        // Like heatmap-color, a ramp rather than a constant, and only over elevation.
+        Case(
+          "color-relief-color",
+          """["interpolate",["linear"],["elevation"],
+             0.0,["rgba",0.0,0.0,255.0,1.0],3000.0,["rgba",255.0,0.0,0.0,1.0]]""",
+          """["interpolate",["linear"],["elevation"],0.0,"rgba(0, 0, 255, 1)",3000.0,"rgba(255, 0, 0, 1)"]""",
+        ) {
+          it.setColorReliefColor(
+            interpolate(linear(), elevation(), 0f to const(Color.Blue), 3000f to const(Color.Red))
+              .c()
+          )
+        },
+        Case("color-relief-opacity", "0.75") { it.setColorReliefOpacity(const(0.75f).c()) },
       )
 
     val SYMBOL_CASES =


### PR DESCRIPTION
## Description

Exposes the MapLibre `color-relief` layer type as a `ColorReliefLayer` composable, with an `elevation()` expression input and a default hypsometric color ramp. Resolves #453.

## Validation

Property round-trip tests added for both paint properties; `mise run test:desktop` and `mise run test:js` pass locally.

## AI assistance

Written by Claude Fable 5 via Claude Code.