### PR TITLE
Document feature state support in layer KDoc

### DIFF
--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/dsl/feature.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/dsl/feature.kt
@@ -48,8 +48,8 @@ public object Feature {
    * When `source.promoteId` is not provided, features are identified by their `id` attribute, which
    * must be an integer or a string that can be cast to an integer. When `source.promoteId` is
    * provided, features are identified by their `promoteId` property, which may be a number, string,
-   * or any primitive data type. [state] can only be used with layer properties that support
-   * data-driven styling.
+   * or any primitive data type. Only data-driven paint properties documented as supporting feature
+   * state accept [state].
    */
   public fun <T : ExpressionValue> state(key: Expression<StringValue>): Expression<T> =
     FunctionCall.of("feature-state", key).cast()
@@ -65,8 +65,8 @@ public object Feature {
    * When `source.promoteId` is not provided, features are identified by their `id` attribute, which
    * must be an integer or a string that can be cast to an integer. When `source.promoteId` is
    * provided, features are identified by their `promoteId` property, which may be a number, string,
-   * or any primitive data type. [state] can only be used with layer properties that support
-   * data-driven styling.
+   * or any primitive data type. Only data-driven paint properties documented as supporting feature
+   * state accept [state].
    */
   public fun <T : ExpressionValue> state(key: String): Expression<T> = state(const(key))
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/CircleLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/CircleLayer.kt
@@ -34,25 +34,31 @@ import org.maplibre.compose.util.MaplibreComposable
  *   this, the layer will be hidden. A value in the range of `[0..24]`.
  * @param filter An expression specifying conditions on source features. Only features that match
  *   the filter are displayed. Zoom expressions in filters are only evaluated at integer zoom
- *   levels. The [featureState][org.maplibre.compose.expressions.dsl.Feature.state] expression is
- *   not supported in filter expressions.
+ *   levels. The expression may use feature properties. The
+ *   [feature state][org.maplibre.compose.expressions.dsl.Feature.state] expression is not
+ *   supported.
  * @param visible Whether the layer should be displayed.
  * @param sortKey Sorts features within this layer in ascending order based on this value. Features
- *   with a higher sort key will appear above features with a lower sort key.
+ *   with a higher sort key will appear above features with a lower sort key. The expression may use
+ *   feature properties.
  * @param translate The geometry's offset relative to the [translateAnchor]. Negative numbers
  *   indicate left and up, respectively.
  * @param translateAnchor Frame of reference for offsetting geometry.
  *
  *   Ignored if [translate] is not set.
  *
- * @param opacity Circles opacity. A value in range `[0..1]`.
- * @param color Circles fill color.
+ * @param opacity Circles opacity. A value in range `[0..1]`. The expression may use feature
+ *   properties and feature state.
+ * @param color Circles fill color. The expression may use feature properties and feature state.
  * @param blur Amount to blur the circle. A value of `1` blurs the circle such that only the
- *   centerpoint has full opacity.
- * @param radius Circles radius.
- * @param strokeOpacity Opacity of the circles' stroke.
- * @param strokeColor Circles' stroke color.
+ *   centerpoint has full opacity. The expression may use feature properties and feature state.
+ * @param radius Circles radius. The expression may use feature properties and feature state.
+ * @param strokeOpacity Opacity of the circles' stroke. The expression may use feature properties
+ *   and feature state.
+ * @param strokeColor Circles' stroke color. The expression may use feature properties and feature
+ *   state.
  * @param strokeWidth Thickness of the circles' stroke. Strokes are placed outside of the [radius].
+ *   The expression may use feature properties and feature state.
  * @param pitchScale Scaling behavior of circles when the map is pitched.
  * @param pitchAlignment Orientation of circles when the map is pitched.
  * @param onClick Function to call when any feature in this layer has been clicked.

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/FillExtrusionLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/FillExtrusionLayer.kt
@@ -32,8 +32,9 @@ import org.maplibre.compose.util.MaplibreComposable
  *   this, the layer will be hidden. A value in the range of `[0..24]`.
  * @param filter An expression specifying conditions on source features. Only features that match
  *   the filter are displayed. Zoom expressions in filters are only evaluated at integer zoom
- *   levels. The [featureState][org.maplibre.compose.expressions.dsl.Feature.state] expression is
- *   not supported in filter expressions.
+ *   levels. The expression may use feature properties. The
+ *   [feature state][org.maplibre.compose.expressions.dsl.Feature.state] expression is not
+ *   supported.
  * @param visible Whether the layer should be displayed.
  * @param roundedCornerDistance The distance in meters from each fill extrusion corner, measured
  *   along the adjacent edges, that is replaced by a rounded corner. A value in the range of
@@ -48,15 +49,18 @@ import org.maplibre.compose.util.MaplibreComposable
  *   not per-feature, basis, and data-driven styling is not available. A value in range `[0..1]`.
  * @param color The base color of the extruded fill. The extrusion's surfaces will be shaded
  *   differently based on this color in combination with the root light settings. The alpha
- *   component of the specified color is ignored. Ignored if [pattern] is specified.
+ *   component of the specified color is ignored. The expression may use feature properties and
+ *   feature state. Ignored if [pattern] is specified.
  * @param pattern Name of image in sprite to use for drawing images on extruded fills. For seamless
  *   patterns, image width and height must be a factor of two (2, 4, 8, ..., 512). Note that
- *   zoom-dependent expressions will be evaluated only at integer zoom levels.
+ *   zoom-dependent expressions will be evaluated only at integer zoom levels. The expression may
+ *   use feature properties.
  * @param height The height in meters with which to extrude the geometries, i.e. the upper end of
- *   the 3D polygon. A value in the range of `[0..infinity)`.
+ *   the 3D polygon. A value in the range of `[0..infinity)`. The expression may use feature
+ *   properties and feature state.
  * @param base The height in meters with which to extrude the base of the geometries, i.e. the lower
  *   end of the 3D polygon. A value in the range of `[0..infinity)`. Must be less than or equal to
- *   [height].
+ *   [height]. The expression may use feature properties and feature state.
  * @param verticalGradient Whether to apply a vertical gradient to the sides of this layer. If
  *   `true`, sides will be shaded slightly darker farther down.
  * @param onClick Function to call when any feature in this layer has been clicked.

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/FillLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/FillLayer.kt
@@ -31,27 +31,31 @@ import org.maplibre.compose.util.MaplibreComposable
  *   this, the layer will be hidden. A value in the range of `[0..24]`.
  * @param filter An expression specifying conditions on source features. Only features that match
  *   the filter are displayed. Zoom expressions in filters are only evaluated at integer zoom
- *   levels. The [featureState][org.maplibre.compose.expressions.dsl.Feature.state] expression is
- *   not supported in filter expressions.
+ *   levels. The expression may use feature properties. The
+ *   [feature state][org.maplibre.compose.expressions.dsl.Feature.state] expression is not
+ *   supported.
  * @param visible Whether the layer should be displayed.
  * @param sortKey Sorts features within this layer in ascending order based on this value. Features
- *   with a higher sort key will appear above features with a lower sort key.
+ *   with a higher sort key will appear above features with a lower sort key. The expression may use
+ *   feature properties.
  * @param translate The geometry's offset relative to the [translateAnchor]. Negative numbers
  *   indicate left and up, respectively.
  * @param translateAnchor Frame of reference for offsetting geometry.
  *
  *   Ignored if [translate] is not set.
  *
- * @param opacity Fill opacity. A value in range `[0..1]`.
- * @param color Fill color.
+ * @param opacity Fill opacity. A value in range `[0..1]`. The expression may use feature properties
+ *   and feature state.
+ * @param color Fill color. The expression may use feature properties and feature state.
  *
  *   Ignored if [pattern] is specified.
  *
  * @param pattern Image to use for drawing image fills. For seamless patterns, image width and
  *   height must be a factor of two (2, 4, 8, ..., 512). Note that zoom-dependent expressions will
- *   be evaluated only at integer zoom levels.
+ *   be evaluated only at integer zoom levels. The expression may use feature properties.
  * @param antialias Whether or not the fill should be antialiased.
- * @param outlineColor The outline color of the fill. The outline is drawn at a hairline width.
+ * @param outlineColor The outline color of the fill. The outline is drawn at a hairline width. The
+ *   expression may use feature properties and feature state.
  *
  *   Ignored if [antialias] is `false`.
  *

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/HeatmapLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/HeatmapLayer.kt
@@ -27,17 +27,19 @@ import org.maplibre.compose.util.MaplibreComposable
  *   this, the layer will be hidden. A value in the range of `[0..24]`.
  * @param filter An expression specifying conditions on source features. Only features that match
  *   the filter are displayed. Zoom expressions in filters are only evaluated at integer zoom
- *   levels. The [featureState][org.maplibre.compose.expressions.dsl.Feature.state] expression is
- *   not supported in filter expressions.
+ *   levels. The expression may use feature properties. The
+ *   [feature state][org.maplibre.compose.expressions.dsl.Feature.state] expression is not
+ *   supported.
  * @param visible Whether the layer should be displayed.
  * @param color Defines the color of each pixel based on its density value in a heatmap. Should be
  *   an expression that uses [heatmapDensity] as input.
  * @param opacity The global opacity at which the heatmap layer will be drawn.
  * @param radius Radius of influence of one heatmap point. Increasing the value makes the heatmap
- *   smoother, but less detailed.
+ *   smoother, but less detailed. The expression may use feature properties and feature state.
  * @param weight A measure of how much an individual point contributes to the heatmap. A value of 10
  *   would be equivalent to having 10 points of weight 1 in the same spot. Especially useful when
- *   combined with clustering. A value in the range of `[0..infinity)`.
+ *   combined with clustering. A value in the range of `[0..infinity)`. The expression may use
+ *   feature properties and feature state.
  * @param intensity Similar to [weight] but controls the intensity of the heatmap globally.
  *   Primarily used for adjusting the heatmap based on zoom level.
  * @param onClick Function to call when any feature in this layer has been clicked.

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/LineLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/LineLayer.kt
@@ -37,19 +37,22 @@ import org.maplibre.compose.util.MaplibreComposable
  *   this, the layer will be hidden. A value in the range of `[0..24]`.
  * @param filter An expression specifying conditions on source features. Only features that match
  *   the filter are displayed. Zoom expressions in filters are only evaluated at integer zoom
- *   levels. The [featureState][org.maplibre.compose.expressions.dsl.Feature.state] expression is
- *   not supported in filter expressions.
+ *   levels. The expression may use feature properties. The
+ *   [feature state][org.maplibre.compose.expressions.dsl.Feature.state] expression is not
+ *   supported.
  * @param visible Whether the layer should be displayed.
  * @param sortKey Sorts features within this layer in ascending order based on this value. Features
- *   with a higher sort key will appear above features with a lower sort key.
+ *   with a higher sort key will appear above features with a lower sort key. The expression may use
+ *   feature properties.
  * @param translate The geometry's offset relative to the [translateAnchor]. Negative numbers
  *   indicate left and up, respectively.
  * @param translateAnchor Frame of reference for offsetting geometry.
  *
  *   Ignored if [translate] is not set.
  *
- * @param opacity Lines opacity. A value in range `[0..1]`.
- * @param color Lines color.
+ * @param opacity Lines opacity. A value in range `[0..1]`. The expression may use feature
+ *   properties and feature state.
+ * @param color Lines color. The expression may use feature properties and feature state.
  *
  *   Ignored if [pattern] is specified.
  *
@@ -57,28 +60,33 @@ import org.maplibre.compose.util.MaplibreComposable
  *   pattern. The lengths are later scaled by the line width. To convert a dash length to pixels,
  *   multiply the length by the current line width. Note that GeoJSON sources with `lineMetrics =
  *   true` specified won't render dashed lines to the expected scale. Also note that zoom-dependent
- *   expressions will be evaluated only at integer zoom levels. Ignored if [pattern] is specified.
+ *   expressions will be evaluated only at integer zoom levels. The expression may use feature
+ *   properties. Ignored if [pattern] is specified.
  * @param pattern Image to use for drawing image lines. For seamless patterns, image width must be a
  *   factor of two (2, 4, 8, ..., 512). Note that zoom-dependent expressions will be evaluated only
- *   at integer zoom levels.
+ *   at integer zoom levels. The expression may use feature properties.
  * @param gradient Defines a gradient with which to color a line feature. Can only be used with
  *   GeoJSON sources that specify `lineMetrics = true`.
  *
  *   Ignored if [pattern] or [dasharray] is specified.
  *
- * @param blur Blur applied to the lines.
- * @param width Thickness of the lines' stroke.
+ * @param blur Blur applied to the lines. The expression may use feature properties and feature
+ *   state.
+ * @param width Thickness of the lines' stroke. The expression may use feature properties and
+ *   feature state.
  * @param gapWidth If not `0`, instead of one, two lines, each left and right of each line's actual
- *   path are drawn, with the given gap in-between them.
+ *   path are drawn, with the given gap in-between them. The expression may use feature properties
+ *   and feature state.
  * @param offset The lines' offset. For linear features, a positive value offsets the line to the
  *   right, relative to the direction of the line, and a negative value to the left. For polygon
- *   features, a positive value results in an inset, and a negative value results in an outset.
- * @param cap Display of line endings.
- * @param join Display of joined lines.
+ *   features, a positive value results in an inset, and a negative value results in an outset. The
+ *   expression may use feature properties and feature state.
+ * @param cap Display of line endings. The expression may use feature properties.
+ * @param join Display of joined lines. The expression may use feature properties.
  * @param miterLimit Limit at which to automatically convert to bevel join for sharp angles when
- *   [join] is [LineJoin.Miter].
+ *   [join] is [LineJoin.Miter]. The expression may use feature properties.
  * @param roundLimit Limit at which to automatically convert to miter join for sharp angles when
- *   [join] is [LineJoin.Round].
+ *   [join] is [LineJoin.Round]. The expression may use feature properties.
  * @param onClick Function to call when any feature in this layer has been clicked.
  * @param onLongClick Function to call when any feature in this layer has been long-clicked.
  */

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/SymbolLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/SymbolLayer.kt
@@ -78,11 +78,13 @@ private fun rememberEmCompiler(textSize: Expression<TextUnitValue>): LayerProper
  *   this, the layer will be hidden. A value in the range of `[0..24]`.
  * @param filter An expression specifying conditions on source features. Only features that match
  *   the filter are displayed. Zoom expressions in filters are only evaluated at integer zoom
- *   levels. The [featureState][org.maplibre.compose.expressions.dsl.Feature.state] expression is
- *   not supported in filter expressions.
+ *   levels. The expression may use feature properties. The
+ *   [feature state][org.maplibre.compose.expressions.dsl.Feature.state] expression is not
+ *   supported.
  * @param visible Whether the layer should be displayed.
  * @param sortKey Sorts features within this layer in ascending order based on this value. Features
- *   with a higher sort key will appear above features with a lower sort key.
+ *   with a higher sort key will appear above features with a lower sort key. The expression may use
+ *   feature properties.
  * @param placement Symbol placement relative to its geometry.
  * @param spacing Distance between two symbol anchors.
  *
@@ -94,32 +96,38 @@ private fun rememberEmCompiler(textSize: Expression<TextUnitValue>): LayerProper
  * @param zOrder Determines whether overlapping symbols in the same layer are rendered in the order
  *   that they appear in the data source or by their y-position relative to the viewport. To control
  *   the order and prioritization of symbols otherwise, use [sortKey].
- * @param iconImage Image to use for drawing an image background.
+ * @param iconImage Image to use for drawing an image background. The expression may use feature
+ *   properties.
  * @param iconOpacity The opacity at which the icon will be drawn. A value in the range `[0..1]`.
+ *   The expression may use feature properties and feature state.
  *
  *   Ignored if [iconImage] is not specified.
  *
- * @param iconColor The color of the icon. This can only be used with SDF icons.
+ * @param iconColor The color of the icon. This can only be used with SDF icons. The expression may
+ *   use feature properties and feature state.
  *
  *   Ignored if [iconImage] is not specified.
  *
  * @param iconHaloColor The color of the icon's halo. Icon halos can only be used with SDF icons.
+ *   The expression may use feature properties and feature state.
  *
  *   Ignored if [iconImage] is not specified.
  *
  * @param iconHaloWidth Distance of halo to the icon outline. The unit is in dp only for SDF sprites
  *   that were created with a blur radius of 8, multiplied by the display density. I.e., the radius
- *   needs to be 16 for @2x sprites, etc.
+ *   needs to be 16 for @2x sprites, etc. The expression may use feature properties and feature
+ *   state.
  *
  *   Ignored if [iconImage] is not specified.
  *
- * @param iconHaloBlur Fade out the halo towards the outside.
+ * @param iconHaloBlur Fade out the halo towards the outside. The expression may use feature
+ *   properties and feature state.
  *
  *   Ignored if [iconImage] is not specified.
  *
  * @param iconSize Scales the original size of the icon by the provided factor. The new pixel size
  *   of the image will be the original pixel size multiplied by [iconSize]. 1 is the original size;
- *   3 triples the size of the image.
+ *   3 triples the size of the image. The expression may use feature properties.
  *
  *   Ignored if [iconImage] is not specified.
  *
@@ -150,23 +158,25 @@ private fun rememberEmCompiler(textSize: Expression<TextUnitValue>): LayerProper
  *
  *   Ignored if [iconImage] is not specified.
  *
- * @param iconRotate Rotates the icon clockwise by the number in degrees.
+ * @param iconRotate Rotates the icon clockwise by the number in degrees. The expression may use
+ *   feature properties.
  *
  *   Ignored if [iconImage] is not specified.
  *
- * @param iconAnchor Part of the icon placed closest to the anchor.
+ * @param iconAnchor Part of the icon placed closest to the anchor. The expression may use feature
+ *   properties.
  *
  *   Ignored if [iconImage] is not specified.
  *
  * @param iconOffset Offset distance of icon from its anchor. Positive values indicate right and
  *   down, while negative values indicate left and up. Each component is multiplied by the value of
  *   [iconSize] to obtain the final offset in dp. When combined with [iconRotate] the offset will be
- *   as if the rotated direction was up.
+ *   as if the rotated direction was up. The expression may use feature properties.
  *
  *   Ignored if [iconImage] is not specified.
  *
  * @param iconPadding Size of additional area round the icon bounding box used for detecting symbol
- *   collisions.
+ *   collisions. The expression may use feature properties.
  *
  *   Ignored if [iconImage] is not specified.
  *
@@ -202,37 +212,42 @@ private fun rememberEmCompiler(textSize: Expression<TextUnitValue>): LayerProper
  *   Ignored if [iconTranslate] is not set.
  *
  * @param textField Value to use for a text label. Use e.g. `format(const("My label"))` to display
- *   the plain string "My label".
+ *   the plain string "My label". The expression may use feature properties.
  *
  *   The text can also be formatted, employing different colors, fonts, etc., see
  *   [format][org.maplibre.compose.expressions.dsl.format].
  *
- * @param textOpacity The opacity at which the text will be drawn.
+ * @param textOpacity The opacity at which the text will be drawn. The expression may use feature
+ *   properties and feature state.
  *
  *   Ignored if [textField] is not specified.
  *
- * @param textColor The color with which the text will be drawn.
+ * @param textColor The color with which the text will be drawn. The expression may use feature
+ *   properties and feature state.
  *
  *   Ignored if [textField] is not specified.
  *
- * @param textHaloColor The color of the text's halo, which helps it stand out from backgrounds.
+ * @param textHaloColor The color of the text's halo, which helps it stand out from backgrounds. The
+ *   expression may use feature properties and feature state.
  *
  *   Ignored if [textField] is not specified.
  *
  * @param textHaloWidth Distance of halo to the font outline. Max text halo width is 1/4 of the
- *   font-size.
+ *   font-size. The expression may use feature properties and feature state.
  *
  *   Ignored if [textField] is not specified.
  *
- * @param textHaloBlur The halo's fadeout distance towards the outside.
+ * @param textHaloBlur The halo's fadeout distance towards the outside. The expression may use
+ *   feature properties and feature state.
  *
  *   Ignored if [textField] is not specified.
  *
- * @param textFont Font stack to use for displaying text.
+ * @param textFont Font stack to use for displaying text. The expression may use feature properties.
  *
  *   Ignored if [textField] is not specified.
  *
- * @param textSize Font size in SP or EM relative to 16sp.
+ * @param textSize Font size in SP or EM relative to 16sp. The expression may use feature
+ *   properties.
  *
  *   Ignored if [textField] is not specified.
  *
@@ -241,8 +256,8 @@ private fun rememberEmCompiler(textSize: Expression<TextUnitValue>): LayerProper
  *   units. This is a limitation of the MapLibre expression parser. If text size does not use zoom
  *   interpolation, then those other properties can be defined in either unit.
  *
- * @param textTransform Specifies how to capitalize text.
- * @param textLetterSpacing Text tracking amount.
+ * @param textTransform Specifies how to capitalize text. The expression may use feature properties.
+ * @param textLetterSpacing Text tracking amount. The expression may use feature properties.
  *
  *   Ignored if [textField] is not specified.
  *
@@ -261,7 +276,8 @@ private fun rememberEmCompiler(textSize: Expression<TextUnitValue>): LayerProper
  *
  *   Ignored if [textField] is not specified.
  *
- * @param textMaxWidth The maximum line width for text wrapping.
+ * @param textMaxWidth The maximum line width for text wrapping. The expression may use feature
+ *   properties.
  *
  *   Ignored if [textField] is not specified.
  *
@@ -269,7 +285,7 @@ private fun rememberEmCompiler(textSize: Expression<TextUnitValue>): LayerProper
  *
  *   Ignored if [textField] is not specified.
  *
- * @param textJustify Text justification options.
+ * @param textJustify Text justification options. The expression may use feature properties.
  *
  *   Ignored if [textField] is not specified.
  *
@@ -289,11 +305,13 @@ private fun rememberEmCompiler(textSize: Expression<TextUnitValue>): LayerProper
  *
  *   Ignored if [textField] is not specified.
  *
- * @param textRotate Rotates the text clockwise. Unit in degrees.
+ * @param textRotate Rotates the text clockwise. Unit in degrees. The expression may use feature
+ *   properties.
  *
  *   Ignored if [textField] is not specified.
  *
- * @param textAnchor Part of the text placed closest to the anchor.
+ * @param textAnchor Part of the text placed closest to the anchor. The expression may use feature
+ *   properties.
  *
  *   Overridden by [textVariableAnchorOffset].
  *
@@ -302,7 +320,7 @@ private fun rememberEmCompiler(textSize: Expression<TextUnitValue>): LayerProper
  * @param textOffset Offset distance of text from its anchor in ems. Positive values indicate right
  *   and down, while negative values indicate left and up. If used with [textVariableAnchor], input
  *   values will be taken as absolute values. Offsets along the x- and y-axis will be applied
- *   automatically based on the anchor position.
+ *   automatically based on the anchor position. The expression may use feature properties.
  *
  *   Overridden by [textRadialOffset].
  *
@@ -320,7 +338,7 @@ private fun rememberEmCompiler(textSize: Expression<TextUnitValue>): LayerProper
  *
  * @param textRadialOffset Radial offset of text, in the direction of the symbol's anchor. Useful in
  *   combination with [textVariableAnchor], which defaults to using the two-dimensional [textOffset]
- *   if present.
+ *   if present. The expression may use feature properties.
  *
  *   Ignored if [textField] is not specified.
  *
@@ -328,7 +346,7 @@ private fun rememberEmCompiler(textSize: Expression<TextUnitValue>): LayerProper
  *   map, you can provide an array of [SymbolAnchor] locations, each paired with an offset value.
  *   The renderer will attempt to place the label at each location, in order, before moving on to
  *   the next location+offset. Use [textJustify] = [TextJustify.Auto] to choose justification based
- *   on anchor position.
+ *   on anchor position. The expression may use feature properties.
  *
  * Each anchor location is accompanied by a point which defines the offset when the corresponding
  * anchor location is used. Positive offset values indicate right and down, while negative values


### PR DESCRIPTION
## Description

This documents feature-property and feature-state expression support on each layer composable parameter, clarifies `Feature.state`, and resolves #195.

## Validation

`mise run check` and the full `mise -E android run build:docs` build pass.

## AI assistance

OpenAI Codex with GPT-5.6 Sol and three GPT-5.6 Luna high-reasoning subagents implemented and independently audited the property mappings.