### PR TITLE
Raise the Android compileSdk to 37

### DIFF
--- a/.mise/bin/sync-android-packages
+++ b/.mise/bin/sync-android-packages
@@ -48,25 +48,11 @@ if [[ -z "$compile_sdk" ]]; then
 fi
 
 # Paired with the directory that proves each is installed, so a rerun starts no
-# JVM and reaches no network.
-#
-# API 37 publishes the platform as android-37.0. AGP 9.1 still consumes
-# Build-Tools 36.0.0; there is no 37.0.0 package.
-if ((compile_sdk >= 37)); then
-  platform="platforms;android-${compile_sdk}.0"
-  platform_dir="platforms/android-${compile_sdk}.0"
-  build_tools="build-tools;36.0.0"
-  build_tools_dir="build-tools/36.0.0"
-else
-  platform="platforms;android-${compile_sdk}"
-  platform_dir="platforms/android-${compile_sdk}"
-  build_tools="build-tools;${compile_sdk}.0.0"
-  build_tools_dir="build-tools/${compile_sdk}.0.0"
-fi
-
+# JVM and reaches no network. The platform for compileSdk 37 is android-37.0.
+# AGP 9.1 consumes Build-Tools 36.0.0.
 packages=(
-  "${platform}|${platform_dir}"
-  "${build_tools}|${build_tools_dir}"
+  "platforms;android-${compile_sdk}.0|platforms/android-${compile_sdk}.0"
+  "build-tools;36.0.0|build-tools/36.0.0"
   "platform-tools|platform-tools"
 )
 

--- a/.mise/bin/sync-android-packages
+++ b/.mise/bin/sync-android-packages
@@ -37,7 +37,7 @@ fi
 
 repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 catalog_version() {
-  sed -n "s/^$1 = \"\\([0-9][0-9]*\\)\"\$/\\1/p" \
+  sed -n "s/^$1 = \"\\([0-9][0-9.]*\\)\"\$/\\1/p" \
     "$repository_root/gradle/libs.versions.toml" | head -n1
 }
 
@@ -47,12 +47,17 @@ if [[ -z "$compile_sdk" ]]; then
   exit 1
 fi
 
+build_tools="$(catalog_version android-buildTools)"
+if [[ -z "$build_tools" ]]; then
+  echo "${0##*/}: could not read android-buildTools from gradle/libs.versions.toml" >&2
+  exit 1
+fi
+
 # Paired with the directory that proves each is installed, so a rerun starts no
 # JVM and reaches no network. The platform for compileSdk 37 is android-37.0.
-# AGP 9.1 consumes Build-Tools 36.0.0.
 packages=(
   "platforms;android-${compile_sdk}.0|platforms/android-${compile_sdk}.0"
-  "build-tools;36.0.0|build-tools/36.0.0"
+  "build-tools;${build_tools}|build-tools/${build_tools}"
   "platform-tools|platform-tools"
 )
 

--- a/.mise/bin/sync-android-packages
+++ b/.mise/bin/sync-android-packages
@@ -49,9 +49,24 @@ fi
 
 # Paired with the directory that proves each is installed, so a rerun starts no
 # JVM and reaches no network.
+#
+# API 37 publishes the platform as android-37.0. AGP 9.1 still consumes
+# Build-Tools 36.0.0; there is no 37.0.0 package.
+if ((compile_sdk >= 37)); then
+  platform="platforms;android-${compile_sdk}.0"
+  platform_dir="platforms/android-${compile_sdk}.0"
+  build_tools="build-tools;36.0.0"
+  build_tools_dir="build-tools/36.0.0"
+else
+  platform="platforms;android-${compile_sdk}"
+  platform_dir="platforms/android-${compile_sdk}"
+  build_tools="build-tools;${compile_sdk}.0.0"
+  build_tools_dir="build-tools/${compile_sdk}.0.0"
+fi
+
 packages=(
-  "platforms;android-${compile_sdk}|platforms/android-${compile_sdk}"
-  "build-tools;${compile_sdk}.0.0|build-tools/${compile_sdk}.0.0"
+  "${platform}|${platform_dir}"
+  "${build_tools}|${build_tools_dir}"
   "platform-tools|platform-tools"
 )
 

--- a/buildSrc/src/main/kotlin/android-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/android-library-conventions.gradle.kts
@@ -28,7 +28,7 @@ kotlin {
         compilerOptions {
           // Set the JVM target on each compilation, because the Android library DSL exposes no
           // property for it and a compilation otherwise inherits the toolchain's Java 25. Still
-          // required as of AGP 9.1.0. https://issuetracker.google.com/issues/379315244
+          // required as of AGP 9.1.1. https://issuetracker.google.com/issues/379315244
           jvmTarget = project.getAndroidJvmTarget()
         }
       }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,8 @@
 [versions]
 # Platform floors and toolchain levels.
-android-compileSdk = "36"
+# compileSdk 37 is the API floor AGP 9.1.1 supports. targetSdk stays on 36,
+# the latest shipping Android 16 behavior.
+android-compileSdk = "37"
 android-minSdk = "24"
 android-targetSdk = "36"
 # Compiler JDK for every JVM compilation. Must be >= java-desktopTarget.
@@ -43,7 +45,7 @@ gradle-mavenPublish = "0.37.0"
 gradle-compose = "1.11.1"
 androidx-compose = "1.11.2"
 jetbrains-compose-material3 = "1.11.0-alpha07"
-# 1.3.x needs compileSdk 37; AGP 9.1 and this catalog stay on 36.
+# 1.3.x is still beta.
 jetbrains-compose-material3-adaptive = "1.2.0"
 jetbrains-navigation = "2.9.2"
 
@@ -51,7 +53,9 @@ jetbrains-navigation = "2.9.2"
 # Also note the Gradle and XCode versions in the matrix!
 # https://www.jetbrains.com/help/kotlin-multiplatform-dev/multiplatform-compatibility-guide.html
 gradle-kotlin = "2.4.10"
-gradle-android = "9.1.0"
+# Kotlin 2.4.10 documents AGP through 9.1.0. 9.1.1 is the floor for
+# compileSdk 37.
+gradle-android = "9.1.1"
 
 [libraries]
 accompanist-permissions = { module = "com.google.accompanist:accompanist-permissions", version.ref = "accompanistPermissions" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,9 @@
 # compileSdk 37 is the API floor AGP 9.1.1 supports. targetSdk stays on 36,
 # the latest shipping Android 16 behavior.
 android-compileSdk = "37"
+# The Build-Tools release AGP 9.1.1 consumes. Read by
+# .mise/bin/sync-android-packages, not by Gradle.
+android-buildTools = "36.0.0"
 android-minSdk = "24"
 android-targetSdk = "36"
 # Compiler JDK for every JVM compilation. Must be >= java-desktopTarget.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Bumps `compileSdk` to 37 and AGP to 9.1.1 so the Android build can consume libraries that now require API 37.

## Validation

`mise -E android` installed `platforms;android-37.0` and Build-Tools 36.0.0, then `mise run lint:android` and `mise run test:android` both succeeded.

## AI assistance

Cursor Grok 4.6 as a Cloud Agent.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-11ab6604-04ae-4ea8-af5f-f52b0e4d8358?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-11ab6604-04ae-4ea8-af5f-f52b0e4d8358&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

