### PR TITLE
Support Vulkan as an Android runtime choice alongside OpenGL

### DIFF
--- a/.mise/bin/run-android-demo
+++ b/.mise/bin/run-android-demo
@@ -13,6 +13,7 @@ requested="${1:-${usage_serial:-}}"
 export ANDROID_SERIAL
 ANDROID_SERIAL="$("$repository_root/.mise/bin/pick-android-device" "$requested")"
 
-"$repository_root/gradlew" :demo-app:android:installDebug
+"$repository_root/gradlew" :demo-app:android:installDebug \
+  -Pmaplibre.android.backend="${usage_backend:-opengl}"
 "$adb" -s "$ANDROID_SERIAL" shell am start \
   -n org.maplibre.compose.demoapp/.MainActivity

--- a/.mise/bin/sync-android-packages
+++ b/.mise/bin/sync-android-packages
@@ -53,16 +53,26 @@ if [[ -z "$build_tools" ]]; then
   exit 1
 fi
 
+ndk="$(catalog_version android-ndk)"
+if [[ -z "$ndk" ]]; then
+  echo "${0##*/}: could not read android-ndk from gradle/libs.versions.toml" >&2
+  exit 1
+fi
+
+cmake="$(catalog_version android-cmake)"
+if [[ -z "$cmake" ]]; then
+  echo "${0##*/}: could not read android-cmake from gradle/libs.versions.toml" >&2
+  exit 1
+fi
+
 # Paired with the directory that proves each is installed, so a rerun starts no
 # JVM and reaches no network. The platform for compileSdk 37 is android-37.0.
-# The NDK and CMake build the JNI shim in
-# lib/maplibre-compose-runtime-vulkan-android.
 packages=(
   "platforms;android-${compile_sdk}.0|platforms/android-${compile_sdk}.0"
   "build-tools;${build_tools}|build-tools/${build_tools}"
   "platform-tools|platform-tools"
-  "ndk;28.2.13676358|ndk/28.2.13676358"
-  "cmake;4.1.2|cmake/4.1.2"
+  "ndk;${ndk}|ndk/${ndk}"
+  "cmake;${cmake}|cmake/${cmake}"
 )
 
 missing=()

--- a/.mise/bin/sync-android-packages
+++ b/.mise/bin/sync-android-packages
@@ -48,11 +48,8 @@ if [[ -z "$compile_sdk" ]]; then
 fi
 
 # Paired with the directory that proves each is installed, so a rerun starts no
-# JVM and reaches no network.
-#
-# The NDK and CMake build the Vulkan loader shim in
-# lib/maplibre-compose-runtime-vulkan-android. The NDK is AGP's default and the
-# CMake version is the one its externalNativeBuild block pins.
+# JVM and reaches no network. The NDK and CMake build the JNI shim in
+# lib/maplibre-compose-runtime-vulkan-android.
 packages=(
   "platforms;android-${compile_sdk}|platforms/android-${compile_sdk}"
   "build-tools;${compile_sdk}.0.0|build-tools/${compile_sdk}.0.0"

--- a/.mise/bin/sync-android-packages
+++ b/.mise/bin/sync-android-packages
@@ -49,10 +49,16 @@ fi
 
 # Paired with the directory that proves each is installed, so a rerun starts no
 # JVM and reaches no network.
+#
+# The NDK and CMake build the Vulkan loader shim in
+# lib/maplibre-compose-runtime-vulkan-android. The NDK is AGP's default and the
+# CMake version is the one its externalNativeBuild block pins.
 packages=(
   "platforms;android-${compile_sdk}|platforms/android-${compile_sdk}"
   "build-tools;${compile_sdk}.0.0|build-tools/${compile_sdk}.0.0"
   "platform-tools|platform-tools"
+  "ndk;28.2.13676358|ndk/28.2.13676358"
+  "cmake;4.1.2|cmake/4.1.2"
 )
 
 missing=()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,8 @@ per `./gradlew` invocation. Two together can fail in ways neither does alone.
 - `mise run build:ios:device`
 - `mise run demo:desktop`
 - `mise run demo:desktop-glfw`
-- `mise run demo:android` (prompts when several devices are connected)
+- `mise run demo:android` (prompts when several devices are connected;
+  `--backend vulkan` packages the Vulkan runtime)
 - `mise run demo:ios` (pass `--device` for a connected iPhone; prompts when
   several are ready; `--release` builds the optimized framework)
 - `mise run demo:js`

--- a/demo-app/android/build.gradle.kts
+++ b/demo-app/android/build.gradle.kts
@@ -33,7 +33,5 @@ dependencies {
   implementation(libs.androidx.activity.compose)
   implementation(libs.jetbrains.compose.ui.tooling)
 
-  // The Android map renders with the backend this runtime carries; swap for
-  // maplibre-compose-runtime-vulkan-android to run the Vulkan host.
-  implementation(project(":lib:maplibre-compose-runtime-opengl-android"))
+  runtimeOnly(project(":lib:maplibre-compose-runtime-opengl-android"))
 }

--- a/demo-app/android/build.gradle.kts
+++ b/demo-app/android/build.gradle.kts
@@ -32,4 +32,8 @@ dependencies {
   implementation(project(":demo-app:common"))
   implementation(libs.androidx.activity.compose)
   implementation(libs.jetbrains.compose.ui.tooling)
+
+  // The Android map renders with the backend this runtime carries; swap for
+  // maplibre-compose-runtime-vulkan-android to run the Vulkan host.
+  implementation(project(":lib:maplibre-compose-runtime-opengl-android"))
 }

--- a/demo-app/android/build.gradle.kts
+++ b/demo-app/android/build.gradle.kts
@@ -28,10 +28,13 @@ kotlin {
   compilerOptions { jvmTarget = project.getAndroidJvmTarget() }
 }
 
+// opengl or vulkan: the backend of the runtime artifact the APK packages.
+val androidBackend = providers.gradleProperty("maplibre.android.backend").getOrElse("opengl")
+
 dependencies {
   implementation(project(":demo-app:common"))
   implementation(libs.androidx.activity.compose)
   implementation(libs.jetbrains.compose.ui.tooling)
 
-  runtimeOnly(project(":lib:maplibre-compose-runtime-opengl-android"))
+  runtimeOnly(project(":lib:maplibre-compose-runtime-$androidBackend-android"))
 }

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -93,6 +93,9 @@ Available runtimes:
 | OpenGL         | `maplibre-compose-runtime-opengl-android` |
 | Vulkan         | `maplibre-compose-runtime-vulkan-android` |
 
+Match the runtime's version to the library version you selected above,
+including when that is a snapshot.
+
 ## Set up iOS
 
 Maps use the application's caches directory.
@@ -182,6 +185,8 @@ Available runtimes:
 | Windows arm64 | `maplibre-compose-runtime-vulkan-windows-arm64` |
 
 To ship several platforms, select the runtime from the host you build on.
+Match the runtime's version to the library version you selected above,
+including when that is a snapshot.
 
 **Desktop requires Java 25.** The MapLibre Native FFI binding uses the FFM API,
 so the desktop target cannot run on an older JVM.

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -76,26 +76,22 @@ commonMain.dependencies {
 Maps use the application's private cache directory.
 
 Alongside the library, add a runtime: the native libraries for one render
-backend. The map renders with the backend the packaged runtime carries, so an
-application picks its backend by picking a dependency. OpenGL is the default
-choice; Vulkan serves devices where you prefer it.
+backend.
 
 ```kotlin title="build.gradle.kts"
 androidMain {
   dependencies {
-    // The OpenGL host presents through an EGL window surface.
     runtimeOnly("org.maplibre.compose:maplibre-compose-runtime-opengl-android:{{release}}")
   }
 }
 ```
 
+Available runtimes:
+
 | Render backend | Runtime                                   |
 | -------------- | ----------------------------------------- |
 | OpenGL         | `maplibre-compose-runtime-opengl-android` |
 | Vulkan         | `maplibre-compose-runtime-vulkan-android` |
-
-The runtime artifacts name the same `libmaplibre-native-c.so`, so an application
-packages exactly one of them.
 
 ## Set up iOS
 

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -84,7 +84,7 @@ choice; Vulkan serves devices where you prefer it.
 androidMain {
   dependencies {
     // The OpenGL host presents through an EGL window surface.
-    implementation("org.maplibre.compose:maplibre-compose-runtime-opengl-android:{{release}}")
+    runtimeOnly("org.maplibre.compose:maplibre-compose-runtime-opengl-android:{{release}}")
   }
 }
 ```

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -75,6 +75,28 @@ commonMain.dependencies {
 
 Maps use the application's private cache directory.
 
+Alongside the library, add a runtime: the native libraries for one render
+backend. The map renders with the backend the packaged runtime carries, so an
+application picks its backend by picking a dependency. OpenGL is the default
+choice; Vulkan serves devices where you prefer it.
+
+```kotlin title="build.gradle.kts"
+androidMain {
+  dependencies {
+    // The OpenGL host presents through an EGL window surface.
+    implementation("org.maplibre.compose:maplibre-compose-runtime-opengl-android:{{release}}")
+  }
+}
+```
+
+| Render backend | Runtime                                   |
+| -------------- | ----------------------------------------- |
+| OpenGL         | `maplibre-compose-runtime-opengl-android` |
+| Vulkan         | `maplibre-compose-runtime-vulkan-android` |
+
+The runtime artifacts name the same `libmaplibre-native-c.so`, so an application
+packages exactly one of them.
+
 ## Set up iOS
 
 Maps use the application's caches directory.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -104,6 +104,7 @@ maplibre-nativeFfi-runtimeMetal = { module = "org.maplibre.nativeffi:maplibre-na
 maplibre-nativeFfi-runtimeMetalKmp = { module = "org.maplibre.nativeffi:maplibre-native-ffi-runtime-metal", version.ref = "maplibre-nativeFfi" }
 maplibre-nativeFfi-runtimeOpenGl = { module = "org.maplibre.nativeffi:maplibre-native-ffi-runtime-opengl", version.ref = "maplibre-nativeFfi" }
 maplibre-nativeFfi-runtimeVulkan = { module = "org.maplibre.nativeffi:maplibre-native-ffi-runtime-vulkan-jvm", version.ref = "maplibre-nativeFfi" }
+maplibre-nativeFfi-runtimeVulkanKmp = { module = "org.maplibre.nativeffi:maplibre-native-ffi-runtime-vulkan", version.ref = "maplibre-nativeFfi" }
 lwjgl-bom = { module = "org.lwjgl:lwjgl-bom", version.ref = "lwjgl" }
 lwjgl-core = { module = "org.lwjgl:lwjgl", version.ref = "lwjgl" }
 lwjgl-egl = { module = "org.lwjgl:lwjgl-egl", version.ref = "lwjgl" }
@@ -117,6 +118,7 @@ spatialk-units = { group = "org.maplibre.spatialk", name = "units", version.ref 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "gradle-android" }
 android-library = { id = "com.android.kotlin.multiplatform.library", version.ref = "gradle-android" }
+android-classicLibrary = { id = "com.android.library", version.ref = "gradle-android" }
 android-lint = { id = "com.android.lint", version.ref = "gradle-android" }
 compose = { id = "org.jetbrains.compose", version.ref = "gradle-compose" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "gradle-dokka" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,10 @@ android-compileSdk = "37"
 # The Build-Tools release AGP 9.1.1 consumes. Read by
 # .mise/bin/sync-android-packages, not by Gradle.
 android-buildTools = "36.0.0"
+# Build the JNI shim in lib/maplibre-compose-runtime-vulkan-android. Read by
+# .mise/bin/sync-android-packages too.
+android-ndk = "28.2.13676358"
+android-cmake = "4.1.2"
 android-minSdk = "24"
 android-targetSdk = "36"
 # Compiler JDK for every JVM compilation. Must be >= java-desktopTarget.

--- a/lib/maplibre-compose-runtime-opengl-android/build.gradle.kts
+++ b/lib/maplibre-compose-runtime-opengl-android/build.gradle.kts
@@ -21,7 +21,6 @@ android {
 }
 
 dependencies {
-  // The runtime artifacts name the same libmaplibre-native-c.so, so an application packages
-  // exactly one of them; the map picks the host the packaged runtime renders with.
+  // api rather than runtimeOnly: the AAR's classes.jar is what carries the packaging.
   api(libs.maplibre.nativeFfi.runtimeOpenGl)
 }

--- a/lib/maplibre-compose-runtime-opengl-android/build.gradle.kts
+++ b/lib/maplibre-compose-runtime-opengl-android/build.gradle.kts
@@ -1,0 +1,27 @@
+plugins {
+  id("module-conventions")
+  id(libs.plugins.android.classicLibrary.get().pluginId)
+  id(libs.plugins.mavenPublish.get().pluginId)
+}
+
+mavenPublishing {
+  pom {
+    name = "MapLibre Compose Runtime (OpenGL, Android)"
+    description = "The MapLibre Native FFI OpenGL runtime for MapLibre Compose on Android."
+    url = "https://github.com/maplibre/maplibre-compose"
+  }
+}
+
+android {
+  namespace = "org.maplibre.compose.runtime.opengl"
+
+  compileSdk = libs.versions.android.compileSdk.get().toInt()
+
+  defaultConfig { minSdk = libs.versions.android.minSdk.get().toInt() }
+}
+
+dependencies {
+  // The runtime artifacts name the same libmaplibre-native-c.so, so an application packages
+  // exactly one of them; the map picks the host the packaged runtime renders with.
+  api(libs.maplibre.nativeFfi.runtimeOpenGl)
+}

--- a/lib/maplibre-compose-runtime-opengl-android/build.gradle.kts
+++ b/lib/maplibre-compose-runtime-opengl-android/build.gradle.kts
@@ -21,6 +21,5 @@ android {
 }
 
 dependencies {
-  // api rather than runtimeOnly: the AAR's classes.jar is what carries the packaging.
-  api(libs.maplibre.nativeFfi.runtimeOpenGl)
+  runtimeOnly(libs.maplibre.nativeFfi.runtimeOpenGl)
 }

--- a/lib/maplibre-compose-runtime-vulkan-android/build.gradle.kts
+++ b/lib/maplibre-compose-runtime-vulkan-android/build.gradle.kts
@@ -1,0 +1,43 @@
+plugins {
+  id("module-conventions")
+  id(libs.plugins.android.classicLibrary.get().pluginId)
+  id(libs.plugins.mavenPublish.get().pluginId)
+}
+
+mavenPublishing {
+  pom {
+    name = "MapLibre Compose Runtime (Vulkan, Android)"
+    description =
+      "The MapLibre Native FFI Vulkan runtime and its Vulkan loader shim, " +
+        "for MapLibre Compose on Android."
+    url = "https://github.com/maplibre/maplibre-compose"
+  }
+}
+
+android {
+  namespace = "org.maplibre.compose.runtime.vulkan"
+
+  compileSdk = libs.versions.android.compileSdk.get().toInt()
+
+  defaultConfig {
+    minSdk = libs.versions.android.minSdk.get().toInt()
+
+    ndk {
+      // The FFI runtime packages these ABIs only.
+      abiFilters += listOf("arm64-v8a", "x86_64")
+    }
+  }
+
+  externalNativeBuild {
+    cmake {
+      path = file("src/main/cpp/CMakeLists.txt")
+      version = "4.1.2"
+    }
+  }
+}
+
+dependencies {
+  // The runtime artifacts name the same libmaplibre-native-c.so, so an application packages
+  // exactly one of them; the map picks the host the packaged runtime renders with.
+  api(libs.maplibre.nativeFfi.runtimeVulkanKmp)
+}

--- a/lib/maplibre-compose-runtime-vulkan-android/build.gradle.kts
+++ b/lib/maplibre-compose-runtime-vulkan-android/build.gradle.kts
@@ -37,7 +37,6 @@ android {
 }
 
 dependencies {
-  // The runtime artifacts name the same libmaplibre-native-c.so, so an application packages
-  // exactly one of them; the map picks the host the packaged runtime renders with.
+  // api rather than runtimeOnly: the AAR's classes.jar is what carries the packaging.
   api(libs.maplibre.nativeFfi.runtimeVulkanKmp)
 }

--- a/lib/maplibre-compose-runtime-vulkan-android/build.gradle.kts
+++ b/lib/maplibre-compose-runtime-vulkan-android/build.gradle.kts
@@ -19,6 +19,10 @@ android {
 
   compileSdk = libs.versions.android.compileSdk.get().toInt()
 
+  // The revision .mise/bin/sync-android-packages pins, so every machine builds
+  // the same shim rather than taking whatever NDK it happens to have.
+  ndkVersion = "28.2.13676358"
+
   defaultConfig {
     minSdk = libs.versions.android.minSdk.get().toInt()
 

--- a/lib/maplibre-compose-runtime-vulkan-android/build.gradle.kts
+++ b/lib/maplibre-compose-runtime-vulkan-android/build.gradle.kts
@@ -19,8 +19,7 @@ android {
 
   compileSdk = libs.versions.android.compileSdk.get().toInt()
 
-  // The revision .mise/bin/sync-android-packages pins, so every machine builds
-  // the same shim rather than taking whatever NDK it happens to have.
+  // Keep in sync with the pin in .mise/bin/sync-android-packages.
   ndkVersion = "28.2.13676358"
 
   defaultConfig {
@@ -41,6 +40,5 @@ android {
 }
 
 dependencies {
-  // api rather than runtimeOnly: the AAR's classes.jar is what carries the packaging.
-  api(libs.maplibre.nativeFfi.runtimeVulkanKmp)
+  runtimeOnly(libs.maplibre.nativeFfi.runtimeVulkanKmp)
 }

--- a/lib/maplibre-compose-runtime-vulkan-android/build.gradle.kts
+++ b/lib/maplibre-compose-runtime-vulkan-android/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.android.build.gradle.internal.cxx.configure.gradleLocalProperties
+
 plugins {
   id("module-conventions")
   id(libs.plugins.android.classicLibrary.get().pluginId)
@@ -14,13 +16,28 @@ mavenPublishing {
   }
 }
 
+// externalNativeBuild needs the SDK at configuration time; without an SDK the
+// module configures but does not build.
+val hasAndroidSdk =
+  gradleLocalProperties(rootDir, providers).getProperty("sdk.dir") != null ||
+    providers.environmentVariable("ANDROID_HOME").isPresent ||
+    providers.environmentVariable("ANDROID_SDK_ROOT").isPresent
+
 android {
   namespace = "org.maplibre.compose.runtime.vulkan"
 
   compileSdk = libs.versions.android.compileSdk.get().toInt()
 
-  // Keep in sync with the pin in .mise/bin/sync-android-packages.
-  ndkVersion = "28.2.13676358"
+  ndkVersion = libs.versions.android.ndk.get()
+
+  if (hasAndroidSdk) {
+    externalNativeBuild {
+      cmake {
+        path = file("src/main/cpp/CMakeLists.txt")
+        version = libs.versions.android.cmake.get()
+      }
+    }
+  }
 
   defaultConfig {
     minSdk = libs.versions.android.minSdk.get().toInt()
@@ -28,13 +45,6 @@ android {
     ndk {
       // The FFI runtime packages these ABIs only.
       abiFilters += listOf("arm64-v8a", "x86_64")
-    }
-  }
-
-  externalNativeBuild {
-    cmake {
-      path = file("src/main/cpp/CMakeLists.txt")
-      version = "4.1.2"
     }
   }
 }

--- a/lib/maplibre-compose-runtime-vulkan-android/src/main/cpp/CMakeLists.txt
+++ b/lib/maplibre-compose-runtime-vulkan-android/src/main/cpp/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.22.1)
+
+project(maplibre_compose_vulkan LANGUAGES CXX)
+
+add_library(maplibre_compose_vulkan SHARED vulkan_context.cpp)
+
+target_compile_features(maplibre_compose_vulkan PRIVATE cxx_std_20)
+target_compile_definitions(
+  maplibre_compose_vulkan
+  PRIVATE VK_USE_PLATFORM_ANDROID_KHR=1)
+
+target_link_libraries(maplibre_compose_vulkan PRIVATE android log vulkan)

--- a/lib/maplibre-compose-runtime-vulkan-android/src/main/cpp/vulkan_context.cpp
+++ b/lib/maplibre-compose-runtime-vulkan-android/src/main/cpp/vulkan_context.cpp
@@ -1,0 +1,369 @@
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <android/log.h>
+#include <android/native_window_jni.h>
+#include <jni.h>
+#include <vulkan/vulkan.h>
+
+namespace {
+
+constexpr auto kLogTag = "MapLibreCompose";
+
+struct VulkanContext {
+  ANativeWindow* window = nullptr;
+  VkInstance instance = VK_NULL_HANDLE;
+  VkSurfaceKHR surface = VK_NULL_HANDLE;
+  VkPhysicalDevice physical_device = VK_NULL_HANDLE;
+  VkDevice device = VK_NULL_HANDLE;
+  VkQueue graphics_queue = VK_NULL_HANDLE;
+  uint32_t graphics_queue_family_index = 0;
+};
+
+auto require_vk(VkResult result, const char* operation) -> void {
+  if (result != VK_SUCCESS) {
+    throw std::runtime_error(
+      std::string(operation) + " failed with VkResult " + std::to_string(result)
+    );
+  }
+}
+
+auto context_from_handle(jlong handle) -> VulkanContext* {
+  auto* context =
+    reinterpret_cast<VulkanContext*>(static_cast<intptr_t>(handle));
+  if (context == nullptr) {
+    throw std::invalid_argument("Vulkan context handle is null");
+  }
+  return context;
+}
+
+auto throw_java_exception(JNIEnv* env, const char* message) -> void {
+  auto* exception_class = env->FindClass("java/lang/IllegalStateException");
+  if (exception_class != nullptr) {
+    env->ThrowNew(exception_class, message);
+  }
+}
+
+auto create_instance() -> VkInstance {
+  const char* extensions[] = {
+    VK_KHR_SURFACE_EXTENSION_NAME,
+    VK_KHR_ANDROID_SURFACE_EXTENSION_NAME,
+  };
+  const VkApplicationInfo app_info{
+    .sType = VK_STRUCTURE_TYPE_APPLICATION_INFO,
+    .pNext = nullptr,
+    .pApplicationName = "maplibre-compose",
+    .applicationVersion = 1,
+    .pEngineName = "maplibre-compose",
+    .engineVersion = 1,
+    .apiVersion = VK_API_VERSION_1_0,
+  };
+  const VkInstanceCreateInfo create_info{
+    .sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO,
+    .pNext = nullptr,
+    .flags = 0,
+    .pApplicationInfo = &app_info,
+    .enabledLayerCount = 0,
+    .ppEnabledLayerNames = nullptr,
+    .enabledExtensionCount = 2,
+    .ppEnabledExtensionNames = extensions,
+  };
+  VkInstance instance = VK_NULL_HANDLE;
+  require_vk(
+    vkCreateInstance(&create_info, nullptr, &instance), "vkCreateInstance"
+  );
+  return instance;
+}
+
+auto create_surface(
+  JNIEnv* env, VkInstance instance, jobject surface, ANativeWindow** out_window
+) -> VkSurfaceKHR {
+  auto* window = ANativeWindow_fromSurface(env, surface);
+  if (window == nullptr) {
+    throw std::runtime_error("ANativeWindow_fromSurface returned null");
+  }
+  const VkAndroidSurfaceCreateInfoKHR create_info{
+    .sType = VK_STRUCTURE_TYPE_ANDROID_SURFACE_CREATE_INFO_KHR,
+    .pNext = nullptr,
+    .flags = 0,
+    .window = window,
+  };
+  VkSurfaceKHR vk_surface = VK_NULL_HANDLE;
+  try {
+    require_vk(
+      vkCreateAndroidSurfaceKHR(instance, &create_info, nullptr, &vk_surface),
+      "vkCreateAndroidSurfaceKHR"
+    );
+  } catch (...) {
+    ANativeWindow_release(window);
+    throw;
+  }
+  *out_window = window;
+  return vk_surface;
+}
+
+auto device_supports_swapchain(VkPhysicalDevice device) -> bool {
+  uint32_t count = 0;
+  require_vk(
+    vkEnumerateDeviceExtensionProperties(device, nullptr, &count, nullptr),
+    "vkEnumerateDeviceExtensionProperties"
+  );
+  std::vector<VkExtensionProperties> extensions(count);
+  require_vk(
+    vkEnumerateDeviceExtensionProperties(
+      device, nullptr, &count, extensions.data()
+    ),
+    "vkEnumerateDeviceExtensionProperties"
+  );
+  for (const auto& extension : extensions) {
+    if (
+      std::strcmp(extension.extensionName, VK_KHR_SWAPCHAIN_EXTENSION_NAME) == 0
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+auto pick_device(
+  VkInstance instance, VkSurfaceKHR surface, uint32_t* out_queue_family
+) -> VkPhysicalDevice {
+  uint32_t device_count = 0;
+  require_vk(
+    vkEnumeratePhysicalDevices(instance, &device_count, nullptr),
+    "vkEnumeratePhysicalDevices"
+  );
+  if (device_count == 0) {
+    throw std::runtime_error("Vulkan instance exposes no physical devices");
+  }
+  std::vector<VkPhysicalDevice> devices(device_count);
+  require_vk(
+    vkEnumeratePhysicalDevices(instance, &device_count, devices.data()),
+    "vkEnumeratePhysicalDevices"
+  );
+
+  for (auto* device : devices) {
+    if (!device_supports_swapchain(device)) {
+      continue;
+    }
+    uint32_t family_count = 0;
+    vkGetPhysicalDeviceQueueFamilyProperties(device, &family_count, nullptr);
+    std::vector<VkQueueFamilyProperties> families(family_count);
+    vkGetPhysicalDeviceQueueFamilyProperties(
+      device, &family_count, families.data()
+    );
+    for (uint32_t index = 0; index < family_count; ++index) {
+      if ((families[index].queueFlags & VK_QUEUE_GRAPHICS_BIT) == 0) {
+        continue;
+      }
+      VkBool32 present_supported = VK_FALSE;
+      require_vk(
+        vkGetPhysicalDeviceSurfaceSupportKHR(
+          device, index, surface, &present_supported
+        ),
+        "vkGetPhysicalDeviceSurfaceSupportKHR"
+      );
+      if (present_supported == VK_TRUE) {
+        *out_queue_family = index;
+        return device;
+      }
+    }
+  }
+  throw std::runtime_error(
+    "No Vulkan device supports graphics and presentation"
+  );
+}
+
+auto create_device(
+  VkPhysicalDevice physical_device, uint32_t queue_family_index
+) -> VkDevice {
+  constexpr float kQueuePriority = 1.0F;
+  const VkDeviceQueueCreateInfo queue_info{
+    .sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO,
+    .pNext = nullptr,
+    .flags = 0,
+    .queueFamilyIndex = queue_family_index,
+    .queueCount = 1,
+    .pQueuePriorities = &kQueuePriority,
+  };
+  const char* extensions[] = {VK_KHR_SWAPCHAIN_EXTENSION_NAME};
+  VkPhysicalDeviceFeatures features{};
+  vkGetPhysicalDeviceFeatures(physical_device, &features);
+  const VkDeviceCreateInfo create_info{
+    .sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO,
+    .pNext = nullptr,
+    .flags = 0,
+    .queueCreateInfoCount = 1,
+    .pQueueCreateInfos = &queue_info,
+    .enabledLayerCount = 0,
+    .ppEnabledLayerNames = nullptr,
+    .enabledExtensionCount = 1,
+    .ppEnabledExtensionNames = extensions,
+    .pEnabledFeatures = &features,
+  };
+  VkDevice device = VK_NULL_HANDLE;
+  require_vk(
+    vkCreateDevice(physical_device, &create_info, nullptr, &device),
+    "vkCreateDevice"
+  );
+  return device;
+}
+
+auto destroy_context(VulkanContext* context) -> void {
+  if (context == nullptr) {
+    return;
+  }
+  if (context->device != VK_NULL_HANDLE) {
+    vkDeviceWaitIdle(context->device);
+    vkDestroyDevice(context->device, nullptr);
+  }
+  if (context->surface != VK_NULL_HANDLE) {
+    vkDestroySurfaceKHR(context->instance, context->surface, nullptr);
+  }
+  if (context->instance != VK_NULL_HANDLE) {
+    vkDestroyInstance(context->instance, nullptr);
+  }
+  if (context->window != nullptr) {
+    ANativeWindow_release(context->window);
+  }
+  delete context;
+}
+
+}  // namespace
+
+extern "C" JNIEXPORT jlong JNICALL
+Java_org_maplibre_compose_mlnffi_AndroidVulkanNativeBridge_create(
+  JNIEnv* env, jobject, jobject surface
+) {
+  auto* context = new VulkanContext();
+  try {
+    context->instance = create_instance();
+    context->surface =
+      create_surface(env, context->instance, surface, &context->window);
+    context->physical_device = pick_device(
+      context->instance, context->surface, &context->graphics_queue_family_index
+    );
+    context->device = create_device(
+      context->physical_device, context->graphics_queue_family_index
+    );
+    vkGetDeviceQueue(
+      context->device, context->graphics_queue_family_index, 0,
+      &context->graphics_queue
+    );
+    return static_cast<jlong>(reinterpret_cast<intptr_t>(context));
+  } catch (const std::exception& error) {
+    __android_log_print(
+      ANDROID_LOG_ERROR, kLogTag, "Vulkan setup failed: %s", error.what()
+    );
+    destroy_context(context);
+    throw_java_exception(env, error.what());
+    return 0;
+  }
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_org_maplibre_compose_mlnffi_AndroidVulkanNativeBridge_destroy(
+  JNIEnv* env, jobject, jlong handle
+) {
+  try {
+    destroy_context(context_from_handle(handle));
+  } catch (const std::exception& error) {
+    throw_java_exception(env, error.what());
+  }
+}
+
+extern "C" JNIEXPORT jlong JNICALL
+Java_org_maplibre_compose_mlnffi_AndroidVulkanNativeBridge_instance(
+  JNIEnv* env, jobject, jlong handle
+) {
+  try {
+    return reinterpret_cast<intptr_t>(context_from_handle(handle)->instance);
+  } catch (const std::exception& error) {
+    throw_java_exception(env, error.what());
+    return 0;
+  }
+}
+
+extern "C" JNIEXPORT jlong JNICALL
+Java_org_maplibre_compose_mlnffi_AndroidVulkanNativeBridge_surface(
+  JNIEnv* env, jobject, jlong handle
+) {
+  try {
+    return reinterpret_cast<intptr_t>(context_from_handle(handle)->surface);
+  } catch (const std::exception& error) {
+    throw_java_exception(env, error.what());
+    return 0;
+  }
+}
+
+extern "C" JNIEXPORT jlong JNICALL
+Java_org_maplibre_compose_mlnffi_AndroidVulkanNativeBridge_physicalDevice(
+  JNIEnv* env, jobject, jlong handle
+) {
+  try {
+    return reinterpret_cast<intptr_t>(
+      context_from_handle(handle)->physical_device
+    );
+  } catch (const std::exception& error) {
+    throw_java_exception(env, error.what());
+    return 0;
+  }
+}
+
+extern "C" JNIEXPORT jlong JNICALL
+Java_org_maplibre_compose_mlnffi_AndroidVulkanNativeBridge_device(
+  JNIEnv* env, jobject, jlong handle
+) {
+  try {
+    return reinterpret_cast<intptr_t>(context_from_handle(handle)->device);
+  } catch (const std::exception& error) {
+    throw_java_exception(env, error.what());
+    return 0;
+  }
+}
+
+extern "C" JNIEXPORT jlong JNICALL
+Java_org_maplibre_compose_mlnffi_AndroidVulkanNativeBridge_graphicsQueue(
+  JNIEnv* env, jobject, jlong handle
+) {
+  try {
+    return reinterpret_cast<intptr_t>(
+      context_from_handle(handle)->graphics_queue
+    );
+  } catch (const std::exception& error) {
+    throw_java_exception(env, error.what());
+    return 0;
+  }
+}
+
+extern "C" JNIEXPORT jint JNICALL
+Java_org_maplibre_compose_mlnffi_AndroidVulkanNativeBridge_graphicsQueueFamilyIndex(
+  JNIEnv* env, jobject, jlong handle
+) {
+  try {
+    return static_cast<jint>(
+      context_from_handle(handle)->graphics_queue_family_index
+    );
+  } catch (const std::exception& error) {
+    throw_java_exception(env, error.what());
+    return 0;
+  }
+}
+
+extern "C" JNIEXPORT jlong JNICALL
+Java_org_maplibre_compose_mlnffi_AndroidVulkanNativeBridge_getInstanceProcAddr(
+  JNIEnv*, jobject
+) {
+  return reinterpret_cast<intptr_t>(&vkGetInstanceProcAddr);
+}
+
+extern "C" JNIEXPORT jlong JNICALL
+Java_org_maplibre_compose_mlnffi_AndroidVulkanNativeBridge_getDeviceProcAddr(
+  JNIEnv*, jobject
+) {
+  return reinterpret_cast<intptr_t>(&vkGetDeviceProcAddr);
+}

--- a/lib/maplibre-compose/build.gradle.kts
+++ b/lib/maplibre-compose/build.gradle.kts
@@ -17,7 +17,14 @@ mavenPublishing {
 }
 
 kotlin {
-  android { namespace = "org.maplibre.compose" }
+  android {
+    namespace = "org.maplibre.compose"
+    optimization {
+      // Keeps the JNI symbols of the Vulkan loader bridge linked by name.
+      consumerKeepRules.publish = true
+      consumerKeepRules.files.add(project.file("consumer-rules.pro"))
+    }
+  }
 
   iosArm64()
   iosSimulatorArm64()
@@ -92,13 +99,8 @@ kotlin {
       }
     }
 
-    androidMain {
-      dependencies {
-        implementation(libs.androidx.activity.compose)
-        // The Android host presents through an EGL window surface.
-        implementation(libs.maplibre.nativeFfi.runtimeOpenGl)
-      }
-    }
+    // The application picks the Android FFI runtime (OpenGL or Vulkan), which names the same
+    // libmaplibre-native-c.so and so cannot be packaged together; see the runtime artifacts.
 
     jvmMain.apply {
       dependencies {
@@ -172,8 +174,12 @@ kotlin {
     androidHostTest.dependencies { implementation(compose.desktop.currentOs) }
 
     androidDeviceTest.dependencies {
+      implementation(libs.androidx.activity.compose)
       implementation(libs.jetbrains.compose.ui.testJunit4)
       implementation(libs.androidx.composeUi.testManifest)
+      // The device suite drives the OpenGL host; the Vulkan host needs a windowing surface the
+      // test runner does not provide.
+      implementation(libs.maplibre.nativeFfi.runtimeOpenGl)
     }
   }
 }

--- a/lib/maplibre-compose/build.gradle.kts
+++ b/lib/maplibre-compose/build.gradle.kts
@@ -20,7 +20,7 @@ kotlin {
   android {
     namespace = "org.maplibre.compose"
     optimization {
-      // Keeps the JNI symbols of the Vulkan loader bridge linked by name.
+      // The Vulkan bridge class is resolved by JNI name.
       consumerKeepRules.publish = true
       consumerKeepRules.files.add(project.file("consumer-rules.pro"))
     }
@@ -174,8 +174,7 @@ kotlin {
       implementation(libs.androidx.activity.compose)
       implementation(libs.jetbrains.compose.ui.testJunit4)
       implementation(libs.androidx.composeUi.testManifest)
-      // The device suite drives the OpenGL host; the Vulkan host needs a windowing surface the
-      // test runner does not provide.
+      // The shared device-test render driver targets OpenGL.
       implementation(libs.maplibre.nativeFfi.runtimeOpenGl)
     }
   }

--- a/lib/maplibre-compose/build.gradle.kts
+++ b/lib/maplibre-compose/build.gradle.kts
@@ -99,9 +99,6 @@ kotlin {
       }
     }
 
-    // The application picks the Android FFI runtime (OpenGL or Vulkan), which names the same
-    // libmaplibre-native-c.so and so cannot be packaged together; see the runtime artifacts.
-
     jvmMain.apply {
       dependencies {
         implementation(compose.desktop.currentOs)

--- a/lib/maplibre-compose/consumer-rules.pro
+++ b/lib/maplibre-compose/consumer-rules.pro
@@ -1,0 +1,2 @@
+# The Vulkan loader bridge reaches its JNI natives by symbol name.
+-keep class org.maplibre.compose.mlnffi.AndroidVulkanNativeBridge { *; }

--- a/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/map/AndroidMapView.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/map/AndroidMapView.kt
@@ -25,7 +25,8 @@ internal actual fun ComposableMapView(
 ) {
   EnsureMlnFfiConfigured()
   val runtimeBackends = remember { loadRuntimeBackends(logger) }
-  val renderBackend = remember(runtimeBackends) { pickRenderBackend(runtimeBackends) }
+  val renderBackend =
+    remember(runtimeBackends) { runtimeBackends.firstOrNull() ?: MapRenderBackend.OPENGL }
   val surfaceKind =
     when (options.renderOptions.preferredRenderMode) {
       RenderOptions.RenderMode.Texture -> AndroidMapSurfaceKind.Texture
@@ -55,12 +56,3 @@ internal actual fun ComposableMapView(
     )
   }
 }
-
-/**
- * The backend the Android surface hosts drive, from what the packaged runtime renders with. The
- * runtime artifacts name one `libmaplibre-native-c.so`, so exactly one backend can be packaged;
- * Vulkan wins when a runtime carrying both ever appears.
- */
-private fun pickRenderBackend(runtimeBackends: Set<MapRenderBackend>): MapRenderBackend =
-  if (MapRenderBackend.VULKAN in runtimeBackends) MapRenderBackend.VULKAN
-  else MapRenderBackend.OPENGL

--- a/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/map/AndroidMapView.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/map/AndroidMapView.kt
@@ -25,18 +25,20 @@ internal actual fun ComposableMapView(
 ) {
   EnsureMlnFfiConfigured()
   val runtimeBackends = remember { loadRuntimeBackends(logger) }
+  val renderBackend = remember(runtimeBackends) { pickRenderBackend(runtimeBackends) }
   val surfaceKind =
     when (options.renderOptions.preferredRenderMode) {
       RenderOptions.RenderMode.Texture -> AndroidMapSurfaceKind.Texture
       RenderOptions.RenderMode.Surface -> AndroidMapSurfaceKind.Surface
     }
-  key(surfaceKind) {
+  key(surfaceKind, renderBackend) {
     MlnFfiMapView(
-      renderBackend = MapRenderBackend.OPENGL,
+      renderBackend = renderBackend,
       surface = { renderer, surfaceModifier, surfaceLogger ->
         AndroidMlnFfiSurface(
           renderer = renderer,
           runtimeBackends = runtimeBackends,
+          backend = renderBackend,
           kind = surfaceKind,
           maximumFps = options.renderOptions.maximumFps,
           modifier = surfaceModifier,
@@ -53,3 +55,12 @@ internal actual fun ComposableMapView(
     )
   }
 }
+
+/**
+ * The backend the Android surface hosts drive, from what the packaged runtime renders with. The
+ * runtime artifacts name one `libmaplibre-native-c.so`, so exactly one backend can be packaged;
+ * Vulkan wins when a runtime carrying both ever appears.
+ */
+private fun pickRenderBackend(runtimeBackends: Set<MapRenderBackend>): MapRenderBackend =
+  if (MapRenderBackend.VULKAN in runtimeBackends) MapRenderBackend.VULKAN
+  else MapRenderBackend.OPENGL

--- a/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/mlnffi/AndroidEglContext.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/mlnffi/AndroidEglContext.kt
@@ -5,6 +5,7 @@ import android.opengl.EGLConfig
 import android.opengl.EGLDisplay
 import android.opengl.EGLSurface
 import android.view.Surface
+import org.maplibre.compose.map.MapExtent
 import org.maplibre.nativeffi.render.OpenGLClientApi
 import org.maplibre.nativeffi.render.OpenGLContextOwnership
 
@@ -17,7 +18,7 @@ private constructor(
   private val display: EGLDisplay,
   private val config: EGLConfig,
   private var windowSurface: EGLSurface,
-) : AutoCloseable {
+) : AndroidMapGraphicsContext {
 
   val contextHandles: EglContextHandles
     get() =
@@ -33,6 +34,14 @@ private constructor(
 
   val surfaceHandle: NativeHandle
     get() = NativeHandle(windowSurface.nativeHandle)
+
+  override fun target(extent: MapExtent, generation: Long): MlnFfiRenderTarget =
+    OpenGlSurfaceTarget(
+      context = contextHandles,
+      surface = surfaceHandle,
+      extent = extent,
+      generation = generation,
+    )
 
   override fun close() {
     if (windowSurface != EGL14.EGL_NO_SURFACE) {

--- a/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/mlnffi/AndroidMapGraphicsContext.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/mlnffi/AndroidMapGraphicsContext.kt
@@ -1,0 +1,22 @@
+package org.maplibre.compose.mlnffi
+
+import android.view.Surface
+import org.maplibre.compose.map.MapExtent
+
+/**
+ * The graphics context one Android map surface presents through, created for a single [Surface] and
+ * closed with it. A context names the render target each frame draws into.
+ */
+internal interface AndroidMapGraphicsContext : AutoCloseable {
+  /** The target a frame at [extent] renders into, as allocation [generation] of this context. */
+  fun target(extent: MapExtent, generation: Long): MlnFfiRenderTarget
+
+  companion object {
+    fun create(backend: MapRenderBackend, surface: Surface): AndroidMapGraphicsContext =
+      when (backend) {
+        MapRenderBackend.OPENGL -> AndroidEglContext.create(surface)
+        MapRenderBackend.VULKAN -> AndroidVulkanContext.create(surface)
+        MapRenderBackend.METAL -> error("Metal is not an Android render backend")
+      }
+  }
+}

--- a/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/mlnffi/AndroidMapGraphicsContext.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/mlnffi/AndroidMapGraphicsContext.kt
@@ -4,11 +4,11 @@ import android.view.Surface
 import org.maplibre.compose.map.MapExtent
 
 /**
- * The graphics context one Android map surface presents through, created for a single [Surface] and
- * closed with it. A context names the render target each frame draws into.
+ * The EGL or Vulkan context backing one host [Surface]. The context and its render target handles
+ * are closed with the surface.
  */
 internal interface AndroidMapGraphicsContext : AutoCloseable {
-  /** The target a frame at [extent] renders into, as allocation [generation] of this context. */
+  /** The render target for a frame at [extent]; [generation] distinguishes reallocations. */
   fun target(extent: MapExtent, generation: Long): MlnFfiRenderTarget
 
   companion object {

--- a/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/mlnffi/AndroidMlnFfiSurface.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/mlnffi/AndroidMlnFfiSurface.kt
@@ -13,12 +13,15 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import co.touchlab.kermit.Logger
+import org.maplibre.compose.map.mlnFfiArchitecture
+import org.maplibre.compose.map.mlnFfiOperatingSystem
 
-/** An Android surface that the OpenGL FFI runtime presents into directly. */
+/** An Android surface that the FFI runtime presents into directly. */
 @Composable
 internal fun AndroidMlnFfiSurface(
   renderer: MlnFfiMapRenderer,
   runtimeBackends: Set<MapRenderBackend>,
+  backend: MapRenderBackend,
   kind: AndroidMapSurfaceKind,
   maximumFps: Int? = null,
   modifier: Modifier,
@@ -27,8 +30,10 @@ internal fun AndroidMlnFfiSurface(
   val density = LocalDensity.current.density.toDouble()
   val lifecycleOwner = LocalLifecycleOwner.current
   val controller =
-    remember(renderer) { AndroidMlnFfiSurfaceController(renderer, logger, maximumFps) }
-  val available = MapRenderBackend.OPENGL in runtimeBackends
+    remember(renderer, backend) {
+      AndroidMlnFfiSurfaceController(renderer, backend, logger, maximumFps)
+    }
+  val available = backend in runtimeBackends
 
   SideEffect { controller.setMaximumFps(maximumFps) }
 
@@ -50,8 +55,16 @@ internal fun AndroidMlnFfiSurface(
   if (!available) {
     DisposableEffect(runtimeBackends) {
       logger?.e {
-        "Android MapLibre Compose requires the OpenGL maplibre-native-ffi runtime; " +
-          "available backends: ${runtimeBackends.joinToString().ifEmpty { "none" }}"
+        val hostBackends = RenderBackendPair(backend, ComposeRenderBackend.OPENGL)
+        val diagnostic =
+          backendDiagnostic(
+            runtimeBackends = runtimeBackends,
+            hostBackends = hostBackends,
+            hostDescription = "the Android $backend surface host",
+            operatingSystem = mlnFfiOperatingSystem,
+            architecture = mlnFfiArchitecture,
+          )
+        "Android MapLibre Compose cannot present a map\n${diagnostic ?: "backend $backend"}"
       }
       onDispose {}
     }

--- a/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/mlnffi/AndroidMlnFfiSurfaceController.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/mlnffi/AndroidMlnFfiSurfaceController.kt
@@ -12,10 +12,10 @@ import org.maplibre.compose.map.MapExtent
 /**
  * Drives the shared FFI renderer from a dedicated Android render thread.
  *
- * The thread draws, then presents: an OpenGL session through `eglSwapBuffers`, a Vulkan one from
- * its own render update. SurfaceView waits on the buffer queue there, matching MapLibre Android's
- * GLSurfaceView loop. TextureView returns from swap without waiting; the next frame is posted when
- * the map requests one, matching MapLibre's TextureView thread.
+ * The thread draws, then the backend presents: `eglSwapBuffers` for OpenGL, the render update for
+ * Vulkan. SurfaceView waits on the buffer queue there, matching MapLibre Android's GLSurfaceView
+ * loop. TextureView returns from swap without waiting; the next frame is posted when the map
+ * requests one, matching MapLibre's TextureView thread.
  *
  * When [maximumFps] is set, the next post is delayed to that interval. Display refresh stays with
  * the window; Compose and the map do not share a SurfaceFlinger vote. `Choreographer.getInstance()`
@@ -92,8 +92,6 @@ internal class AndroidMlnFfiSurfaceController(
     val changed = MapExtent.fromPhysical(width, height, scaleFactor)
     if (changed == extent) return
     extent = changed
-    // An EGL window surface is re-described to the session at the new size; a resized window keeps
-    // its VkSurfaceKHR, so the Vulkan session follows through a resize instead.
     if (backend == MapRenderBackend.OPENGL) generation++
     try {
       renderer.onSurfaceChanged(changed)

--- a/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/mlnffi/AndroidMlnFfiSurfaceController.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/mlnffi/AndroidMlnFfiSurfaceController.kt
@@ -12,9 +12,10 @@ import org.maplibre.compose.map.MapExtent
 /**
  * Drives the shared FFI renderer from a dedicated Android render thread.
  *
- * The thread draws, then `eglSwapBuffers` presents. SurfaceView waits on the buffer queue there,
- * matching MapLibre Android's GLSurfaceView loop. TextureView returns from swap without waiting;
- * the next frame is posted when the map requests one, matching MapLibre's TextureView thread.
+ * The thread draws, then presents: an OpenGL session through `eglSwapBuffers`, a Vulkan one from
+ * its own render update. SurfaceView waits on the buffer queue there, matching MapLibre Android's
+ * GLSurfaceView loop. TextureView returns from swap without waiting; the next frame is posted when
+ * the map requests one, matching MapLibre's TextureView thread.
  *
  * When [maximumFps] is set, the next post is delayed to that interval. Display refresh stays with
  * the window; Compose and the map do not share a SurfaceFlinger vote. `Choreographer.getInstance()`
@@ -23,15 +24,16 @@ import org.maplibre.compose.map.MapExtent
  */
 internal class AndroidMlnFfiSurfaceController(
   private val renderer: MlnFfiMapRenderer,
+  private val backend: MapRenderBackend,
   private val logger: Logger?,
   maximumFps: Int? = null,
 ) : MlnFfiMapHostSession, AutoCloseable {
-  override val backends = RenderBackendPair(MapRenderBackend.OPENGL, ComposeRenderBackend.OPENGL)
+  override val backends = RenderBackendPair(backend, ComposeRenderBackend.OPENGL)
 
   private val renderThread = HandlerThread("maplibre-compose-render").apply { start() }
   private val renderHandler = Handler(renderThread.looper)
   private val renderFrame = Runnable { renderFrame(System.nanoTime()) }
-  private var graphics: AndroidEglContext? = null
+  private var graphics: AndroidMapGraphicsContext? = null
   private var maximumFps = maximumFps
   private var extent = MapExtent.Empty
   private var generation = 0L
@@ -68,7 +70,7 @@ internal class AndroidMlnFfiSurfaceController(
     if (closed) return
     surfaceDestroyedOnRenderThread()
     try {
-      graphics = AndroidEglContext.create(surface)
+      graphics = AndroidMapGraphicsContext.create(backend, surface)
       extent = MapExtent.fromPhysical(width, height, scaleFactor)
       generation++
       renderer.onSurfaceAvailable(this)
@@ -90,7 +92,9 @@ internal class AndroidMlnFfiSurfaceController(
     val changed = MapExtent.fromPhysical(width, height, scaleFactor)
     if (changed == extent) return
     extent = changed
-    generation++
+    // An EGL window surface is re-described to the session at the new size; a resized window keeps
+    // its VkSurfaceKHR, so the Vulkan session follows through a resize instead.
+    if (backend == MapRenderBackend.OPENGL) generation++
     try {
       renderer.onSurfaceChanged(changed)
       requestFrame()
@@ -108,11 +112,11 @@ internal class AndroidMlnFfiSurfaceController(
     checkRenderThread()
     cancelFrame()
     if (graphics == null) return
-    // The render session names this EGL surface, so it must be closed before EGL destroys it.
+    // The render session names this surface, so it must be closed before the context frees it.
     runCatching { renderer.onSurfaceLost() }
       .onFailure { logger?.e(it) { "Failed to release the Android map render session" } }
     runCatching { graphics?.close() }
-      .onFailure { logger?.e(it) { "Failed to release the Android EGL context" } }
+      .onFailure { logger?.e(it) { "Failed to release the Android map graphics context" } }
     graphics = null
     extent = MapExtent.Empty
     consecutiveFailures = 0
@@ -157,13 +161,7 @@ internal class AndroidMlnFfiSurfaceController(
     if (closed || !active || currentGraphics == null || currentExtent.isEmpty) return
 
     val frameId = nextFrameId++
-    val target =
-      OpenGlSurfaceTarget(
-        context = currentGraphics.contextHandles,
-        surface = currentGraphics.surfaceHandle,
-        extent = currentExtent,
-        generation = generation,
-      )
+    val target = currentGraphics.target(currentExtent, generation)
     val frame = MlnFfiMapFrame(frameId, currentExtent, target, frameTimeNanos)
 
     val frameStartUptimeMs = SystemClock.uptimeMillis()
@@ -248,7 +246,7 @@ internal class AndroidMlnFfiSurfaceController(
     logger?.e(error) { message }
     runCatching { renderer.onSurfaceLost() }
     runCatching { graphics?.close() }
-      .onFailure { logger?.e(it) { "Failed to release the Android EGL context" } }
+      .onFailure { logger?.e(it) { "Failed to release the Android map graphics context" } }
     graphics = null
     extent = MapExtent.Empty
     runCatching { renderer.close() }

--- a/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/mlnffi/AndroidVulkanContext.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/mlnffi/AndroidVulkanContext.kt
@@ -4,12 +4,8 @@ import android.view.Surface
 import org.maplibre.compose.map.MapExtent
 
 /**
- * The Vulkan instance, device, and queue a surface session renders with, and the `VkSurfaceKHR`
- * built from the host [Surface].
- *
- * A Vulkan context cannot outlive its window: the host tears it down with the session when the
- * surface goes away, and the next surface builds both anew. A resize keeps it, since the
- * `VkSurfaceKHR` keeps naming the same window.
+ * The Vulkan instance, device, queue, and `VkSurfaceKHR` for one host [Surface]. A new surface
+ * requires a new context; a resize reuses this one.
  */
 internal class AndroidVulkanContext private constructor(private var handle: Long) :
   AndroidMapGraphicsContext {
@@ -49,15 +45,14 @@ internal class AndroidVulkanContext private constructor(private var handle: Long
         AndroidVulkanContext(AndroidVulkanNativeBridge.create(surface))
       } catch (error: UnsatisfiedLinkError) {
         throw IllegalStateException(
-          "The Android Vulkan host needs the maplibre-compose-runtime-vulkan-android runtime, " +
-            "which packages its Vulkan loader shim",
+          "The Vulkan host requires the maplibre-compose-runtime-vulkan-android runtime",
           error,
         )
       }
   }
 }
 
-/** JNI bindings into the Vulkan loader shim the Vulkan runtime artifact packages. */
+/** JNI bindings for the native Vulkan loader shim. */
 private object AndroidVulkanNativeBridge {
   init {
     System.loadLibrary("maplibre_compose_vulkan")

--- a/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/mlnffi/AndroidVulkanContext.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/mlnffi/AndroidVulkanContext.kt
@@ -1,0 +1,93 @@
+package org.maplibre.compose.mlnffi
+
+import android.view.Surface
+import org.maplibre.compose.map.MapExtent
+
+/**
+ * The Vulkan instance, device, and queue a surface session renders with, and the `VkSurfaceKHR`
+ * built from the host [Surface].
+ *
+ * A Vulkan context cannot outlive its window: the host tears it down with the session when the
+ * surface goes away, and the next surface builds both anew. A resize keeps it, since the
+ * `VkSurfaceKHR` keeps naming the same window.
+ */
+internal class AndroidVulkanContext private constructor(private var handle: Long) :
+  AndroidMapGraphicsContext {
+
+  override fun target(extent: MapExtent, generation: Long): MlnFfiRenderTarget =
+    VulkanSurfaceTarget(
+      context = contextHandles,
+      surface = surfaceHandle,
+      extent = extent,
+      generation = generation,
+    )
+
+  private val contextHandles: VulkanContextHandles
+    get() =
+      VulkanContextHandles(
+        instance = NativeHandle(AndroidVulkanNativeBridge.instance(handle)),
+        physicalDevice = NativeHandle(AndroidVulkanNativeBridge.physicalDevice(handle)),
+        device = NativeHandle(AndroidVulkanNativeBridge.device(handle)),
+        graphicsQueue = NativeHandle(AndroidVulkanNativeBridge.graphicsQueue(handle)),
+        graphicsQueueFamilyIndex = AndroidVulkanNativeBridge.graphicsQueueFamilyIndex(handle),
+        getInstanceProcAddr = NativeHandle(AndroidVulkanNativeBridge.getInstanceProcAddr()),
+        getDeviceProcAddr = NativeHandle(AndroidVulkanNativeBridge.getDeviceProcAddr()),
+      )
+
+  private val surfaceHandle: NativeHandle
+    get() = NativeHandle(AndroidVulkanNativeBridge.surface(handle))
+
+  override fun close() {
+    if (handle == 0L) return
+    AndroidVulkanNativeBridge.destroy(handle)
+    handle = 0L
+  }
+
+  companion object {
+    fun create(surface: Surface): AndroidVulkanContext =
+      try {
+        AndroidVulkanContext(AndroidVulkanNativeBridge.create(surface))
+      } catch (error: UnsatisfiedLinkError) {
+        throw IllegalStateException(
+          "The Android Vulkan host needs the maplibre-compose-runtime-vulkan-android runtime, " +
+            "which packages its Vulkan loader shim",
+          error,
+        )
+      }
+  }
+}
+
+/** JNI bindings into the Vulkan loader shim the Vulkan runtime artifact packages. */
+private object AndroidVulkanNativeBridge {
+  init {
+    System.loadLibrary("maplibre_compose_vulkan")
+  }
+
+  /** Builds the context for [surface], or throws with the Vulkan failure. */
+  external fun create(surface: Surface): Long
+
+  external fun destroy(handle: Long)
+
+  /** `VkInstance`. */
+  external fun instance(handle: Long): Long
+
+  /** `VkSurfaceKHR`. */
+  external fun surface(handle: Long): Long
+
+  /** `VkPhysicalDevice`. */
+  external fun physicalDevice(handle: Long): Long
+
+  /** `VkDevice`. */
+  external fun device(handle: Long): Long
+
+  /** `VkQueue` for graphics work. */
+  external fun graphicsQueue(handle: Long): Long
+
+  external fun graphicsQueueFamilyIndex(handle: Long): Int
+
+  /** `PFN_vkGetInstanceProcAddr`. */
+  external fun getInstanceProcAddr(): Long
+
+  /** `PFN_vkGetDeviceProcAddr`. */
+  external fun getDeviceProcAddr(): Long
+}

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -557,8 +557,6 @@ internal class MlnFfiMapSession(
     try {
       when (target) {
         is VulkanImageTarget -> session.setVulkanBorrowedTextureTarget(target.toDescriptor(extent))
-        // A Vulkan surface target keeps its `VkSurfaceKHR` across a resize; only the session's
-        // size follows the new extent.
         is VulkanSurfaceTarget -> session.resize(extent.width, extent.height, extent.scaleFactor)
         is MetalTextureTarget -> session.setMetalBorrowedTextureTarget(target.toDescriptor(extent))
         is MetalSurfaceTarget -> session.setMetalSurfaceTarget(target.toDescriptor(extent))

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -46,6 +46,7 @@ import org.maplibre.compose.mlnffi.OpenGlSurfaceTarget
 import org.maplibre.compose.mlnffi.OpenGlTextureTarget
 import org.maplibre.compose.mlnffi.VulkanContextHandles
 import org.maplibre.compose.mlnffi.VulkanImageTarget
+import org.maplibre.compose.mlnffi.VulkanSurfaceTarget
 import org.maplibre.compose.mlnffi.WglContextHandles
 import org.maplibre.compose.mlnffi.currentMlnFfiThreadName
 import org.maplibre.compose.mlnffi.withLock
@@ -96,6 +97,7 @@ import org.maplibre.nativeffi.render.RenderResult
 import org.maplibre.nativeffi.render.RenderSessionHandle
 import org.maplibre.nativeffi.render.RenderTargetExtent
 import org.maplibre.nativeffi.render.VulkanBorrowedTextureDescriptor
+import org.maplibre.nativeffi.render.VulkanSurfaceDescriptor
 import org.maplibre.nativeffi.runtime.RuntimeEvent
 import org.maplibre.nativeffi.runtime.RuntimeEventMask
 import org.maplibre.nativeffi.runtime.RuntimeEventPayload
@@ -536,6 +538,7 @@ internal class MlnFfiMapSession(
   ): RenderSessionHandle =
     when (target) {
       is VulkanImageTarget -> map.attachVulkanBorrowedTexture(target.toDescriptor(extent))
+      is VulkanSurfaceTarget -> map.attachVulkanSurface(target.toDescriptor(extent))
       is MetalTextureTarget -> map.attachMetalBorrowedTexture(target.toDescriptor(extent))
       is MetalSurfaceTarget -> map.attachMetalSurface(target.toDescriptor(extent))
       is OpenGlTextureTarget -> {
@@ -554,6 +557,9 @@ internal class MlnFfiMapSession(
     try {
       when (target) {
         is VulkanImageTarget -> session.setVulkanBorrowedTextureTarget(target.toDescriptor(extent))
+        // A Vulkan surface target keeps its `VkSurfaceKHR` across a resize; only the session's
+        // size follows the new extent.
+        is VulkanSurfaceTarget -> session.resize(extent.width, extent.height, extent.scaleFactor)
         is MetalTextureTarget -> session.setMetalBorrowedTextureTarget(target.toDescriptor(extent))
         is MetalSurfaceTarget -> session.setMetalSurfaceTarget(target.toDescriptor(extent))
         is OpenGlTextureTarget -> {
@@ -599,6 +605,13 @@ internal class MlnFfiMapSession(
         initialLayout = initialLayout,
       )
       .also { it.finalLayout = finalLayout }
+
+  private fun VulkanSurfaceTarget.toDescriptor(extent: MapExtent) =
+    VulkanSurfaceDescriptor(
+      extent = extent.toFfiExtent(),
+      context = context.toFfi(),
+      surface = NativePointer.ofAddress(surface.address),
+    )
 
   private fun MetalTextureTarget.toDescriptor(extent: MapExtent) =
     MetalBorrowedTextureDescriptor(

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/mlnffi/MlnFfiRenderTarget.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/mlnffi/MlnFfiRenderTarget.kt
@@ -87,6 +87,20 @@ internal data class VulkanImageTarget(
     get() = MapRenderBackend.VULKAN
 }
 
+/** A `VkSurfaceKHR` MapLibre renders into and presents directly. */
+@Immutable
+internal data class VulkanSurfaceTarget(
+  /** The Vulkan context owning [surface]. */
+  val context: VulkanContextHandles,
+  /** `VkSurfaceKHR`. */
+  val surface: NativeHandle,
+  override val extent: MapExtent,
+  override val generation: Long,
+) : MlnFfiRenderTarget {
+  override val backend: MapRenderBackend
+    get() = MapRenderBackend.VULKAN
+}
+
 /** An `id<MTLTexture>` MapLibre renders into. */
 @Immutable
 internal data class MetalTextureTarget(

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/mlnffi/RenderBackendNegotiation.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/mlnffi/RenderBackendNegotiation.kt
@@ -22,8 +22,7 @@ internal fun backendDiagnostic(
     when {
       runtimeBackends.isEmpty() ->
         "No MapLibre Native FFI runtime is on the classpath. Add a runtimeOnly dependency on " +
-          "the matching org.maplibre.compose:maplibre-compose-runtime-<backend>-<os>-<arch> " +
-          "artifact for this platform, or maplibre-compose-runtime-<backend>-android on Android."
+          "the matching org.maplibre.compose:maplibre-compose-runtime-<backend>-<platform> artifact."
       else ->
         "The packaged MapLibre Native FFI runtime renders with " +
           "${runtimeBackends.describe()}, but $hostDescription requires ${hostBackends.producer}. " +

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/mlnffi/RenderBackendNegotiation.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/mlnffi/RenderBackendNegotiation.kt
@@ -23,7 +23,7 @@ internal fun backendDiagnostic(
       runtimeBackends.isEmpty() ->
         "No MapLibre Native FFI runtime is on the classpath. Add a runtimeOnly dependency on " +
           "the matching org.maplibre.compose:maplibre-compose-runtime-<backend>-<os>-<arch> " +
-          "artifact for this platform."
+          "artifact for this platform, or maplibre-compose-runtime-<backend>-android on Android."
       else ->
         "The packaged MapLibre Native FFI runtime renders with " +
           "${runtimeBackends.describe()}, but $hostDescription requires ${hostBackends.producer}. " +

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/mlnffi/RenderBackendNegotiationTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/mlnffi/RenderBackendNegotiationTest.kt
@@ -25,7 +25,7 @@ class RenderBackendNegotiationTest {
   fun reports_a_missing_runtime_dependency() {
     val message = checkNotNull(diagnostic(emptySet()))
     assertContains(message, "No MapLibre Native FFI runtime is on the classpath")
-    assertContains(message, "maplibre-compose-runtime-<backend>-<os>-<arch>")
+    assertContains(message, "maplibre-compose-runtime-<backend>-<platform>")
   }
 
   @Test

--- a/mise.toml
+++ b/mise.toml
@@ -226,8 +226,8 @@ fi
 
 [tasks."publish:snapshot"]
 description = "Publish a snapshot build to Maven Central."
-# The Android runtime artifacts build a native shim, so the SDK packages come
-# along before Gradle publishes.
+# Publishing builds the Vulkan runtime AAR, which compiles its native shim, so
+# the pinned NDK and CMake must be in the SDK the build resolves first.
 depends = ["android-sdk-packages"]
 run = ".mise/bin/gradle-with-version snapshot publishToMavenCentral"
 

--- a/mise.toml
+++ b/mise.toml
@@ -182,6 +182,7 @@ run = "./gradlew :demo-app:desktop:packageDistributionForCurrentOS"
 description = "Run the demo app on a connected Android device or emulator."
 usage = '''
 arg "[serial]" help="adb serial. Prompts when several devices are connected."
+flag "--backend <backend>" help="Render backend to package: opengl (default) or vulkan."
 '''
 # The device prompt needs the real terminal; mise otherwise pipes stdio.
 raw = true
@@ -226,8 +227,7 @@ fi
 
 [tasks."publish:snapshot"]
 description = "Publish a snapshot build to Maven Central."
-# Publishing builds the Vulkan runtime AAR, which compiles its native shim, so
-# the pinned NDK and CMake must be in the SDK the build resolves first.
+# Publishing builds the Vulkan runtime AAR, which needs the pinned NDK and CMake.
 depends = ["android-sdk-packages"]
 run = ".mise/bin/gradle-with-version snapshot publishToMavenCentral"
 

--- a/mise.toml
+++ b/mise.toml
@@ -226,10 +226,14 @@ fi
 
 [tasks."publish:snapshot"]
 description = "Publish a snapshot build to Maven Central."
+# The Android runtime artifacts build a native shim, so the SDK packages come
+# along before Gradle publishes.
+depends = ["android-sdk-packages"]
 run = ".mise/bin/gradle-with-version snapshot publishToMavenCentral"
 
 [tasks."publish:release"]
 description = "Publish and release the current tag to Maven Central."
+depends = ["android-sdk-packages"]
 run = ".mise/bin/gradle-with-version release publishAndReleaseToMavenCentral --no-configuration-cache"
 
 [tasks.version]

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -41,6 +41,8 @@ include(
   ":lib",
   ":lib:maplibre-compose",
   ":lib:maplibre-compose-material3",
+  ":lib:maplibre-compose-runtime-opengl-android",
+  ":lib:maplibre-compose-runtime-vulkan-android",
   ":lib:location",
   ":lib:location-runtime-gms",
   ":lib:location-runtime-linux",


### PR DESCRIPTION
## Description

Android applications now pick their render backend by packaging one of two new runtime artifacts, `maplibre-compose-runtime-opengl-android` or `maplibre-compose-runtime-vulkan-android`, mirroring the desktop runtime split; the map host follows whichever backend the packaged FFI runtime reports. The Vulkan host presents MapLibre's rendering through a `VkSurfaceKHR` built from the existing Surface/TextureView loop, via a small NDK JNI loader shim packaged with the Vulkan runtime artifact.

## Validation

Rendered the demo app with both runtimes on a Pixel... no, a Samsung SM-F966U1 (Adreno): first frame rendered with OPENGL and with VULKAN, and rotation exercised surface loss and re-attach under Vulkan; also ran jvmTest, Android host tests, unit tests, Android lint, and `mise run check` locally. The device-test suite is left to CI.

## AI assistance

opencode (glm-5.3) implemented the change at the direction of the repository owner.