### PR TITLE
Document that preferredRenderMode is Android-only

### DIFF
--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/RenderOptions.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/RenderOptions.kt
@@ -8,8 +8,7 @@ import androidx.compose.runtime.Immutable
  * @param isCollisionBoxesEnabled Draws the boxes symbol placement uses to decide what to hide.
  * @param isTileParseStatusEnabled Draws tile parse state on each tile.
  * @param maximumFps Caps how often the map is rendered. Null uses the display refresh rate.
- * @param preferredRenderMode A hint for how the host presents the map. A platform may ignore a
- *   value it does not support.
+ * @param preferredRenderMode How Android presents the map. iOS and desktop ignore this value.
  */
 @Immutable
 public actual data class RenderOptions(
@@ -32,7 +31,7 @@ public actual data class RenderOptions(
   }
 
   /**
-   * A hint for how the host presents the map. A platform may ignore a value it does not support.
+   * How Android presents the map. iOS and desktop ignore this value.
    *
    * [Surface] is preferred for performance. A SurfaceView is a separate window layer, so some
    * Compose modifiers do not apply to it. Use [Texture] when a modifier such as alpha must affect


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

The shared native `RenderOptions` KDoc now says Android is the only platform that honors `preferredRenderMode`.

## Validation

Read the updated KDoc; no runtime tests, because this is documentation only.

## AI assistance

Cursor Grok 4.6 in Cursor Cloud.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-766e0564-ea01-49b9-9c2e-7ba7b870c3f9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-766e0564-ea01-49b9-9c2e-7ba7b870c3f9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

