### PR TITLE
Provision Chromium for browser tests

### DIFF
--- a/demo-app/common/karma.config.d/ci.js
+++ b/demo-app/common/karma.config.d/ci.js
@@ -1,0 +1,10 @@
+// The CI runner is an isolated VM, so its launcher disables Chromium's unavailable sandbox.
+if (process.env.CI && process.platform === "linux") {
+  config.customLaunchers = {
+    ChromeHeadlessCI: {
+      base: "ChromeHeadless",
+      flags: ["--no-sandbox"],
+    },
+  };
+  config.browsers = ["ChromeHeadlessCI"];
+}

--- a/mise.lock
+++ b/mise.lock
@@ -299,6 +299,10 @@ url = "https://nodejs.org/dist/v24.19.0/node-v24.19.0-win-arm64.zip"
 checksum = "sha256:57f71ab3652e797d84acddc79c81cc9ff1c6ddb2a1974cdb83f00fee9bff4c73"
 url = "https://nodejs.org/dist/v24.19.0/node-v24.19.0-win-x64.zip"
 
+[[tools."npm:playwright"]]
+version = "1.62.1"
+backend = "npm:playwright"
+
 [[tools.python]]
 version = "3.14.7"
 backend = "core:python"

--- a/mise.toml
+++ b/mise.toml
@@ -39,6 +39,7 @@ java_version = "zulu-25.36.15.0"
 jvl_version = "2026.05.03"
 ktfmt_version = "0.64"
 node_version = "24.19.0"
+playwright_version = "1.62.1"
 pnpm_version = "10.33.2"
 python_version = "3.14.7"
 ruff_version = "0.16.2"
@@ -148,7 +149,16 @@ udid="$(.mise/bin/boot-ios-simulator)"
 
 [tasks."test:js"]
 description = "Run the Kotlin/JS browser test suite."
+depends = ["install:chromium"]
+tools = { "npm:playwright" = "{{vars.playwright_version}}" }
+env = { PLAYWRIGHT_BROWSERS_PATH = "0", CHROME_BIN = '''{{ exec(command="node -e 'console.log(require(process.argv[1]).chromium.executablePath())' \"" ~ tools.playwright.path ~ "/node_modules/playwright\"") }}''' }
 run = "./gradlew jsBrowserTest"
+
+[tasks."install:chromium"]
+hide = true
+tools = { "npm:playwright" = "{{vars.playwright_version}}" }
+env = { PLAYWRIGHT_BROWSERS_PATH = "0" }
+run = "playwright install chromium --no-shell"
 
 [tasks."test:desktop"]
 description = "Run the desktop (JVM) test suite against a real Vulkan or Metal device."

--- a/mise.toml
+++ b/mise.toml
@@ -61,6 +61,7 @@ xcodes_version = "2.0.3"
 # For tooling outside Gradle; Kotlin/JS brings its own Node and Yarn.
 "core:node" = "{{vars.node_version}}"
 "aqua:pnpm/pnpm" = "{{vars.pnpm_version}}"
+"npm:playwright" = "{{vars.playwright_version}}"
 
 # Runs the Python file tasks under .mise/tasks/.
 "core:python" = "{{vars.python_version}}"
@@ -72,11 +73,21 @@ swiftformat = { version = "{{vars.swiftformat_version}}", backend = "github:nick
 # The CLI only. Xcode itself comes from `mise run install-xcode`.
 "aqua:XcodesOrg/xcodes" = { version = "{{vars.xcodes_version}}", os = ["macos"] }
 
+[env]
+PLAYWRIGHT_BROWSERS_PATH = "{{ config_root }}/.cache/playwright"
+CHROME_BIN = { value = '''{{ exec(command="node -e 'console.log(require(process.argv[1]).chromium.executablePath())' \"" ~ tools.playwright.path ~ "/node_modules/playwright\"") }}''', tools = true }
+
 [hooks]
 postinstall = ["hk install --mise --quiet"]
 
 [deps.pnpm]
 auto = true
+
+[deps.chromium]
+auto = true
+sources = ["mise.lock"]
+outputs = [".cache/playwright/chromium-*"]
+run = "playwright install chromium --no-shell"
 
 [tasks.check]
 description = "Run every formatter and linter in report-only mode."
@@ -149,16 +160,7 @@ udid="$(.mise/bin/boot-ios-simulator)"
 
 [tasks."test:js"]
 description = "Run the Kotlin/JS browser test suite."
-depends = ["install:chromium"]
-tools = { "npm:playwright" = "{{vars.playwright_version}}" }
-env = { PLAYWRIGHT_BROWSERS_PATH = "0", CHROME_BIN = '''{{ exec(command="node -e 'console.log(require(process.argv[1]).chromium.executablePath())' \"" ~ tools.playwright.path ~ "/node_modules/playwright\"") }}''' }
 run = "./gradlew jsBrowserTest"
-
-[tasks."install:chromium"]
-hide = true
-tools = { "npm:playwright" = "{{vars.playwright_version}}" }
-env = { PLAYWRIGHT_BROWSERS_PATH = "0" }
-run = "playwright install chromium --no-shell"
 
 [tasks."test:desktop"]
 description = "Run the desktop (JVM) test suite against a real Vulkan or Metal device."

--- a/mise.toml
+++ b/mise.toml
@@ -75,7 +75,7 @@ swiftformat = { version = "{{vars.swiftformat_version}}", backend = "github:nick
 
 [env]
 PLAYWRIGHT_BROWSERS_PATH = "{{ config_root }}/.cache/playwright"
-CHROME_BIN = { value = '''{{ exec(command="node -e 'console.log(require(process.argv[1]).chromium.executablePath())' \"" ~ tools.playwright.path ~ "/node_modules/playwright\"") }}''', tools = true }
+CHROME_BIN = { value = '''{{ exec(command="node -e \"console.log(require(process.argv[1]).chromium.executablePath())\" \"" ~ tools.playwright.path ~ "/node_modules/playwright\"") }}''', tools = true }
 
 [hooks]
 postinstall = ["hk install --mise --quiet"]


### PR DESCRIPTION
## Description

Provision pinned Playwright Chromium as an automatic mise dependency, export its executable to Karma, and disable its unavailable sandbox only on Linux CI.

## Validation

Ran `caffeinate -dimsu mise run test:js -- --rerun-tasks` on macOS arm64, verified the dependency transition and browser executable, and ran `HK_FIX=0 mise exec -- hk check --no-stage mise.toml mise.lock demo-app/common/karma.config.d/ci.js` plus `git diff --check`.

## AI assistance

OpenAI Codex (GPT-5) implemented and validated the change.
