### PR TITLE
Move asymmetric layer property gaps to the style binding

### DIFF
--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/ColorReliefLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/ColorReliefLayer.kt
@@ -30,7 +30,8 @@ import org.maplibre.compose.util.MaplibreComposable
  * @param resampling The resampling/interpolation method to use for overscaling, also known as
  *   texture magnification filter.
  *
- *   **Note**: This property is not supported on native platforms yet.
+ *   **Note**: Ignored with a logged warning on native platforms, which do not implement it yet;
+ *   supported on the web.
  */
 @Composable
 @MaplibreComposable

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/SymbolLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/SymbolLayer.kt
@@ -179,8 +179,9 @@ private fun rememberEmCompiler(textSize: Expression<TextUnitValue>): LayerProper
  *
  *   Ignored if [iconImage] is not specified.
  *
- *   **Note**: This property is not supported on native platforms yet, see
- *   [maplibre-native#251](https://github.com/maplibre/maplibre-native/issues/251)**
+ *   **Note**: Ignored with a logged warning on native platforms, which do not implement it yet
+ *   ([maplibre-native#251](https://github.com/maplibre/maplibre-native/issues/251)); supported on
+ *   the web.
  *
  * @param iconIgnorePlacement If true, other symbols can be visible even if they collide with the
  *   icon.
@@ -374,8 +375,9 @@ private fun rememberEmCompiler(textSize: Expression<TextUnitValue>): LayerProper
  *
  *   Ignored if [textField] is not specified.
  *
- *   **Note**: This property is not supported on native platforms, yet, see
- *   [maplibre-native#251](https://github.com/maplibre/maplibre-native/issues/251)**
+ *   **Note**: Ignored with a logged warning on native platforms, which do not implement it yet
+ *   ([maplibre-native#251](https://github.com/maplibre/maplibre-native/issues/251)); supported on
+ *   the web.
  *
  * @param textIgnorePlacement If true, other symbols can be visible even if they collide with the
  *   text.

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/style/MlnFfiStyleBinding.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/style/MlnFfiStyleBinding.kt
@@ -93,7 +93,25 @@ internal interface MlnFfiStyleBinding : StyleBinding {
     map.styleLayerIds().contains(layerId)
   }
 
+  override fun unsupportedLayerPropertyReason(layerType: String, name: String): String? =
+    UNSUPPORTED_LAYER_PROPERTIES[layerType to name]
+
   companion object {
+    /**
+     * Style-spec properties MapLibre Native does not implement; writing one makes it refuse the
+     * entire layer. Revisit when bumping the maplibre-native-ffi pin.
+     */
+    private val UNSUPPORTED_LAYER_PROPERTIES: Map<Pair<String, String>, String> =
+      mapOf(
+        ("symbol" to "icon-overlap") to
+          "MapLibre Native does not implement it. Use iconAllowOverlap instead; note that it " +
+            "cannot express the 'cooperative' value.",
+        ("symbol" to "text-overlap") to
+          "MapLibre Native does not implement it. Use textAllowOverlap instead; note that it " +
+            "cannot express the 'cooperative' value.",
+        ("color-relief" to "resampling") to "MapLibre Native does not implement it.",
+      )
+
     /** A binding for a descriptor that has never been added to a style. */
     val UNLOADED: MlnFfiStyleBinding =
       object : MlnFfiStyleBinding {

--- a/lib/maplibre-compose/src/nextCommonMain/kotlin/org/maplibre/compose/layers/ColorReliefLayer.kt
+++ b/lib/maplibre-compose/src/nextCommonMain/kotlin/org/maplibre/compose/layers/ColorReliefLayer.kt
@@ -24,12 +24,7 @@ internal actual class ColorReliefLayer actual constructor(id: String, actual val
     setPaintProperty("color-relief-opacity", opacity)
   }
 
-  /** TODO: write this property once MapLibre Native implements `resampling` on color-relief. */
   actual fun setResampling(resampling: CompiledExpression<RasterResampling>) {
-    skipUnsupportedProperty(
-      "resampling",
-      resampling,
-      "MapLibre Native does not implement it on color-relief layers.",
-    )
+    setPaintProperty("resampling", resampling)
   }
 }

--- a/lib/maplibre-compose/src/nextCommonMain/kotlin/org/maplibre/compose/layers/Layer.kt
+++ b/lib/maplibre-compose/src/nextCommonMain/kotlin/org/maplibre/compose/layers/Layer.kt
@@ -106,6 +106,7 @@ internal actual sealed class Layer(actual val id: String) {
    * where an escaping exception would kill the composition. [attach] does throw.
    */
   private fun pushProperty(name: String, value: JsonElement, kind: LayerPropertyKind) {
+    if (recordIfUnsupported(name, value)) return
     try {
       binding.setLayerProperty(id, name, value, kind)
     } catch (error: StyleMutationException) {
@@ -121,8 +122,15 @@ internal actual sealed class Layer(actual val id: String) {
   private val unsupportedProperties = mutableMapOf<String, String>()
 
   /**
-   * Drops a property MapLibre Native will not accept, and says so once; writing it anyway would
-   * make MapLibre refuse the entire layer.
+   * Records a property [binding] will not accept, and says so once when attached; writing it anyway
+   * would make MapLibre refuse the entire layer. A null value asks for nothing and is not reported.
+   *
+   * @return whether the property is unsupported and must not be written.
+   */
+  /**
+   * Drops a value MapLibre will not accept for a property it otherwise supports, and says so once.
+   * Properties an engine lacks outright belong in the binding's
+   * [unsupportedLayerPropertyReason][StyleBinding.unsupportedLayerPropertyReason] table instead.
    *
    * @param value the value that was asked for. A null literal asks for nothing and is not reported.
    */
@@ -136,6 +144,18 @@ internal actual sealed class Layer(actual val id: String) {
     if (isAttached) reportUnsupportedProperty(name, reason)
   }
 
+  private fun recordIfUnsupported(
+    name: String,
+    value: JsonElement,
+    binding: StyleBinding = this.binding,
+  ): Boolean {
+    val reason = binding.unsupportedLayerPropertyReason(type, name) ?: return false
+    if (value is JsonNull) return true
+    if (unsupportedProperties.put(name, reason) != null) return true
+    if (isAttached) reportUnsupportedProperty(name, reason)
+    return true
+  }
+
   private fun reportUnsupportedProperty(name: String, reason: String) {
     binding.logger?.w { "Layer '$id' of type '$type' cannot set '$name': $reason" }
   }
@@ -144,16 +164,21 @@ internal actual sealed class Layer(actual val id: String) {
    * The complete layer object, as the style spec defines it. Null-valued properties are omitted;
    * the spec has no null, and MapLibre rejects the whole layer over one.
    */
-  internal fun toJson(): JsonObject = buildJsonObject {
+  internal fun toJson(binding: StyleBinding = this.binding): JsonObject = buildJsonObject {
+    fun accepted(name: String, value: JsonElement) =
+      value !is JsonNull && binding.unsupportedLayerPropertyReason(type, name) == null
+
     // `id` and `type` first: MapLibre reads the type before the properties that depend on it.
     put("id", id)
     put("type", type)
     sourceId?.let { put("source", it) }
     root.forEach { (key, value) -> if (key in ROOT_KEYS && value !is JsonNull) put(key, value) }
     layout
-      .filterValues { it !is JsonNull }
+      .filterTo(mutableMapOf()) { (key, value) -> accepted(key, value) }
       .let { if (it.isNotEmpty()) put("layout", JsonObject(it)) }
-    paint.filterValues { it !is JsonNull }.let { if (it.isNotEmpty()) put("paint", JsonObject(it)) }
+    paint
+      .filterTo(mutableMapOf()) { (key, value) -> accepted(key, value) }
+      .let { if (it.isNotEmpty()) put("paint", JsonObject(it)) }
   }
 
   /** Adds this layer directly below [beforeLayerId], or on top when that is empty. */
@@ -175,14 +200,17 @@ internal actual sealed class Layer(actual val id: String) {
       "Layer ID '$id' is already owned by a different live layer descriptor; create a separate " +
         "layer instance for each map"
     }
+    // Buffered properties this engine cannot take stay out of the JSON; the drain below says so.
+    layout.forEach { (name, value) -> recordIfUnsupported(name, value, binding) }
+    paint.forEach { (name, value) -> recordIfUnsupported(name, value, binding) }
     val added =
       try {
-        binding.addLayer(toJson(), beforeLayerId)
+        binding.addLayer(toJson(binding), beforeLayerId)
       } catch (error: StyleMutationException) {
         throw IllegalStateException(
           "Could not add layer '$id' of type '$type'" +
             (sourceId?.let { " over source '$it'" } ?: "") +
-            ": ${error.message}. Layer JSON: ${toJson()}",
+            ": ${error.message}. Layer JSON: ${toJson(binding)}",
           error,
         )
       }

--- a/lib/maplibre-compose/src/nextCommonMain/kotlin/org/maplibre/compose/layers/SymbolLayer.kt
+++ b/lib/maplibre-compose/src/nextCommonMain/kotlin/org/maplibre/compose/layers/SymbolLayer.kt
@@ -69,17 +69,8 @@ internal actual class SymbolLayer actual constructor(id: String, source: Source)
     setLayoutProperty("icon-allow-overlap", allowOverlap)
   }
 
-  /**
-   * TODO: write this property once MapLibre Native implements `icon-overlap`, including its
-   *   `cooperative` value, which `icon-allow-overlap` cannot express.
-   */
   actual fun setIconOverlap(overlap: CompiledExpression<StringValue>) {
-    skipUnsupportedProperty(
-      "icon-overlap",
-      overlap,
-      "MapLibre Native does not implement it. Use iconAllowOverlap instead; note that it cannot " +
-        "express the 'cooperative' value.",
-    )
+    setLayoutProperty("icon-overlap", overlap)
   }
 
   actual fun setIconIgnorePlacement(ignorePlacement: CompiledExpression<BooleanValue>) {
@@ -252,14 +243,8 @@ internal actual class SymbolLayer actual constructor(id: String, source: Source)
     setLayoutProperty("text-allow-overlap", allowOverlap)
   }
 
-  /** TODO: write this property once MapLibre Native implements `text-overlap`. */
   actual fun setTextOverlap(overlap: CompiledExpression<SymbolOverlap>) {
-    skipUnsupportedProperty(
-      "text-overlap",
-      overlap,
-      "MapLibre Native does not implement it. Use textAllowOverlap instead; note that it cannot " +
-        "express the 'cooperative' value.",
-    )
+    setLayoutProperty("text-overlap", overlap)
   }
 
   actual fun setTextIgnorePlacement(ignorePlacement: CompiledExpression<BooleanValue>) {

--- a/lib/maplibre-compose/src/nextCommonMain/kotlin/org/maplibre/compose/style/StyleBinding.kt
+++ b/lib/maplibre-compose/src/nextCommonMain/kotlin/org/maplibre/compose/style/StyleBinding.kt
@@ -54,6 +54,13 @@ internal interface StyleBinding {
    */
   fun layerExists(layerId: String): Boolean?
 
+  /**
+   * Why this engine cannot take a layer property, or null when it can. The style spec is shared,
+   * but each engine implements it at its own pace; a non-null reason keeps the property out of
+   * every write to this binding, and the layer reports it once instead.
+   */
+  fun unsupportedLayerPropertyReason(layerType: String, name: String): String? = null
+
   companion object {
     /** A binding for a descriptor that has never been added to a style. */
     val UNLOADED: StyleBinding =

--- a/lib/maplibre-compose/src/nextCommonTest/kotlin/org/maplibre/compose/layers/LayerPropertyRoundTripTest.kt
+++ b/lib/maplibre-compose/src/nextCommonTest/kotlin/org/maplibre/compose/layers/LayerPropertyRoundTripTest.kt
@@ -42,6 +42,7 @@ import org.maplibre.compose.expressions.value.LineJoin
 import org.maplibre.compose.expressions.value.ListValue
 import org.maplibre.compose.expressions.value.RasterResampling
 import org.maplibre.compose.expressions.value.SymbolAnchor
+import org.maplibre.compose.expressions.value.SymbolOverlap
 import org.maplibre.compose.expressions.value.SymbolPlacement
 import org.maplibre.compose.expressions.value.SymbolZOrder
 import org.maplibre.compose.expressions.value.TextJustify
@@ -483,7 +484,17 @@ class LayerPropertyRoundTripTest {
           )
         },
         Case("color-relief-opacity", "0.75") { it.setColorReliefOpacity(const(0.75f).c()) },
-      )
+      ) + glJsOnlyColorReliefCases()
+
+    /** Properties MapLibre GL JS implements and MapLibre Native does not, yet. */
+    fun glJsOnlyColorReliefCases(): List<Case<ColorReliefLayer>> =
+      if (mapLibreFlavor != MapLibreFlavor.GL_JS) emptyList()
+      else
+        listOf(
+          Case("resampling", "\"nearest\"") {
+            it.setResampling(const(RasterResampling.Nearest).c())
+          }
+        )
 
     val SYMBOL_CASES =
       listOf<Case<SymbolLayer>>(
@@ -629,6 +640,17 @@ class LayerPropertyRoundTripTest {
         Case("text-translate-anchor", "\"viewport\"") {
           it.setTextTranslateAnchor(const(TranslateAnchor.Viewport).c())
         },
-      )
+      ) + glJsOnlySymbolCases()
+
+    /** Properties MapLibre GL JS implements and MapLibre Native does not, yet. */
+    fun glJsOnlySymbolCases(): List<Case<SymbolLayer>> =
+      if (mapLibreFlavor != MapLibreFlavor.GL_JS) emptyList()
+      else
+        listOf(
+          Case("icon-overlap", "\"cooperative\"") { it.setIconOverlap(const("cooperative").c()) },
+          Case("text-overlap", "\"cooperative\"") {
+            it.setTextOverlap(const(SymbolOverlap.Cooperative).c())
+          },
+        )
   }
 }


### PR DESCRIPTION
## Description

Each style binding now reports which layer properties its engine lacks, so properties like `icon-overlap`, `text-overlap`, and color-relief `resampling` work on the platforms that implement them instead of being skipped everywhere. Fixes a regression where these were dropped on web too.

## Validation

GL JS-only round-trip test cases added for the three properties; `mise run test:desktop` and `mise run test:js` pass locally.

## AI assistance

Written by Claude Fable 5 via Claude Code.