### PR TITLE
prepare for desktop backend selection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,7 +97,8 @@ For a machine with no SDK, install the pinned SDK with
   headless emulator; `android-emulator:boot`/`:stop` drive it directly)
 - **iOS:** `mise run test:ios` (boots its own simulator)
 - **Web:** `mise run test:js`
-- **Desktop:** `mise run test:desktop`
+- **Desktop:** `mise run test:desktop` (add `--backend <name>` to package a
+  non-default render backend, e.g. `opengl` on Linux)
 
 Tests live in platform-specific source sets:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,6 +128,12 @@ launch on iOS. Every other host has a task:
 - Desktop on the compose-glfw host instead of the AWT one:
   `mise run demo:desktop-glfw`
 
+The desktop demos and test suite take `--backend <name>` to package a different
+Map render backend than the platform default, as in
+`mise run demo:desktop -- --backend=opengl`. It passes the
+`maplibre.desktop.backend` Gradle property, which swaps the packaged
+`maplibre-compose-runtime-*` artifact.
+
 ## Run the tests
 
 CI runs these same tasks, so you can reproduce a failure with the command the

--- a/buildSrc/src/main/kotlin/ffi.kt
+++ b/buildSrc/src/main/kotlin/ffi.kt
@@ -2,28 +2,31 @@
  * The desktop platforms MapLibre Native FFI publishes a native runtime for.
  *
  * The FFI ships one artifact per render backend, each carrying per-platform natives under a
- * classifier; an application picks exactly one.
+ * classifier; an application picks exactly one. Which backends a platform can run is a property of
+ * the platform; which one runs is the application's choice of runtime artifact.
  */
 enum class DesktopHostPlatform(
   private val os: String,
   private val arch: String,
 
-  /**
-   * The one backend `ComposeMapHostFactory` can bridge here today, not a property of the platform:
-   * the FFI offers OpenGL and Vulkan everywhere, and an application chooses by choosing a runtime.
-   */
-  val defaultRenderBackend: RenderBackend,
+  /** Every backend this platform runs, in preference order. */
+  val supportedBackends: List<RenderBackend>,
 ) {
-  LinuxX64("linux", "x64", RenderBackend.VULKAN),
-  LinuxArm64("linux", "arm64", RenderBackend.VULKAN),
-  MacosArm64("macos", "arm64", RenderBackend.METAL),
-  WindowsX64("windows", "x64", RenderBackend.VULKAN),
-  WindowsArm64("windows", "arm64", RenderBackend.VULKAN);
+  LinuxX64("linux", "x64", listOf(RenderBackend.VULKAN, RenderBackend.OPENGL)),
+  LinuxArm64("linux", "arm64", listOf(RenderBackend.VULKAN, RenderBackend.OPENGL)),
+  MacosArm64("macos", "arm64", listOf(RenderBackend.METAL)),
+  WindowsX64("windows", "x64", listOf(RenderBackend.VULKAN, RenderBackend.OPENGL)),
+  WindowsArm64("windows", "arm64", listOf(RenderBackend.VULKAN, RenderBackend.OPENGL));
 
   enum class RenderBackend(val artifactInfix: String) {
     METAL("metal"),
     VULKAN("vulkan"),
+    OPENGL("opengl"),
   }
+
+  /** The backend packaged when the build does not select one, the first of [supportedBackends]. */
+  val defaultRenderBackend: RenderBackend
+    get() = supportedBackends.first()
 
   /** Classifier of the natives jar for this platform, e.g. `natives-linux-x64`. */
   val nativesClassifier: String
@@ -43,10 +46,6 @@ enum class DesktopHostPlatform(
   /** Our runtime artifact for [backend] on this platform. */
   fun runtimeArtifactId(backend: RenderBackend): String =
     "maplibre-compose-runtime-${backend.artifactInfix}-$artifactSuffix"
-
-  /** Our runtime artifact for [defaultRenderBackend]. */
-  val defaultRuntimeArtifactId: String
-    get() = runtimeArtifactId(defaultRenderBackend)
 
   /** Module carrying [backend]'s native runtime, without a version. */
   fun runtimeModule(backend: RenderBackend): String =
@@ -126,4 +125,25 @@ enum class DesktopHostPlatform(
         )
     }
   }
+}
+
+/**
+ * The backend the `maplibre.desktop.backend` Gradle property selects for this platform, or the
+ * default when the property is unset.
+ *
+ * Pass `providers.gradleProperty("maplibre.desktop.backend").orNull`; the property names a backend
+ * by its artifact infix, as in `-Pmaplibre.desktop.backend=opengl`.
+ */
+fun DesktopHostPlatform.selectedRenderBackend(
+  requested: String?
+): DesktopHostPlatform.RenderBackend {
+  if (requested.isNullOrBlank()) return defaultRenderBackend
+  val backend =
+    DesktopHostPlatform.RenderBackend.entries.singleOrNull { it.artifactInfix == requested }
+  check(backend != null && backend in supportedBackends) {
+    "Backend '$requested' does not run on $artifactSuffix. Choose one of " +
+      supportedBackends.joinToString { it.artifactInfix } +
+      '.'
+  }
+  return backend
 }

--- a/demo-app/desktop-glfw/build.gradle.kts
+++ b/demo-app/desktop-glfw/build.gradle.kts
@@ -8,6 +8,10 @@ plugins {
 }
 
 val desktopHostPlatform = DesktopHostPlatform.current()
+val desktopRenderBackend =
+  desktopHostPlatform.selectedRenderBackend(
+    providers.gradleProperty("maplibre.desktop.backend").orNull
+  )
 
 kotlin {
   jvmToolchain(libs.versions.java.toolchain.get().toInt())
@@ -21,7 +25,7 @@ dependencies {
   implementation(libs.composeGlfw)
 
   runtimeOnly(desktopHostPlatform.composeGlfwRuntimeDependency(libs.versions.composeGlfw.get()))
-  runtimeOnly(project(":lib:${desktopHostPlatform.defaultRuntimeArtifactId}"))
+  runtimeOnly(project(":lib:${desktopHostPlatform.runtimeArtifactId(desktopRenderBackend)}"))
 }
 
 /**

--- a/demo-app/desktop/build.gradle.kts
+++ b/demo-app/desktop/build.gradle.kts
@@ -8,6 +8,10 @@ plugins {
 }
 
 val desktopHostPlatform = DesktopHostPlatform.current()
+val desktopRenderBackend =
+  desktopHostPlatform.selectedRenderBackend(
+    providers.gradleProperty("maplibre.desktop.backend").orNull
+  )
 
 kotlin {
   jvmToolchain(libs.versions.java.toolchain.get().toInt())
@@ -20,7 +24,7 @@ dependencies {
   implementation(compose.desktop.currentOs)
   implementation(libs.kotlinx.coroutines.swing)
 
-  runtimeOnly(project(":lib:${desktopHostPlatform.defaultRuntimeArtifactId}"))
+  runtimeOnly(project(":lib:${desktopHostPlatform.runtimeArtifactId(desktopRenderBackend)}"))
 }
 
 compose.desktop {

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -122,7 +122,8 @@ fun main() {
 ## Set up Desktop (JVM)
 
 Alongside the library, add a runtime: the native libraries for one platform and
-one render backend.
+one render backend. The runtime artifact you package is what picks the backend
+the map renders with.
 
 ```kotlin title="build.gradle.kts"
 sourceSets {
@@ -131,7 +132,7 @@ sourceSets {
       implementation(compose.desktop.currentOs)
       implementation("org.maplibre.compose:maplibre-compose:{{release}}")
 
-      // Linux x64, for example.
+      // Linux x64 with Vulkan, for example.
       runtimeOnly(
         "org.maplibre.compose:maplibre-compose-runtime-vulkan-linux-x64:" +
           "{{release}}"
@@ -155,13 +156,21 @@ fun main() {
 
 Available runtimes:
 
-| Platform      | Runtime                                         |
-| ------------- | ----------------------------------------------- |
-| Linux x64     | `maplibre-compose-runtime-vulkan-linux-x64`     |
-| Linux arm64   | `maplibre-compose-runtime-vulkan-linux-arm64`   |
-| macOS arm64   | `maplibre-compose-runtime-metal-macos-arm64`    |
-| Windows x64   | `maplibre-compose-runtime-vulkan-windows-x64`   |
-| Windows arm64 | `maplibre-compose-runtime-vulkan-windows-arm64` |
+| Platform      | Backend | Runtime                                         |
+| ------------- | ------- | ----------------------------------------------- |
+| Linux x64     | Vulkan  | `maplibre-compose-runtime-vulkan-linux-x64`     |
+| Linux x64     | OpenGL  | `maplibre-compose-runtime-opengl-linux-x64`     |
+| Linux arm64   | Vulkan  | `maplibre-compose-runtime-vulkan-linux-arm64`   |
+| Linux arm64   | OpenGL  | `maplibre-compose-runtime-opengl-linux-arm64`   |
+| macOS arm64   | Metal   | `maplibre-compose-runtime-metal-macos-arm64`    |
+| Windows x64   | Vulkan  | `maplibre-compose-runtime-vulkan-windows-x64`   |
+| Windows x64   | OpenGL  | `maplibre-compose-runtime-opengl-windows-x64`   |
+| Windows arm64 | Vulkan  | `maplibre-compose-runtime-vulkan-windows-arm64` |
+| Windows arm64 | OpenGL  | `maplibre-compose-runtime-opengl-windows-arm64` |
+
+Prefer Vulkan on Linux and Windows, and Metal on macOS. A runtime also needs
+a Compose bridge for its backend; when the map starts without one, it reports
+a diagnostic naming the bridge that is missing.
 
 To ship several platforms, select the runtime from the host you build on.
 

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -156,21 +156,13 @@ fun main() {
 
 Available runtimes:
 
-| Platform      | Backend | Runtime                                         |
-| ------------- | ------- | ----------------------------------------------- |
-| Linux x64     | Vulkan  | `maplibre-compose-runtime-vulkan-linux-x64`     |
-| Linux x64     | OpenGL  | `maplibre-compose-runtime-opengl-linux-x64`     |
-| Linux arm64   | Vulkan  | `maplibre-compose-runtime-vulkan-linux-arm64`   |
-| Linux arm64   | OpenGL  | `maplibre-compose-runtime-opengl-linux-arm64`   |
-| macOS arm64   | Metal   | `maplibre-compose-runtime-metal-macos-arm64`    |
-| Windows x64   | Vulkan  | `maplibre-compose-runtime-vulkan-windows-x64`   |
-| Windows x64   | OpenGL  | `maplibre-compose-runtime-opengl-windows-x64`   |
-| Windows arm64 | Vulkan  | `maplibre-compose-runtime-vulkan-windows-arm64` |
-| Windows arm64 | OpenGL  | `maplibre-compose-runtime-opengl-windows-arm64` |
-
-Prefer Vulkan on Linux and Windows, and Metal on macOS. A runtime also needs
-a Compose bridge for its backend; when the map starts without one, it reports
-a diagnostic naming the bridge that is missing.
+| Platform      | Runtime                                         |
+| ------------- | ----------------------------------------------- |
+| Linux x64     | `maplibre-compose-runtime-vulkan-linux-x64`     |
+| Linux arm64   | `maplibre-compose-runtime-vulkan-linux-arm64`   |
+| macOS arm64   | `maplibre-compose-runtime-metal-macos-arm64`    |
+| Windows x64   | `maplibre-compose-runtime-vulkan-windows-x64`   |
+| Windows arm64 | `maplibre-compose-runtime-vulkan-windows-arm64` |
 
 To ship several platforms, select the runtime from the host you build on.
 

--- a/lib/maplibre-compose-runtime-opengl-linux-arm64/build.gradle.kts
+++ b/lib/maplibre-compose-runtime-opengl-linux-arm64/build.gradle.kts
@@ -1,0 +1,26 @@
+plugins {
+  id("module-conventions")
+  `java-library`
+  id(libs.plugins.mavenPublish.get().pluginId)
+}
+
+mavenPublishing {
+  pom {
+    name = "MapLibre Compose Runtime (OpenGL, Linux arm64)"
+    description =
+      "MapLibre Native and LWJGL native libraries for running MapLibre Compose " +
+        "on Linux arm64 with the OpenGL backend."
+    url = "https://github.com/maplibre/maplibre-compose"
+  }
+}
+
+dependencies {
+  runtimeOnly(project(":lib:location-runtime-linux"))
+
+  DesktopHostPlatform.LinuxArm64.runtimeDependencies(
+      backend = DesktopHostPlatform.RenderBackend.OPENGL,
+      ffiVersion = libs.versions.maplibre.nativeFfi.get(),
+      lwjglVersion = libs.versions.lwjgl.get(),
+    )
+    .forEach { runtimeOnly(it) }
+}

--- a/lib/maplibre-compose-runtime-opengl-linux-arm64/build.gradle.kts
+++ b/lib/maplibre-compose-runtime-opengl-linux-arm64/build.gradle.kts
@@ -1,18 +1,9 @@
 plugins {
   id("module-conventions")
   `java-library`
-  id(libs.plugins.mavenPublish.get().pluginId)
 }
 
-mavenPublishing {
-  pom {
-    name = "MapLibre Compose Runtime (OpenGL, Linux arm64)"
-    description =
-      "MapLibre Native and LWJGL native libraries for running MapLibre Compose " +
-        "on Linux arm64 with the OpenGL backend."
-    url = "https://github.com/maplibre/maplibre-compose"
-  }
-}
+// Local development only until the OpenGL Compose bridge ships; not published.
 
 dependencies {
   runtimeOnly(project(":lib:location-runtime-linux"))

--- a/lib/maplibre-compose-runtime-opengl-linux-x64/build.gradle.kts
+++ b/lib/maplibre-compose-runtime-opengl-linux-x64/build.gradle.kts
@@ -1,18 +1,9 @@
 plugins {
   id("module-conventions")
   `java-library`
-  id(libs.plugins.mavenPublish.get().pluginId)
 }
 
-mavenPublishing {
-  pom {
-    name = "MapLibre Compose Runtime (OpenGL, Linux x64)"
-    description =
-      "MapLibre Native and LWJGL native libraries for running MapLibre Compose " +
-        "on Linux x64 with the OpenGL backend."
-    url = "https://github.com/maplibre/maplibre-compose"
-  }
-}
+// Local development only until the OpenGL Compose bridge ships; not published.
 
 dependencies {
   runtimeOnly(project(":lib:location-runtime-linux"))

--- a/lib/maplibre-compose-runtime-opengl-linux-x64/build.gradle.kts
+++ b/lib/maplibre-compose-runtime-opengl-linux-x64/build.gradle.kts
@@ -1,0 +1,26 @@
+plugins {
+  id("module-conventions")
+  `java-library`
+  id(libs.plugins.mavenPublish.get().pluginId)
+}
+
+mavenPublishing {
+  pom {
+    name = "MapLibre Compose Runtime (OpenGL, Linux x64)"
+    description =
+      "MapLibre Native and LWJGL native libraries for running MapLibre Compose " +
+        "on Linux x64 with the OpenGL backend."
+    url = "https://github.com/maplibre/maplibre-compose"
+  }
+}
+
+dependencies {
+  runtimeOnly(project(":lib:location-runtime-linux"))
+
+  DesktopHostPlatform.LinuxX64.runtimeDependencies(
+      backend = DesktopHostPlatform.RenderBackend.OPENGL,
+      ffiVersion = libs.versions.maplibre.nativeFfi.get(),
+      lwjglVersion = libs.versions.lwjgl.get(),
+    )
+    .forEach { runtimeOnly(it) }
+}

--- a/lib/maplibre-compose-runtime-opengl-windows-arm64/build.gradle.kts
+++ b/lib/maplibre-compose-runtime-opengl-windows-arm64/build.gradle.kts
@@ -1,0 +1,26 @@
+plugins {
+  id("module-conventions")
+  `java-library`
+  id(libs.plugins.mavenPublish.get().pluginId)
+}
+
+mavenPublishing {
+  pom {
+    name = "MapLibre Compose Runtime (OpenGL, Windows arm64)"
+    description =
+      "MapLibre Native and LWJGL native libraries for running MapLibre Compose " +
+        "on Windows arm64 with the OpenGL backend."
+    url = "https://github.com/maplibre/maplibre-compose"
+  }
+}
+
+dependencies {
+  runtimeOnly(project(":lib:location-runtime-windows"))
+
+  DesktopHostPlatform.WindowsArm64.runtimeDependencies(
+      backend = DesktopHostPlatform.RenderBackend.OPENGL,
+      ffiVersion = libs.versions.maplibre.nativeFfi.get(),
+      lwjglVersion = libs.versions.lwjgl.get(),
+    )
+    .forEach { runtimeOnly(it) }
+}

--- a/lib/maplibre-compose-runtime-opengl-windows-arm64/build.gradle.kts
+++ b/lib/maplibre-compose-runtime-opengl-windows-arm64/build.gradle.kts
@@ -1,18 +1,9 @@
 plugins {
   id("module-conventions")
   `java-library`
-  id(libs.plugins.mavenPublish.get().pluginId)
 }
 
-mavenPublishing {
-  pom {
-    name = "MapLibre Compose Runtime (OpenGL, Windows arm64)"
-    description =
-      "MapLibre Native and LWJGL native libraries for running MapLibre Compose " +
-        "on Windows arm64 with the OpenGL backend."
-    url = "https://github.com/maplibre/maplibre-compose"
-  }
-}
+// Local development only until the OpenGL Compose bridge ships; not published.
 
 dependencies {
   runtimeOnly(project(":lib:location-runtime-windows"))

--- a/lib/maplibre-compose-runtime-opengl-windows-x64/build.gradle.kts
+++ b/lib/maplibre-compose-runtime-opengl-windows-x64/build.gradle.kts
@@ -1,0 +1,26 @@
+plugins {
+  id("module-conventions")
+  `java-library`
+  id(libs.plugins.mavenPublish.get().pluginId)
+}
+
+mavenPublishing {
+  pom {
+    name = "MapLibre Compose Runtime (OpenGL, Windows x64)"
+    description =
+      "MapLibre Native and LWJGL native libraries for running MapLibre Compose " +
+        "on Windows x64 with the OpenGL backend."
+    url = "https://github.com/maplibre/maplibre-compose"
+  }
+}
+
+dependencies {
+  runtimeOnly(project(":lib:location-runtime-windows"))
+
+  DesktopHostPlatform.WindowsX64.runtimeDependencies(
+      backend = DesktopHostPlatform.RenderBackend.OPENGL,
+      ffiVersion = libs.versions.maplibre.nativeFfi.get(),
+      lwjglVersion = libs.versions.lwjgl.get(),
+    )
+    .forEach { runtimeOnly(it) }
+}

--- a/lib/maplibre-compose-runtime-opengl-windows-x64/build.gradle.kts
+++ b/lib/maplibre-compose-runtime-opengl-windows-x64/build.gradle.kts
@@ -1,18 +1,9 @@
 plugins {
   id("module-conventions")
   `java-library`
-  id(libs.plugins.mavenPublish.get().pluginId)
 }
 
-mavenPublishing {
-  pom {
-    name = "MapLibre Compose Runtime (OpenGL, Windows x64)"
-    description =
-      "MapLibre Native and LWJGL native libraries for running MapLibre Compose " +
-        "on Windows x64 with the OpenGL backend."
-    url = "https://github.com/maplibre/maplibre-compose"
-  }
-}
+// Local development only until the OpenGL Compose bridge ships; not published.
 
 dependencies {
   runtimeOnly(project(":lib:location-runtime-windows"))

--- a/lib/maplibre-compose/build.gradle.kts
+++ b/lib/maplibre-compose/build.gradle.kts
@@ -104,8 +104,8 @@ kotlin {
       dependencies {
         implementation(compose.desktop.currentOs)
 
-        // The AWT Compose host needs direct Vulkan/OpenGL access; the natives come from the
-        // runtime artifact the application picks.
+        // The Compose host needs direct Vulkan/OpenGL access; the natives come from the runtime
+        // artifact the application picks.
         implementation(libs.lwjgl.core)
         implementation(libs.lwjgl.opengl)
         implementation(libs.lwjgl.vulkan)
@@ -161,11 +161,11 @@ kotlin {
     // platform adapters instead of the Java ones in androidJvmTest.
     getByName("iosTest").dependsOn(maplibreNativeTest)
 
-    // Runtime dependencies belong to platform/backend adapters. One native runtime is loaded per
-    // test process; a CI matrix adds processes for additional applicable backends.
+    // One native runtime is loaded per test process; `maplibre.desktop.backend` selects which, and
+    // a CI matrix adds processes for additional applicable backends.
     val jvmTest by getting
     jvmTest.dependencies {
-      // Only the EGL interop test binds EGL directly; nothing in the library does.
+      // Only the EGL interop tests bind EGL directly; nothing in the library does.
       implementation(libs.lwjgl.egl)
     }
 
@@ -178,13 +178,15 @@ kotlin {
   }
 }
 
+val requestedDesktopBackend = providers.gradleProperty("maplibre.desktop.backend")
+
 configurations.named("jvmTestRuntimeOnly") {
   dependencies.addAllLater(
     providers.provider {
       val platform = DesktopHostPlatform.current()
       platform
         .runtimeDependencies(
-          backend = platform.defaultRenderBackend,
+          backend = platform.selectedRenderBackend(requestedDesktopBackend.orNull),
           ffiVersion = libs.versions.maplibre.nativeFfi.get(),
           lwjglVersion = libs.versions.lwjgl.get(),
         )

--- a/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/mlnffi/AndroidMlnFfiSurface.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/mlnffi/AndroidMlnFfiSurface.kt
@@ -57,11 +57,10 @@ internal fun AndroidMlnFfiSurface(
   if (!available) {
     DisposableEffect(runtimeBackends) {
       logger?.e {
-        val hostBackends = RenderBackendPair(backend, ComposeRenderBackend.OPENGL)
         val diagnostic =
           backendDiagnostic(
             runtimeBackends = runtimeBackends,
-            hostBackends = hostBackends,
+            hostBridges = listOf(RenderBackendPair(backend, ComposeRenderBackend.OPENGL)),
             hostDescription = "the Android $backend surface host",
             operatingSystem = mlnFfiOperatingSystem,
             architecture = mlnFfiArchitecture,

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/bridge/ComposeMapHostBridge.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/bridge/ComposeMapHostBridge.kt
@@ -17,23 +17,27 @@ internal class ComposeMapHostFactory(private val mapHost: ComposeMapHost) : MlnF
   override val description: String
     get() = mapHost.description
 
-  override val backends: RenderBackendPair =
+  override val bridges: List<RenderBackendPair> =
     when (mapHost.backend) {
       ComposeRenderBackend.METAL ->
-        RenderBackendPair(MapRenderBackend.METAL, ComposeRenderBackend.METAL)
+        listOf(RenderBackendPair(MapRenderBackend.METAL, ComposeRenderBackend.METAL))
       ComposeRenderBackend.OPENGL ->
-        RenderBackendPair(MapRenderBackend.VULKAN, ComposeRenderBackend.OPENGL)
+        listOf(RenderBackendPair(MapRenderBackend.VULKAN, ComposeRenderBackend.OPENGL))
       ComposeRenderBackend.DIRECT3D12 ->
-        RenderBackendPair(MapRenderBackend.VULKAN, ComposeRenderBackend.DIRECT3D12)
+        listOf(RenderBackendPair(MapRenderBackend.VULKAN, ComposeRenderBackend.DIRECT3D12))
     }
 
-  override fun create(): MlnFfiMapHostResult =
+  override fun create(backends: RenderBackendPair): MlnFfiMapHostResult =
     try {
       val host =
-        when (mapHost.backend) {
-          ComposeRenderBackend.METAL -> MetalMapHost(mapHost)
-          ComposeRenderBackend.OPENGL -> VulkanOpenGlMapHost(mapHost)
-          ComposeRenderBackend.DIRECT3D12 -> VulkanDirect3D12MapHost(mapHost)
+        when (backends) {
+          RenderBackendPair(MapRenderBackend.METAL, ComposeRenderBackend.METAL) ->
+            MetalMapHost(mapHost)
+          RenderBackendPair(MapRenderBackend.VULKAN, ComposeRenderBackend.OPENGL) ->
+            VulkanOpenGlMapHost(mapHost)
+          RenderBackendPair(MapRenderBackend.VULKAN, ComposeRenderBackend.DIRECT3D12) ->
+            VulkanDirect3D12MapHost(mapHost)
+          else -> return MlnFfiMapHostResult.Failed("$description cannot bridge $backends")
         }
       MlnFfiMapHostResult.Created(host)
     } catch (error: Throwable) {

--- a/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/desktop/bridge/LinuxVulkanOpenGlInteropTest.kt
+++ b/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/desktop/bridge/LinuxVulkanOpenGlInteropTest.kt
@@ -78,6 +78,8 @@ import org.maplibre.compose.mlnffi.MlnFfiRenderTarget
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.compose.style.Style
 import org.maplibre.compose.testing.RgbaPixel
+import org.maplibre.nativeffi.Maplibre
+import org.maplibre.nativeffi.render.RenderBackend
 import org.maplibre.spatialk.geojson.Position
 
 class LinuxVulkanOpenGlInteropTest {
@@ -190,8 +192,18 @@ class LinuxVulkanOpenGlInteropTest {
 
   private inline fun onLinux(reason: String, block: () -> Unit) {
     assumeTrue(reason, System.getProperty("os.name").orEmpty().lowercase().contains("linux"))
+    assumeTrue(
+      "the Vulkan to OpenGL bridge needs the Vulkan runtime packaged",
+      packagedRuntime() == RenderBackend.VULKAN,
+    )
     block()
   }
+
+  private fun packagedRuntime(): RenderBackend? = runCatching {
+    Maplibre.loadNativeLibrary()
+    Maplibre.supportedRenderBackends().singleOrNull()
+  }
+    .getOrNull()
 
   private fun assertNear(expected: RgbaPixel, actual: RgbaPixel, label: String) {
     assertTrue(

--- a/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/mlnffi/FfiComposeTestPlatform.desktop.kt
+++ b/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/mlnffi/FfiComposeTestPlatform.desktop.kt
@@ -76,21 +76,18 @@ internal actual fun ComposeUiTest.setFfiTestMapContent(
 /** Creates a production bridge for whichever runtime this Desktop test process packages. */
 private class CurrentRuntimeTestMapHostFactory
 private constructor(private var preparedDriver: FfiTestRenderDriver?) : MlnFfiMapHostFactory {
-  override val backends: RenderBackendPair =
-    Maplibre.supportedRenderBackends()
-      .map {
-        when (it) {
-          RenderBackend.METAL ->
-            RenderBackendPair(MapRenderBackend.METAL, ComposeRenderBackend.METAL)
-          RenderBackend.VULKAN -> RenderBackendPair(MapRenderBackend.VULKAN, composeBackend())
-          else -> error("No Desktop test map host for $it")
-        }
+  override val bridges: List<RenderBackendPair> =
+    listOf(
+      when (val packaged = Maplibre.supportedRenderBackends().singleOrNull()) {
+        RenderBackend.METAL -> RenderBackendPair(MapRenderBackend.METAL, ComposeRenderBackend.METAL)
+        RenderBackend.VULKAN -> RenderBackendPair(MapRenderBackend.VULKAN, composeBackend())
+        else -> error("No Desktop test map host for ${packaged ?: "no packaged runtime"}")
       }
-      .single()
+    )
 
-  override val description: String = "production $backends test bridge"
+  override val description: String = "production ${bridges.single()} test bridge"
 
-  override fun create(): MlnFfiMapHostResult {
+  override fun create(backends: RenderBackendPair): MlnFfiMapHostResult {
     val driver =
       preparedDriver
         ?: return MlnFfiMapHostResult.Failed(

--- a/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/mlnffi/ProductionBridgeTestRenderDriver.kt
+++ b/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/mlnffi/ProductionBridgeTestRenderDriver.kt
@@ -128,11 +128,11 @@ private constructor(
       val environment = DesktopTestGpuEnvironment.create()
       return try {
         val factory = ComposeMapHostFactory(environment.gpuHost)
-        check(factory.backends.producer == producer) {
-          "${factory.description} cannot bridge packaged runtime $producer"
-        }
+        val backends =
+          factory.bridges.singleOrNull { it.producer == producer }
+            ?: error("${factory.description} cannot bridge packaged runtime $producer")
         val bridge =
-          when (val result = factory.create()) {
+          when (val result = factory.create(backends)) {
             is MlnFfiMapHostResult.Created -> result.host
             is MlnFfiMapHostResult.Failed ->
               throw IllegalStateException(result.diagnostic, result.cause)

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapView.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapView.kt
@@ -22,7 +22,9 @@ import org.maplibre.compose.mlnffi.MlnFfiMapHostFactory
 import org.maplibre.compose.mlnffi.MlnFfiMapHostResult
 import org.maplibre.compose.mlnffi.MlnFfiMapRenderer
 import org.maplibre.compose.mlnffi.MlnFfiMapSurface
+import org.maplibre.compose.mlnffi.RenderBackendPair
 import org.maplibre.compose.mlnffi.backendDiagnostic
+import org.maplibre.compose.mlnffi.selectBridge
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.compose.util.rethrowIfFatal
 import org.maplibre.nativeffi.Maplibre
@@ -48,15 +50,15 @@ internal fun MlnFfiMapView(
   // Safe to call off the owner thread: it only inspects what the loaded library was built with.
   val runtimeBackends = remember { loadRuntimeBackends(logger) }
   val scaleFactor = density.density.toDouble()
-  val hostResult =
-    remember(hostFactory, runtimeBackends, scaleFactor) { createHost(runtimeBackends, hostFactory) }
+  val hostSelection =
+    remember(hostFactory, runtimeBackends, scaleFactor) { selectHost(runtimeBackends, hostFactory) }
 
   MlnFfiMapView(
-    renderBackend = hostFactory.backends.producer,
+    renderBackend = hostSelection.backends.producer,
     surface = { renderer, surfaceModifier, surfaceLogger, presentFrames ->
       MlnFfiMapSurface(
         renderer = renderer,
-        hostResult = hostResult,
+        hostResult = hostSelection.result,
         modifier = surfaceModifier,
         logger = surfaceLogger,
         presentFrames = presentFrames,
@@ -154,26 +156,39 @@ internal fun MlnFfiMapView(
   }
 }
 
-private fun createHost(
+/** The bridge a map selected, with the outcome of creating its host. */
+private class MlnFfiHostSelection(
+  val backends: RenderBackendPair,
+  val result: MlnFfiMapHostResult,
+)
+
+private fun selectHost(
   runtimeBackends: Set<MapRenderBackend>,
   factory: MlnFfiMapHostFactory,
-): MlnFfiMapHostResult {
+): MlnFfiHostSelection {
+  // The factory's first bridge stands in when nothing matches, so a failed selection still builds
+  // the session the diagnostic is reported against.
+  val backends = selectBridge(runtimeBackends, factory.bridges) ?: factory.bridges.first()
   val diagnostic =
     backendDiagnostic(
       runtimeBackends = runtimeBackends,
-      hostBackends = factory.backends,
+      hostBridges = factory.bridges,
       hostDescription = factory.description,
       operatingSystem = mlnFfiOperatingSystem,
       architecture = mlnFfiArchitecture,
     )
-  if (diagnostic != null) return MlnFfiMapHostResult.Failed(diagnostic)
+  if (diagnostic != null)
+    return MlnFfiHostSelection(backends, MlnFfiMapHostResult.Failed(diagnostic))
 
-  return try {
-    factory.create()
-  } catch (error: Throwable) {
-    rethrowIfFatal(error)
-    MlnFfiMapHostResult.Failed("${factory.description} threw while creating a map host", error)
-  }
+  return MlnFfiHostSelection(
+    backends,
+    try {
+      factory.create(backends)
+    } catch (error: Throwable) {
+      rethrowIfFatal(error)
+      MlnFfiMapHostResult.Failed("${factory.description} threw while creating a map host", error)
+    },
+  )
 }
 
 /**

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/mlnffi/MlnFfiMapHost.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/mlnffi/MlnFfiMapHost.kt
@@ -121,14 +121,18 @@ internal interface MlnFfiMapHostFactory {
   /** A short description of this factory, used in diagnostics. */
   val description: String
 
-  /** The one producer/consumer combination this factory bridges on the current machine. */
-  val backends: RenderBackendPair
+  /**
+   * The producer/consumer combinations this factory can bridge on the current machine, in
+   * preference order. The bridge the map uses is the first whose producer the packaged FFI runtime
+   * provides; the runtime artifact the application packaged is what chooses between them.
+   */
+  val bridges: List<RenderBackendPair>
 
   /**
-   * Creates a host for [backends]. Prefer returning [MlnFfiMapHostResult.Failed] over throwing, so
-   * the failure reaches the user as a diagnostic.
+   * Creates a host for [backends], one of [bridges]. Prefer returning [MlnFfiMapHostResult.Failed]
+   * over throwing, so the failure reaches the user as a diagnostic.
    */
-  fun create(): MlnFfiMapHostResult
+  fun create(backends: RenderBackendPair): MlnFfiMapHostResult
 }
 
 /** The outcome of [MlnFfiMapHostFactory.create]. */

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/mlnffi/RenderBackendNegotiation.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/mlnffi/RenderBackendNegotiation.kt
@@ -1,23 +1,32 @@
 package org.maplibre.compose.mlnffi
 
 /**
- * Validates the platform host's exact backend pair against the loaded FFI runtime.
+ * The first of [bridges] whose producer the packaged FFI runtime provides, or null when the runtime
+ * provides none of them.
+ */
+internal fun selectBridge(
+  runtimeBackends: Set<MapRenderBackend>,
+  bridges: List<RenderBackendPair>,
+): RenderBackendPair? = bridges.firstOrNull { it.producer in runtimeBackends }
+
+/**
+ * Validates the host's available bridges against the loaded FFI runtime.
  *
  * @param runtimeBackends what the loaded FFI runtime was built with, from
  *   `Maplibre.supportedRenderBackends()`
- * @param hostBackends what the bridge into the Compose host carries
+ * @param hostBridges what the bridge into the Compose host can carry, in preference order
  * @param hostDescription names the host in diagnostics
  * @param operatingSystem for diagnostics, e.g. the `os.name` system property
  * @param architecture for diagnostics, e.g. the `os.arch` system property
  */
 internal fun backendDiagnostic(
   runtimeBackends: Set<MapRenderBackend>,
-  hostBackends: RenderBackendPair,
+  hostBridges: List<RenderBackendPair>,
   hostDescription: String,
   operatingSystem: String,
   architecture: String,
 ): String? {
-  if (hostBackends.producer in runtimeBackends) return null
+  if (selectBridge(runtimeBackends, hostBridges) != null) return null
   val cause =
     when {
       runtimeBackends.isEmpty() ->
@@ -25,9 +34,9 @@ internal fun backendDiagnostic(
           "the matching org.maplibre.compose:maplibre-compose-runtime-<backend>-<os>-<arch> " +
           "artifact for this platform."
       else ->
-        "The packaged MapLibre Native FFI runtime renders with " +
-          "${runtimeBackends.describe()}, but $hostDescription requires ${hostBackends.producer}. " +
-          "Package the runtime matching the host."
+        "The packaged MapLibre Native FFI runtime renders with ${runtimeBackends.describe()}, " +
+          "but $hostDescription bridges only ${hostBridges.describe()}. Package the runtime " +
+          "matching one of those bridges."
     }
 
   return buildString {
@@ -36,9 +45,11 @@ internal fun backendDiagnostic(
     appendLine("  operating system: $operatingSystem ($architecture)")
     appendLine("  FFI runtime backends: ${runtimeBackends.describe()}")
     appendLine("  Compose host: $hostDescription")
-    append("  required bridge: $hostBackends")
+    append("  available bridges: ${hostBridges.describe()}")
   }
 }
 
 private fun Set<*>.describe(): String =
   if (isEmpty()) "none" else sortedBy { it.toString() }.joinToString { it.toString() }
+
+private fun List<*>.describe(): String = joinToString { it.toString() }

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/mlnffi/FakeMlnFfiMapHost.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/mlnffi/FakeMlnFfiMapHost.kt
@@ -171,7 +171,7 @@ internal class FakeMlnFfiMapHost(
 
 /** A [MlnFfiMapHostFactory] producing [FakeMlnFfiMapHost]s. */
 internal class FakeMlnFfiMapHostFactory(
-  override val backends: RenderBackendPair =
+  private val bridge: RenderBackendPair =
     RenderBackendPair(MapRenderBackend.VULKAN, ComposeRenderBackend.OPENGL),
   override val description: String = "fake test host",
   private val result: ((MapRenderBackend) -> MlnFfiMapHostResult)? = null,
@@ -182,9 +182,12 @@ internal class FakeMlnFfiMapHostFactory(
   private val configureHost: (FakeMlnFfiMapHost) -> Unit = {},
 ) : MlnFfiMapHostFactory {
 
+  override val bridges: List<RenderBackendPair> = listOf(bridge)
+
   val created: MutableList<FakeMlnFfiMapHost> = mutableListOf()
 
-  override fun create(): MlnFfiMapHostResult {
+  override fun create(backends: RenderBackendPair): MlnFfiMapHostResult {
+    check(backends == bridge) { "The fake factory was asked for $backends, not $bridge" }
     result?.let {
       return it(backends.producer)
     }

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/mlnffi/MlnFfiMapSurfaceRecoveryTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/mlnffi/MlnFfiMapSurfaceRecoveryTest.kt
@@ -172,7 +172,7 @@ class MlnFfiMapSurfaceRecoveryTest {
     val renderer = RecordingRenderer()
     val factory = FakeMlnFfiMapHostFactory()
     val size = mutableStateOf(64.dp)
-    val hostResult = factory.create()
+    val hostResult = factory.create(factory.bridges.single())
 
     setContent { MlnFfiMapSurface(renderer, hostResult, Modifier.size(size.value)) }
     waitUntil(timeoutMillis = TIMEOUT_MILLIS) { renderer.renderedFrames > 0 }
@@ -187,7 +187,7 @@ class MlnFfiMapSurfaceRecoveryTest {
     renderer: MlnFfiMapRenderer,
     factory: FakeMlnFfiMapHostFactory,
   ) {
-    val hostResult = factory.create()
+    val hostResult = factory.create(factory.bridges.single())
     setContent {
       MlnFfiMapSurface(
         renderer = renderer,

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/mlnffi/RenderBackendNegotiationTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/mlnffi/RenderBackendNegotiationTest.kt
@@ -2,22 +2,54 @@ package org.maplibre.compose.mlnffi
 
 import kotlin.test.Test
 import kotlin.test.assertContains
+import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
 class RenderBackendNegotiationTest {
-  private val pair = RenderBackendPair(MapRenderBackend.VULKAN, ComposeRenderBackend.OPENGL)
+  private val openGlHostBridges =
+    listOf(
+      RenderBackendPair(MapRenderBackend.OPENGL, ComposeRenderBackend.OPENGL),
+      RenderBackendPair(MapRenderBackend.VULKAN, ComposeRenderBackend.OPENGL),
+    )
+
+  private fun selected(runtimeBackends: Set<MapRenderBackend>): RenderBackendPair? =
+    selectBridge(runtimeBackends, openGlHostBridges)
 
   private fun diagnostic(runtimeBackends: Set<MapRenderBackend>): String? =
     backendDiagnostic(
       runtimeBackends = runtimeBackends,
-      hostBackends = pair,
+      hostBridges = openGlHostBridges,
       hostDescription = "fake test host",
       operatingSystem = "Linux",
       architecture = "amd64",
     )
 
   @Test
-  fun accepts_the_host_pair_when_its_producer_is_packaged() {
+  fun selects_the_first_bridge_the_runtime_drives() {
+    assertEquals(openGlHostBridges[0], selected(setOf(MapRenderBackend.OPENGL)))
+  }
+
+  @Test
+  fun falls_back_to_a_later_bridge_when_the_runtime_does_not_drive_the_first() {
+    assertEquals(openGlHostBridges[1], selected(setOf(MapRenderBackend.VULKAN)))
+  }
+
+  @Test
+  fun selects_among_extra_backends_the_runtime_provides() {
+    assertEquals(
+      openGlHostBridges[1],
+      selected(setOf(MapRenderBackend.VULKAN, MapRenderBackend.METAL)),
+    )
+  }
+
+  @Test
+  fun selects_nothing_when_the_runtime_drives_no_bridge() {
+    assertNull(selected(setOf(MapRenderBackend.METAL)))
+    assertNull(selected(emptySet()))
+  }
+
+  @Test
+  fun accepts_a_host_bridge_whose_producer_is_packaged() {
     assertNull(diagnostic(setOf(MapRenderBackend.VULKAN)))
   }
 
@@ -29,12 +61,13 @@ class RenderBackendNegotiationTest {
   }
 
   @Test
-  fun reports_an_exact_pair_mismatch() {
+  fun reports_an_unbridgeable_runtime_backend() {
     val message = checkNotNull(diagnostic(setOf(MapRenderBackend.METAL)))
     assertContains(message, "METAL")
-    assertContains(message, "VULKAN")
+    assertContains(message, "OPENGL -> OPENGL")
+    assertContains(message, "VULKAN -> OPENGL")
     assertContains(message, "operating system: Linux (amd64)")
     assertContains(message, "Compose host: fake test host")
-    assertContains(message, "required bridge: $pair")
+    assertContains(message, "available bridges: ${openGlHostBridges.joinToString()}")
   }
 }

--- a/mise.toml
+++ b/mise.toml
@@ -164,7 +164,16 @@ run = "./gradlew jsBrowserTest"
 
 [tasks."test:desktop"]
 description = "Run the desktop (JVM) test suite against a real Vulkan or Metal device."
-run = "./gradlew jvmTest"
+usage = '''
+flag "--backend <name>" help="Map render backend to test, e.g. opengl or vulkan. Defaults to the platform's preferred backend."
+'''
+run = '''
+if [ -n "$usage_backend" ]; then
+  ./gradlew jvmTest -Pmaplibre.desktop.backend="$usage_backend"
+else
+  ./gradlew jvmTest
+fi
+'''
 
 [tasks."build:docs"]
 description = "Build the documentation site and the Dokka API reference into docs/dist."
@@ -189,12 +198,19 @@ run = ".mise/bin/run-android-demo"
 
 [tasks."demo:desktop"]
 description = "Run the demo app on this host."
+usage = '''
+flag "--backend <name>" help="Map render backend to run, e.g. opengl or vulkan. Defaults to the platform's preferred backend."
+'''
 run = '''
+args=""
+if [ -n "$usage_backend" ]; then
+  args="-Pmaplibre.desktop.backend=$usage_backend"
+fi
 if [ "$(uname -s)" = Darwin ]; then
   # Core Location reads the usage description from a packaged app Info.plist.
-  ./gradlew :demo-app:desktop:runDistributable
+  ./gradlew :demo-app:desktop:runDistributable $args
 else
-  ./gradlew :demo-app:desktop:run
+  ./gradlew :demo-app:desktop:run $args
 fi
 '''
 
@@ -215,12 +231,19 @@ run = '.mise/bin/run-ios-demo'
 
 [tasks."demo:desktop-glfw"]
 description = "Run the demo app on the compose-glfw desktop host instead of the AWT one."
+usage = '''
+flag "--backend <name>" help="Map render backend to run, e.g. opengl or vulkan. Defaults to the platform's preferred backend."
+'''
 run = '''
+args=""
+if [ -n "$usage_backend" ]; then
+  args="-Pmaplibre.desktop.backend=$usage_backend"
+fi
 if [ "$(uname -s)" = Darwin ]; then
   # Core Location reads the usage description from a packaged app Info.plist.
-  ./gradlew :demo-app:desktop-glfw:runDistributable
+  ./gradlew :demo-app:desktop-glfw:runDistributable $args
 else
-  ./gradlew :demo-app:desktop-glfw:run
+  ./gradlew :demo-app:desktop-glfw:run $args
 fi
 '''
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -48,7 +48,11 @@ include(
   ":lib:location-runtime-windows",
   ":lib:maplibre-compose-runtime-vulkan-linux-x64",
   ":lib:maplibre-compose-runtime-vulkan-linux-arm64",
+  ":lib:maplibre-compose-runtime-opengl-linux-x64",
+  ":lib:maplibre-compose-runtime-opengl-linux-arm64",
   ":lib:maplibre-compose-runtime-metal-macos-arm64",
   ":lib:maplibre-compose-runtime-vulkan-windows-x64",
   ":lib:maplibre-compose-runtime-vulkan-windows-arm64",
+  ":lib:maplibre-compose-runtime-opengl-windows-x64",
+  ":lib:maplibre-compose-runtime-opengl-windows-arm64",
 )


### PR DESCRIPTION
## Description

Redesigns backend picking so the library can bridge more than one producer/consumer pair. The map negotiates the pairing based on the backend compiled into the native runtime.

I didn't yet implement the additional bridges; ideally I want to add opengl maps on linux/windows, eventually probably every runtime mlnffi provides.

## AI assistance

opencode with GLM (zai-coding-plan/glm-5.3).