### PR TITLE
Drop the portal distance threshold that starves the first Linux fix

### DIFF
--- a/lib/location-runtime-linux/src/main/kotlin/org/maplibre/compose/location/desktop/linux/DbusLocationPortal.kt
+++ b/lib/location-runtime-linux/src/main/kotlin/org/maplibre/compose/location/desktop/linux/DbusLocationPortal.kt
@@ -43,9 +43,7 @@ import org.maplibre.compose.location.desktop.linux.portal.PortalSession
 import org.maplibre.compose.location.desktop.linux.portal.PortalTimestamp
 import org.maplibre.spatialk.geojson.Position
 import org.maplibre.spatialk.units.Bearing
-import org.maplibre.spatialk.units.Length
 import org.maplibre.spatialk.units.extensions.degrees
-import org.maplibre.spatialk.units.extensions.inMeters
 import org.maplibre.spatialk.units.extensions.meters
 
 internal class DbusLocationPortal(private val window: XdgPortalWindow? = null) :
@@ -224,10 +222,11 @@ internal class DbusLocationPortal(private val window: XdgPortalWindow? = null) :
     }
   }
 
+  // No distance-threshold: GeoClue emits nothing, not even the first fix, when the position has
+  // not moved that far, and a GeoIP-located desktop never moves.
   private fun sessionOptions(request: LocationRequest): Map<String, Variant<*>> =
     mapOf(
       "session_handle_token" to Variant(newToken()),
-      "distance-threshold" to Variant(UInt32(request.minimumDistance.asPortalThreshold())),
       "time-threshold" to Variant(UInt32(request.minimumInterval.asPortalThreshold())),
       "accuracy" to Variant(UInt32(request.accuracy.portalValue)),
     )
@@ -260,8 +259,6 @@ private val LocationAccuracy.portalValue: Long
       LocationAccuracy.Lowest -> 1L
     }
 
-private fun Length.asPortalThreshold(): Long = ceil(inMeters).toLong().coerceIn(0, UInt32.MAX_VALUE)
-
 private fun Duration.asPortalThreshold(): Long =
   ceil(inWholeMilliseconds / 1_000.0).toLong().coerceIn(0, UInt32.MAX_VALUE)
 
@@ -285,7 +282,8 @@ internal fun Map<String, Variant<*>>.toLocationEvent(): LocationEvent.Fix {
             Position(
               longitude = number("Longitude") ?: error("Portal location has no Longitude"),
               latitude = number("Latitude") ?: error("Portal location has no Latitude"),
-              altitude = number("Altitude"),
+              // GeoClue reports unknown altitude as -G_MAXDOUBLE.
+              altitude = number("Altitude")?.takeIf { it != -Double.MAX_VALUE },
             ),
           accuracy = number("Accuracy")?.meters,
         ),

--- a/lib/location-runtime-linux/src/main/kotlin/org/maplibre/compose/location/desktop/linux/LinuxPortalLocationBackend.kt
+++ b/lib/location-runtime-linux/src/main/kotlin/org/maplibre/compose/location/desktop/linux/LinuxPortalLocationBackend.kt
@@ -62,6 +62,10 @@ internal suspend fun <T> XdgPortalWindow?.withPortalParentWindow(action: suspend
  * and [LocationAccuracy.Lowest] maps to
  * [`COUNTRY`](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Location.html#org-freedesktop-portal-location-createsession).
  *
+ * Unlike the other desktop backends, this provider ignores [LocationRequest.minimumDistance]. A
+ * portal distance threshold suppresses every update, including the first, on a host whose GeoIP
+ * position never moves.
+ *
  * A missing portal maps [LocationProvider.backendAvailability] to
  * [LocationBackendAvailability.Unsupported], and collection emits
  * [LocationUnavailableReason.Unsupported]. A cancelled

--- a/lib/location-runtime-linux/src/test/kotlin/org/maplibre/compose/location/desktop/linux/LinuxPortalLocationProviderTest.kt
+++ b/lib/location-runtime-linux/src/test/kotlin/org/maplibre/compose/location/desktop/linux/LinuxPortalLocationProviderTest.kt
@@ -152,6 +152,23 @@ class LinuxPortalLocationProviderTest {
   }
 
   @Test
+  fun convertsUnknownPortalMeasurementsToNull() {
+    val event =
+      mapOf(
+          "Latitude" to Variant(52.0),
+          "Longitude" to Variant(13.0),
+          "Altitude" to Variant(-Double.MAX_VALUE),
+          "Speed" to Variant(-1.0),
+          "Heading" to Variant(-1.0),
+        )
+        .toLocationEvent()
+
+    assertEquals(null, event.location.position.value.altitude)
+    assertEquals(null, event.location.speed)
+    assertEquals(null, event.location.course)
+  }
+
+  @Test
   fun realPortalSessionCanOpenAndClose() = runTest {
     if (System.getenv("MAPLIBRE_TEST_LINUX_LOCATION_PORTAL") != "true") return@runTest
 


### PR DESCRIPTION
## Description

The Linux portal backend no longer forwards `minimumDistance` as a portal `distance-threshold`, because GeoClue then withholds every update, including the first, on a host whose GeoIP position never moves; the portal's unknown-altitude sentinel now maps to null.

## Validation

Verified live on a Fedora 44 desktop where the demo previously hung on "Finding your location": a probe through `DbusLocationPortal.updates()` now receives its first fix in about a second, and the module's unit tests (including a new sentinel-conversion test) pass.

## AI assistance

Written by Claude Fable 5 in Claude Code, driven and reviewed by @sargunv.