### PR TITLE
Report the permission request path when location is not granted

### DIFF
--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/LocationDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/LocationDemo.kt
@@ -20,6 +20,7 @@ import org.maplibre.compose.demoapp.DemoFlightDuration
 import org.maplibre.compose.demoapp.OpenFreeMap
 import org.maplibre.compose.demoapp.design.SegmentedRow
 import org.maplibre.compose.demoapp.design.SwitchRow
+import org.maplibre.compose.location.LocationPermission
 import org.maplibre.compose.location.LocationPuck
 import org.maplibre.compose.location.LocationState
 import org.maplibre.compose.location.LocationTrackingEffect
@@ -138,7 +139,14 @@ object LocationDemo : Demo {
 private fun LocationState.statusMessage(): String =
   when (val status = this.status) {
     LocationTrackingStatus.Stopped -> "Location is off"
-    LocationTrackingStatus.WaitingForPermission -> "Waiting for location permission"
+    LocationTrackingStatus.WaitingForPermission -> {
+      val permission = this.permission
+      if (permission is LocationPermission.NotGranted && permission.canRequest == false) {
+        "Location permission was denied; turn it on in the system settings"
+      } else {
+        "Waiting for location permission"
+      }
+    }
     LocationTrackingStatus.Starting -> "Finding your location"
     LocationTrackingStatus.Tracking -> "Tracking your location"
     is LocationTrackingStatus.Unavailable ->

--- a/docs/src/content/docs/location.mdx
+++ b/docs/src/content/docs/location.mdx
@@ -53,6 +53,22 @@ if (locationState.permission !is LocationPermission.Granted) {
 }
 ```
 
+When permission is not granted, `LocationPermission.NotGranted` says which step
+comes next: explain first when `shouldShowRationale` is set (Android only),
+request when `canRequest` is not `false`, and send the user to the system
+settings otherwise.
+
+```kotlin
+val permission = locationState.permission
+if (permission is LocationPermission.NotGranted) {
+  when {
+    permission.shouldShowRationale -> showLocationRationale()
+    permission.canRequest != false -> locationState.requestPermission()
+    else -> showOpenSettingsHint()
+  }
+}
+```
+
 `locationState.location` is `null` until the first fix arrives, so the puck
 initially draws nothing. Afterward, the state retains the last fix when tracking
 stops or permission changes.

--- a/docs/src/content/docs/location.mdx
+++ b/docs/src/content/docs/location.mdx
@@ -62,9 +62,11 @@ settings otherwise.
 val permission = locationState.permission
 if (permission is LocationPermission.NotGranted) {
   when {
-    permission.shouldShowRationale -> showLocationRationale()
-    permission.canRequest != false -> locationState.requestPermission()
-    else -> showOpenSettingsHint()
+    permission.shouldShowRationale ->
+      LocationRationale(onAccept = locationState::requestPermission)
+    permission.canRequest != false ->
+      Button(onClick = locationState::requestPermission) { Text("Use my location") }
+    else -> OpenSettingsHint()
   }
 }
 ```

--- a/lib/location/src/androidHostTest/kotlin/org/maplibre/compose/location/ResolveAndroidLocationPermissionTest.kt
+++ b/lib/location/src/androidHostTest/kotlin/org/maplibre/compose/location/ResolveAndroidLocationPermissionTest.kt
@@ -1,0 +1,67 @@
+package org.maplibre.compose.location
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ResolveAndroidLocationPermissionTest {
+
+  @Test
+  fun a_granted_permission_reports_its_accuracy() {
+    assertEquals(
+      LocationPermission.Granted(LocationAccuracyAuthorization.Precise),
+      resolveAndroidLocationPermission(
+        granted = LocationAccuracyAuthorization.Precise,
+        shouldShowRationale = false,
+        permanentlyDenied = false,
+      ),
+    )
+  }
+
+  @Test
+  fun a_never_requested_permission_can_be_requested() {
+    assertEquals(
+      LocationPermission.NotGranted(canRequest = true),
+      resolveAndroidLocationPermission(
+        granted = null,
+        shouldShowRationale = false,
+        permanentlyDenied = false,
+      ),
+    )
+  }
+
+  @Test
+  fun a_rationale_reports_a_requestable_permission() {
+    assertEquals(
+      LocationPermission.NotGranted(canRequest = true, shouldShowRationale = true),
+      resolveAndroidLocationPermission(
+        granted = null,
+        shouldShowRationale = true,
+        permanentlyDenied = false,
+      ),
+    )
+  }
+
+  @Test
+  fun no_activity_reports_an_unknown_request_path() {
+    assertEquals(
+      LocationPermission.NotGranted(canRequest = null),
+      resolveAndroidLocationPermission(
+        granted = null,
+        shouldShowRationale = null,
+        permanentlyDenied = true,
+      ),
+    )
+  }
+
+  @Test
+  fun a_permanent_denial_blocks_further_requests() {
+    assertEquals(
+      LocationPermission.NotGranted(canRequest = false),
+      resolveAndroidLocationPermission(
+        granted = null,
+        shouldShowRationale = false,
+        permanentlyDenied = true,
+      ),
+    )
+  }
+}

--- a/lib/location/src/androidMain/kotlin/org/maplibre/compose/location/AndroidLocationPermissionRequester.kt
+++ b/lib/location/src/androidMain/kotlin/org/maplibre/compose/location/AndroidLocationPermissionRequester.kt
@@ -29,19 +29,10 @@ import kotlinx.coroutines.flow.StateFlow
  */
 public class AndroidLocationPermissionRequester(private val context: Context) {
 
-  private val preferences =
-    context.applicationContext.getSharedPreferences(
-      "org.maplibre.compose.location",
-      Context.MODE_PRIVATE,
-    )
-
-  private var permanentlyDenied: Boolean
-    get() = preferences.getBoolean(PERMANENTLY_DENIED_KEY, false)
-    set(value) {
-      if (value != permanentlyDenied) {
-        preferences.edit().putBoolean(PERMANENTLY_DENIED_KEY, value).apply()
-      }
-    }
+  // In-memory only: Android can silently make the permission requestable again (auto-reset,
+  // revocation in settings), and no API distinguishes that from a permanent denial, so a
+  // persisted record could go stale forever.
+  private var permanentlyDenied = false
 
   private val mutableStatus = MutableStateFlow(readStatus())
 
@@ -81,8 +72,9 @@ public class AndroidLocationPermissionRequester(private val context: Context) {
    *
    * Android's rationale check returns `false` both before the first request and after a permanent
    * denial. This requester tells the two apart by recording a denial that arrives while the check
-   * stays `false`. The record lives in a library-owned [android.content.SharedPreferences] file and
-   * clears once permission is granted or the check returns `true`.
+   * stays `false`. The record lives only in memory and clears once permission is granted or the
+   * check returns `true`, so the first request in a fresh process may silently return a denial
+   * before [status] reports `canRequest = false` again.
    */
   public fun requestForegroundPermission() {
     val current = refresh()
@@ -148,7 +140,6 @@ public class AndroidLocationPermissionRequester(private val context: Context) {
     }
 
   private companion object {
-    private const val PERMANENTLY_DENIED_KEY = "permission-permanently-denied"
     private val nextKey = AtomicInteger()
   }
 }

--- a/lib/location/src/androidMain/kotlin/org/maplibre/compose/location/AndroidLocationPermissionRequester.kt
+++ b/lib/location/src/androidMain/kotlin/org/maplibre/compose/location/AndroidLocationPermissionRequester.kt
@@ -19,30 +19,44 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
 /**
- * Foreground location permission building block for Android.
+ * Observes and requests foreground location permission on Android.
  *
- * Fine and coarse permission map to [LocationPermission.Granted] with precise and approximate
- * accuracy. When permission is absent,
- * [`Activity.shouldShowRequestPermissionRationale`](https://developer.android.com/reference/android/app/Activity#shouldShowRequestPermissionRationale(java.lang.String))
- * maps `true` to [LocationPermission.NotGranted] with `canRequest = true`. Android returns `false`
- * both before the first request and after a permanent denial, so both map to `canRequest = null`. A
- * [context] that cannot reach an [Activity] also maps to `canRequest = null`, because the rationale
- * check requires an activity.
+ * Android [LocationProvider] implementations hold a requester and expose it through
+ * [LocationProvider.permission] and [LocationProvider.requestPermission].
  *
- * Android [LocationProvider] implementations hold a requester and expose [status] and
- * [requestForegroundPermission] through [LocationProvider.permission] and
- * [LocationProvider.requestPermission].
- *
- * [requestForegroundPermission] registers a launcher on the activity's result registry at request
- * time, so a directly constructed requester is fully functional when [context] can reach a
- * [ComponentActivity]. When it cannot, such as with a service context,
- * [requestForegroundPermission] does nothing and [status] stays accurate. [status] refreshes when
- * the resolved activity resumes.
- *
- * @param context Any [Context]; the permission status is read from the application package.
+ * @param context Any [Context]; the permission status is read from the application package. A
+ *   context that cannot reach an [Activity] cannot answer the rationale check or launch a request.
  */
 public class AndroidLocationPermissionRequester(private val context: Context) {
+
+  private val preferences =
+    context.applicationContext.getSharedPreferences(
+      "org.maplibre.compose.location",
+      Context.MODE_PRIVATE,
+    )
+
+  private var permanentlyDenied: Boolean
+    get() = preferences.getBoolean(PERMANENTLY_DENIED_KEY, false)
+    set(value) {
+      if (value != permanentlyDenied) {
+        preferences.edit().putBoolean(PERMANENTLY_DENIED_KEY, value).apply()
+      }
+    }
+
   private val mutableStatus = MutableStateFlow(readStatus())
+
+  /**
+   * Current foreground location permission.
+   *
+   * Fine permission maps to [LocationPermission.Granted] at precise accuracy, and coarse at
+   * approximate. Otherwise the status is [LocationPermission.NotGranted]:
+   * - `shouldShowRationale = true` when Android advises explaining the request first.
+   * - `canRequest = false` after a permanent denial that [requestForegroundPermission] recorded.
+   * - `canRequest = null` when [context] cannot reach an activity for the rationale check.
+   * - `canRequest = true` otherwise.
+   *
+   * The value refreshes when the resolved activity resumes.
+   */
   public val status: StateFlow<LocationPermission> = mutableStatus
 
   private var requestPending = false
@@ -57,6 +71,19 @@ public class AndroidLocationPermissionRequester(private val context: Context) {
       )
   }
 
+  /**
+   * Starts a foreground permission request and returns immediately. The result is published to
+   * [status].
+   *
+   * The launcher registers on the activity's result registry at request time, so a directly
+   * constructed requester works when [context] can reach a [ComponentActivity]. With a context that
+   * cannot, such as a service context, this call does nothing and [status] stays accurate.
+   *
+   * Android's rationale check returns `false` both before the first request and after a permanent
+   * denial. This requester tells the two apart by recording a denial that arrives while the check
+   * stays `false`. The record lives in a library-owned [android.content.SharedPreferences] file and
+   * clears once permission is granted or the check returns `true`.
+   */
   public fun requestForegroundPermission() {
     val current = refresh()
     if (current is LocationPermission.Granted || requestPending) return
@@ -67,8 +94,12 @@ public class AndroidLocationPermissionRequester(private val context: Context) {
       activity.activityResultRegistry.register(
         "org.maplibre.compose.location.permission.${nextKey.getAndIncrement()}",
         ActivityResultContracts.RequestMultiplePermissions(),
-      ) {
+      ) { results ->
         requestPending = false
+        // The map holds one granted flag per permission; a fine request can still return a coarse
+        // grant. An empty map is a cancelled request, not a user denial.
+        val nothingGranted = results.isNotEmpty() && results.values.none { granted -> granted }
+        if (nothingGranted && readRationale() == false) permanentlyDenied = true
         refresh()
         launcher.unregister()
       }
@@ -86,44 +117,59 @@ public class AndroidLocationPermissionRequester(private val context: Context) {
     }
   }
 
+  /** Re-reads the permission status, publishes it to [status], and returns it. */
   public fun refresh(): LocationPermission {
     val result = readStatus()
     mutableStatus.value = result
     return result
   }
 
-  private fun readStatus(): LocationPermission =
+  private fun readStatus(): LocationPermission {
+    val granted = readGrantedAccuracy()
+    val shouldShowRationale = readRationale()
+    // A grant or a rationale proves the permission is requestable, so any record is stale.
+    if (granted != null || shouldShowRationale == true) permanentlyDenied = false
+    return resolveAndroidLocationPermission(granted, shouldShowRationale, permanentlyDenied)
+  }
+
+  private fun readGrantedAccuracy(): LocationAccuracyAuthorization? =
     when {
       context.checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION) ==
-        PackageManager.PERMISSION_GRANTED ->
-        LocationPermission.Granted(LocationAccuracyAuthorization.Precise)
+        PackageManager.PERMISSION_GRANTED -> LocationAccuracyAuthorization.Precise
       context.checkSelfPermission(Manifest.permission.ACCESS_COARSE_LOCATION) ==
-        PackageManager.PERMISSION_GRANTED ->
-        LocationPermission.Granted(LocationAccuracyAuthorization.Approximate)
-      else ->
-        LocationPermission.NotGranted(
-          canRequest =
-            context.findActivityOrNull()?.let { activity ->
-              if (
-                activity.shouldShowRequestPermissionRationale(
-                  Manifest.permission.ACCESS_FINE_LOCATION
-                ) ||
-                  activity.shouldShowRequestPermissionRationale(
-                    Manifest.permission.ACCESS_COARSE_LOCATION
-                  )
-              ) {
-                true
-              } else {
-                null
-              }
-            }
-        )
+        PackageManager.PERMISSION_GRANTED -> LocationAccuracyAuthorization.Approximate
+      else -> null
+    }
+
+  private fun readRationale(): Boolean? =
+    context.findActivityOrNull()?.let { activity ->
+      activity.shouldShowRequestPermissionRationale(Manifest.permission.ACCESS_FINE_LOCATION) ||
+        activity.shouldShowRequestPermissionRationale(Manifest.permission.ACCESS_COARSE_LOCATION)
     }
 
   private companion object {
+    private const val PERMANENTLY_DENIED_KEY = "permission-permanently-denied"
     private val nextKey = AtomicInteger()
   }
 }
+
+/**
+ * Maps the platform permission signals to [LocationPermission]. [granted] is the granted accuracy,
+ * or null when permission is absent. [shouldShowRationale] is the platform rationale check, or null
+ * when no activity can answer it. [permanentlyDenied] is the recorded permanent denial.
+ */
+internal fun resolveAndroidLocationPermission(
+  granted: LocationAccuracyAuthorization?,
+  shouldShowRationale: Boolean?,
+  permanentlyDenied: Boolean,
+): LocationPermission =
+  when {
+    granted != null -> LocationPermission.Granted(granted)
+    shouldShowRationale == null -> LocationPermission.NotGranted(canRequest = null)
+    shouldShowRationale ->
+      LocationPermission.NotGranted(canRequest = true, shouldShowRationale = true)
+    else -> LocationPermission.NotGranted(canRequest = !permanentlyDenied)
+  }
 
 /** Remembers the permission requester used by Android location providers. */
 @Composable

--- a/lib/location/src/commonMain/kotlin/org/maplibre/compose/location/LocationProvider.kt
+++ b/lib/location/src/commonMain/kotlin/org/maplibre/compose/location/LocationProvider.kt
@@ -85,7 +85,8 @@ public sealed interface LocationBackendAvailability {
    * An installed implementation could not be selected or initialized.
    *
    * For example, a desktop runtime may contain two location backends when exactly one is required.
-   * [cause] contains the underlying setup failure when one is available.
+   *
+   * @property cause The underlying setup failure, when one is available.
    */
   public data class Misconfigured(val cause: Throwable? = null) : LocationBackendAvailability
 }
@@ -226,11 +227,18 @@ public sealed interface LocationPermission {
   /**
    * Foreground authorization is not granted.
    *
-   * [canRequest] is `true` when the platform reports that the application can request
-   * authorization, `false` when it reports that authorization must change outside the application,
-   * and `null` when the platform does not expose that distinction.
+   * @property canRequest `true` when the platform reports that the application can request
+   *   authorization, `false` when it reports that authorization must change outside the
+   *   application, and `null` when the platform does not expose that distinction.
+   * @property shouldShowRationale `true` when the platform advises explaining the request before
+   *   making it, which implies `canRequest = true`. Android reports it from
+   *   [`shouldShowRequestPermissionRationale`](https://developer.android.com/reference/android/app/Activity#shouldShowRequestPermissionRationale(java.lang.String));
+   *   every other platform reports `false`.
    */
-  public data class NotGranted(val canRequest: Boolean?) : LocationPermission
+  public data class NotGranted(
+    val canRequest: Boolean?,
+    val shouldShowRationale: Boolean = false,
+  ) : LocationPermission
 }
 
 /** A provider for a target or host that has no installed location implementation. */

--- a/lib/location/src/iosMain/kotlin/org/maplibre/compose/location/IosLocationPermissionRequester.kt
+++ b/lib/location/src/iosMain/kotlin/org/maplibre/compose/location/IosLocationPermissionRequester.kt
@@ -57,7 +57,8 @@ public class IosLocationPermissionRequester {
    */
   public fun requestForegroundPermission() {
     val current = readStatus(manager)
-    if (current != LocationPermission.NotGranted(canRequest = true) || requestPending) return
+    if (current !is LocationPermission.NotGranted || current.canRequest != true || requestPending)
+      return
     requestPending = true
     manager.requestWhenInUseAuthorization()
   }


### PR DESCRIPTION
## Description

See https://github.com/maplibre/maplibre-compose/pull/1022#issuecomment-5370183204

`LocationPermission.NotGranted` gains `shouldShowRationale`, and Android sets `canRequest` by persisting a denial record that clears whenever permission is granted or the rationale check returns true.

## Validation

Android host tests cover the denial tracker's truth table, and the Android, iOS, JS, desktop, and macOS-runtime targets build and pass their existing tests.

## AI assistance

Claude Fable 5 via Claude Code.