### PR TITLE
Open the system settings screens for location

### DIFF
--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/LocationDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/LocationDemo.kt
@@ -134,10 +134,12 @@ object LocationDemo : Demo {
     val status = panelLocationState?.status
     if (
       status is LocationTrackingStatus.Unavailable &&
-        status.reason == LocationUnavailableReason.ServicesDisabled &&
-        settings.canOpenLocationServicesSettings
+        status.reason == LocationUnavailableReason.ServicesDisabled
     ) {
-      ButtonRow("Open location settings") { settings.openLocationServicesSettings() }
+      if (settings.canOpenLocationServicesSettings) {
+        ButtonRow("Open location settings") { settings.openLocationServicesSettings() }
+      }
+      ButtonRow("Retry") { panelLocationState?.retry() }
     }
     SwitchRow("Follow me", follow) { follow = it }
     if (isNativeLocationIndicatorAvailable) {

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/LocationDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/LocationDemo.kt
@@ -18,6 +18,7 @@ import org.maplibre.compose.camera.CameraState
 import org.maplibre.compose.demoapp.Demo
 import org.maplibre.compose.demoapp.DemoFlightDuration
 import org.maplibre.compose.demoapp.OpenFreeMap
+import org.maplibre.compose.demoapp.design.ButtonRow
 import org.maplibre.compose.demoapp.design.SegmentedRow
 import org.maplibre.compose.demoapp.design.SwitchRow
 import org.maplibre.compose.location.LocationPermission
@@ -28,6 +29,7 @@ import org.maplibre.compose.location.LocationTrackingStatus
 import org.maplibre.compose.location.LocationUnavailableReason
 import org.maplibre.compose.location.mostAccurateBearing
 import org.maplibre.compose.location.rememberLocationState
+import org.maplibre.compose.location.rememberSystemSettingsLauncher
 import org.maplibre.compose.location.updateCamera
 import org.maplibre.compose.material3.LocationPuckDefaults
 import org.maplibre.spatialk.geojson.BoundingBox
@@ -120,6 +122,23 @@ object LocationDemo : Demo {
       color = MaterialTheme.colorScheme.onSurfaceVariant,
       modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
     )
+    val settings = rememberSystemSettingsLauncher()
+    val permission = panelLocationState?.permission
+    if (
+      permission is LocationPermission.NotGranted &&
+        permission.canRequest == false &&
+        settings.canOpenApplicationSettings
+    ) {
+      ButtonRow("Open system settings") { settings.openApplicationSettings() }
+    }
+    val status = panelLocationState?.status
+    if (
+      status is LocationTrackingStatus.Unavailable &&
+        status.reason == LocationUnavailableReason.ServicesDisabled &&
+        settings.canOpenLocationServicesSettings
+    ) {
+      ButtonRow("Open location settings") { settings.openLocationServicesSettings() }
+    }
     SwitchRow("Follow me", follow) { follow = it }
     if (isNativeLocationIndicatorAvailable) {
       SwitchRow("Native indicator", useNativeIndicator) { useNativeIndicator = it }

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/design/SettingsComponents.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/design/SettingsComponents.kt
@@ -38,6 +38,15 @@ fun SwitchRow(label: String, checked: Boolean, onCheckedChange: (Boolean) -> Uni
   )
 }
 
+@Composable
+fun ButtonRow(label: String, onClick: () -> Unit) {
+  ListItem(
+    headlineContent = { Text(label, color = MaterialTheme.colorScheme.primary) },
+    colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+    modifier = Modifier.clickable(role = Role.Button, onClick = onClick),
+  )
+}
+
 /** A single-choice row of short options, as a settings list item. */
 @Composable
 fun <T> SegmentedRow(

--- a/docs/src/content/docs/location.mdx
+++ b/docs/src/content/docs/location.mdx
@@ -56,9 +56,11 @@ if (locationState.permission !is LocationPermission.Granted) {
 When permission is not granted, `LocationPermission.NotGranted` says which step
 comes next: explain first when `shouldShowRationale` is set (Android only),
 request when `canRequest` is not `false`, and send the user to the system
-settings otherwise.
+settings otherwise. `rememberSystemSettingsLauncher` opens the settings screens
+on the platforms that have them.
 
 ```kotlin
+val settings = rememberSystemSettingsLauncher()
 val permission = locationState.permission
 if (permission is LocationPermission.NotGranted) {
   when {
@@ -66,7 +68,8 @@ if (permission is LocationPermission.NotGranted) {
       LocationRationale(onAccept = locationState::requestPermission)
     permission.canRequest != false ->
       Button(onClick = locationState::requestPermission) { Text("Use my location") }
-    else -> OpenSettingsHint()
+    settings.canOpenApplicationSettings ->
+      Button(onClick = { settings.openApplicationSettings() }) { Text("Open settings") }
   }
 }
 ```

--- a/lib/location/src/androidMain/kotlin/org/maplibre/compose/location/AndroidSystemSettingsLauncher.kt
+++ b/lib/location/src/androidMain/kotlin/org/maplibre/compose/location/AndroidSystemSettingsLauncher.kt
@@ -1,0 +1,54 @@
+package org.maplibre.compose.location
+
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.provider.Settings
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+
+/**
+ * Opens Android settings screens related to location.
+ *
+ * @param context Any [Context]; a context that cannot reach an activity launches the screen in a
+ *   new task.
+ */
+public class AndroidSystemSettingsLauncher(private val context: Context) : SystemSettingsLauncher {
+  override val canOpenApplicationSettings: Boolean = true
+
+  /**
+   * Opens this application's details screen in the system settings, where the user manages its
+   * permissions.
+   */
+  override fun openApplicationSettings(): Boolean =
+    launch(
+      Intent(
+        Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+        Uri.fromParts("package", context.packageName, null),
+      )
+    )
+
+  override val canOpenLocationServicesSettings: Boolean = true
+
+  /** Opens the location settings screen, where the user turns location services on. */
+  override fun openLocationServicesSettings(): Boolean =
+    launch(Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS))
+
+  private fun launch(intent: Intent): Boolean {
+    if (context.findActivityOrNull() == null) intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    return try {
+      context.startActivity(intent)
+      true
+    } catch (_: ActivityNotFoundException) {
+      false
+    }
+  }
+}
+
+@Composable
+public actual fun rememberSystemSettingsLauncher(): SystemSettingsLauncher {
+  val context = LocalContext.current
+  return remember(context) { AndroidSystemSettingsLauncher(context) }
+}

--- a/lib/location/src/commonMain/kotlin/org/maplibre/compose/location/LocationState.kt
+++ b/lib/location/src/commonMain/kotlin/org/maplibre/compose/location/LocationState.kt
@@ -50,9 +50,23 @@ internal constructor(initialPermission: LocationPermission = LocationPermission.
 
   internal var requestPermissionAction: () -> Unit = {}
 
+  internal var retryKey: Int by mutableStateOf(0)
+    private set
+
   /** Requests foreground permission; the result is published to [permission]. */
   public fun requestPermission() {
     requestPermissionAction()
+  }
+
+  /**
+   * Restarts a collection that ended in [LocationTrackingStatus.Unavailable].
+   *
+   * A provider may end its updates on a condition it cannot observe changing, such as the macOS
+   * location services toggle, which the user can flip without the window ever losing its lifecycle
+   * state. Call this when the user asks to try again.
+   */
+  public fun retry() {
+    retryKey++
   }
 
   internal fun accept(event: LocationEvent.Fix) {
@@ -130,6 +144,7 @@ public fun rememberLocationState(
     request,
     permission,
     state,
+    state.retryKey,
     lifecycleOwner.lifecycle,
     minActiveState,
     coroutineContext,

--- a/lib/location/src/commonMain/kotlin/org/maplibre/compose/location/SystemSettingsLauncher.kt
+++ b/lib/location/src/commonMain/kotlin/org/maplibre/compose/location/SystemSettingsLauncher.kt
@@ -1,0 +1,36 @@
+package org.maplibre.compose.location
+
+import androidx.compose.runtime.Composable
+
+/** Opens system settings screens related to location. */
+public interface SystemSettingsLauncher {
+  /** Whether [openApplicationSettings] can open a screen on this platform. */
+  public val canOpenApplicationSettings: Boolean
+
+  /**
+   * Opens the screen where the user manages this application's location permission, and returns
+   * whether the screen opened.
+   *
+   * Android opens the application's details screen in the system settings. iOS opens the
+   * application's page in the Settings app. macOS opens the Location Services pane in System
+   * Settings. Windows opens the location privacy page in Settings. Linux and web expose no such
+   * screen, so the call returns `false`.
+   */
+  public fun openApplicationSettings(): Boolean
+
+  /** Whether [openLocationServicesSettings] can open a screen on this platform. */
+  public val canOpenLocationServicesSettings: Boolean
+
+  /**
+   * Opens the screen where the user turns system location services on, and returns whether the
+   * screen opened.
+   *
+   * Android opens the location settings screen. macOS opens the Location Services pane in System
+   * Settings. Windows opens the location privacy page in Settings. iOS, Linux, and web expose no
+   * such screen, so the call returns `false`.
+   */
+  public fun openLocationServicesSettings(): Boolean
+}
+
+/** Creates and remembers the platform [SystemSettingsLauncher]. */
+@Composable public expect fun rememberSystemSettingsLauncher(): SystemSettingsLauncher

--- a/lib/location/src/iosMain/kotlin/org/maplibre/compose/location/IosSystemSettingsLauncher.kt
+++ b/lib/location/src/iosMain/kotlin/org/maplibre/compose/location/IosSystemSettingsLauncher.kt
@@ -1,0 +1,31 @@
+package org.maplibre.compose.location
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import platform.Foundation.NSURL
+import platform.UIKit.UIApplication
+import platform.UIKit.UIApplicationOpenSettingsURLString
+
+/** Opens the iOS settings screen related to location. */
+public class IosSystemSettingsLauncher : SystemSettingsLauncher {
+  override val canOpenApplicationSettings: Boolean = true
+
+  /** Opens this application's page in the Settings app, where the user manages its permissions. */
+  override fun openApplicationSettings(): Boolean {
+    val url = NSURL.URLWithString(UIApplicationOpenSettingsURLString) ?: return false
+    val application = UIApplication.sharedApplication
+    if (!application.canOpenURL(url)) return false
+    application.openURL(url, options = emptyMap<Any?, Any>(), completionHandler = null)
+    return true
+  }
+
+  override val canOpenLocationServicesSettings: Boolean = false
+
+  /** Returns `false`; iOS exposes no URL that opens the system Location Services screen. */
+  override fun openLocationServicesSettings(): Boolean = false
+}
+
+@Composable
+public actual fun rememberSystemSettingsLauncher(): SystemSettingsLauncher = remember {
+  IosSystemSettingsLauncher()
+}

--- a/lib/location/src/jsMain/kotlin/org/maplibre/compose/location/BrowserSystemSettingsLauncher.kt
+++ b/lib/location/src/jsMain/kotlin/org/maplibre/compose/location/BrowserSystemSettingsLauncher.kt
@@ -1,0 +1,18 @@
+package org.maplibre.compose.location
+
+import androidx.compose.runtime.Composable
+
+/** The browser exposes no way to open its settings, so every screen is unavailable. */
+public object BrowserSystemSettingsLauncher : SystemSettingsLauncher {
+  override val canOpenApplicationSettings: Boolean = false
+
+  override fun openApplicationSettings(): Boolean = false
+
+  override val canOpenLocationServicesSettings: Boolean = false
+
+  override fun openLocationServicesSettings(): Boolean = false
+}
+
+@Composable
+public actual fun rememberSystemSettingsLauncher(): SystemSettingsLauncher =
+  BrowserSystemSettingsLauncher

--- a/lib/location/src/jvmMain/kotlin/org/maplibre/compose/location/DesktopSystemSettingsLauncher.kt
+++ b/lib/location/src/jvmMain/kotlin/org/maplibre/compose/location/DesktopSystemSettingsLauncher.kt
@@ -1,0 +1,52 @@
+package org.maplibre.compose.location
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import java.io.IOException
+
+/** Opens the desktop settings screen related to location. */
+public class DesktopSystemSettingsLauncher : SystemSettingsLauncher {
+
+  private val command: List<String>? =
+    with(System.getProperty("os.name").orEmpty().lowercase()) {
+      when {
+        contains("mac") ->
+          listOf(
+            "open",
+            "x-apple.systempreferences:com.apple.preference.security?Privacy_LocationServices",
+          )
+        contains("win") -> listOf("explorer.exe", "ms-settings:privacy-location")
+        else -> null
+      }
+    }
+
+  override val canOpenApplicationSettings: Boolean = command != null
+
+  /**
+   * Opens the screen that holds the services toggle and the per-application location permissions:
+   * the Location Services pane in System Settings on macOS, and the location privacy page in
+   * Settings on Windows. Linux exposes no desktop-neutral settings screen, so the call returns
+   * `false`.
+   */
+  override fun openApplicationSettings(): Boolean = openLocationScreen()
+
+  override val canOpenLocationServicesSettings: Boolean = command != null
+
+  /** Opens the same screen as [openApplicationSettings], which also holds the services toggle. */
+  override fun openLocationServicesSettings(): Boolean = openLocationScreen()
+
+  private fun openLocationScreen(): Boolean {
+    val command = command ?: return false
+    return try {
+      ProcessBuilder(command).start()
+      true
+    } catch (_: IOException) {
+      false
+    }
+  }
+}
+
+@Composable
+public actual fun rememberSystemSettingsLauncher(): SystemSettingsLauncher = remember {
+  DesktopSystemSettingsLauncher()
+}


### PR DESCRIPTION
## Description

Adds `SystemSettingsLauncher` with two methods that open system settings screens:

- `openApplicationSettings` intended to show the app's permission settings for manually granting permission
- `openLocationServicesSettings` intended to show the system's settings for enabling location services

The difference mainly exists on Android. On macOS and Windows, these are the same. On iOS, afaik, there's no way to open the location settings screen. Browsers expose no apis for opening settings, and I haven't done the research to see if there's something standardized across DEs on Linux.

| Platform | `openApplicationSettings` | `openLocationServicesSettings` |
|---|---|---|
| Android | application details screen | location settings screen |
| iOS | application's page in the Settings app | unavailable |
| macOS | Location Services pane | Location Services pane (same screen) |
| Windows | location privacy page | location privacy page (same screen) |
| Linux | unavailable | unavailable |
| Web | unavailable | unavailable |

## Validation

the launch paths are untested so far on real devices (todo after my flight today)

## AI assistance

Claude Fable 5 via Claude Code.