### PR TITLE
Fix source and layer composition order

### DIFF
--- a/.agents/docs/COMMON_API_GAPS.md
+++ b/.agents/docs/COMMON_API_GAPS.md
@@ -42,17 +42,7 @@ Nothing here is a desktop bug.
 
 Not missing capabilities — shapes in the common layer that the desktop rewrite
 had to work around, and that step 3 is the moment to fix rather than reproduce.
-Both are cross-platform; desktop is only where they became visible.
-
-**A layer reaches the style before its source does.** Compose inserts nodes and
-calls the applier's `onEndChanges`, which is where `LayerManager` reaches
-MapLibre, and only afterwards dispatches remember-observers, where
-`SourceReferenceEffect` lives. So a layer names a source that does not exist
-yet. The mobile SDKs tolerate that; the C API rejects it. Desktop works around
-it by having a layer attach its own source first, with `Source.attach` made
-idempotent so the effect's later add is harmless. The ordering is fragile on
-every platform — only desktop is strict enough to notice — so the workaround
-belongs in the shared layer, or the ordering does.
+The desktop rewrite exposed them.
 
 **Unloading the outgoing style is a contract no platform states.** Switching a
 style has to mark the previous one unloaded, because `LayerManager` skips anchor

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/MapNode.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/MapNode.kt
@@ -10,6 +10,4 @@ internal sealed class MapNode {
   open fun onChildRemoved(oldIndex: Int, node: MapNode) {}
 
   open fun onChildMoved(oldIndex: Int, index: Int, node: MapNode) {}
-
-  open fun onEndChanges() {}
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/MapNodeApplier.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/MapNodeApplier.kt
@@ -2,16 +2,21 @@ package org.maplibre.compose.style
 
 import androidx.compose.runtime.AbstractApplier
 
-internal class MapNodeApplier(root: StyleNode) : AbstractApplier<MapNode>(root) {
+internal class MapNodeApplier(private val styleRoot: StyleNode) :
+  AbstractApplier<MapNode>(styleRoot) {
+  private var hasStructuralChanges = false
+
   override fun insertBottomUp(index: Int, instance: MapNode) {}
 
   override fun insertTopDown(index: Int, instance: MapNode) {
+    hasStructuralChanges = true
     current.allowsChild(instance)
     current.children.add(index, instance)
     current.onChildInserted(index, instance)
   }
 
   override fun move(from: Int, to: Int, count: Int) {
+    hasStructuralChanges = true
     val moved = current.children.slice(from until (from + count))
     current.children.move(from, to, count)
     (if (from < to) (0 until count) else (count - 1 downTo 0)).forEach { i ->
@@ -22,12 +27,15 @@ internal class MapNodeApplier(root: StyleNode) : AbstractApplier<MapNode>(root) 
   override fun onClear() = remove(0, current.children.size)
 
   override fun remove(index: Int, count: Int) {
+    hasStructuralChanges = true
     val removed = current.children.slice(index until (index + count))
     current.children.remove(index, count)
     removed.forEach { instance -> current.onChildRemoved(index, instance) }
   }
 
   override fun onEndChanges() {
-    root.onEndChanges()
+    if (!hasStructuralChanges) return
+    hasStructuralChanges = false
+    styleRoot.scheduleApplyChanges()
   }
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleNode.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleNode.kt
@@ -1,5 +1,8 @@
 package org.maplibre.compose.style
 
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.setValue
 import co.touchlab.kermit.Logger
 
 internal class StyleNode(var style: SafeStyle, logger: Logger?) : MapNode() {
@@ -16,6 +19,17 @@ internal class StyleNode(var style: SafeStyle, logger: Logger?) : MapNode() {
   internal val sourceManager = SourceManager(this)
   internal val layerManager = LayerManager(this)
   internal val imageManager = ImageManager(this)
+
+  // A nested content scope can recompose without its StyleContent parent. This state invalidates
+  // that parent after a structural change so it records the post-observer layer-application effect.
+  private var applyGeneration by mutableIntStateOf(0)
+
+  internal val currentApplyGeneration: Int
+    get() = applyGeneration
+
+  internal fun scheduleApplyChanges() {
+    applyGeneration++
+  }
 
   override fun allowsChild(node: MapNode) = node is LayerNode<*>
 
@@ -34,9 +48,5 @@ internal class StyleNode(var style: SafeStyle, logger: Logger?) : MapNode() {
     layerManager.moveLayer(node, oldIndex, index)
   }
 
-  override fun onEndChanges() {
-    // Only layers: sources are referenced and released from a DisposableEffect, which Compose
-    // dispatches after this hook, so applying them here would always be a frame early.
-    layerManager.applyChanges()
-  }
+  internal fun applyChanges() = layerManager.applyChanges()
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/rememberStyleComposition.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/rememberStyleComposition.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.State
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCompositionContext
@@ -37,9 +38,7 @@ internal fun rememberStyleComposition(
     styleState.attach(rootNode)
     val composition = Composition(MapNodeApplier(rootNode), compositionContext)
 
-    composition.setContent {
-      CompositionLocalProvider(LocalStyleNode provides rootNode) { content() }
-    }
+    composition.setContent { StyleContent(rootNode, content) }
 
     try {
       awaitCancellation()
@@ -52,6 +51,18 @@ internal fun rememberStyleComposition(
   SideEffect { nodeState.value?.logger = logger }
 
   return nodeState
+}
+
+@Composable
+internal fun StyleContent(
+  rootNode: StyleNode,
+  content: @Composable @MaplibreComposable () -> Unit,
+) {
+  CompositionLocalProvider(LocalStyleNode provides rootNode) { content() }
+  key(rootNode.currentApplyGeneration) {
+    // Side effects run after remember observers, so source effects attach before layers do.
+    SideEffect { rootNode.applyChanges() }
+  }
 }
 
 internal val LocalStyleNode = staticCompositionLocalOf<StyleNode> { throw IllegalStateException() }

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/style/StyleNodeTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/style/StyleNodeTest.kt
@@ -67,7 +67,7 @@ abstract class StyleNodeTest {
       val newSource =
         GeoJsonSource("new", GeoJsonData.Features(featureCollectionOf()), GeoJsonOptions())
       s.sourceManager.addReference(newSource)
-      s.onEndChanges()
+      s.applyChanges()
       assertEquals(4, s.style.getSources().size)
       assertEquals(newSource, s.style.getSource("new"))
     }
@@ -80,7 +80,7 @@ abstract class StyleNodeTest {
       val newSource =
         GeoJsonSource("new", GeoJsonData.Features(featureCollectionOf()), GeoJsonOptions())
       s.sourceManager.addReference(newSource)
-      s.onEndChanges()
+      s.applyChanges()
       s.sourceManager.removeReference(newSource)
       assertEquals(3, s.style.getSources().size)
       assertNull(s.style.getSource("new"))
@@ -190,7 +190,7 @@ abstract class StyleNodeTest {
       val s = makeStyleNode()
       val nodes = (0..2).map { LayerNode(LineLayer("new$it", testSources[0]), Anchor.Top) }
       nodes.forEachIndexed { i, node -> s.layerManager.addLayer(node, i) }
-      s.onEndChanges()
+      s.applyChanges()
       assertEquals(
         listOf("foo", "bar", "baz", "new0", "new1", "new2"),
         s.style.getLayers().map(Layer::id),
@@ -204,7 +204,7 @@ abstract class StyleNodeTest {
       val s = makeStyleNode()
       val nodes = (0..2).map { LayerNode(LineLayer("new$it", testSources[0]), Anchor.Bottom) }
       nodes.forEachIndexed { i, node -> s.layerManager.addLayer(node, i) }
-      s.onEndChanges()
+      s.applyChanges()
       assertEquals(
         listOf("new0", "new1", "new2", "foo", "bar", "baz"),
         s.style.getLayers().map(Layer::id),
@@ -218,7 +218,7 @@ abstract class StyleNodeTest {
       val s = makeStyleNode()
       val nodes = (0..2).map { LayerNode(LineLayer("new$it", testSources[0]), Anchor.Above("foo")) }
       nodes.forEachIndexed { i, node -> s.layerManager.addLayer(node, i) }
-      s.onEndChanges()
+      s.applyChanges()
       assertEquals(
         listOf("foo", "new0", "new1", "new2", "bar", "baz"),
         s.style.getLayers().map(Layer::id),
@@ -232,7 +232,7 @@ abstract class StyleNodeTest {
       val s = makeStyleNode()
       val nodes = (0..2).map { LayerNode(LineLayer("new$it", testSources[0]), Anchor.Below("baz")) }
       nodes.forEachIndexed { i, node -> s.layerManager.addLayer(node, i) }
-      s.onEndChanges()
+      s.applyChanges()
       assertEquals(
         listOf("foo", "bar", "new0", "new1", "new2", "baz"),
         s.style.getLayers().map(Layer::id),
@@ -247,7 +247,7 @@ abstract class StyleNodeTest {
       val nodes =
         (0..2).map { LayerNode(LineLayer("new$it", testSources[0]), Anchor.Replace("bar")) }
       nodes.forEachIndexed { i, node -> s.layerManager.addLayer(node, i) }
-      s.onEndChanges()
+      s.applyChanges()
       assertEquals(listOf("foo", "new0", "new1", "new2", "baz"), s.style.getLayers().map(Layer::id))
     }
   }
@@ -260,12 +260,12 @@ abstract class StyleNodeTest {
         (0..2).map { LayerNode(LineLayer("new$it", testSources[0]), Anchor.Replace("bar")) }
 
       nodes.forEachIndexed { i, node -> s.layerManager.addLayer(node, i) }
-      s.onEndChanges()
+      s.applyChanges()
 
       assertEquals(listOf("foo", "new0", "new1", "new2", "baz"), s.style.getLayers().map(Layer::id))
 
       nodes.forEach { node -> s.layerManager.removeLayer(node, 0) }
-      s.onEndChanges()
+      s.applyChanges()
 
       assertEquals(listOf("foo", "bar", "baz"), s.style.getLayers().map(Layer::id))
     }
@@ -279,12 +279,12 @@ abstract class StyleNodeTest {
       val newNode = LayerNode(LineLayer("new", testSources[0]), Anchor.Replace("bar"))
 
       s.layerManager.addLayer(oldNode, 0)
-      s.onEndChanges()
+      s.applyChanges()
       s.style.unload()
 
       s.layerManager.addLayer(newNode, 0)
       s.layerManager.removeLayer(oldNode, 1)
-      s.onEndChanges()
+      s.applyChanges()
       s.layerManager.removeLayer(newNode, 0)
     }
   }
@@ -297,13 +297,13 @@ abstract class StyleNodeTest {
       val l2 = LayerNode(LineLayer("new", testSources[1]), Anchor.Top)
 
       s.layerManager.addLayer(l1, 0)
-      s.onEndChanges()
+      s.applyChanges()
 
       assertEquals(l1.layer, s.style.getLayer("new"))
 
       s.layerManager.addLayer(l2, 0)
       s.layerManager.removeLayer(l1, 1)
-      s.onEndChanges()
+      s.applyChanges()
 
       assertEquals(l2.layer, s.style.getLayer("new"))
     }
@@ -316,13 +316,13 @@ abstract class StyleNodeTest {
 
       s.layerManager.addLayer(LayerNode(LineLayer("b1", testSources[0]), Anchor.Bottom), 0)
       s.layerManager.addLayer(LayerNode(LineLayer("t1", testSources[0]), Anchor.Top), 0)
-      s.onEndChanges()
+      s.applyChanges()
 
       assertEquals(listOf("b1", "foo", "bar", "baz", "t1"), s.style.getLayers().map(Layer::id))
 
       s.layerManager.addLayer(LayerNode(LineLayer("b2", testSources[0]), Anchor.Bottom), 0)
       s.layerManager.addLayer(LayerNode(LineLayer("t2", testSources[0]), Anchor.Top), 0)
-      s.onEndChanges()
+      s.applyChanges()
 
       assertEquals(
         listOf("b2", "b1", "foo", "bar", "baz", "t2", "t1"),

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/style/GlJsStyleBinding.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/style/GlJsStyleBinding.kt
@@ -12,7 +12,6 @@ import org.maplibre.compose.gljs.MaplibreMap
 import org.maplibre.compose.gljs.SourceHandle
 import org.maplibre.compose.gljs.SourceSpecification
 import org.maplibre.compose.gljs.subscribe
-import org.maplibre.compose.sources.Source
 import org.maplibre.compose.util.toJsValue
 import org.maplibre.compose.util.toJsonElement
 
@@ -42,10 +41,6 @@ internal class GlJsStyleBinding(private val map: MaplibreMap, override val logge
     if (!loaded) return
     loaded = false
     errors.cancel()
-  }
-
-  override fun attachSource(source: Source) {
-    source.attach(this)
   }
 
   fun addSource(id: String, definition: JsonObject) {

--- a/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/style/MlnFfiStyleBinding.kt
+++ b/lib/maplibre-compose/src/mlnFfiShared/kotlin/org/maplibre/compose/style/MlnFfiStyleBinding.kt
@@ -4,7 +4,6 @@ import co.touchlab.kermit.Logger
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import org.maplibre.compose.sources.MlnFfiFeatureStateStore
-import org.maplibre.compose.sources.Source
 import org.maplibre.compose.util.toJsonBytes
 import org.maplibre.compose.util.toJsonElement
 import org.maplibre.nativeffi.error.MaplibreException
@@ -43,10 +42,6 @@ internal interface MlnFfiStyleBinding : StyleBinding {
    * waiting for idle. Call only from the owner thread, after the native add or remove.
    */
   fun reportSourceChanged(sourceId: String) {}
-
-  override fun attachSource(source: Source) {
-    source.attach(this)
-  }
 
   override fun addLayer(layer: JsonObject, beforeLayerId: String): Boolean =
     mutateMap { map ->

--- a/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/sources/TiledSourceAttachTest.kt
+++ b/lib/maplibre-compose/src/mlnFfiSharedTest/kotlin/org/maplibre/compose/sources/TiledSourceAttachTest.kt
@@ -42,7 +42,7 @@ class TiledSourceAttachTest {
       style.addSource(fromUrl)
 
       val layer = RasterLayer("raster", fromTiles)
-      // The layer must attach a fresh source before MapLibre validates the layer JSON.
+      style.addSource(fromTiles)
       style.addLayer(layer)
 
       layer.onMap { map ->
@@ -75,6 +75,7 @@ class TiledSourceAttachTest {
       style.addSource(fromUrl)
 
       val layer = HillshadeLayer("hillshade", fromTiles)
+      style.addSource(fromTiles)
       style.addLayer(layer)
 
       layer.onMap { map ->

--- a/lib/maplibre-compose/src/nextCommonMain/kotlin/org/maplibre/compose/layers/ColorReliefLayer.kt
+++ b/lib/maplibre-compose/src/nextCommonMain/kotlin/org/maplibre/compose/layers/ColorReliefLayer.kt
@@ -13,9 +13,6 @@ internal actual class ColorReliefLayer actual constructor(id: String, actual val
 
   override val sourceId: String = source.id
 
-  override val sourceDescriptor: Source
-    get() = source
-
   actual fun setColorReliefColor(color: CompiledExpression<ColorValue>) {
     setPaintProperty("color-relief-color", color)
   }

--- a/lib/maplibre-compose/src/nextCommonMain/kotlin/org/maplibre/compose/layers/FeatureLayer.kt
+++ b/lib/maplibre-compose/src/nextCommonMain/kotlin/org/maplibre/compose/layers/FeatureLayer.kt
@@ -10,9 +10,6 @@ internal actual sealed class FeatureLayer(id: String, actual val source: Source)
   override val sourceId: String
     get() = source.id
 
-  override val sourceDescriptor: Source
-    get() = source
-
   actual abstract var sourceLayer: String
 
   actual abstract fun setFilter(filter: CompiledExpression<BooleanValue>)

--- a/lib/maplibre-compose/src/nextCommonMain/kotlin/org/maplibre/compose/layers/HillshadeLayer.kt
+++ b/lib/maplibre-compose/src/nextCommonMain/kotlin/org/maplibre/compose/layers/HillshadeLayer.kt
@@ -13,9 +13,6 @@ internal actual class HillshadeLayer actual constructor(id: String, actual val s
 
   override val sourceId: String = source.id
 
-  override val sourceDescriptor: Source
-    get() = source
-
   actual fun setHillshadeIlluminationDirection(direction: CompiledExpression<FloatValue>) {
     setPaintProperty("hillshade-illumination-direction", direction)
   }

--- a/lib/maplibre-compose/src/nextCommonMain/kotlin/org/maplibre/compose/layers/Layer.kt
+++ b/lib/maplibre-compose/src/nextCommonMain/kotlin/org/maplibre/compose/layers/Layer.kt
@@ -26,9 +26,6 @@ internal actual sealed class Layer(actual val id: String) {
   /** The source this layer draws from, or null for layers that have none, such as background. */
   protected open val sourceId: String? = null
 
-  internal open val sourceDescriptor: org.maplibre.compose.sources.Source?
-    get() = null
-
   private val layout = mutableMapOf<String, JsonElement>()
   private val paint = mutableMapOf<String, JsonElement>()
   private val root = mutableMapOf<String, JsonElement>()
@@ -187,9 +184,6 @@ internal actual sealed class Layer(actual val id: String) {
       "Layer '$id' already belongs to another loaded style; create a separate layer instance for " +
         "each map"
     }
-    // The source's own effect has not run yet on a fresh style composition, and MapLibre rejects a
-    // layer naming a source that does not exist.
-    sourceDescriptor?.let { binding.attachSource(it) }
     // A duplicate ID fails here, on the caller, with the message that names the cause; the add
     // itself would fail too, but with MapLibre's generic refusal. A same-binding re-attach is
     // idempotent: the layer is already in this style. Null means the check could not run; the add

--- a/lib/maplibre-compose/src/nextCommonMain/kotlin/org/maplibre/compose/layers/RasterLayer.kt
+++ b/lib/maplibre-compose/src/nextCommonMain/kotlin/org/maplibre/compose/layers/RasterLayer.kt
@@ -13,9 +13,6 @@ internal actual class RasterLayer actual constructor(id: String, actual val sour
 
   override val sourceId: String = source.id
 
-  override val sourceDescriptor: Source
-    get() = source
-
   actual fun setRasterOpacity(opacity: CompiledExpression<FloatValue>) {
     setPaintProperty("raster-opacity", opacity)
   }

--- a/lib/maplibre-compose/src/nextCommonMain/kotlin/org/maplibre/compose/style/StyleBinding.kt
+++ b/lib/maplibre-compose/src/nextCommonMain/kotlin/org/maplibre/compose/style/StyleBinding.kt
@@ -3,7 +3,6 @@ package org.maplibre.compose.style
 import co.touchlab.kermit.Logger
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
-import org.maplibre.compose.sources.Source
 
 /**
  * A layer's connection to its live style, as a layer ID and style-spec JSON. A binding stops
@@ -14,9 +13,6 @@ internal interface StyleBinding {
   val isLoaded: Boolean
 
   val logger: Logger?
-
-  /** Adds [source] unless it is already here, reporting its errors as this binding's own. */
-  fun attachSource(source: Source)
 
   /**
    * Adds a complete layer object directly below [beforeLayerId], or on top when that is empty.
@@ -68,8 +64,6 @@ internal interface StyleBinding {
         override val isLoaded: Boolean = false
 
         override val logger: Logger? = null
-
-        override fun attachSource(source: Source) = Unit
 
         override fun addLayer(layer: JsonObject, beforeLayerId: String): Boolean = false
 

--- a/lib/maplibre-compose/src/nextCommonTest/kotlin/org/maplibre/compose/style/StyleCompositionOrderTest.kt
+++ b/lib/maplibre-compose/src/nextCommonTest/kotlin/org/maplibre/compose/style/StyleCompositionOrderTest.kt
@@ -1,0 +1,76 @@
+package org.maplibre.compose.style
+
+import androidx.compose.runtime.BroadcastFrameClock
+import androidx.compose.runtime.Composition
+import androidx.compose.runtime.withRunningRecomposer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.yield
+import org.maplibre.compose.layers.FillLayer
+import org.maplibre.compose.layers.Layer
+import org.maplibre.compose.layers.LayerNode as ComposeLayerNode
+import org.maplibre.compose.sources.GeoJsonData
+import org.maplibre.compose.sources.GeoJsonOptions
+import org.maplibre.compose.sources.GeoJsonSource
+import org.maplibre.compose.sources.Source
+import org.maplibre.compose.sources.SourceReferenceEffect
+import org.maplibre.spatialk.geojson.dsl.featureCollectionOf
+
+class StyleCompositionOrderTest {
+
+  @Test
+  fun a_source_reaches_the_style_before_its_layer() = runTest {
+    val frameClock = BroadcastFrameClock()
+    withContext(frameClock) {
+      withRunningRecomposer { recomposer ->
+        val style = SourceBeforeLayerStyle()
+        val rootNode = StyleNode(SafeStyle(style), logger = null)
+        val source =
+          GeoJsonSource(
+            "composed-source",
+            GeoJsonData.Features(featureCollectionOf()),
+            GeoJsonOptions(),
+          )
+        val composition = Composition(MapNodeApplier(rootNode), recomposer)
+        try {
+          composition.setContent {
+            StyleContent(rootNode) {
+              SourceReferenceEffect(source)
+              ComposeLayerNode(
+                factory = { FillLayer("composed-layer", source) },
+                update = {},
+                onClick = null,
+                onLongClick = null,
+              )
+            }
+          }
+          while (!frameClock.hasAwaiters) yield()
+          frameClock.sendFrame(0)
+          yield()
+          recomposer.awaitIdle()
+          assertEquals(listOf("source:composed-source", "layer:composed-layer"), style.additions)
+        } finally {
+          composition.dispose()
+        }
+      }
+    }
+  }
+
+  private class SourceBeforeLayerStyle(
+    private val delegate: Style = FakeStyle(emptyList(), emptyList(), emptyList())
+  ) : Style by delegate {
+    val additions = mutableListOf<String>()
+
+    override fun addSource(source: Source) {
+      delegate.addSource(source)
+      additions += "source:${source.id}"
+    }
+
+    override fun addLayer(layer: Layer) {
+      delegate.addLayer(layer)
+      additions += "layer:${layer.id}"
+    }
+  }
+}

--- a/lib/maplibre-compose/src/nextCommonTest/kotlin/org/maplibre/compose/style/StyleOwnershipTest.kt
+++ b/lib/maplibre-compose/src/nextCommonTest/kotlin/org/maplibre/compose/style/StyleOwnershipTest.kt
@@ -129,23 +129,6 @@ class StyleOwnershipTest {
   }
 
   @Test
-  fun layer_before_source_attachment_is_idempotent_for_the_same_descriptor(): MapTestResult =
-    runMapTest {
-      createMapFixture().use { fixture ->
-        fixture.loadStyle(BaseStyle.Empty)
-        val style = requireNotNull(fixture.style)
-        val source = emptySource("layer-first-source")
-        val layer = FillLayer("layer-first", source)
-
-        style.addLayer(layer)
-        style.addSource(source)
-
-        assertNotNull(style.getSource(source.id))
-        assertNotNull(style.getLayer(layer.id))
-      }
-    }
-
-  @Test
   fun a_layer_can_use_a_source_read_from_the_base_style(): MapTestResult = runMapTest {
     createMapFixture().use { fixture ->
       fixture.loadStyle(BASE_SOURCE_STYLE)


### PR DESCRIPTION
## Description

Schedule layer application after Compose remember observers so sources reach the style first, remove the eager source-attachment workaround, and cover the order with a regression test.

## Validation

Passed `mise run test:desktop` and `mise run check` after rebasing, and passed `mise run test:android` and `mise run test:ios` before the clean rebase; `mise run test:js` compiled but Chrome was unavailable.

## AI assistance

OpenAI Codex with GPT-5 assisted with implementation, testing, and pull request preparation.