### PR TITLE
Align desktop GLFW LWJGL dependencies

### DIFF
--- a/demo-app/desktop-glfw/build.gradle.kts
+++ b/demo-app/desktop-glfw/build.gradle.kts
@@ -17,6 +17,7 @@ kotlin {
 dependencies {
   implementation(project(":demo-app:common"))
   implementation(project(":lib:maplibre-compose"))
+  implementation(platform(libs.lwjgl.bom))
   implementation(libs.composeGlfw)
 
   runtimeOnly(desktopHostPlatform.composeGlfwRuntimeDependency(libs.versions.composeGlfw.get()))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -95,6 +95,7 @@ maplibre-nativeFfi-runtimeMetal = { module = "org.maplibre.nativeffi:maplibre-na
 maplibre-nativeFfi-runtimeMetalKmp = { module = "org.maplibre.nativeffi:maplibre-native-ffi-runtime-metal", version.ref = "maplibre-nativeFfi" }
 maplibre-nativeFfi-runtimeOpenGl = { module = "org.maplibre.nativeffi:maplibre-native-ffi-runtime-opengl", version.ref = "maplibre-nativeFfi" }
 maplibre-nativeFfi-runtimeVulkan = { module = "org.maplibre.nativeffi:maplibre-native-ffi-runtime-vulkan-jvm", version.ref = "maplibre-nativeFfi" }
+lwjgl-bom = { module = "org.lwjgl:lwjgl-bom", version.ref = "lwjgl" }
 lwjgl-core = { module = "org.lwjgl:lwjgl", version.ref = "lwjgl" }
 lwjgl-egl = { module = "org.lwjgl:lwjgl-egl", version.ref = "lwjgl" }
 lwjgl-opengl = { module = "org.lwjgl:lwjgl-opengl", version.ref = "lwjgl" }


### PR DESCRIPTION
## Description

Align the desktop GLFW demo on LWJGL 3.4.2 through the shared BOM so compose-glfw cannot introduce incompatible LWJGL module versions at runtime.

## Validation

Verified on macOS ARM64 with mise run check, Gradle dependency insight, and mise run demo:desktop-glfw, which launched the distributable and rendered the first Metal map frame.

## AI assistance

OpenAI Codex using GPT-5 assisted with diagnosis, implementation, and validation.