### PR TITLE
Add a drag and drop demo and a px-based positionFromScreenLocation overload

### DIFF
--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/Demo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/Demo.kt
@@ -6,6 +6,7 @@ import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.camera.CameraState
 import org.maplibre.compose.demoapp.demos.CastelloPlanDemo
 import org.maplibre.compose.demoapp.demos.DataVizDemo
+import org.maplibre.compose.demoapp.demos.DragDropDemo
 import org.maplibre.compose.demoapp.demos.LiveTrackingDemo
 import org.maplibre.compose.demoapp.demos.LocationDemo
 import org.maplibre.compose.demoapp.demos.Manhattan3dDemo
@@ -71,6 +72,6 @@ internal expect val extraDemos: List<Demo>
 
 /** Demos appear in the shell in this order. */
 val allDemos: List<Demo> =
-  listOf(Manhattan3dDemo, CastelloPlanDemo, DataVizDemo, LiveTrackingDemo) +
+  listOf(Manhattan3dDemo, CastelloPlanDemo, DataVizDemo, LiveTrackingDemo, DragDropDemo) +
     extraDemos +
     listOf(LocationDemo)

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/DragDropDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/DragDropDemo.kt
@@ -1,0 +1,241 @@
+package org.maplibre.compose.demoapp.demos
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.unit.dp
+import kotlin.math.roundToInt
+import org.maplibre.compose.camera.CameraPosition
+import org.maplibre.compose.camera.CameraState
+import org.maplibre.compose.demoapp.Demo
+import org.maplibre.compose.demoapp.OpenFreeMap
+import org.maplibre.compose.demoapp.design.SegmentedRow
+import org.maplibre.compose.expressions.dsl.const
+import org.maplibre.compose.layers.FillLayer
+import org.maplibre.compose.layers.LineLayer
+import org.maplibre.compose.overlay.MapOverlayScope
+import org.maplibre.compose.sources.GeoJsonData
+import org.maplibre.compose.sources.rememberGeoJsonSource
+import org.maplibre.spatialk.geojson.BoundingBox
+import org.maplibre.spatialk.geojson.Feature
+import org.maplibre.spatialk.geojson.Polygon
+import org.maplibre.spatialk.geojson.Position
+
+private val DragColor = Color(0xFF00695C)
+
+/**
+ * Drags overlay children placed on the map: a location-picker pin, or the two corner handles of a
+ * bounding box. The drag accumulates pointer deltas on the screen offset captured when the drag
+ * started, which keeps the child from jittering under the pointer as it follows the position.
+ */
+object DragDropDemo : Demo {
+  override val name = "Drag & drop"
+  override val description = "Drag a location-picker pin or the corner handles of a bounding box."
+  override val region =
+    BoundingBox(west = -122.3452, south = 47.6155, east = -122.3252, north = 47.6255)
+  override val preferredStyle = OpenFreeMap.Liberty
+  override val showsPointerPin = false
+
+  // A neighborhood zoom gives both modes room to drag in without a detour through the camera.
+  override val camera =
+    CameraPosition(target = Position(longitude = -122.3352, latitude = 47.6205), zoom = 15.0)
+
+  private enum class Mode(val label: String) {
+    Pin("Pin"),
+    BoundingBox("Bounding box"),
+  }
+
+  private var mode by mutableStateOf(Mode.Pin)
+  private var pinPosition by mutableStateOf(Position(longitude = -122.3352, latitude = 47.6205))
+  private var northwest by mutableStateOf(Position(longitude = -122.3377, latitude = 47.6225))
+  private var southeast by mutableStateOf(Position(longitude = -122.3327, latitude = 47.6185))
+
+  /**
+   * Moves the overlay child with the pointer. The screen offset of [position] is captured on drag
+   * start and pointer deltas are accumulated onto it, so the child never has to be read back while
+   * it moves under the pointer. Pointer events report pixels, so the anchor captured from
+   * [CameraState.screenLocationFromPosition] is scaled up before the px-based
+   * [CameraState.positionFromScreenLocation] receives the sum.
+   */
+  private fun Modifier.draggablePosition(
+    cameraState: CameraState,
+    position: () -> Position,
+    onDrag: (Position) -> Unit,
+  ): Modifier =
+    pointerInput(cameraState) {
+      var start: Offset? = null
+      var accumulated = Offset.Zero
+      detectDragGestures(
+        onDragStart = {
+          start =
+            cameraState.screenLocationFromPosition(position())?.let {
+              Offset(it.x.toPx(), it.y.toPx())
+            }
+          accumulated = Offset.Zero
+        },
+        onDrag = onDrag@{ change, dragAmount ->
+            change.consume()
+            val startOffset = start ?: return@onDrag
+            accumulated += dragAmount
+            cameraState.positionFromScreenLocation(startOffset + accumulated)?.let(onDrag)
+          },
+      )
+    }
+
+  /** The box the two handles span, normalized so it stays valid when a handle crosses the other. */
+  private fun boundingBox() =
+    BoundingBox(
+      west = minOf(northwest.longitude, southeast.longitude),
+      south = minOf(northwest.latitude, southeast.latitude),
+      east = maxOf(northwest.longitude, southeast.longitude),
+      north = maxOf(northwest.latitude, southeast.latitude),
+    )
+
+  private fun BoundingBox.toPolygon() =
+    Polygon(
+      listOf(
+        listOf(
+          Position(longitude = west, latitude = north),
+          Position(longitude = east, latitude = north),
+          Position(longitude = east, latitude = south),
+          Position(longitude = west, latitude = south),
+          Position(longitude = west, latitude = north),
+        )
+      )
+    )
+
+  @Composable
+  override fun MapContent(cameraState: CameraState) {
+    if (mode != Mode.BoundingBox) return
+    val source =
+      rememberGeoJsonSource(
+        GeoJsonData.Features(Feature(geometry = boundingBox().toPolygon(), properties = null))
+      )
+    FillLayer(
+      id = "drag-drop-box",
+      source = source,
+      color = const(DragColor),
+      opacity = const(0.2f),
+    )
+    LineLayer(
+      id = "drag-drop-box-outline",
+      source = source,
+      color = const(DragColor),
+      width = const(2.dp),
+    )
+  }
+
+  @Composable
+  override fun MapOverlayScope.Overlay() {
+    when (mode) {
+      Mode.Pin ->
+        Pin(
+          Modifier.placedAt(pinPosition, Alignment.BottomCenter).draggablePosition(
+            cameraState,
+            { pinPosition },
+          ) {
+            pinPosition = it
+          }
+        )
+      Mode.BoundingBox -> {
+        Handle(
+          Modifier.placedAt(northwest).draggablePosition(cameraState, { northwest }) {
+            northwest = it
+          }
+        )
+        Handle(
+          Modifier.placedAt(southeast).draggablePosition(cameraState, { southeast }) {
+            southeast = it
+          }
+        )
+      }
+    }
+  }
+
+  @Composable
+  override fun Panel() {
+    SegmentedRow(
+      label = "Drag",
+      options = Mode.entries,
+      selected = mode,
+      optionLabel = { it.label },
+      onSelect = { mode = it },
+    )
+    Column(Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp)) {
+      when (mode) {
+        Mode.Pin -> {
+          Text("Pin location", style = MaterialTheme.typography.bodyLarge)
+          Text(
+            "lat ${pinPosition.latitude.format(5)}, lng ${pinPosition.longitude.format(5)}",
+            style = MaterialTheme.typography.bodyMedium,
+          )
+        }
+        Mode.BoundingBox -> {
+          val box = boundingBox()
+          Text("Bounding box", style = MaterialTheme.typography.bodyLarge)
+          Text(
+            "north ${box.north.format(5)}, south ${box.south.format(5)}",
+            style = MaterialTheme.typography.bodyMedium,
+          )
+          Text(
+            "west ${box.west.format(5)}, east ${box.east.format(5)}",
+            style = MaterialTheme.typography.bodyMedium,
+          )
+        }
+      }
+    }
+  }
+}
+
+/**
+ * A teardrop pin: a round head over a tip. Placed at [Alignment.BottomCenter], the tip is the
+ * point.
+ */
+@Composable
+private fun Pin(modifier: Modifier = Modifier) {
+  Column(modifier = modifier, horizontalAlignment = Alignment.CenterHorizontally) {
+    Box(
+      Modifier.size(24.dp).background(DragColor, CircleShape).border(2.dp, Color.White, CircleShape)
+    )
+    Canvas(Modifier.size(width = 12.dp, height = 7.dp)) {
+      val tip = Path()
+      tip.moveTo(0f, 0f)
+      tip.lineTo(size.width, 0f)
+      tip.lineTo(size.width / 2, size.height)
+      tip.close()
+      drawPath(tip, DragColor)
+    }
+  }
+}
+
+@Composable
+private fun Handle(modifier: Modifier = Modifier) {
+  Box(
+    modifier.size(20.dp).background(DragColor, CircleShape).border(2.dp, Color.White, CircleShape)
+  )
+}
+
+private fun Double.format(decimals: Int): String {
+  var factor = 1.0
+  repeat(decimals) { factor *= 10 }
+  return ((this * factor).roundToInt() / factor).toString()
+}

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/CameraState.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/CameraState.kt
@@ -5,6 +5,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.DpRect
 import androidx.compose.ui.unit.dp
@@ -54,6 +56,9 @@ public class CameraState(firstPosition: CameraPosition) {
       }
     }
 
+  /** The density of the map composable this state is attached to, or null before composition. */
+  internal var density: Density? = null
+
   /**
    * What the map shows right now: the size of the map composable and the visible area. Null until
    * the map has rendered its first viewport. A composition that reads this property recomposes
@@ -84,6 +89,19 @@ public class CameraState(firstPosition: CameraPosition) {
    */
   public fun positionFromScreenLocation(offset: DpOffset): Position? {
     return map?.positionFromScreenLocation(offset)
+  }
+
+  /**
+   * Returns the position that corresponds to the given [offset] in pixels from the top-left corner
+   * of the map composable, in the units that pointer events report, or null while the map has no
+   * [viewport].
+   *
+   * The answer describes the transform that the map has at the time of the call. To recompose when
+   * the transform changes, read [viewport].
+   */
+  public fun positionFromScreenLocation(offset: Offset): Position? {
+    val density = density ?: return null
+    return positionFromScreenLocation(with(density) { DpOffset(offset.x.toDp(), offset.y.toDp()) })
   }
 
   /**

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MaplibreMap.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MaplibreMap.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.unit.DpOffset
 import co.touchlab.kermit.Logger
@@ -145,6 +146,9 @@ public fun MaplibreMap(
   val styleComposition by rememberStyleComposition(styleState, rememberedStyle, logger, content)
   SideEffect { rememberedStyle?.logger = currentLogger }
   val mapClickScope = rememberCoroutineScope()
+
+  val density = LocalDensity.current
+  SideEffect { cameraState.density = density }
 
   val callbacks =
     remember(cameraState, styleState, styleComposition, mapClickScope) {


### PR DESCRIPTION
## Description

Adds a drag & drop demo (draggable location pin and bounding-box corner handles) and a px-based `CameraState.positionFromScreenLocation(Offset)` overload; resolves #953.

## Validation

Dragged the pin and handles on desktop, web, and iOS; `mise run fix`, `build:desktop-app`, and the JS compile all pass.

## AI assistance

Kimi Code CLI with subagents wrote and verified the code; the human tested the interactions on each platform.