### PR TITLE
Discover the gms location as default android backend when available

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,9 +139,9 @@ rendering interactive maps across Android, iOS, Desktop, and Web platforms.
   - `maplibre-compose`: Main map composables and core functionality
   - `maplibre-compose-material3`: Material 3 themed UI components
   - `location`: Location and orientation providers, usable without a map
-  - `location-runtime-gms`: Google Play Services location providers
-  - `location-runtime-linux|macos|windows`: Desktop location backends, loaded
-    through `ServiceLoader`
+  - `location-runtime-gms|linux|macos|windows`: Location backends that
+    `ServiceLoader` discovers; gms upgrades the Android defaults to Google Play
+    services, and the desktop backends supply the only desktop implementations
 - **`demo-app/`**: Multiplatform demo application
   - `common`: Every line of the app, and the only Kotlin Multiplatform module
   - `android`: An Android application that launches `common`

--- a/demo-app/common/src/androidMain/kotlin/org/maplibre/compose/demoapp/demos/LocationEngine.android.kt
+++ b/demo-app/common/src/androidMain/kotlin/org/maplibre/compose/demoapp/demos/LocationEngine.android.kt
@@ -1,23 +1,37 @@
 package org.maplibre.compose.demoapp.demos
 
 import androidx.compose.runtime.Composable
-import org.maplibre.compose.demoapp.design.SwitchRow
+import kotlin.time.Duration.Companion.seconds
 import org.maplibre.compose.gms.rememberFusedLocationProvider
 import org.maplibre.compose.gms.rememberFusedOrientationProvider
 import org.maplibre.compose.location.LocationProvider
 import org.maplibre.compose.location.OrientationProvider
-import org.maplibre.compose.location.rememberDefaultLocationProvider
-import org.maplibre.compose.location.rememberDefaultOrientationProvider
+import org.maplibre.compose.location.rememberAndroidLocationProvider
+import org.maplibre.compose.location.rememberAndroidOrientationProvider
 
-@Composable
-internal actual fun rememberDemoLocationProvider(usePlayServices: Boolean): LocationProvider =
-  if (usePlayServices) rememberFusedLocationProvider() else rememberDefaultLocationProvider()
+/** The Google Play Services fused providers, regardless of backend discovery. */
+private object FusedLocationEngine : DemoLocationEngine {
+  override val label = "Fused"
 
-@Composable
-internal actual fun rememberDemoOrientationProvider(usePlayServices: Boolean): OrientationProvider =
-  if (usePlayServices) rememberFusedOrientationProvider() else rememberDefaultOrientationProvider()
+  @Composable
+  override fun rememberLocationProvider(): LocationProvider = rememberFusedLocationProvider()
 
-@Composable
-internal actual fun LocationEngineRow(usePlayServices: Boolean, onChange: (Boolean) -> Unit) {
-  SwitchRow("Google Play Services", usePlayServices, onChange)
+  @Composable
+  override fun rememberOrientationProvider(): OrientationProvider =
+    rememberFusedOrientationProvider()
 }
+
+/** The Android framework providers, regardless of backend discovery. */
+private object FrameworkLocationEngine : DemoLocationEngine {
+  override val label = "Framework"
+
+  @Composable
+  override fun rememberLocationProvider(): LocationProvider = rememberAndroidLocationProvider()
+
+  @Composable
+  override fun rememberOrientationProvider(): OrientationProvider =
+    rememberAndroidOrientationProvider(updateInterval = 1.seconds)
+}
+
+internal actual val demoLocationEngines: List<DemoLocationEngine> =
+  listOf(DefaultLocationEngine, FusedLocationEngine, FrameworkLocationEngine)

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/LocationDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/LocationDemo.kt
@@ -18,6 +18,7 @@ import org.maplibre.compose.camera.CameraState
 import org.maplibre.compose.demoapp.Demo
 import org.maplibre.compose.demoapp.DemoFlightDuration
 import org.maplibre.compose.demoapp.OpenFreeMap
+import org.maplibre.compose.demoapp.design.SegmentedRow
 import org.maplibre.compose.demoapp.design.SwitchRow
 import org.maplibre.compose.location.LocationPuck
 import org.maplibre.compose.location.LocationState
@@ -53,7 +54,7 @@ object LocationDemo : Demo {
     }
 
   private var follow by mutableStateOf(true)
-  private var usePlayServices by mutableStateOf(true)
+  private var engine by mutableStateOf(demoLocationEngines.first())
   private var useNativeIndicator by mutableStateOf(false)
   private var lastFix by mutableStateOf<Position?>(null)
   private var panelLocationState by mutableStateOf<LocationState?>(null)
@@ -62,8 +63,8 @@ object LocationDemo : Demo {
   override fun MapContent(cameraState: CameraState) {
     val locationState =
       rememberLocationState(
-        provider = rememberDemoLocationProvider(usePlayServices),
-        orientationProvider = rememberDemoOrientationProvider(usePlayServices),
+        provider = engine.rememberLocationProvider(),
+        orientationProvider = engine.rememberOrientationProvider(),
       )
     DisposableEffect(locationState) {
       panelLocationState = locationState
@@ -122,7 +123,15 @@ object LocationDemo : Demo {
     if (isNativeLocationIndicatorAvailable) {
       SwitchRow("Native indicator", useNativeIndicator) { useNativeIndicator = it }
     }
-    LocationEngineRow(usePlayServices) { usePlayServices = it }
+    if (demoLocationEngines.size > 1) {
+      SegmentedRow(
+        label = "Location engine",
+        options = demoLocationEngines,
+        selected = engine,
+        optionLabel = { it.label },
+        onSelect = { engine = it },
+      )
+    }
   }
 }
 

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/LocationEngine.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/LocationEngine.kt
@@ -3,16 +3,33 @@ package org.maplibre.compose.demoapp.demos
 import androidx.compose.runtime.Composable
 import org.maplibre.compose.location.LocationProvider
 import org.maplibre.compose.location.OrientationProvider
+import org.maplibre.compose.location.rememberDefaultLocationProvider
+import org.maplibre.compose.location.rememberDefaultOrientationProvider
+
+/** A location engine that [LocationDemo] offers on its engine selector. */
+internal interface DemoLocationEngine {
+  /** The short label that names this engine on the selector. */
+  val label: String
+
+  @Composable fun rememberLocationProvider(): LocationProvider
+
+  @Composable fun rememberOrientationProvider(): OrientationProvider
+}
+
+/** The providers that the platform selects by default. */
+internal object DefaultLocationEngine : DemoLocationEngine {
+  override val label = "Default"
+
+  @Composable
+  override fun rememberLocationProvider(): LocationProvider = rememberDefaultLocationProvider()
+
+  @Composable
+  override fun rememberOrientationProvider(): OrientationProvider =
+    rememberDefaultOrientationProvider()
+}
 
 /**
- * Platform location and orientation used by [LocationDemo]. Android can switch to Play Services.
+ * The engines this platform offers, starting with [DefaultLocationEngine]. A platform with one
+ * engine shows no selector.
  */
-@Composable
-internal expect fun rememberDemoLocationProvider(usePlayServices: Boolean): LocationProvider
-
-@Composable
-internal expect fun rememberDemoOrientationProvider(usePlayServices: Boolean): OrientationProvider
-
-/** Android-only switch between Play Services and the platform location engine. */
-@Composable
-internal expect fun LocationEngineRow(usePlayServices: Boolean, onChange: (Boolean) -> Unit)
+internal expect val demoLocationEngines: List<DemoLocationEngine>

--- a/demo-app/common/src/iosMain/kotlin/org/maplibre/compose/demoapp/demos/LocationEngine.ios.kt
+++ b/demo-app/common/src/iosMain/kotlin/org/maplibre/compose/demoapp/demos/LocationEngine.ios.kt
@@ -1,18 +1,3 @@
 package org.maplibre.compose.demoapp.demos
 
-import androidx.compose.runtime.Composable
-import org.maplibre.compose.location.LocationProvider
-import org.maplibre.compose.location.OrientationProvider
-import org.maplibre.compose.location.rememberDefaultLocationProvider
-import org.maplibre.compose.location.rememberDefaultOrientationProvider
-
-@Composable
-internal actual fun rememberDemoLocationProvider(usePlayServices: Boolean): LocationProvider =
-  rememberDefaultLocationProvider()
-
-@Composable
-internal actual fun rememberDemoOrientationProvider(usePlayServices: Boolean): OrientationProvider =
-  rememberDefaultOrientationProvider()
-
-@Composable
-internal actual fun LocationEngineRow(usePlayServices: Boolean, onChange: (Boolean) -> Unit) {}
+internal actual val demoLocationEngines: List<DemoLocationEngine> = listOf(DefaultLocationEngine)

--- a/demo-app/common/src/jsMain/kotlin/org/maplibre/compose/demoapp/demos/LocationEngine.js.kt
+++ b/demo-app/common/src/jsMain/kotlin/org/maplibre/compose/demoapp/demos/LocationEngine.js.kt
@@ -1,18 +1,3 @@
 package org.maplibre.compose.demoapp.demos
 
-import androidx.compose.runtime.Composable
-import org.maplibre.compose.location.LocationProvider
-import org.maplibre.compose.location.OrientationProvider
-import org.maplibre.compose.location.rememberDefaultLocationProvider
-import org.maplibre.compose.location.rememberDefaultOrientationProvider
-
-@Composable
-internal actual fun rememberDemoLocationProvider(usePlayServices: Boolean): LocationProvider =
-  rememberDefaultLocationProvider()
-
-@Composable
-internal actual fun rememberDemoOrientationProvider(usePlayServices: Boolean): OrientationProvider =
-  rememberDefaultOrientationProvider()
-
-@Composable
-internal actual fun LocationEngineRow(usePlayServices: Boolean, onChange: (Boolean) -> Unit) {}
+internal actual val demoLocationEngines: List<DemoLocationEngine> = listOf(DefaultLocationEngine)

--- a/demo-app/common/src/jvmMain/kotlin/org/maplibre/compose/demoapp/demos/LocationEngine.jvm.kt
+++ b/demo-app/common/src/jvmMain/kotlin/org/maplibre/compose/demoapp/demos/LocationEngine.jvm.kt
@@ -1,18 +1,3 @@
 package org.maplibre.compose.demoapp.demos
 
-import androidx.compose.runtime.Composable
-import org.maplibre.compose.location.LocationProvider
-import org.maplibre.compose.location.OrientationProvider
-import org.maplibre.compose.location.rememberDefaultLocationProvider
-import org.maplibre.compose.location.rememberDefaultOrientationProvider
-
-@Composable
-internal actual fun rememberDemoLocationProvider(usePlayServices: Boolean): LocationProvider =
-  rememberDefaultLocationProvider()
-
-@Composable
-internal actual fun rememberDemoOrientationProvider(usePlayServices: Boolean): OrientationProvider =
-  rememberDefaultOrientationProvider()
-
-@Composable
-internal actual fun LocationEngineRow(usePlayServices: Boolean, onChange: (Boolean) -> Unit) {}
+internal actual val demoLocationEngines: List<DemoLocationEngine> = listOf(DefaultLocationEngine)

--- a/docs/src/content/docs/location.mdx
+++ b/docs/src/content/docs/location.mdx
@@ -126,20 +126,10 @@ androidMain.dependencies {
 }
 ```
 
-`ServiceLoader` discovers the module, so `rememberDefaultLocationProvider` and
-`rememberDefaultOrientationProvider` return the fused providers on a device
-where Google Play services is available and the framework providers otherwise.
-
-An application that configures the fused providers directly uses them by name:
-
-```kotlin
-val locationProvider = rememberFusedLocationProvider()
-val orientationProvider = rememberFusedOrientationProvider()
-```
-
-`rememberFusedLocationProvider` delegates permission to the Android provider
-above. The `FusedLocationProvider(client)` constructor keeps the always-granted
-default.
+The default providers then use fused location and orientation on a device where
+Google Play services is available, and the framework providers otherwise. Use
+`rememberFusedLocationProvider` and `rememberFusedOrientationProvider` to
+configure the fused providers directly.
 
 #### Web
 

--- a/docs/src/content/docs/location.mdx
+++ b/docs/src/content/docs/location.mdx
@@ -112,19 +112,8 @@ activity that the context resolves to, so it works from a directly constructed
 provider too; with a context that cannot reach an activity, the request does
 nothing and the reported permission stays accurate.
 
-For better accuracy, use the Fused Location/Orientation Provider
-(requires Google Play Services):
-
-```kotlin
-val locationProvider = rememberFusedLocationProvider()
-val orientationProvider = rememberFusedOrientationProvider()
-```
-
-`rememberFusedLocationProvider` delegates permission to the Android provider
-above. The `FusedLocationProvider(client)` constructor keeps the always-granted
-default.
-
-Add the extension module to the Android source set:
+For better accuracy, add the Google Play services module to the Android source
+set:
 
 ```toml title="libs.versions.toml"
 [libraries]
@@ -136,6 +125,21 @@ androidMain.dependencies {
   implementation(libs.maplibre.locationRuntimeGms)
 }
 ```
+
+`ServiceLoader` discovers the module, so `rememberDefaultLocationProvider` and
+`rememberDefaultOrientationProvider` return the fused providers on a device
+where Google Play services is available and the framework providers otherwise.
+
+An application that configures the fused providers directly uses them by name:
+
+```kotlin
+val locationProvider = rememberFusedLocationProvider()
+val orientationProvider = rememberFusedOrientationProvider()
+```
+
+`rememberFusedLocationProvider` delegates permission to the Android provider
+above. The `FusedLocationProvider(client)` constructor keeps the always-granted
+default.
 
 #### Web
 

--- a/lib/location-runtime-gms/MODULE.md
+++ b/lib/location-runtime-gms/MODULE.md
@@ -1,3 +1,3 @@
 # Module location-runtime-gms
 
-Google Mobile Services extensions for MapLibre Compose.
+Google Play services location backend for MapLibre Compose Android applications.

--- a/lib/location-runtime-gms/build.gradle.kts
+++ b/lib/location-runtime-gms/build.gradle.kts
@@ -17,7 +17,14 @@ mavenPublishing {
 }
 
 kotlin {
-  android { namespace = "org.maplibre.compose.gms" }
+  android {
+    namespace = "org.maplibre.compose.gms"
+    optimization {
+      // Keeps the ServiceLoader-registered backend in consuming applications.
+      consumerKeepRules.publish = true
+      consumerKeepRules.files.add(project.file("consumer-rules.pro"))
+    }
+  }
 
   applyDefaultHierarchyTemplate()
 

--- a/lib/location-runtime-gms/consumer-rules.pro
+++ b/lib/location-runtime-gms/consumer-rules.pro
@@ -1,0 +1,5 @@
+# Only the ServiceLoader registration file references the backend, so R8 would
+# otherwise strip it from the application.
+-keep class org.maplibre.compose.gms.GmsLocationBackend {
+  <init>();
+}

--- a/lib/location-runtime-gms/src/androidHostTest/kotlin/org/maplibre/compose/gms/GmsLocationBackendTest.kt
+++ b/lib/location-runtime-gms/src/androidHostTest/kotlin/org/maplibre/compose/gms/GmsLocationBackendTest.kt
@@ -1,0 +1,16 @@
+package org.maplibre.compose.gms
+
+import java.util.ServiceLoader
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import org.maplibre.compose.location.AndroidLocationBackend
+
+class GmsLocationBackendTest {
+
+  @Test
+  fun serviceLoaderFindsGmsBackend() {
+    assertTrue(
+      ServiceLoader.load(AndroidLocationBackend::class.java).any { it is GmsLocationBackend }
+    )
+  }
+}

--- a/lib/location-runtime-gms/src/androidMain/kotlin/org/maplibre/compose/gms/FusedOrientationProvider.kt
+++ b/lib/location-runtime-gms/src/androidMain/kotlin/org/maplibre/compose/gms/FusedOrientationProvider.kt
@@ -102,7 +102,12 @@ public fun rememberFusedOrientationProvider(
   coroutineScope: CoroutineScope = rememberCoroutineScope(),
   sharingStarted: SharingStarted = SharingStarted.WhileSubscribed(stopTimeoutMillis = 1000),
 ): FusedOrientationProvider {
-  return remember(fusedOrientationProviderClient) {
+  return remember(
+    fusedOrientationProviderClient,
+    deviceOrientationRequest,
+    coroutineScope,
+    sharingStarted,
+  ) {
     FusedOrientationProvider(
       orientationClient = fusedOrientationProviderClient,
       deviceOrientationRequest = deviceOrientationRequest,

--- a/lib/location-runtime-gms/src/androidMain/kotlin/org/maplibre/compose/gms/GmsLocationBackend.kt
+++ b/lib/location-runtime-gms/src/androidMain/kotlin/org/maplibre/compose/gms/GmsLocationBackend.kt
@@ -1,0 +1,42 @@
+package org.maplibre.compose.gms
+
+import android.content.Context
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import com.google.android.gms.common.ConnectionResult
+import com.google.android.gms.common.GoogleApiAvailability
+import com.google.android.gms.location.DeviceOrientationRequest
+import kotlin.time.Duration
+import org.maplibre.compose.location.AndroidLocationBackend
+import org.maplibre.compose.location.LocationProvider
+import org.maplibre.compose.location.OrientationProvider
+import org.maplibre.compose.location.rememberDefaultLocationProvider
+import org.maplibre.compose.location.rememberDefaultOrientationProvider
+
+/**
+ * Installs the fused providers as the Android defaults.
+ *
+ * [java.util.ServiceLoader] discovers this backend when an application packages this module, so
+ * [rememberDefaultLocationProvider] and [rememberDefaultOrientationProvider] return the fused
+ * providers. [isAvailable] reports whether Google Play services is available on the device, and the
+ * defaults fall back to the framework providers on a device without it.
+ */
+public class GmsLocationBackend : AndroidLocationBackend {
+  override val id: String = "gms-fused"
+
+  override fun isAvailable(context: Context): Boolean =
+    GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(context) ==
+      ConnectionResult.SUCCESS
+
+  @Composable
+  override fun rememberLocationProvider(): LocationProvider = rememberFusedLocationProvider()
+
+  @Composable
+  override fun rememberOrientationProvider(updateInterval: Duration): OrientationProvider {
+    val request =
+      remember(updateInterval) {
+        DeviceOrientationRequest.Builder(updateInterval.inWholeMicroseconds).build()
+      }
+    return rememberFusedOrientationProvider(deviceOrientationRequest = request)
+  }
+}

--- a/lib/location-runtime-gms/src/androidMain/resources/META-INF/services/org.maplibre.compose.location.AndroidLocationBackend
+++ b/lib/location-runtime-gms/src/androidMain/resources/META-INF/services/org.maplibre.compose.location.AndroidLocationBackend
@@ -1,0 +1,1 @@
+org.maplibre.compose.gms.GmsLocationBackend

--- a/lib/location/src/androidHostTest/kotlin/org/maplibre/compose/location/AndroidLocationBackendResolverTest.kt
+++ b/lib/location/src/androidHostTest/kotlin/org/maplibre/compose/location/AndroidLocationBackendResolverTest.kt
@@ -1,0 +1,43 @@
+package org.maplibre.compose.location
+
+import android.content.Context
+import androidx.compose.runtime.Composable
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertIs
+import kotlin.test.assertSame
+
+class AndroidLocationBackendResolverTest {
+
+  @Test
+  fun no_available_backend_resolves_to_the_framework_default() {
+    assertIs<AndroidBackendResolution.None>(AndroidLocationBackendResolver.resolve(emptyList()))
+  }
+
+  @Test
+  fun one_available_backend_is_discovered() {
+    val backend = FakeBackend("fake")
+
+    val resolution = AndroidLocationBackendResolver.resolve(listOf(backend))
+
+    assertSame(backend, assertIs<AndroidBackendResolution.Discovered>(resolution).backend)
+  }
+
+  @Test
+  fun multiple_available_backends_are_a_misconfiguration() {
+    val resolution =
+      AndroidLocationBackendResolver.resolve(listOf(FakeBackend("first"), FakeBackend("second")))
+
+    val cause = assertIs<AndroidBackendResolution.Misconfigured>(resolution).cause
+    assertContains(cause.message.orEmpty(), "first")
+    assertContains(cause.message.orEmpty(), "second")
+  }
+}
+
+private class FakeBackend(override val id: String) : AndroidLocationBackend {
+  override fun isAvailable(context: Context) = true
+
+  @Composable
+  override fun rememberLocationProvider(): LocationProvider =
+    error("this test never composes a provider")
+}

--- a/lib/location/src/androidHostTest/kotlin/org/maplibre/compose/location/AndroidLocationBackendResolverTest.kt
+++ b/lib/location/src/androidHostTest/kotlin/org/maplibre/compose/location/AndroidLocationBackendResolverTest.kt
@@ -3,7 +3,6 @@ package org.maplibre.compose.location
 import android.content.Context
 import androidx.compose.runtime.Composable
 import kotlin.test.Test
-import kotlin.test.assertContains
 import kotlin.test.assertIs
 import kotlin.test.assertSame
 
@@ -24,17 +23,27 @@ class AndroidLocationBackendResolverTest {
   }
 
   @Test
-  fun multiple_available_backends_are_a_misconfiguration() {
-    val resolution =
-      AndroidLocationBackendResolver.resolve(listOf(FakeBackend("first"), FakeBackend("second")))
+  fun the_highest_priority_backend_wins() {
+    val winner = FakeBackend("low-id", priority = 1)
 
-    val cause = assertIs<AndroidBackendResolution.Misconfigured>(resolution).cause
-    assertContains(cause.message.orEmpty(), "first")
-    assertContains(cause.message.orEmpty(), "second")
+    val resolution =
+      AndroidLocationBackendResolver.resolve(listOf(FakeBackend("a-first-id"), winner))
+
+    assertSame(winner, assertIs<AndroidBackendResolution.Discovered>(resolution).backend)
+  }
+
+  @Test
+  fun equal_priorities_resolve_to_the_first_id() {
+    val winner = FakeBackend("first")
+
+    val resolution = AndroidLocationBackendResolver.resolve(listOf(FakeBackend("second"), winner))
+
+    assertSame(winner, assertIs<AndroidBackendResolution.Discovered>(resolution).backend)
   }
 }
 
-private class FakeBackend(override val id: String) : AndroidLocationBackend {
+private class FakeBackend(override val id: String, override val priority: Int = 0) :
+  AndroidLocationBackend {
   override fun isAvailable(context: Context) = true
 
   @Composable

--- a/lib/location/src/androidMain/kotlin/org/maplibre/compose/location/AndroidLocationBackend.kt
+++ b/lib/location/src/androidMain/kotlin/org/maplibre/compose/location/AndroidLocationBackend.kt
@@ -13,14 +13,23 @@ import kotlinx.coroutines.flow.flowOf
  *
  * An installed and available backend supplies the providers that [rememberDefaultLocationProvider]
  * and [rememberDefaultOrientationProvider] create; the framework providers remain the default
- * otherwise. A [ServiceConfigurationError], an exception while checking a backend, or more than one
- * available backend maps [LocationProvider.backendAvailability] to
+ * otherwise. When several backends are available, the highest [priority] wins, and equal priorities
+ * resolve to the first [id] in lexicographic order. A [ServiceConfigurationError] or an exception
+ * while checking a backend maps [LocationProvider.backendAvailability] to
  * [LocationBackendAvailability.Misconfigured]. The installed backend documents its own availability
  * conditions.
  */
 public interface AndroidLocationBackend {
-  /** A stable name used in diagnostics. */
+  /** A stable name used in diagnostics and to break priority ties. */
   public val id: String
+
+  /**
+   * The precedence of this backend when several are available. The backend with the highest
+   * priority supplies the default providers. Backends ship with priority 0; declare a higher value
+   * for a backend that is a better fit on its own hardware, or a negative value for a last resort.
+   */
+  public val priority: Int
+    get() = 0
 
   /** Whether this backend can run on the current device. */
   public fun isAvailable(context: Context): Boolean
@@ -62,18 +71,14 @@ internal object AndroidLocationBackendResolver {
     return resolve(availableBackends)
   }
 
-  fun resolve(availableBackends: List<AndroidLocationBackend>): AndroidBackendResolution =
-    when {
-      availableBackends.isEmpty() -> AndroidBackendResolution.None
-      availableBackends.size > 1 ->
-        AndroidBackendResolution.Misconfigured(
-          IllegalStateException(
-            "Multiple Android location backends are available: " +
-              availableBackends.joinToString { it.id }
-          )
-        )
-      else -> AndroidBackendResolution.Discovered(availableBackends.single())
-    }
+  fun resolve(availableBackends: List<AndroidLocationBackend>): AndroidBackendResolution {
+    val backend =
+      availableBackends.minWithOrNull(
+        compareByDescending<AndroidLocationBackend> { it.priority }.thenBy { it.id }
+      )
+    return if (backend == null) AndroidBackendResolution.None
+    else AndroidBackendResolution.Discovered(backend)
+  }
 }
 
 internal class MisconfiguredLocationProvider(private val cause: Throwable) : LocationProvider {

--- a/lib/location/src/androidMain/kotlin/org/maplibre/compose/location/AndroidLocationBackend.kt
+++ b/lib/location/src/androidMain/kotlin/org/maplibre/compose/location/AndroidLocationBackend.kt
@@ -1,0 +1,85 @@
+package org.maplibre.compose.location
+
+import android.content.Context
+import androidx.compose.runtime.Composable
+import java.util.ServiceConfigurationError
+import java.util.ServiceLoader
+import kotlin.time.Duration
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+
+/**
+ * An Android location implementation discovered through [ServiceLoader].
+ *
+ * An installed and available backend supplies the providers that [rememberDefaultLocationProvider]
+ * and [rememberDefaultOrientationProvider] create; the framework providers remain the default
+ * otherwise. A [ServiceConfigurationError], an exception while checking a backend, or more than one
+ * available backend maps [LocationProvider.backendAvailability] to
+ * [LocationBackendAvailability.Misconfigured]. The installed backend documents its own availability
+ * conditions.
+ */
+public interface AndroidLocationBackend {
+  /** A stable name used in diagnostics. */
+  public val id: String
+
+  /** Whether this backend can run on the current device. */
+  public fun isAvailable(context: Context): Boolean
+
+  /** Creates and remembers this backend's location provider. */
+  @Composable public fun rememberLocationProvider(): LocationProvider
+
+  /**
+   * Creates and remembers this backend's orientation provider, or returns null so the default
+   * framework orientation provider is used.
+   */
+  @Composable
+  public fun rememberOrientationProvider(updateInterval: Duration): OrientationProvider? = null
+}
+
+internal sealed interface AndroidBackendResolution {
+  data class Discovered(val backend: AndroidLocationBackend) : AndroidBackendResolution
+
+  data class Misconfigured(val cause: Throwable) : AndroidBackendResolution
+
+  data object None : AndroidBackendResolution
+}
+
+internal object AndroidLocationBackendResolver {
+  fun discover(
+    context: Context,
+    loadBackends: () -> List<AndroidLocationBackend> = {
+      ServiceLoader.load(AndroidLocationBackend::class.java).toList()
+    },
+  ): AndroidBackendResolution {
+    val availableBackends =
+      try {
+        loadBackends().filter { it.isAvailable(context) }
+      } catch (error: ServiceConfigurationError) {
+        return AndroidBackendResolution.Misconfigured(error)
+      } catch (error: Exception) {
+        return AndroidBackendResolution.Misconfigured(error)
+      }
+    return resolve(availableBackends)
+  }
+
+  fun resolve(availableBackends: List<AndroidLocationBackend>): AndroidBackendResolution =
+    when {
+      availableBackends.isEmpty() -> AndroidBackendResolution.None
+      availableBackends.size > 1 ->
+        AndroidBackendResolution.Misconfigured(
+          IllegalStateException(
+            "Multiple Android location backends are available: " +
+              availableBackends.joinToString { it.id }
+          )
+        )
+      else -> AndroidBackendResolution.Discovered(availableBackends.single())
+    }
+}
+
+internal class MisconfiguredLocationProvider(private val cause: Throwable) : LocationProvider {
+  override val backendAvailability: LocationBackendAvailability =
+    LocationBackendAvailability.Misconfigured(cause)
+
+  override fun updates(request: LocationRequest): Flow<LocationEvent> =
+    flowOf(LocationEvent.Unavailable(LocationUnavailableReason.Misconfigured, cause))
+}

--- a/lib/location/src/androidMain/kotlin/org/maplibre/compose/location/AndroidLocationBackend.kt
+++ b/lib/location/src/androidMain/kotlin/org/maplibre/compose/location/AndroidLocationBackend.kt
@@ -14,10 +14,10 @@ import kotlinx.coroutines.flow.flowOf
  * An installed and available backend supplies the providers that [rememberDefaultLocationProvider]
  * and [rememberDefaultOrientationProvider] create; the framework providers remain the default
  * otherwise. When several backends are available, the highest [priority] wins, and equal priorities
- * resolve to the first [id] in lexicographic order. A [ServiceConfigurationError] or an exception
- * while checking a backend maps [LocationProvider.backendAvailability] to
- * [LocationBackendAvailability.Misconfigured]. The installed backend documents its own availability
- * conditions.
+ * resolve to the first [id] in lexicographic order. A [ServiceConfigurationError], a
+ * [LinkageError], or an exception while loading or checking a backend maps
+ * [LocationProvider.backendAvailability] to [LocationBackendAvailability.Misconfigured]. The
+ * installed backend documents its own availability conditions.
  */
 public interface AndroidLocationBackend {
   /** A stable name used in diagnostics and to break priority ties. */
@@ -64,6 +64,9 @@ internal object AndroidLocationBackendResolver {
       try {
         loadBackends().filter { it.isAvailable(context) }
       } catch (error: ServiceConfigurationError) {
+        return AndroidBackendResolution.Misconfigured(error)
+      } catch (error: LinkageError) {
+        // A backend packaged without its vendor SDK fails with NoClassDefFoundError.
         return AndroidBackendResolution.Misconfigured(error)
       } catch (error: Exception) {
         return AndroidBackendResolution.Misconfigured(error)

--- a/lib/location/src/androidMain/kotlin/org/maplibre/compose/location/AndroidLocationProvider.kt
+++ b/lib/location/src/androidMain/kotlin/org/maplibre/compose/location/AndroidLocationProvider.kt
@@ -226,8 +226,17 @@ internal constructor(context: Context, private val requester: AndroidLocationPer
 }
 
 @Composable
-public actual fun rememberDefaultLocationProvider(): LocationProvider =
-  rememberAndroidLocationProvider()
+public actual fun rememberDefaultLocationProvider(): LocationProvider {
+  val context = LocalContext.current
+  return when (
+    val resolution = remember(context) { AndroidLocationBackendResolver.discover(context) }
+  ) {
+    is AndroidBackendResolution.Discovered -> resolution.backend.rememberLocationProvider()
+    is AndroidBackendResolution.Misconfigured ->
+      remember(resolution) { MisconfiguredLocationProvider(resolution.cause) }
+    AndroidBackendResolution.None -> rememberAndroidLocationProvider(context)
+  }
+}
 
 /** Creates the default Android location provider. */
 @Composable

--- a/lib/location/src/androidMain/kotlin/org/maplibre/compose/location/AndroidOrientationProvider.kt
+++ b/lib/location/src/androidMain/kotlin/org/maplibre/compose/location/AndroidOrientationProvider.kt
@@ -111,7 +111,13 @@ public class AndroidOrientationProvider(
 public actual fun rememberDefaultOrientationProvider(
   updateInterval: Duration
 ): OrientationProvider {
-  return rememberAndroidOrientationProvider(updateInterval = updateInterval)
+  val context = LocalContext.current
+  val resolution = remember(context) { AndroidLocationBackendResolver.discover(context) }
+  val backendProvider =
+    (resolution as? AndroidBackendResolution.Discovered)
+      ?.backend
+      ?.rememberOrientationProvider(updateInterval)
+  return backendProvider ?: rememberAndroidOrientationProvider(updateInterval = updateInterval)
 }
 
 /** Creates and remembers the default Android [OrientationProvider]. */


### PR DESCRIPTION
## Description

- Added an `AndroidLocationBackend` SPI mirroring the desktop backend SPI with the framework providers as the fallback
- Register the fused providers from `location-runtime-gms` as such a backend so adding that dependency upgrades default providers on devices where Google Play services is available when the dependency is declared

## Validation

`test:android` (host) passes on macOS, including new resolver and ServiceLoader-registration tests.

## AI assistance

Written by Claude Code (Fable 5)