### PR TITLE
Bound the input tests' viewport wait and dump threads on a hang

### DIFF
--- a/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MlnFfiMapInputTest.kt
+++ b/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MlnFfiMapInputTest.kt
@@ -995,7 +995,9 @@ class MlnFfiMapInputTest {
       }
     }
 
-    cameraState.awaitViewport()
+    // The map thread reports the first viewport, and a suspended test body pumps no snapshot apply
+    // notifications; waitUntil polls with frame pumps, so that report can't strand it.
+    waitUntil(timeoutMillis = TIMEOUT) { cameraState.viewport != null }
     cameraState.position = initialPosition
     waitUntil(timeoutMillis = TIMEOUT) { frames.load() > 0 }
     waitUntil(timeoutMillis = TIMEOUT) {

--- a/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/mlnffi/FfiComposeTestPlatform.desktop.kt
+++ b/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/mlnffi/FfiComposeTestPlatform.desktop.kt
@@ -17,6 +17,8 @@ internal actual fun runFfiComposeUiTest(block: suspend ComposeUiTest.() -> Unit)
     runComposeUiTest { block() }
   } finally {
     watchdog.interrupt()
+    // Tests share a JVM; a dump left printing here would interleave into the next test's output.
+    watchdog.join()
     MlnFfiApplication.resetForTest()
   }
 }

--- a/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/mlnffi/FfiComposeTestPlatform.desktop.kt
+++ b/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/mlnffi/FfiComposeTestPlatform.desktop.kt
@@ -18,7 +18,8 @@ internal actual fun runFfiComposeUiTest(block: suspend ComposeUiTest.() -> Unit)
   } finally {
     watchdog.interrupt()
     // Tests share a JVM; a dump left printing here would interleave into the next test's output.
-    watchdog.join()
+    // Bounded, so a wedged stderr could never hold up teardown for the daemon thread's sake.
+    watchdog.join(1_000)
     MlnFfiApplication.resetForTest()
   }
 }

--- a/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/mlnffi/FfiComposeTestPlatform.desktop.kt
+++ b/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/mlnffi/FfiComposeTestPlatform.desktop.kt
@@ -12,11 +12,41 @@ import org.maplibre.nativeffi.render.RenderBackend
 
 @OptIn(ExperimentalTestApi::class)
 internal actual fun runFfiComposeUiTest(block: suspend ComposeUiTest.() -> Unit) {
+  val watchdog = startHangWatchdog()
   try {
     runComposeUiTest { block() }
   } finally {
+    watchdog.interrupt()
     MlnFfiApplication.resetForTest()
   }
+}
+
+/**
+ * How long a test may run before the watchdog dumps every thread's stack. Just under the one-minute
+ * `runTest` watchdog, which reports only its own cancellation machinery.
+ */
+private const val HANG_DUMP_DELAY_MILLIS = 50_000L
+
+/** Attributes a hang to a stack trace before `runTest` cancels the test body anonymously. */
+private fun startHangWatchdog(): Thread {
+  val watchdog = Thread {
+    try {
+      Thread.sleep(HANG_DUMP_DELAY_MILLIS)
+    } catch (_: InterruptedException) {
+      return@Thread
+    }
+    System.err.println(
+      "An FFI Compose test has run for ${HANG_DUMP_DELAY_MILLIS} ms; dumping all threads:"
+    )
+    for ((thread, stack) in Thread.getAllStackTraces()) {
+      System.err.println(thread)
+      for (frame in stack) System.err.println("\tat $frame")
+    }
+  }
+  watchdog.name = "ffi-test-hang-watchdog"
+  watchdog.isDaemon = true
+  watchdog.start()
+  return watchdog
 }
 
 @OptIn(ExperimentalTestApi::class)


### PR DESCRIPTION
## Description

Replaces the input tests' unbounded `awaitViewport()` suspend with a frame-pumping `waitUntil`, and adds a watchdog that dumps all thread stacks just before `runTest`'s one-minute timeout, so the intermittent `UncompletedCoroutinesError` hangs in #1033 either stop or become attributable.

## Validation

`:lib:maplibre-compose:jvmTest --tests MlnFfiMapInputTest` passes on macOS.

## AI assistance

Written by Claude Code (Fable 5), reviewed by the author.