### PR TITLE
Add map-level camera padding

### DIFF
--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/Demo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/Demo.kt
@@ -33,7 +33,7 @@ interface Demo {
   val pointerPin: DemoPointerPin?
     get() = null
 
-  @MaplibreComposable @Composable fun MapContent(camera: CameraState) {}
+  @MaplibreComposable @Composable fun MapContent(cameraState: CameraState) {}
 
   /**
    * Compose UI drawn over the map while this demo is selected. [state] exposes the shell's
@@ -52,12 +52,8 @@ interface Demo {
 
 /** The camera movement that occurs when a demo is selected or its pointer pin is pressed. */
 sealed interface DemoDestination {
-  /** Fits a geographic region inside the unobstructed map viewport. */
-  data class FitBounds(
-    val bounds: BoundingBox,
-    val bearing: Double = 0.0,
-    val tilt: Double = 0.0,
-  ) : DemoDestination
+  /** Fits a geographic region inside the camera viewport. */
+  data class FitBounds(val bounds: BoundingBox) : DemoDestination
 
   /** Moves to a complete camera position without deriving a zoom level from geographic bounds. */
   data class ExactCamera(val position: CameraPosition) : DemoDestination
@@ -70,11 +66,13 @@ sealed interface DemoDestination {
 data class DemoPointerPin(val target: Position, val destination: DemoDestination)
 
 internal val BoundingBox.center: Position
-  get() =
-    Position(
-      longitude = (west + east) / 2,
+  get() {
+    val centerLongitude = (west + if (east < west) east + 360.0 else east) / 2
+    return Position(
+      longitude = if (centerLongitude > 180.0) centerLongitude - 360.0 else centerLongitude,
       latitude = (south + north) / 2,
     )
+  }
 
 /** Demos that cannot run in the browser; empty on the js target. */
 internal expect val extraDemos: List<Demo>

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/Demo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/Demo.kt
@@ -17,38 +17,23 @@ import org.maplibre.spatialk.geojson.BoundingBox
 import org.maplibre.spatialk.geojson.Position
 
 /**
- * A demo lives at a real place in the world. Selecting it composes [MapContent] into the shared map
- * and [Overlay] on top of the map. When [fliesOnSelect] is true, the camera flies to [region] or
- * [camera]. Each demo owns its state internally.
+ * Selecting a demo composes [MapContent] into the shared map and [Overlay] on top of the map. The
+ * camera moves to [destination]. Each demo owns its state internally.
  */
 interface Demo {
   val name: String
   val description: String
-  val region: BoundingBox
+  val destination: DemoDestination
 
   /** Applied once when the demo is selected; a later choice by the user wins. */
   val preferredStyle: DemoStyle?
     get() = null
 
-  /**
-   * The exact camera the flight ends at. Null fits [region] to the viewport instead; set this when
-   * the demo needs a composed view, such as a pitched skyline.
-   */
-  val camera: CameraPosition?
+  /** An optional map pin that restores a useful view of the demo. */
+  val pointerPin: DemoPointerPin?
     get() = null
 
-  /** Whether the pointer pin points back to [region]. A worldwide demo turns it off. */
-  val showsPointerPin: Boolean
-    get() = true
-
-  /**
-   * Whether the shell flies to [region] or [camera] when this demo is selected. A demo that drives
-   * the camera from live data turns this off.
-   */
-  val fliesOnSelect: Boolean
-    get() = true
-
-  @MaplibreComposable @Composable fun MapContent(cameraState: CameraState) {}
+  @MaplibreComposable @Composable fun MapContent(camera: CameraState) {}
 
   /**
    * Compose UI drawn over the map while this demo is selected. [state] exposes the shell's
@@ -65,11 +50,30 @@ interface Demo {
   @UiComposable @Composable fun Panel(state: DemoAppState) {}
 }
 
-val Demo.center: Position
+/** The camera movement that occurs when a demo is selected or its pointer pin is pressed. */
+sealed interface DemoDestination {
+  /** Fits a geographic region inside the unobstructed map viewport. */
+  data class FitBounds(
+    val bounds: BoundingBox,
+    val bearing: Double = 0.0,
+    val tilt: Double = 0.0,
+  ) : DemoDestination
+
+  /** Moves to a complete camera position without deriving a zoom level from geographic bounds. */
+  data class ExactCamera(val position: CameraPosition) : DemoDestination
+
+  /** Preserves the current camera until the demo moves it from live data or user input. */
+  data object None : DemoDestination
+}
+
+/** A point shown on the map and the camera movement that its button restores. */
+data class DemoPointerPin(val target: Position, val destination: DemoDestination)
+
+internal val BoundingBox.center: Position
   get() =
     Position(
-      longitude = (region.west + region.east) / 2,
-      latitude = (region.south + region.north) / 2,
+      longitude = (west + east) / 2,
+      latitude = (south + north) / 2,
     )
 
 /** Demos that cannot run in the browser; empty on the js target. */

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoApp.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoApp.kt
@@ -1,18 +1,22 @@
 package org.maplibre.compose.demoapp
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.width
+import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.BottomSheetScaffold
+import androidx.compose.material3.BottomSheetScaffoldState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
@@ -20,12 +24,21 @@ import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.material3.rememberBottomSheetScaffoldState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.movableContentOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.window.core.layout.WindowSizeClass
+import kotlinx.coroutines.flow.filterNotNull
 import org.maplibre.compose.demoapp.benchmark.BenchmarkMap
 
 @Composable
@@ -35,70 +48,154 @@ fun DemoApp() {
     if (state.shell == DemoShell.Benchmarks) state.selectedScenario.style.isDark
     else state.selectedStyle.isDark
   val colorScheme = if (dark) darkColorScheme() else lightColorScheme()
-  // One composition for the panel, so the NavHost keeps its back stack when the
-  // viewport crosses the side-pane / bottom-sheet breakpoint.
-  val panel = remember { movableContentOf { modifier: Modifier -> DemoPanel(state, modifier) } }
+  val sheetState = rememberBottomSheetScaffoldState()
+  // One composition for the panel, so the NavHost keeps its back stack when the viewport crosses
+  // the floating-panel / bottom-sheet breakpoint.
+  val panel = remember {
+    movableContentOf { modifier: Modifier, revealMap: suspend () -> Unit ->
+      DemoPanel(state, modifier, revealMap)
+    }
+  }
   MaterialTheme(colorScheme = colorScheme) {
     val windowSizeClass = currentWindowAdaptiveInfo().windowSizeClass
     if (windowSizeClass.isWidthAtLeastBreakpoint(WindowSizeClass.WIDTH_DP_EXPANDED_LOWER_BOUND)) {
       WideLayout(state, panel)
     } else {
-      NarrowLayout(state, panel)
+      NarrowLayout(state, sheetState, panel)
     }
   }
 }
 
 private val PanelWidth = 360.dp
-
-/** How much of the map the collapsed sheet covers. */
+private val ShellSpacing = 16.dp
 private val SheetPeekHeight = 128.dp
+private val SheetHandleHeight = 48.dp
+private val MinimumUsefulSheetHeight = 320.dp
 
 @Composable
-private fun WideLayout(state: DemoAppState, panel: @Composable (Modifier) -> Unit) {
-  Row(Modifier.fillMaxSize()) {
-    Surface(modifier = Modifier.width(PanelWidth).fillMaxHeight(), tonalElevation = 1.dp) {
-      panel(Modifier.fillMaxHeight())
+private fun WideLayout(
+  state: DemoAppState,
+  panel: @Composable (Modifier, suspend () -> Unit) -> Unit,
+) {
+  val density = LocalDensity.current
+  val layoutDirection = LocalLayoutDirection.current
+  val safeInsets = WindowInsets.safeDrawing.toMapViewportInsets(density, layoutDirection)
+  val panelEdge =
+    when (layoutDirection) {
+      LayoutDirection.Ltr ->
+        MapViewportInsets(left = safeInsets.left + ShellSpacing + PanelWidth + ShellSpacing)
+      LayoutDirection.Rtl ->
+        MapViewportInsets(right = safeInsets.right + ShellSpacing + PanelWidth + ShellSpacing)
     }
-    ShellMap(state, sheetInsets = WindowInsets(0))
+  val viewportInsets = safeInsets.union(panelEdge)
+
+  Box(Modifier.fillMaxSize()) {
+    ShellMap(state, viewportInsets)
+    Box(
+      modifier =
+        Modifier.align(Alignment.CenterStart)
+          .fillMaxHeight()
+          .padding(safeInsets.asPaddingValues())
+          .padding(ShellSpacing)
+    ) {
+      Surface(
+        modifier = Modifier.width(PanelWidth).fillMaxHeight(),
+        shape = MaterialTheme.shapes.extraLarge,
+        tonalElevation = 2.dp,
+        shadowElevation = 8.dp,
+      ) {
+        panel(
+          Modifier.fillMaxHeight().consumeWindowInsets(WindowInsets.safeDrawing),
+          {},
+        )
+      }
+    }
   }
 }
 
-/** Height of the scaffold's default drag handle, which sits above the sheet content. */
-private val SheetHandleHeight = 48.dp
-
 @Composable
-private fun NarrowLayout(state: DemoAppState, panel: @Composable (Modifier) -> Unit) {
+private fun NarrowLayout(
+  state: DemoAppState,
+  scaffoldState: BottomSheetScaffoldState,
+  panel: @Composable (Modifier, suspend () -> Unit) -> Unit,
+) {
   BoxWithConstraints(Modifier.fillMaxSize()) {
-    val topInset = WindowInsets.safeDrawing.getTop(LocalDensity.current)
-    // Expanded is the measured height of this content, capped so the sheet never enters
-    // the top safe area. Only the map draws behind the notch.
+    val density = LocalDensity.current
+    val layoutDirection = LocalLayoutDirection.current
+    val safeInsets = WindowInsets.safeDrawing.toMapViewportInsets(density, layoutDirection)
     val maxSheetHeight =
-      maxHeight - with(LocalDensity.current) { topInset.toDp() } - SheetHandleHeight
+      maximumSheetHeight(
+        viewportHeight = maxHeight,
+        topSafeInset = safeInsets.top,
+        minimumUsefulHeight = MinimumUsefulSheetHeight,
+      )
+    val sheetHeight by
+      rememberVisibleSheetHeight(
+        scaffoldState = scaffoldState,
+        viewportHeightPx = constraints.maxHeight,
+        maximumHeightPx = with(density) { maxSheetHeight.roundToPx() },
+        density = density,
+      )
+    val viewportInsets = safeInsets.union(MapViewportInsets(bottom = sheetHeight))
+
     BottomSheetScaffold(
       sheetPeekHeight = SheetPeekHeight,
-      scaffoldState = rememberBottomSheetScaffoldState(),
-      // NavHost SizeTransform interpolates the expanded height with the destination.
+      scaffoldState = scaffoldState,
+      sheetDragHandle = {
+        Box(
+          modifier = Modifier.fillMaxWidth().height(SheetHandleHeight),
+          contentAlignment = Alignment.Center,
+        ) {
+          BottomSheetDefaults.DragHandle()
+        }
+      },
       sheetContent = {
         panel(
           Modifier.fillMaxWidth()
-            .heightIn(max = maxSheetHeight)
-            // Stop the panel's TopAppBar from padding itself for the top inset. The sheet
-            // stays below the safe area, so that padding is just a bare forehead.
-            .consumeWindowInsets(WindowInsets.safeDrawing.only(WindowInsetsSides.Top))
+            .heightIn(max = (maxSheetHeight - SheetHandleHeight).coerceAtLeast(0.dp))
+            // The sheet already stays below the top safe area.
+            .consumeWindowInsets(WindowInsets.safeDrawing.only(WindowInsetsSides.Top)),
+          {
+            val sheet = scaffoldState.bottomSheetState
+            if (sheet.hasPartiallyExpandedState) sheet.partialExpand()
+          },
         )
       },
     ) {
-      // The map draws under the scaffold content area, so the sheet covers its bottom edge.
-      ShellMap(state, sheetInsets = WindowInsets(bottom = SheetPeekHeight))
+      ShellMap(state, viewportInsets)
     }
   }
 }
 
 @Composable
-private fun ShellMap(state: DemoAppState, sheetInsets: WindowInsets) {
+private fun rememberVisibleSheetHeight(
+  scaffoldState: BottomSheetScaffoldState,
+  viewportHeightPx: Int,
+  maximumHeightPx: Int,
+  density: androidx.compose.ui.unit.Density,
+): State<Dp> =
+  produceState(
+    initialValue = SheetPeekHeight,
+    scaffoldState,
+    viewportHeightPx,
+    maximumHeightPx,
+    density,
+  ) {
+    snapshotFlow {
+      runCatching { scaffoldState.bottomSheetState.requireOffset() }.getOrNull()
+    }
+      .filterNotNull()
+      .collect { offset ->
+        val visiblePx = visibleSheetHeight(viewportHeightPx, offset).coerceAtMost(maximumHeightPx)
+        value = with(density) { visiblePx.toDp() }
+      }
+  }
+
+@Composable
+private fun ShellMap(state: DemoAppState, viewportInsets: MapViewportInsets) {
   if (state.shell == DemoShell.Benchmarks) {
-    BenchmarkMap(state, sheetInsets)
+    BenchmarkMap(state, viewportInsets)
   } else {
-    DemoMap(state, sheetInsets)
+    DemoMap(state, viewportInsets)
   }
 }

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoApp.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoApp.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
@@ -172,7 +173,7 @@ private fun rememberVisibleSheetHeight(
   scaffoldState: BottomSheetScaffoldState,
   viewportHeightPx: Int,
   maximumHeightPx: Int,
-  density: androidx.compose.ui.unit.Density,
+  density: Density,
 ): State<Dp> =
   produceState(
     initialValue = SheetPeekHeight,
@@ -190,6 +191,19 @@ private fun rememberVisibleSheetHeight(
         value = with(density) { visiblePx.toDp() }
       }
   }
+
+private fun maximumSheetHeight(
+  viewportHeight: Dp,
+  topSafeInset: Dp,
+  minimumUsefulHeight: Dp,
+): Dp =
+  minOf(
+    (viewportHeight - topSafeInset).coerceAtLeast(0.dp),
+    maxOf(viewportHeight / 2, minimumUsefulHeight),
+  )
+
+private fun visibleSheetHeight(viewportHeightPx: Int, sheetOffsetPx: Float): Int =
+  (viewportHeightPx - sheetOffsetPx).toInt().coerceIn(0, viewportHeightPx)
 
 @Composable
 private fun ShellMap(state: DemoAppState, viewportInsets: MapViewportInsets) {

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoAppState.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoAppState.kt
@@ -23,7 +23,7 @@ enum class DemoShell {
 /** The state the shell owns: the shared map, the selection, and the settings. */
 @Stable
 class DemoAppState(
-  val cameraState: CameraState,
+  val camera: CameraState,
   val styleState: StyleState,
   val settings: DemoSettings,
   val frameRateState: FrameRateState,
@@ -37,9 +37,9 @@ class DemoAppState(
 
 @Composable
 fun rememberDemoAppState(): DemoAppState {
-  val cameraState = rememberCameraState()
+  val camera = rememberCameraState()
   val styleState = rememberStyleState()
   val settings = rememberDemoSettings()
   val frameRateState = remember { FrameRateState() }
-  return remember { DemoAppState(cameraState, styleState, settings, frameRateState) }
+  return remember { DemoAppState(camera, styleState, settings, frameRateState) }
 }

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoAppState.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoAppState.kt
@@ -23,7 +23,7 @@ enum class DemoShell {
 /** The state the shell owns: the shared map, the selection, and the settings. */
 @Stable
 class DemoAppState(
-  val camera: CameraState,
+  val cameraState: CameraState,
   val styleState: StyleState,
   val settings: DemoSettings,
   val frameRateState: FrameRateState,
@@ -37,9 +37,9 @@ class DemoAppState(
 
 @Composable
 fun rememberDemoAppState(): DemoAppState {
-  val camera = rememberCameraState()
+  val cameraState = rememberCameraState()
   val styleState = rememberStyleState()
   val settings = rememberDemoSettings()
   val frameRateState = remember { FrameRateState() }
-  return remember { DemoAppState(camera, styleState, settings, frameRateState) }
+  return remember { DemoAppState(cameraState, styleState, settings, frameRateState) }
 }

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoMap.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoMap.kt
@@ -44,8 +44,6 @@ internal suspend fun CameraState.flyTo(destination: DemoDestination) {
     is DemoDestination.FitBounds ->
       animateTo(
         boundingBox = destination.bounds,
-        bearing = destination.bearing,
-        tilt = destination.tilt,
         padding = DemoBoundsPadding,
         duration = DemoFlightDuration,
       )
@@ -59,7 +57,7 @@ fun DemoMap(state: DemoAppState, viewportInsets: MapViewportInsets) {
   Box(Modifier.fillMaxSize()) {
     MaplibreMap(
       baseStyle = state.selectedStyle.base,
-      cameraState = state.camera,
+      cameraState = state.cameraState,
       cameraPadding = viewportInsets.asPaddingValues(),
       styleState = state.styleState,
       options =
@@ -83,7 +81,7 @@ fun DemoMap(state: DemoAppState, viewportInsets: MapViewportInsets) {
       allDemos.forEach { demo ->
         key(demo) {
           if (demo == state.selectedDemo) {
-            demo.MapContent(state.camera)
+            demo.MapContent(state.cameraState)
           }
         }
       }
@@ -91,14 +89,13 @@ fun DemoMap(state: DemoAppState, viewportInsets: MapViewportInsets) {
 
     val scope = rememberCoroutineScope()
     Box(Modifier.fillMaxSize().padding(viewportInsets.asPaddingValues())) {
-      state.selectedDemo
-        ?.let { demo -> demo.pointerPin?.let { demo to it } }
-        ?.let { (demo, pointerPin) ->
+      state.selectedDemo?.let { demo ->
+        demo.pointerPin?.let { pointerPin ->
           // The pin fills this box to place itself; sizing the pin itself is up to its content.
           PointerPinButton(
-            cameraState = state.camera,
+            cameraState = state.cameraState,
             targetPosition = pointerPin.target,
-            onClick = { scope.launch { state.camera.flyTo(pointerPin.destination) } },
+            onClick = { scope.launch { state.cameraState.flyTo(pointerPin.destination) } },
           ) {
             Icon(
               vectorResource(Res.drawable.filter_center_focus_24px),
@@ -106,6 +103,7 @@ fun DemoMap(state: DemoAppState, viewportInsets: MapViewportInsets) {
             )
           }
         }
+      }
 
       DiagnosticOverlays(state = state, modifier = Modifier.align(Alignment.TopCenter))
     }
@@ -135,7 +133,7 @@ private fun DiagnosticOverlays(state: DemoAppState, modifier: Modifier = Modifie
       )
     }
     if (state.settings.showCameraOverlay) {
-      val position = state.camera.position
+      val position = state.cameraState.position
       Text(
         text =
           "lat ${position.target.latitude.format(4)} " +

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoMap.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoMap.kt
@@ -4,12 +4,8 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.safeDrawing
-import androidx.compose.foundation.layout.union
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -38,33 +34,33 @@ import org.maplibre.compose.overlay.include
 /** How long the camera takes to fly to a newly selected demo. */
 val DemoFlightDuration = 2.seconds
 
-/** Padding between a demo's region and the edge of the map viewport. */
-val DemoRegionPadding = PaddingValues(48.dp)
+/** Padding between fitted bounds and the edge of the map viewport. */
+val DemoBoundsPadding = PaddingValues(48.dp)
 
-private suspend fun CameraState.flyToDemo(demo: Demo) {
-  val camera = demo.camera
-  if (camera != null) {
-    animateTo(finalPosition = camera, duration = DemoFlightDuration)
-  } else {
-    animateTo(boundingBox = demo.region, padding = DemoRegionPadding, duration = DemoFlightDuration)
+internal suspend fun CameraState.flyTo(destination: DemoDestination) {
+  when (destination) {
+    is DemoDestination.ExactCamera ->
+      animateTo(finalPosition = destination.position, duration = DemoFlightDuration)
+    is DemoDestination.FitBounds ->
+      animateTo(
+        boundingBox = destination.bounds,
+        bearing = destination.bearing,
+        tilt = destination.tilt,
+        padding = DemoBoundsPadding,
+        duration = DemoFlightDuration,
+      )
+    DemoDestination.None -> Unit
   }
 }
 
 /** The shared map, the selected demo's overlay, the pointer pin, and the diagnostic overlays. */
 @Composable
-fun DemoMap(state: DemoAppState, sheetInsets: WindowInsets = WindowInsets(0)) {
-  val insets = WindowInsets.safeDrawing.union(sheetInsets)
-
-  LaunchedEffect(state.selectedDemo) {
-    val demo = state.selectedDemo ?: return@LaunchedEffect
-    demo.preferredStyle?.let { state.selectedStyle = it }
-    if (demo.fliesOnSelect) state.cameraState.flyToDemo(demo)
-  }
-
+fun DemoMap(state: DemoAppState, viewportInsets: MapViewportInsets) {
   Box(Modifier.fillMaxSize()) {
     MaplibreMap(
       baseStyle = state.selectedStyle.base,
-      cameraState = state.cameraState,
+      cameraState = state.camera,
+      cameraPadding = viewportInsets.asPaddingValues(),
       styleState = state.styleState,
       options =
         MapOptions(
@@ -73,7 +69,7 @@ fun DemoMap(state: DemoAppState, sheetInsets: WindowInsets = WindowInsets(0)) {
           tileLodOptions = state.settings.tileLodOptions,
         ),
       onFrame = { state.frameRateState.record() },
-      contentWindowInsets = insets,
+      contentWindowInsets = viewportInsets.asWindowInsets(),
       overlay =
         MapOverlay {
           include(
@@ -87,22 +83,22 @@ fun DemoMap(state: DemoAppState, sheetInsets: WindowInsets = WindowInsets(0)) {
       allDemos.forEach { demo ->
         key(demo) {
           if (demo == state.selectedDemo) {
-            demo.MapContent(state.cameraState)
+            demo.MapContent(state.camera)
           }
         }
       }
     }
 
     val scope = rememberCoroutineScope()
-    state.selectedDemo
-      ?.takeIf { it.showsPointerPin }
-      ?.let { demo ->
-        // The pin fills this box to place itself; sizing the pin itself is up to its content.
-        Box(Modifier.fillMaxSize().padding(insets.asPaddingValues())) {
+    Box(Modifier.fillMaxSize().padding(viewportInsets.asPaddingValues())) {
+      state.selectedDemo
+        ?.let { demo -> demo.pointerPin?.let { demo to it } }
+        ?.let { (demo, pointerPin) ->
+          // The pin fills this box to place itself; sizing the pin itself is up to its content.
           PointerPinButton(
-            cameraState = state.cameraState,
-            targetPosition = demo.center,
-            onClick = { scope.launch { state.cameraState.flyToDemo(demo) } },
+            cameraState = state.camera,
+            targetPosition = pointerPin.target,
+            onClick = { scope.launch { state.camera.flyTo(pointerPin.destination) } },
           ) {
             Icon(
               vectorResource(Res.drawable.filter_center_focus_24px),
@@ -110,12 +106,9 @@ fun DemoMap(state: DemoAppState, sheetInsets: WindowInsets = WindowInsets(0)) {
             )
           }
         }
-      }
 
-    DiagnosticOverlays(
-      state = state,
-      modifier = Modifier.align(Alignment.TopCenter).padding(insets.asPaddingValues()),
-    )
+      DiagnosticOverlays(state = state, modifier = Modifier.align(Alignment.TopCenter))
+    }
   }
 }
 
@@ -142,7 +135,7 @@ private fun DiagnosticOverlays(state: DemoAppState, modifier: Modifier = Modifie
       )
     }
     if (state.settings.showCameraOverlay) {
-      val position = state.cameraState.position
+      val position = state.camera.position
       Text(
         text =
           "lat ${position.target.latitude.format(4)} " +

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoPanel.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoPanel.kt
@@ -33,6 +33,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -43,6 +44,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.vectorResource
 import org.maplibre.compose.demoapp.design.SectionHeader
 import org.maplibre.compose.demoapp.design.SwitchRow
@@ -53,8 +55,13 @@ import org.maplibre.compose.demoapp.generated.speed_24px
 
 /** The demo list, the style knob, and the selected demo's controls — or the settings page. */
 @Composable
-fun DemoPanel(state: DemoAppState, modifier: Modifier = Modifier) {
+fun DemoPanel(
+  state: DemoAppState,
+  modifier: Modifier = Modifier,
+  revealMap: suspend () -> Unit = {},
+) {
   val navController = rememberNavController()
+  val scope = rememberCoroutineScope()
   val route = navController.currentBackStackEntryAsState().value?.destination?.route
   // selectedDemo drives the map overlay. Keep it aligned with this destination so
   // system and predictive back clear the overlay too.
@@ -85,8 +92,13 @@ fun DemoPanel(state: DemoAppState, modifier: Modifier = Modifier) {
         state,
         onOpenSettings = { navController.navigate("settings") },
         onOpenDemo = { demo ->
-          state.selectedDemo = demo
-          navController.navigate("demo")
+          scope.launch {
+            revealMap()
+            demo.preferredStyle?.let { state.selectedStyle = it }
+            state.selectedDemo = demo
+            navController.navigate("demo")
+            state.camera.flyTo(demo.destination)
+          }
         },
         onOpenBenchmarks = {
           state.selectedDemo = null
@@ -114,8 +126,11 @@ fun DemoPanel(state: DemoAppState, modifier: Modifier = Modifier) {
       BenchmarksScreen(
         onBack = { navController.popBackStack() },
         onOpenScenario = { scenario ->
-          state.selectedScenario = scenario
-          navController.navigate("benchmark")
+          scope.launch {
+            revealMap()
+            state.selectedScenario = scenario
+            navController.navigate("benchmark")
+          }
         },
       )
     }

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoPanel.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoPanel.kt
@@ -97,7 +97,7 @@ fun DemoPanel(
             demo.preferredStyle?.let { state.selectedStyle = it }
             state.selectedDemo = demo
             navController.navigate("demo")
-            state.camera.flyTo(demo.destination)
+            state.cameraState.flyTo(demo.destination)
           }
         },
         onOpenBenchmarks = {

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/MapViewportInsets.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/MapViewportInsets.kt
@@ -8,7 +8,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 
-/** Physical insets around the part of the map that the app can use. */
+/** Physical insets around the map viewport. */
 @Immutable
 data class MapViewportInsets(
   val left: Dp = 0.dp,
@@ -29,10 +29,6 @@ data class MapViewportInsets(
 
   fun asWindowInsets(): WindowInsets =
     WindowInsets(left = left, top = top, right = right, bottom = bottom)
-
-  companion object {
-    val Zero = MapViewportInsets()
-  }
 }
 
 fun WindowInsets.toMapViewportInsets(
@@ -47,16 +43,3 @@ fun WindowInsets.toMapViewportInsets(
       bottom = getBottom(density).toDp(),
     )
   }
-
-internal fun maximumSheetHeight(
-  viewportHeight: Dp,
-  topSafeInset: Dp,
-  minimumUsefulHeight: Dp,
-): Dp =
-  minOf(
-    (viewportHeight - topSafeInset).coerceAtLeast(0.dp),
-    maxOf(viewportHeight / 2, minimumUsefulHeight),
-  )
-
-internal fun visibleSheetHeight(viewportHeightPx: Int, sheetOffsetPx: Float): Int =
-  (viewportHeightPx - sheetOffsetPx).toInt().coerceIn(0, viewportHeightPx)

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/MapViewportInsets.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/MapViewportInsets.kt
@@ -1,0 +1,62 @@
+package org.maplibre.compose.demoapp
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+
+/** Physical insets around the part of the map that the app can use. */
+@Immutable
+data class MapViewportInsets(
+  val left: Dp = 0.dp,
+  val top: Dp = 0.dp,
+  val right: Dp = 0.dp,
+  val bottom: Dp = 0.dp,
+) {
+  fun union(other: MapViewportInsets): MapViewportInsets =
+    MapViewportInsets(
+      left = maxOf(left, other.left),
+      top = maxOf(top, other.top),
+      right = maxOf(right, other.right),
+      bottom = maxOf(bottom, other.bottom),
+    )
+
+  fun asPaddingValues(): PaddingValues.Absolute =
+    PaddingValues.Absolute(left = left, top = top, right = right, bottom = bottom)
+
+  fun asWindowInsets(): WindowInsets =
+    WindowInsets(left = left, top = top, right = right, bottom = bottom)
+
+  companion object {
+    val Zero = MapViewportInsets()
+  }
+}
+
+fun WindowInsets.toMapViewportInsets(
+  density: Density,
+  layoutDirection: LayoutDirection,
+): MapViewportInsets =
+  with(density) {
+    MapViewportInsets(
+      left = getLeft(density, layoutDirection).toDp(),
+      top = getTop(density).toDp(),
+      right = getRight(density, layoutDirection).toDp(),
+      bottom = getBottom(density).toDp(),
+    )
+  }
+
+internal fun maximumSheetHeight(
+  viewportHeight: Dp,
+  topSafeInset: Dp,
+  minimumUsefulHeight: Dp,
+): Dp =
+  minOf(
+    (viewportHeight - topSafeInset).coerceAtLeast(0.dp),
+    maxOf(viewportHeight / 2, minimumUsefulHeight),
+  )
+
+internal fun visibleSheetHeight(viewportHeightPx: Int, sheetOffsetPx: Float): Int =
+  (viewportHeightPx - sheetOffsetPx).toInt().coerceIn(0, viewportHeightPx)

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/benchmark/BenchmarkMap.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/benchmark/BenchmarkMap.kt
@@ -3,12 +3,8 @@ package org.maplibre.compose.demoapp.benchmark
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.safeDrawing
-import androidx.compose.foundation.layout.union
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -37,6 +33,7 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import org.maplibre.compose.camera.rememberCameraState
 import org.maplibre.compose.demoapp.DemoAppState
+import org.maplibre.compose.demoapp.MapViewportInsets
 import org.maplibre.compose.map.GestureOptions
 import org.maplibre.compose.map.MapOptions
 import org.maplibre.compose.map.MaplibreMap
@@ -52,7 +49,7 @@ private val benchLog = Logger.withTag(BenchmarkReport.LogPrefix)
  * settings do not compose here.
  */
 @Composable
-internal fun BenchmarkMap(state: DemoAppState, sheetInsets: WindowInsets = WindowInsets(0)) {
+internal fun BenchmarkMap(state: DemoAppState, viewportInsets: MapViewportInsets) {
   val scenario = state.selectedScenario
   val density = LocalDensity.current
   val prefetcher = rememberTilePrefetcher()
@@ -68,9 +65,7 @@ internal fun BenchmarkMap(state: DemoAppState, sheetInsets: WindowInsets = Windo
       )
     }
   val mapLoaded = remember(scenario.id) { CompletableDeferred<Unit>() }
-  val insets = WindowInsets.safeDrawing.union(sheetInsets)
   val styleUrl = (scenario.style.base as BaseStyle.Uri).uri
-
   LaunchedEffect(scenario.id) {
     state.benchmark.abandonRun()
     cameraState.position = scenario.camera
@@ -192,6 +187,7 @@ internal fun BenchmarkMap(state: DemoAppState, sheetInsets: WindowInsets = Windo
       MaplibreMap(
         baseStyle = scenario.style.base,
         cameraState = cameraState,
+        cameraPadding = viewportInsets.asPaddingValues(),
         styleState = styleState,
         options =
           MapOptions(
@@ -204,29 +200,30 @@ internal fun BenchmarkMap(state: DemoAppState, sheetInsets: WindowInsets = Windo
         onMapLoadFailed = { reason ->
           mapLoaded.completeExceptionally(IllegalStateException(reason ?: "Map failed to load"))
         },
-        contentWindowInsets = insets,
+        contentWindowInsets = viewportInsets.asWindowInsets(),
         overlay = MapOverlay.None,
       ) {
         scenario.MapContent(session)
       }
     }
 
-    Column(
-      modifier =
-        Modifier.align(Alignment.TopCenter).padding(insets.asPaddingValues()).padding(8.dp),
-      horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
-      Text(
-        text = state.benchmark.status,
-        style = MaterialTheme.typography.labelMedium,
-        color = MaterialTheme.colorScheme.onSurface,
-        modifier =
-          Modifier.background(
-              color = MaterialTheme.colorScheme.surface.copy(alpha = 0.85f),
-              shape = RoundedCornerShape(8.dp),
-            )
-            .padding(horizontal = 8.dp, vertical = 4.dp),
-      )
+    Box(Modifier.fillMaxSize().padding(viewportInsets.asPaddingValues())) {
+      Column(
+        modifier = Modifier.align(Alignment.TopCenter).padding(8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+      ) {
+        Text(
+          text = state.benchmark.status,
+          style = MaterialTheme.typography.labelMedium,
+          color = MaterialTheme.colorScheme.onSurface,
+          modifier =
+            Modifier.background(
+                color = MaterialTheme.colorScheme.surface.copy(alpha = 0.85f),
+                shape = RoundedCornerShape(8.dp),
+              )
+              .padding(horizontal = 8.dp, vertical = 4.dp),
+        )
+      }
     }
   }
 }

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/benchmark/CameraPlayback.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/benchmark/CameraPlayback.kt
@@ -39,7 +39,6 @@ internal fun lerp(from: CameraPosition, to: CameraPosition, t: Double): CameraPo
       ),
     tilt = lerp(from.tilt, to.tilt, u),
     zoom = lerp(from.zoom, to.zoom, u),
-    padding = from.padding,
   )
 }
 

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/CastelloPlanDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/CastelloPlanDemo.kt
@@ -53,7 +53,7 @@ object CastelloPlanDemo : Demo {
     )
 
   @Composable
-  override fun MapContent(camera: CameraState) {
+  override fun MapContent(cameraState: CameraState) {
     val source =
       rememberImageSource(position = corners, uri = Res.getUri("files/castello-plan.jpg"))
     RasterLayer(id = "castello-plan", source = source, opacity = const(opacity))

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/CastelloPlanDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/CastelloPlanDemo.kt
@@ -12,11 +12,13 @@ import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.camera.CameraState
 import org.maplibre.compose.demoapp.Demo
 import org.maplibre.compose.demoapp.DemoAppState
+import org.maplibre.compose.demoapp.DemoDestination
+import org.maplibre.compose.demoapp.DemoPointerPin
 import org.maplibre.compose.demoapp.OpenFreeMap
+import org.maplibre.compose.demoapp.center
 import org.maplibre.compose.demoapp.generated.Res
 import org.maplibre.compose.expressions.dsl.const
 import org.maplibre.compose.layers.RasterLayer
@@ -28,11 +30,13 @@ import org.maplibre.spatialk.geojson.Position
 object CastelloPlanDemo : Demo {
   override val name = "Castello Plan"
   override val description = "The 1660 map of New Amsterdam draped over lower Manhattan."
-  override val region = BoundingBox(west = -74.018, south = 40.7005, east = -74.006, north = 40.710)
   override val preferredStyle = OpenFreeMap.Liberty
 
-  override val camera =
-    CameraPosition(target = Position(longitude = -74.0119, latitude = 40.7053), zoom = 15.5)
+  private val imageRegion =
+    BoundingBox(west = -74.018, south = 40.7005, east = -74.006, north = 40.710)
+
+  override val destination = DemoDestination.FitBounds(imageRegion)
+  override val pointerPin = DemoPointerPin(imageRegion.center, destination)
 
   private var opacity by mutableFloatStateOf(0.7f)
 
@@ -49,7 +53,7 @@ object CastelloPlanDemo : Demo {
     )
 
   @Composable
-  override fun MapContent(cameraState: CameraState) {
+  override fun MapContent(camera: CameraState) {
     val source =
       rememberImageSource(position = corners, uri = Res.getUri("files/castello-plan.jpg"))
     RasterLayer(id = "castello-plan", source = source, opacity = const(opacity))

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/DataVizDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/DataVizDemo.kt
@@ -52,7 +52,7 @@ object DataVizDemo : Demo {
   private val magnitude = feature["mag"].asNumber()
 
   @Composable
-  override fun MapContent(camera: CameraState) {
+  override fun MapContent(cameraState: CameraState) {
     when (mode) {
       Mode.Points -> Points()
       Mode.Heatmap -> Heatmap()

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/DataVizDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/DataVizDemo.kt
@@ -6,10 +6,10 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.camera.CameraState
 import org.maplibre.compose.demoapp.Demo
 import org.maplibre.compose.demoapp.DemoAppState
+import org.maplibre.compose.demoapp.DemoDestination
 import org.maplibre.compose.demoapp.OpenFreeMap
 import org.maplibre.compose.demoapp.design.SegmentedRow
 import org.maplibre.compose.expressions.dsl.asNumber
@@ -27,18 +27,15 @@ import org.maplibre.compose.sources.GeoJsonData
 import org.maplibre.compose.sources.GeoJsonOptions
 import org.maplibre.compose.sources.rememberGeoJsonSource
 import org.maplibre.spatialk.geojson.BoundingBox
-import org.maplibre.spatialk.geojson.Position
 
 object DataVizDemo : Demo {
   override val name = "Data visualization"
   override val description = "A month of earthquakes as points, a heatmap, or clusters."
-  override val region = BoundingBox(west = -180.0, south = -60.0, east = 180.0, north = 70.0)
   override val preferredStyle = OpenFreeMap.Positron
-  override val showsPointerPin = false
 
-  // Centered on the Pacific, so the Ring of Fire frames the data.
-  override val camera =
-    CameraPosition(target = Position(longitude = -160.0, latitude = 10.0), zoom = 1.6)
+  // These bounds cross the antimeridian and frame the Pacific Ring of Fire.
+  override val destination =
+    DemoDestination.FitBounds(BoundingBox(west = 100.0, south = -60.0, east = -65.0, north = 70.0))
 
   /** USGS serves this feed with open CORS headers, so every platform can fetch it directly. */
   private const val FEED_URI =
@@ -55,7 +52,7 @@ object DataVizDemo : Demo {
   private val magnitude = feature["mag"].asNumber()
 
   @Composable
-  override fun MapContent(cameraState: CameraState) {
+  override fun MapContent(camera: CameraState) {
     when (mode) {
       Mode.Points -> Points()
       Mode.Heatmap -> Heatmap()

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/DragDropDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/DragDropDemo.kt
@@ -24,10 +24,10 @@ import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.dp
 import kotlin.math.roundToInt
-import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.camera.CameraState
 import org.maplibre.compose.demoapp.Demo
 import org.maplibre.compose.demoapp.DemoAppState
+import org.maplibre.compose.demoapp.DemoDestination
 import org.maplibre.compose.demoapp.OpenFreeMap
 import org.maplibre.compose.demoapp.design.SegmentedRow
 import org.maplibre.compose.expressions.dsl.const
@@ -51,14 +51,13 @@ private val DragColor = Color(0xFF00695C)
 object DragDropDemo : Demo {
   override val name = "Drag & drop"
   override val description = "Drag a location-picker pin or the corner handles of a bounding box."
-  override val region =
-    BoundingBox(west = -122.3452, south = 47.6155, east = -122.3252, north = 47.6255)
   override val preferredStyle = OpenFreeMap.Liberty
-  override val showsPointerPin = false
 
-  // A neighborhood zoom gives both modes room to drag in without a detour through the camera.
-  override val camera =
-    CameraPosition(target = Position(longitude = -122.3352, latitude = 47.6205), zoom = 15.0)
+  // A neighborhood view gives both modes room to drag in without a detour through the camera.
+  override val destination =
+    DemoDestination.FitBounds(
+      BoundingBox(west = -122.3452, south = 47.6155, east = -122.3252, north = 47.6255)
+    )
 
   private enum class Mode(val label: String) {
     Pin("Pin"),
@@ -125,7 +124,7 @@ object DragDropDemo : Demo {
     )
 
   @Composable
-  override fun MapContent(cameraState: CameraState) {
+  override fun MapContent(camera: CameraState) {
     if (mode != Mode.BoundingBox) return
     val source =
       rememberGeoJsonSource(

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/DragDropDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/DragDropDemo.kt
@@ -124,7 +124,7 @@ object DragDropDemo : Demo {
     )
 
   @Composable
-  override fun MapContent(camera: CameraState) {
+  override fun MapContent(cameraState: CameraState) {
     if (mode != Mode.BoundingBox) return
     val source =
       rememberGeoJsonSource(

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/LiveTrackingDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/LiveTrackingDemo.kt
@@ -112,9 +112,9 @@ object LiveTrackingDemo : Demo {
   }
 
   @Composable
-  override fun MapContent(camera: CameraState) {
-    LaunchedEffect(camera.moveReason) {
-      if (camera.moveReason == CameraMoveReason.GESTURE) {
+  override fun MapContent(cameraState: CameraState) {
+    LaunchedEffect(cameraState.moveReason) {
+      if (cameraState.moveReason == CameraMoveReason.GESTURE) {
         followVehicle = false
       }
     }
@@ -129,7 +129,7 @@ object LiveTrackingDemo : Demo {
           vehiclePosition = positionAt(routeLength - abs(phase - routeLength))
         }
         if (followVehicle) {
-          camera.position = camera.position.copy(target = vehiclePosition)
+          cameraState.position = cameraState.position.copy(target = vehiclePosition)
         }
       }
     }

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/LiveTrackingDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/LiveTrackingDemo.kt
@@ -16,7 +16,10 @@ import org.maplibre.compose.camera.CameraMoveReason
 import org.maplibre.compose.camera.CameraState
 import org.maplibre.compose.demoapp.Demo
 import org.maplibre.compose.demoapp.DemoAppState
+import org.maplibre.compose.demoapp.DemoDestination
+import org.maplibre.compose.demoapp.DemoPointerPin
 import org.maplibre.compose.demoapp.OpenFreeMap
+import org.maplibre.compose.demoapp.center
 import org.maplibre.compose.demoapp.design.SwitchRow
 import org.maplibre.compose.expressions.dsl.const
 import org.maplibre.compose.layers.CircleLayer
@@ -32,8 +35,10 @@ import org.maplibre.spatialk.geojson.Position
 object LiveTrackingDemo : Demo {
   override val name = "Live tracking"
   override val description = "A simulated ferry crosses Elliott Bay with a camera-follow toggle."
-  override val region =
+  private val routeRegion =
     BoundingBox(west = -122.5195, south = 47.5925, east = -122.3298, north = 47.6321)
+  override val destination = DemoDestination.FitBounds(routeRegion)
+  override val pointerPin = DemoPointerPin(routeRegion.center, destination)
   override val preferredStyle = OpenFreeMap.Liberty
 
   // The Seattle-Bainbridge ferry crossing, traced from OpenStreetMap (ODbL).
@@ -67,7 +72,7 @@ object LiveTrackingDemo : Demo {
   // The real ferry's ~8 m/s is imperceptible with the whole crossing in the viewport.
   private const val SPEED_METERS_PER_SECOND = 250.0
 
-  // Off by default so the flight to the demo region runs uninterrupted.
+  // Off by default so the initial flight runs uninterrupted.
   private var followVehicle by mutableStateOf(false)
   private var vehiclePosition by mutableStateOf(route.first())
 
@@ -107,9 +112,9 @@ object LiveTrackingDemo : Demo {
   }
 
   @Composable
-  override fun MapContent(cameraState: CameraState) {
-    LaunchedEffect(cameraState.moveReason) {
-      if (cameraState.moveReason == CameraMoveReason.GESTURE) {
+  override fun MapContent(camera: CameraState) {
+    LaunchedEffect(camera.moveReason) {
+      if (camera.moveReason == CameraMoveReason.GESTURE) {
         followVehicle = false
       }
     }
@@ -124,7 +129,7 @@ object LiveTrackingDemo : Demo {
           vehiclePosition = positionAt(routeLength - abs(phase - routeLength))
         }
         if (followVehicle) {
-          cameraState.position = cameraState.position.copy(target = vehiclePosition)
+          camera.position = camera.position.copy(target = vehiclePosition)
         }
       }
     }

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/LocationDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/LocationDemo.kt
@@ -17,7 +17,9 @@ import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.camera.CameraState
 import org.maplibre.compose.demoapp.Demo
 import org.maplibre.compose.demoapp.DemoAppState
+import org.maplibre.compose.demoapp.DemoDestination
 import org.maplibre.compose.demoapp.DemoFlightDuration
+import org.maplibre.compose.demoapp.DemoPointerPin
 import org.maplibre.compose.demoapp.OpenFreeMap
 import org.maplibre.compose.demoapp.design.ButtonRow
 import org.maplibre.compose.demoapp.design.SegmentedRow
@@ -41,20 +43,19 @@ object LocationDemo : Demo {
   override val description =
     "The location puck, device heading, and a camera-follow toggle on the real device."
   override val preferredStyle = OpenFreeMap.Liberty
-  override val fliesOnSelect = false
-  override val showsPointerPin
-    get() = lastFix != null
+  override val destination = DemoDestination.None
 
-  override val region: BoundingBox
-    get() {
-      val p = lastFix ?: Position(longitude = 0.0, latitude = 0.0)
+  override val pointerPin: DemoPointerPin?
+    get() = lastFix?.let { position ->
       val delta = 0.005
-      return BoundingBox(
-        west = p.longitude - delta,
-        south = p.latitude - delta,
-        east = p.longitude + delta,
-        north = p.latitude + delta,
-      )
+      val bounds =
+        BoundingBox(
+          west = position.longitude - delta,
+          south = position.latitude - delta,
+          east = position.longitude + delta,
+          north = position.latitude + delta,
+        )
+      DemoPointerPin(position, DemoDestination.FitBounds(bounds))
     }
 
   private var follow by mutableStateOf(true)
@@ -64,7 +65,7 @@ object LocationDemo : Demo {
   private var panelLocationState by mutableStateOf<LocationState?>(null)
 
   @Composable
-  override fun MapContent(cameraState: CameraState) {
+  override fun MapContent(camera: CameraState) {
     val locationState =
       rememberLocationState(
         provider = engine.rememberLocationProvider(),
@@ -76,9 +77,9 @@ object LocationDemo : Demo {
     }
     LaunchedEffect(locationState) { locationState.requestPermission() }
 
-    LaunchedEffect(cameraState) {
-      var previous = cameraState.moveReason
-      snapshotFlow { cameraState.moveReason }
+    LaunchedEffect(camera) {
+      var previous = camera.moveReason
+      snapshotFlow { camera.moveReason }
         .collect { reason ->
           // Follow moves the camera programmatically; a pan is the GESTURE that interrupts it.
           if (previous != CameraMoveReason.GESTURE && reason == CameraMoveReason.GESTURE) {
@@ -93,12 +94,12 @@ object LocationDemo : Demo {
 
     LocationTrackingEffect(locationState = locationState, enabled = follow) {
       if (previousLocation == null) {
-        cameraState.animateTo(
+        camera.animateTo(
           CameraPosition(target = currentLocation.position.value, zoom = 16.0),
           duration = DemoFlightDuration,
         )
       } else {
-        updateCamera(cameraState)
+        updateCamera(camera)
       }
     }
 
@@ -109,7 +110,7 @@ object LocationDemo : Demo {
         idPrefix = "user",
         location = location,
         bearing = locationState.mostAccurateBearing(),
-        cameraState = cameraState,
+        cameraState = camera,
         colors = LocationPuckDefaults.colors(),
       )
     }

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/LocationDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/LocationDemo.kt
@@ -65,7 +65,7 @@ object LocationDemo : Demo {
   private var panelLocationState by mutableStateOf<LocationState?>(null)
 
   @Composable
-  override fun MapContent(camera: CameraState) {
+  override fun MapContent(cameraState: CameraState) {
     val locationState =
       rememberLocationState(
         provider = engine.rememberLocationProvider(),
@@ -77,9 +77,9 @@ object LocationDemo : Demo {
     }
     LaunchedEffect(locationState) { locationState.requestPermission() }
 
-    LaunchedEffect(camera) {
-      var previous = camera.moveReason
-      snapshotFlow { camera.moveReason }
+    LaunchedEffect(cameraState) {
+      var previous = cameraState.moveReason
+      snapshotFlow { cameraState.moveReason }
         .collect { reason ->
           // Follow moves the camera programmatically; a pan is the GESTURE that interrupts it.
           if (previous != CameraMoveReason.GESTURE && reason == CameraMoveReason.GESTURE) {
@@ -94,12 +94,12 @@ object LocationDemo : Demo {
 
     LocationTrackingEffect(locationState = locationState, enabled = follow) {
       if (previousLocation == null) {
-        camera.animateTo(
+        cameraState.animateTo(
           CameraPosition(target = currentLocation.position.value, zoom = 16.0),
           duration = DemoFlightDuration,
         )
       } else {
-        updateCamera(camera)
+        updateCamera(cameraState)
       }
     }
 
@@ -110,7 +110,7 @@ object LocationDemo : Demo {
         idPrefix = "user",
         location = location,
         bearing = locationState.mostAccurateBearing(),
-        cameraState = camera,
+        cameraState = cameraState,
         colors = LocationPuckDefaults.colors(),
       )
     }

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/MagnifyingLensDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/MagnifyingLensDemo.kt
@@ -33,12 +33,14 @@ import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import kotlin.math.roundToInt
-import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.camera.rememberCameraState
 import org.maplibre.compose.demoapp.Demo
 import org.maplibre.compose.demoapp.DemoAppState
+import org.maplibre.compose.demoapp.DemoDestination
+import org.maplibre.compose.demoapp.DemoPointerPin
 import org.maplibre.compose.demoapp.DemoSettings
 import org.maplibre.compose.demoapp.OpenFreeMap
+import org.maplibre.compose.demoapp.center
 import org.maplibre.compose.demoapp.design.SectionHeader
 import org.maplibre.compose.demoapp.design.SegmentedRow
 import org.maplibre.compose.demoapp.design.SliderRow
@@ -49,7 +51,6 @@ import org.maplibre.compose.map.RenderOptions
 import org.maplibre.compose.overlay.MapOverlay
 import org.maplibre.compose.overlay.MapOverlayScope
 import org.maplibre.spatialk.geojson.BoundingBox
-import org.maplibre.spatialk.geojson.Position
 
 /**
  * A second map floats over the shared one as a magnifying lens.
@@ -64,11 +65,13 @@ import org.maplibre.spatialk.geojson.Position
 object MagnifyingLensDemo : Demo {
   override val name = "Magnifying lens"
   override val description = "A second map composited into a draggable lens with Compose modifiers."
-  override val region = BoundingBox(west = -74.002, south = 40.748, east = -73.968, north = 40.768)
   override val preferredStyle = OpenFreeMap.Liberty
 
-  override val camera =
-    CameraPosition(target = Position(longitude = -73.9851, latitude = 40.7589), zoom = 15.0)
+  private val lensRegion =
+    BoundingBox(west = -74.002, south = 40.748, east = -73.968, north = 40.768)
+
+  override val destination = DemoDestination.FitBounds(lensRegion)
+  override val pointerPin = DemoPointerPin(lensRegion.center, destination)
 
   private enum class LensShape(val label: String, val shape: Shape) {
     Circle("Circle", CircleShape),

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/Manhattan3dDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/Manhattan3dDemo.kt
@@ -4,27 +4,39 @@ import androidx.compose.runtime.Composable
 import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.demoapp.Demo
 import org.maplibre.compose.demoapp.DemoAppState
+import org.maplibre.compose.demoapp.DemoDestination
+import org.maplibre.compose.demoapp.DemoPointerPin
 import org.maplibre.compose.demoapp.OpenFreeMap
+import org.maplibre.compose.demoapp.center
 import org.maplibre.spatialk.geojson.BoundingBox
 import org.maplibre.spatialk.geojson.Position
 
 object Manhattan3dDemo : Demo {
   override val name = "3D Manhattan"
   override val description = "Liberty's building extrusions pitched over the financial district."
-  override val region = BoundingBox(west = -74.020, south = 40.700, east = -73.993, north = 40.722)
   override val preferredStyle = OpenFreeMap.Liberty
 
-  override val camera =
-    CameraPosition(
-      target = Position(longitude = -74.0109, latitude = 40.7085),
-      zoom = 14.2,
-      bearing = 2.0,
-      tilt = 60.0,
+  private val offlineRegion =
+    BoundingBox(west = -74.020, south = 40.700, east = -73.993, north = 40.722)
+
+  override val destination =
+    DemoDestination.ExactCamera(
+      CameraPosition(
+        target = Position(longitude = -74.0109, latitude = 40.7085),
+        zoom = 14.2,
+        bearing = 2.0,
+        tilt = 60.0,
+      )
     )
+  override val pointerPin = DemoPointerPin(offlineRegion.center, destination)
 
   @Composable
   override fun Panel(state: DemoAppState) {
-    OfflineRegionSection(region = region, styleUrl = preferredStyle.base.uri, packName = name)
+    OfflineRegionSection(
+      region = offlineRegion,
+      styleUrl = preferredStyle.base.uri,
+      packName = name,
+    )
   }
 }
 

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Controls.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Controls.kt
@@ -3,6 +3,7 @@
 package org.maplibre.compose.docsnippets
 
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.union
@@ -44,8 +45,10 @@ fun Controls() {
   // #endregion custom
 
   // #region insets
+  val mapInsets = WindowInsets.safeDrawing.union(WindowInsets(bottom = 128.dp))
   MaplibreMap(
-    contentWindowInsets = WindowInsets.safeDrawing.union(WindowInsets(bottom = 128.dp)) // (1)!
+    contentWindowInsets = mapInsets, // (1)!
+    cameraPadding = mapInsets.asPaddingValues(),
   )
   // #endregion insets
 }

--- a/demo-app/common/src/maplibreNativeMain/kotlin/org/maplibre/compose/demoapp/demos/TransitNetworkDemo.kt
+++ b/demo-app/common/src/maplibreNativeMain/kotlin/org/maplibre/compose/demoapp/demos/TransitNetworkDemo.kt
@@ -62,7 +62,10 @@ import kotlinx.serialization.json.put
 import org.maplibre.compose.camera.CameraState
 import org.maplibre.compose.demoapp.Demo
 import org.maplibre.compose.demoapp.DemoAppState
+import org.maplibre.compose.demoapp.DemoDestination
+import org.maplibre.compose.demoapp.DemoPointerPin
 import org.maplibre.compose.demoapp.OpenFreeMap
+import org.maplibre.compose.demoapp.center
 import org.maplibre.compose.demoapp.design.SectionHeader
 import org.maplibre.compose.demoapp.util.unzip
 import org.maplibre.compose.expressions.dsl.asString
@@ -89,7 +92,9 @@ object TransitNetworkDemo : Demo {
   override val name = "Transit network"
   override val description =
     "The Washington State Ferries network from its GTFS feed. Select a route to see the next sailing at each terminal."
-  override val region = BoundingBox(west = -123.2, south = 47.0, east = -122.2, north = 48.8)
+  private val networkRegion = BoundingBox(west = -123.2, south = 47.0, east = -122.2, north = 48.8)
+  override val destination = DemoDestination.FitBounds(networkRegion)
+  override val pointerPin = DemoPointerPin(networkRegion.center, destination)
   override val preferredStyle = OpenFreeMap.Positron
 
   /** The feed sends no CORS headers, which is why this demo is absent from the browser. */
@@ -350,13 +355,13 @@ object TransitNetworkDemo : Demo {
   }
 
   @Composable
-  override fun MapContent(cameraState: CameraState) {
+  override fun MapContent(camera: CameraState) {
     val network = (feedState as? FeedState.Loaded)?.network ?: return
     val selected = selectedRouteId
 
     LaunchedEffect(selected) {
       val route = network.routes.find { it.id == selected } ?: return@LaunchedEffect
-      cameraState.animateTo(
+      camera.animateTo(
         boundingBox = route.bounds,
         padding = RouteFitPadding,
         duration = 1.seconds,

--- a/demo-app/common/src/maplibreNativeMain/kotlin/org/maplibre/compose/demoapp/demos/TransitNetworkDemo.kt
+++ b/demo-app/common/src/maplibreNativeMain/kotlin/org/maplibre/compose/demoapp/demos/TransitNetworkDemo.kt
@@ -355,13 +355,13 @@ object TransitNetworkDemo : Demo {
   }
 
   @Composable
-  override fun MapContent(camera: CameraState) {
+  override fun MapContent(cameraState: CameraState) {
     val network = (feedState as? FeedState.Loaded)?.network ?: return
     val selected = selectedRouteId
 
     LaunchedEffect(selected) {
       val route = network.routes.find { it.id == selected } ?: return@LaunchedEffect
-      camera.animateTo(
+      cameraState.animateTo(
         boundingBox = route.bounds,
         padding = RouteFitPadding,
         duration = 1.seconds,

--- a/docs/src/content/docs/controls.mdx
+++ b/docs/src/content/docs/controls.mdx
@@ -29,7 +29,7 @@ somewhere else, such as an about screen.
 <Code code={region(controls, "disabled")} lang="kotlin" title="App.kt" />
 
 A `MapOverlay` block draws the controls you list in it. `Modifier.align`
-positions a control against an edge of the unobstructed map.
+positions a control against an inset edge of the map.
 
 <Code code={region(controls, "custom")} lang="kotlin" title="App.kt" />
 
@@ -40,24 +40,21 @@ positions a control against an edge of the unobstructed map.
 [Material 3 extensions](/maplibre-compose/material3/) draws the same controls,
 themed from your color scheme and typography.
 
-## Make room for other UI
+## Inset overlays and the camera
 
-A system bar or a bottom sheet can cover part of the map. Set
-`contentWindowInsets` to the covered region, and the overlay places its controls
-in the rest.
+Use `contentWindowInsets` to inset overlay controls and `cameraPadding` to inset
+the camera viewport. They can use the same values or vary independently.
 
-The default is `WindowInsets.safeDrawing`. It excludes the insets that an
-ancestor already applied, so a map inside a scaffold reads zero and a
-full-screen map reads the system bars. Add to it when other UI covers the map.
+The default `contentWindowInsets` is `WindowInsets.safeDrawing`. It excludes
+insets that an ancestor already applied.
 
 <Code code={region(controls, "insets")} lang="kotlin" title="App.kt" />
 
-1. `union` takes the larger inset on each edge, so the sheet and the system bars
-   both stay clear.
+1. `union` takes the larger inset on each edge.
 
-The camera has its own padding, which moves the point that the map centers and
-rotates around. See
-[`CameraPosition.padding`](/maplibre-compose/api/lib/maplibre-compose/org.maplibre.compose.camera/-camera-position/padding.html).
+`cameraPadding` is persistent while the map is composed. Padding passed to a
+bounding-box camera move adds temporary space around those bounds without
+changing the persistent value.
 
 ## Pin Compose UI to a location
 

--- a/docs/src/content/docs/controls.mdx
+++ b/docs/src/content/docs/controls.mdx
@@ -42,19 +42,14 @@ themed from your color scheme and typography.
 
 ## Inset overlays and the camera
 
-Use `contentWindowInsets` to inset overlay controls and `cameraPadding` to inset
-the camera viewport. They can use the same values or vary independently.
-
-The default `contentWindowInsets` is `WindowInsets.safeDrawing`. It excludes
-insets that an ancestor already applied.
+Use `contentWindowInsets` to inset overlay controls. Use `cameraPadding` to shift
+the camera center. They can use the same values or vary independently.
 
 <Code code={region(controls, "insets")} lang="kotlin" title="App.kt" />
 
 1. `union` takes the larger inset on each edge.
 
-`cameraPadding` is persistent while the map is composed. Padding passed to a
-bounding-box camera move adds temporary space around those bounds without
-changing the persistent value.
+Padding on a bounding-box camera move adds to `cameraPadding` for that fit.
 
 ## Pin Compose UI to a location
 

--- a/lib/maplibre-compose/src/androidDeviceTest/kotlin/org/maplibre/compose/camera/AndroidCameraStateRecreationTest.kt
+++ b/lib/maplibre-compose/src/androidDeviceTest/kotlin/org/maplibre/compose/camera/AndroidCameraStateRecreationTest.kt
@@ -3,16 +3,11 @@ package org.maplibre.compose.camera
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.calculateEndPadding
-import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.v2.runAndroidComposeUiTest
-import androidx.compose.ui.unit.LayoutDirection
-import androidx.compose.ui.unit.dp
 import kotlin.math.abs
 import kotlin.test.Test
 import kotlin.test.assertNotSame
@@ -82,7 +77,6 @@ class AndroidCameraStateRecreationTest {
         target = Position(longitude = 11.5761, latitude = 48.1371),
         tilt = 42.0,
         zoom = 8.5,
-        padding = PaddingValues.Absolute(left = 5.dp, top = 7.dp, right = 11.dp, bottom = 13.dp),
       )
 
     fun MapAdapter.hasCamera(expected: CameraPosition): Boolean =
@@ -100,21 +94,7 @@ class AndroidCameraStateRecreationTest {
         near(expected.target.longitude, actual.target.longitude) &&
         near(expected.target.latitude, actual.target.latitude) &&
         near(expected.tilt, actual.tilt) &&
-        near(expected.zoom, actual.zoom) &&
-        near(expected.padding.left(), actual.padding.left()) &&
-        near(
-          expected.padding.calculateTopPadding().value,
-          actual.padding.calculateTopPadding().value,
-        ) &&
-        near(expected.padding.right(), actual.padding.right()) &&
-        near(
-          expected.padding.calculateBottomPadding().value,
-          actual.padding.calculateBottomPadding().value,
-        )
-
-    fun PaddingValues.left(): Float = calculateStartPadding(LayoutDirection.Ltr).value
-
-    fun PaddingValues.right(): Float = calculateEndPadding(LayoutDirection.Ltr).value
+        near(expected.zoom, actual.zoom)
 
     fun near(expected: Number, actual: Number): Boolean =
       abs(expected.toDouble() - actual.toDouble()) < TOLERANCE

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/CameraPosition.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/CameraPosition.kt
@@ -1,29 +1,21 @@
 package org.maplibre.compose.camera
 
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.runtime.Stable
-import androidx.compose.ui.unit.dp
+import androidx.compose.runtime.Immutable
 import org.maplibre.spatialk.geojson.Position
 
 /**
  * Defines how the camera is oriented towards the map.
  *
  * @param bearing Direction that the camera is pointing in, in degrees clockwise from north.
- * @param target Target position to align with the center of the screen, i.e. where the camera is
- *   pointing at.
+ * @param target Position that the camera points at.
  * @param tilt The camera angle, in degrees, from the nadir (directly down). A value in the range of
  *   `[0 .. 60]`
  * @param zoom Zoom level at target. A value in the range of `[0 .. 25.5]`
- * @param padding By default, the camera points at the center of the screen, i.e. it also rotates
- *   and tilts around that point. By specifying a padding, this center point can be altered, for
- *   example if you want to display a bottom sheet above the lower part of the map, focussing on a
- *   POI in the upper part of the map.
  */
-@Stable // not @Immutable because of PaddingValues
+@Immutable
 public data class CameraPosition(
   public val bearing: Double = 0.0,
   public val target: Position = Position(0.0, 0.0),
   public val tilt: Double = 0.0,
   public val zoom: Double = 1.0,
-  public val padding: PaddingValues = PaddingValues(0.dp),
 )

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/CameraState.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/CameraState.kt
@@ -184,11 +184,6 @@ public class CameraState(firstPosition: CameraPosition) {
     awaitMap().animateCameraPosition(finalPosition, duration)
   }
 
-  /** Immediately moves the camera to [finalPosition]. */
-  public suspend fun jumpTo(finalPosition: CameraPosition) {
-    awaitMap().setCameraPosition(finalPosition)
-  }
-
   /**
    * Animates the camera towards the specified [boundingBox] in the given [duration] time with the
    * specified [bearing], [tilt], and [padding].
@@ -196,8 +191,7 @@ public class CameraState(firstPosition: CameraPosition) {
    * @param boundingBox The bounds to animate the camera to.
    * @param bearing The bearing to set during the animation. Defaults to 0.0.
    * @param tilt The tilt to set during the animation. Defaults to 0.0.
-   * @param padding Additional space between the bounds and the camera viewport. The `cameraPadding`
-   *   configured on [org.maplibre.compose.map.MaplibreMap] remains active after the animation.
+   * @param padding Insets added while fitting [boundingBox].
    * @param duration The duration of the animation. Defaults to 300 ms.
    */
   public suspend fun animateTo(
@@ -217,8 +211,7 @@ public class CameraState(firstPosition: CameraPosition) {
    * @param boundingBox The bounds to animate the camera to.
    * @param bearing The bearing to set during the animation. Defaults to 0.0.
    * @param tilt The tilt to set during the animation. Defaults to 0.0.
-   * @param padding Additional space between the bounds and the camera viewport. The `cameraPadding`
-   *   configured on [org.maplibre.compose.map.MaplibreMap] remains active after the move.
+   * @param padding Insets added while fitting [boundingBox].
    */
   public suspend fun jumpTo(
     boundingBox: BoundingBox,

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/CameraState.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/CameraState.kt
@@ -184,6 +184,11 @@ public class CameraState(firstPosition: CameraPosition) {
     awaitMap().animateCameraPosition(finalPosition, duration)
   }
 
+  /** Immediately moves the camera to [finalPosition]. */
+  public suspend fun jumpTo(finalPosition: CameraPosition) {
+    awaitMap().setCameraPosition(finalPosition)
+  }
+
   /**
    * Animates the camera towards the specified [boundingBox] in the given [duration] time with the
    * specified [bearing], [tilt], and [padding].
@@ -191,8 +196,9 @@ public class CameraState(firstPosition: CameraPosition) {
    * @param boundingBox The bounds to animate the camera to.
    * @param bearing The bearing to set during the animation. Defaults to 0.0.
    * @param tilt The tilt to set during the animation. Defaults to 0.0.
-   * @param padding The padding to apply during the animation. Defaults to no padding.
-   * @param duration The duration of the animation. Defaults to 300 ms. Has no effect on JS.
+   * @param padding Additional space between the bounds and the camera viewport. The `cameraPadding`
+   *   configured on [org.maplibre.compose.map.MaplibreMap] remains active after the animation.
+   * @param duration The duration of the animation. Defaults to 300 ms.
    */
   public suspend fun animateTo(
     boundingBox: BoundingBox,
@@ -211,7 +217,8 @@ public class CameraState(firstPosition: CameraPosition) {
    * @param boundingBox The bounds to animate the camera to.
    * @param bearing The bearing to set during the animation. Defaults to 0.0.
    * @param tilt The tilt to set during the animation. Defaults to 0.0.
-   * @param padding The padding to apply during the animation. Defaults to no padding.
+   * @param padding Additional space between the bounds and the camera viewport. The `cameraPadding`
+   *   configured on [org.maplibre.compose.map.MaplibreMap] remains active after the move.
    */
   public suspend fun jumpTo(
     boundingBox: BoundingBox,

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/CameraStateSaver.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/CameraStateSaver.kt
@@ -1,12 +1,7 @@
 package org.maplibre.compose.camera
 
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.calculateEndPadding
-import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.SaverScope
-import androidx.compose.ui.unit.LayoutDirection
-import androidx.compose.ui.unit.dp
 import org.maplibre.spatialk.geojson.Position
 
 /** Saves and restores a [CameraState] with `rememberSaveable`. */
@@ -19,12 +14,6 @@ public object CameraStateSaver : Saver<CameraState, Map<String, Double>> {
       Keys.LONGITUDE to position.target.longitude,
       Keys.TILT to position.tilt,
       Keys.ZOOM to position.zoom,
-      Keys.PADDING_LEFT to
-        position.padding.calculateStartPadding(LayoutDirection.Ltr).value.toDouble(),
-      Keys.PADDING_TOP to position.padding.calculateTopPadding().value.toDouble(),
-      Keys.PADDING_RIGHT to
-        position.padding.calculateEndPadding(LayoutDirection.Ltr).value.toDouble(),
-      Keys.PADDING_BOTTOM to position.padding.calculateBottomPadding().value.toDouble(),
     )
   }
 
@@ -35,13 +24,6 @@ public object CameraStateSaver : Saver<CameraState, Map<String, Double>> {
         target = Position(latitude = value[Keys.LATITUDE]!!, longitude = value[Keys.LONGITUDE]!!),
         tilt = value[Keys.TILT]!!,
         zoom = value[Keys.ZOOM]!!,
-        padding =
-          PaddingValues.Absolute(
-            left = value[Keys.PADDING_LEFT]!!.dp,
-            top = value[Keys.PADDING_TOP]!!.dp,
-            right = value[Keys.PADDING_RIGHT]!!.dp,
-            bottom = value[Keys.PADDING_BOTTOM]!!.dp,
-          ),
       )
     )
   }
@@ -52,9 +34,5 @@ public object CameraStateSaver : Saver<CameraState, Map<String, Double>> {
     const val LONGITUDE = "longitude"
     const val TILT = "tilt"
     const val ZOOM = "zoom"
-    const val PADDING_LEFT = "padding_left"
-    const val PADDING_TOP = "padding_top"
-    const val PADDING_RIGHT = "padding_right"
-    const val PADDING_BOTTOM = "padding_bottom"
   }
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapAdapter.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapAdapter.kt
@@ -35,6 +35,8 @@ internal interface MapAdapter {
 
   fun setCameraPosition(cameraPosition: CameraPosition)
 
+  fun setCameraPadding(padding: PaddingValues)
+
   fun setCameraPosition(
     boundingBox: BoundingBox,
     bearing: Double,

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MaplibreMap.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MaplibreMap.kt
@@ -52,8 +52,8 @@ import org.maplibre.spatialk.geojson.Position
  *   [MapLibre Style](https://maplibre.org/maplibre-style-spec/).
  * @param cameraState The camera state specifies what position of the map is rendered, at what zoom,
  *   at what tilt, etc.
- * @param cameraPadding Insets from the map edges to the camera viewport. The camera targets the
- *   center of this viewport, and bounds-fit padding is additional.
+ * @param cameraPadding Insets that shift the camera center. A bounds move adds its padding to these
+ *   insets.
  * @param zoomRange The allowable camera zoom range.
  * @param pitchRange The allowable camera pitch range.
  * @param boundingBox The allowable bounds for the camera position. On iOS and Web, it prevents the
@@ -69,9 +69,7 @@ import org.maplibre.spatialk.geojson.Position
  * @param logger kermit logger to use.
  * @param onMapLoadFailed Invoked when the map failed to load.
  * @param onMapLoadFinished Invoked when the map finished loading.
- * @param contentWindowInsets Insets applied to [overlay]. The default, [WindowInsets.safeDrawing],
- *   accounts for insets that an ancestor has already consumed, so a map inside a scaffold gets zero
- *   and a full-bleed map gets the system bars.
+ * @param contentWindowInsets Insets applied to [overlay]. Defaults to safe drawing insets.
  * @param overlay Controls drawn on top of the map. [MapOverlay.Default] draws the MapLibre logo and
  *   an attribution button; [MapOverlay.None] draws the map alone.
  *   [Modifier.placedAt][org.maplibre.compose.overlay.MapOverlayScope.placedAt] in the overlay pins

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MaplibreMap.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MaplibreMap.kt
@@ -2,6 +2,7 @@ package org.maplibre.compose.map
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.safeDrawing
@@ -18,6 +19,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.dp
 import co.touchlab.kermit.Logger
 import kotlinx.coroutines.launch
 import org.maplibre.compose.camera.CameraMoveReason
@@ -50,6 +52,8 @@ import org.maplibre.spatialk.geojson.Position
  *   [MapLibre Style](https://maplibre.org/maplibre-style-spec/).
  * @param cameraState The camera state specifies what position of the map is rendered, at what zoom,
  *   at what tilt, etc.
+ * @param cameraPadding Insets from the map edges to the camera viewport. The camera targets the
+ *   center of this viewport, and bounds-fit padding is additional.
  * @param zoomRange The allowable camera zoom range.
  * @param pitchRange The allowable camera pitch range.
  * @param boundingBox The allowable bounds for the camera position. On iOS and Web, it prevents the
@@ -65,10 +69,9 @@ import org.maplibre.spatialk.geojson.Position
  * @param logger kermit logger to use.
  * @param onMapLoadFailed Invoked when the map failed to load.
  * @param onMapLoadFinished Invoked when the map finished loading.
- * @param contentWindowInsets The region of the map that other UI covers, such as system bars or a
- *   bottom sheet. [overlay] lays aligned controls out inside what is left. The default,
- *   [WindowInsets.safeDrawing], accounts for insets that an ancestor has already consumed, so a map
- *   inside a scaffold gets zero and a full-bleed map gets the system bars.
+ * @param contentWindowInsets Insets applied to [overlay]. The default, [WindowInsets.safeDrawing],
+ *   accounts for insets that an ancestor has already consumed, so a map inside a scaffold gets zero
+ *   and a full-bleed map gets the system bars.
  * @param overlay Controls drawn on top of the map. [MapOverlay.Default] draws the MapLibre logo and
  *   an attribution button; [MapOverlay.None] draws the map alone.
  *   [Modifier.placedAt][org.maplibre.compose.overlay.MapOverlayScope.placedAt] in the overlay pins
@@ -121,6 +124,7 @@ public fun MaplibreMap(
   modifier: Modifier = Modifier,
   baseStyle: BaseStyle = BaseStyle.Demo,
   cameraState: CameraState = rememberCameraState(),
+  cameraPadding: PaddingValues = PaddingValues(0.dp),
   zoomRange: ClosedRange<Float> = 0f..20f,
   pitchRange: ClosedRange<Float> = 0f..60f,
   boundingBox: BoundingBox? = null,
@@ -256,6 +260,7 @@ public fun MaplibreMap(
       modifier = Modifier.fillMaxSize(),
       style = baseStyle,
       update = { map ->
+        map.setCameraPadding(cameraPadding)
         cameraState.map = map
         map.setMinZoom(zoomRange.start.toDouble())
         map.setMaxZoom(zoomRange.endInclusive.toDouble())

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsModule.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsModule.kt
@@ -54,6 +54,8 @@ internal external class MaplibreMap(options: MapOptions) {
 
   fun flyTo(options: FlyToOptions)
 
+  fun cameraForBounds(bounds: LngLatBounds, options: CameraForBoundsOptions): CenterZoomBearing?
+
   fun fitBounds(bounds: LngLatBounds, options: FitBoundsOptions)
 
   fun panBy(offset: Point, options: EaseToOptions)

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsModule.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsModule.kt
@@ -44,8 +44,6 @@ internal external class MaplibreMap(options: MapOptions) {
 
   fun getPitch(): Double
 
-  fun getPadding(): PaddingOptions
-
   fun getBounds(): LngLatBounds
 
   fun jumpTo(options: JumpToOptions)
@@ -55,8 +53,6 @@ internal external class MaplibreMap(options: MapOptions) {
   fun flyTo(options: FlyToOptions)
 
   fun cameraForBounds(bounds: LngLatBounds, options: CameraForBoundsOptions): CenterZoomBearing?
-
-  fun fitBounds(bounds: LngLatBounds, options: FitBoundsOptions)
 
   fun panBy(offset: Point, options: EaseToOptions)
 

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsTypes.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsTypes.kt
@@ -187,10 +187,6 @@ internal external interface CameraForBoundsOptions : CameraOptions {
   var padding: PaddingOptions?
 }
 
-internal external interface FitBoundsOptions : FlyToOptions {
-  var linear: Boolean?
-}
-
 internal external interface Painter {
   val context: Context
 }

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsTypes.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsTypes.kt
@@ -160,6 +160,12 @@ internal external interface CameraOptions {
   var pitch: Double?
 }
 
+internal external interface CenterZoomBearing {
+  var center: LngLat?
+  var zoom: Double?
+  var bearing: Double?
+}
+
 internal external interface AnimationOptions {
   var duration: Double?
 }
@@ -170,9 +176,14 @@ internal external interface JumpToOptions : CameraOptions {
 
 internal external interface EaseToOptions : CameraOptions, AnimationOptions {
   var around: LngLat?
+  var padding: PaddingOptions?
 }
 
 internal external interface FlyToOptions : CameraOptions, AnimationOptions {
+  var padding: PaddingOptions?
+}
+
+internal external interface CameraForBoundsOptions : CameraOptions {
   var padding: PaddingOptions?
 }
 

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
@@ -24,10 +24,10 @@ import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.camera.Viewport
 import org.maplibre.compose.expressions.ast.CompiledExpression
 import org.maplibre.compose.expressions.value.BooleanValue
+import org.maplibre.compose.gljs.CameraForBoundsOptions
 import org.maplibre.compose.gljs.DEFAULT_WORKER_URL
 import org.maplibre.compose.gljs.EaseToOptions
 import org.maplibre.compose.gljs.FilterSpecification
-import org.maplibre.compose.gljs.FitBoundsOptions
 import org.maplibre.compose.gljs.FlyToOptions
 import org.maplibre.compose.gljs.GlJsFrameTarget
 import org.maplibre.compose.gljs.GlJsMapRenderer
@@ -37,6 +37,7 @@ import org.maplibre.compose.gljs.GlJsSurfaceSession
 import org.maplibre.compose.gljs.JumpToOptions
 import org.maplibre.compose.gljs.MapOptions
 import org.maplibre.compose.gljs.MaplibreMap
+import org.maplibre.compose.gljs.PaddingOptions
 import org.maplibre.compose.gljs.Point
 import org.maplibre.compose.gljs.QueryGeometry
 import org.maplibre.compose.gljs.QueryRenderedFeaturesOptions
@@ -59,7 +60,6 @@ import org.maplibre.compose.util.toJsValue
 import org.maplibre.compose.util.toLngLat
 import org.maplibre.compose.util.toLngLatBounds
 import org.maplibre.compose.util.toPaddingOptions
-import org.maplibre.compose.util.toPaddingValues
 import org.maplibre.compose.util.toPoint
 import org.maplibre.compose.util.toPosition
 import org.maplibre.compose.util.toStyleJson
@@ -473,21 +473,29 @@ internal class GlJsMapSession(
 
   /** Answers camera reads made before the map exists. */
   private var requestedCamera: CameraPosition? = null
+  private var cameraPadding: PaddingOptions = PaddingValues(0.dp).toPaddingOptions(layoutDirection)
 
   override fun getCameraPosition(): CameraPosition =
-    withMap(requestedCamera ?: CameraPosition()) { map ->
-      CameraPosition(
-        bearing = map.getBearing(),
-        target = map.getCenter().toPosition(),
-        tilt = map.getPitch(),
-        zoom = map.getZoom(),
-        padding = map.getPadding().toPaddingValues(),
-      )
-    }
+    withMap(requestedCamera ?: CameraPosition()) { map -> map.cameraPosition() }
+
+  private fun MaplibreMap.cameraPosition(): CameraPosition =
+    CameraPosition(
+      bearing = getBearing(),
+      target = getCenter().toPosition(),
+      tilt = getPitch(),
+      zoom = getZoom(),
+    )
 
   override fun setCameraPosition(cameraPosition: CameraPosition) {
     requestedCamera = cameraPosition
     onMap { map -> map.jumpTo(cameraPosition.toJumpToOptions()) }
+  }
+
+  override fun setCameraPadding(padding: PaddingValues) {
+    val resolved = padding.toPaddingOptions(layoutDirection)
+    if (cameraPadding.sameAs(resolved)) return
+    cameraPadding = resolved
+    onMap { map -> map.jumpTo(unsafeJso<JumpToOptions> { this.padding = resolved }) }
   }
 
   override fun setCameraPosition(
@@ -496,7 +504,11 @@ internal class GlJsMapSession(
     tilt: Double,
     padding: PaddingValues,
   ) {
-    onMap { map -> map.fitBounds(boundingBox.toLngLatBounds(), fitOptions(bearing, tilt, padding)) }
+    onMap { map ->
+      map.cameraPositionForBounds(boundingBox, bearing, tilt, padding)?.let {
+        map.jumpTo(it.toJumpToOptions())
+      }
+    }
   }
 
   override suspend fun animateCameraPosition(finalPosition: CameraPosition, duration: Duration) {
@@ -507,7 +519,7 @@ internal class GlJsMapSession(
           zoom = finalPosition.zoom
           bearing = finalPosition.bearing
           pitch = finalPosition.tilt
-          padding = finalPosition.padding.toPaddingOptions(layoutDirection)
+          padding = cameraPadding
           this.duration = duration.inWholeMilliseconds.toDouble()
         }
       )
@@ -522,24 +534,37 @@ internal class GlJsMapSession(
     duration: Duration,
   ) {
     awaitCameraRelease { map ->
-      map.fitBounds(
-        boundingBox.toLngLatBounds(),
-        fitOptions(bearing, tilt, padding).also {
-          it.duration = duration.inWholeMilliseconds.toDouble()
-        },
-      )
+      map.cameraPositionForBounds(boundingBox, bearing, tilt, padding)?.let {
+        map.easeTo(it.toEaseToOptions(duration))
+      }
     }
   }
 
-  private fun fitOptions(bearing: Double, tilt: Double, padding: PaddingValues): FitBoundsOptions =
-    unsafeJso {
-      this.bearing = bearing
-      pitch = tilt
-      this.padding = padding.toPaddingOptions(layoutDirection)
-      // flyTo's arc would zoom out and back in on its way to a camera the caller already named.
-      linear = true
-      duration = 0.0
-    }
+  private fun MaplibreMap.cameraPositionForBounds(
+    boundingBox: BoundingBox,
+    bearing: Double,
+    tilt: Double,
+    padding: PaddingValues,
+  ): CameraPosition? {
+    val previous = cameraPosition()
+    val result =
+      cameraForBounds(boundingBox.toLngLatBounds(), cameraForBoundsOptions(bearing, padding))
+        ?: return null
+    return CameraPosition(
+      bearing = result.bearing ?: bearing,
+      target = result.center?.toPosition() ?: previous.target,
+      tilt = tilt,
+      zoom = result.zoom ?: previous.zoom,
+    )
+  }
+
+  private fun cameraForBoundsOptions(
+    bearing: Double,
+    padding: PaddingValues,
+  ): CameraForBoundsOptions = unsafeJso {
+    this.bearing = bearing
+    this.padding = padding.toPaddingOptions(layoutDirection)
+  }
 
   override fun setCameraBoundingBox(boundingBox: BoundingBox?) {
     onMap { map -> map.setMaxBounds(boundingBox?.toLngLatBounds()) }
@@ -880,8 +905,20 @@ internal class GlJsMapSession(
     zoom = this@toJumpToOptions.zoom
     bearing = this@toJumpToOptions.bearing
     pitch = tilt
-    padding = this@toJumpToOptions.padding.toPaddingOptions(layoutDirection)
+    padding = cameraPadding
   }
+
+  private fun CameraPosition.toEaseToOptions(duration: Duration): EaseToOptions = unsafeJso {
+    center = target.toLngLat()
+    zoom = this@toEaseToOptions.zoom
+    bearing = this@toEaseToOptions.bearing
+    pitch = tilt
+    padding = cameraPadding
+    this.duration = duration.inWholeMilliseconds.toDouble()
+  }
+
+  private fun PaddingOptions.sameAs(other: PaddingOptions): Boolean =
+    top == other.top && left == other.left && bottom == other.bottom && right == other.right
 
   private fun MaplibreMap.unprojectAt(x: Double, y: Double): Position =
     unproject(

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/util/GlJsConversions.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/util/GlJsConversions.kt
@@ -39,6 +39,3 @@ internal fun PaddingValues.toPaddingOptions(layoutDirection: LayoutDirection): P
     bottom = calculateBottomPadding().value.toDouble()
     right = calculateRightPadding(layoutDirection).value.toDouble()
   }
-
-internal fun PaddingOptions.toPaddingValues(): PaddingValues =
-  PaddingValues.Absolute(left = left.dp, top = top.dp, right = right.dp, bottom = bottom.dp)

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/MapCameraTransitionTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/MapCameraTransitionTest.kt
@@ -1,6 +1,7 @@
 package org.maplibre.compose.map
 
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import kotlin.math.abs
 import kotlin.test.Test
@@ -131,6 +132,81 @@ class MapCameraTransitionTest {
         )
       }
     }
+
+  @Test
+  fun a_bounds_jump_adds_transient_fit_padding_to_camera_padding(): MapTestResult = runMapTest {
+    createMapFixture().use {
+      it.loadStyle(BaseStyle.Empty)
+      it.session.setCameraPadding(CAMERA_PADDING)
+      it.session.setCameraPosition(START)
+      it.awaitMapReady()
+      it.pumpUntil("the camera padding to be applied") {
+        it.cameraTargetMatches(START, CAMERA_PADDING)
+      }
+
+      it.session.setCameraPosition(BOUNDS, 0.0, 0.0, FIT_PADDING)
+      it.pumpUntil("the bounds fit to be applied") {
+        abs(it.session.getCameraPosition().zoom - START.zoom) > 0.1
+      }
+      val fitAfterPadding = it.session.getCameraPosition()
+      it.assertCameraTarget(fitAfterPadding, CAMERA_PADDING)
+      it.assertBoundsInside(CAMERA_PADDING + FIT_PADDING)
+
+      it.session.setCameraPosition(BOUNDS, 0.0, 0.0, FIT_PADDING)
+      it.pump(frames = 2)
+      val repeatedFit = it.session.getCameraPosition()
+      assertSameFit(fitAfterPadding, repeatedFit, "repeating the bounds fit changed its camera")
+
+      it.session.setCameraPadding(REPLACEMENT_CAMERA_PADDING)
+      it.pumpUntil("the replacement camera padding to be applied") {
+        it.cameraTargetMatches(fitAfterPadding, REPLACEMENT_CAMERA_PADDING)
+      }
+    }
+  }
+
+  @Test
+  fun a_bounds_fit_crosses_the_antimeridian_the_short_way(): MapTestResult = runMapTest {
+    createMapFixture().use {
+      it.startAtOrigin()
+
+      it.session.setCameraPosition(ANTIMERIDIAN_BOUNDS, 0.0, 0.0, PaddingValues(0.dp))
+      it.pumpUntil("the antimeridian bounds fit to be applied") {
+        val camera = it.session.getCameraPosition()
+        abs(abs(camera.target.longitude) - 180.0) < 1.0 && camera.zoom > START.zoom
+      }
+    }
+  }
+
+  @Test
+  fun a_bounds_animation_keeps_fit_padding_transient(): MapTestResult = runMapTest {
+    createMapFixture().use {
+      it.loadStyle(BaseStyle.Empty)
+      it.session.setCameraPadding(CAMERA_PADDING)
+      it.session.setCameraPosition(START)
+      it.awaitMapReady()
+      it.pumpUntil("the camera padding to be applied") {
+        it.cameraTargetMatches(START, CAMERA_PADDING)
+      }
+
+      it.awaitWhileRendering("the bounds animation to complete") {
+        it.session.animateCameraPosition(BOUNDS, 0.0, 0.0, FIT_PADDING, 200.milliseconds)
+      }
+
+      val firstFit = it.session.getCameraPosition()
+      it.assertCameraTarget(firstFit, CAMERA_PADDING)
+      it.assertBoundsInside(CAMERA_PADDING + FIT_PADDING)
+
+      it.awaitWhileRendering("the repeated bounds animation to complete") {
+        it.session.animateCameraPosition(BOUNDS, 0.0, 0.0, FIT_PADDING, 200.milliseconds)
+      }
+
+      assertSameFit(
+        firstFit,
+        it.session.getCameraPosition(),
+        "repeating the bounds animation changed its camera",
+      )
+    }
+  }
 
   @Test
   fun an_animation_completes_and_lands_on_its_target(): MapTestResult = runMapTest {
@@ -298,9 +374,73 @@ class MapCameraTransitionTest {
         southwest = Position(longitude = -5.0, latitude = -5.0),
         northeast = Position(longitude = 5.0, latitude = 5.0),
       )
+    val ANTIMERIDIAN_BOUNDS =
+      BoundingBox(
+        southwest = Position(longitude = 170.0, latitude = -10.0),
+        northeast = Position(longitude = -170.0, latitude = 10.0),
+      )
+    val CAMERA_PADDING =
+      PaddingValues.Absolute(left = 120.dp, top = 10.dp, right = 5.dp, bottom = 30.dp)
+    val FIT_PADDING =
+      PaddingValues.Absolute(left = 40.dp, top = 20.dp, right = 70.dp, bottom = 60.dp)
+    val REPLACEMENT_CAMERA_PADDING =
+      PaddingValues.Absolute(left = 15.dp, top = 35.dp, right = 80.dp, bottom = 5.dp)
+
+    operator fun PaddingValues.plus(other: PaddingValues): PaddingValues =
+      PaddingValues.Absolute(
+        left = left() + other.left(),
+        top = calculateTopPadding() + other.calculateTopPadding(),
+        right = right() + other.right(),
+        bottom = calculateBottomPadding() + other.calculateBottomPadding(),
+      )
+
+    fun PaddingValues.left() = calculateLeftPadding(LayoutDirection.Ltr)
+
+    fun PaddingValues.right() = calculateRightPadding(LayoutDirection.Ltr)
+
+    fun MapFixture.cameraTargetMatches(
+      position: CameraPosition,
+      padding: PaddingValues,
+    ): Boolean {
+      val viewport = session.getViewport() ?: return false
+      val target = session.screenLocationFromPosition(position.target) ?: return false
+      val expectedX = (viewport.size.width + padding.left() - padding.right()) / 2
+      val expectedY =
+        (viewport.size.height + padding.calculateTopPadding() - padding.calculateBottomPadding()) /
+          2
+      return abs(target.x.value - expectedX.value) < 0.01 &&
+        abs(target.y.value - expectedY.value) < 0.01
+    }
+
+    fun MapFixture.assertCameraTarget(position: CameraPosition, padding: PaddingValues) {
+      assertTrue(
+        cameraTargetMatches(position, padding),
+        "the camera target does not use the persistent camera padding",
+      )
+    }
+
+    fun MapFixture.assertBoundsInside(padding: PaddingValues) {
+      val viewport = requireNotNull(session.getViewport())
+      val southwest = requireNotNull(session.screenLocationFromPosition(BOUNDS.southwest))
+      val northeast = requireNotNull(session.screenLocationFromPosition(BOUNDS.northeast))
+      val tolerance = 1.0
+      assertTrue(southwest.x.value + tolerance >= padding.left().value)
+      assertTrue(
+        southwest.y.value - tolerance <=
+          viewport.size.height.value - padding.calculateBottomPadding().value
+      )
+      assertTrue(northeast.x.value - tolerance <= viewport.size.width.value - padding.right().value)
+      assertTrue(northeast.y.value + tolerance >= padding.calculateTopPadding().value)
+    }
 
     fun assertNear(expected: Double, actual: Double, message: String) {
       assertTrue(abs(expected - actual) < 0.01, "$message (expected $expected, was $actual)")
+    }
+
+    fun assertSameFit(expected: CameraPosition, actual: CameraPosition, message: String) {
+      assertNear(expected.zoom, actual.zoom, "$message zoom")
+      assertNear(expected.target.longitude, actual.target.longitude, "$message longitude")
+      assertNear(expected.target.latitude, actual.target.latitude, "$message latitude")
     }
   }
 }

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -155,7 +155,7 @@ internal class MlnFfiMapSession(
 
   @Volatile private var loop: MlnFfiMapRuntimeLoop? = null
 
-  @Volatile private var cameraPadding: EdgeInsets = EdgeInsets(0.0, 0.0, 0.0, 0.0)
+  @Volatile private var cameraPadding: EdgeInsets = EdgeInsets.ZERO
 
   /** One-shot map actions accepted before this session starts. Guarded by [stateLock]. */
   private class PendingMapAction(val run: (MapHandle) -> Unit, val abandon: () -> Unit)

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -75,6 +75,7 @@ import org.maplibre.nativeffi.camera.BoundOptions
 import org.maplibre.nativeffi.camera.BoundsConstraint
 import org.maplibre.nativeffi.camera.CameraFitOptions
 import org.maplibre.nativeffi.camera.CameraOptions
+import org.maplibre.nativeffi.camera.EdgeInsets
 import org.maplibre.nativeffi.error.InvalidArgumentException
 import org.maplibre.nativeffi.error.MaplibreException
 import org.maplibre.nativeffi.error.NativeErrorException
@@ -153,6 +154,8 @@ internal class MlnFfiMapSession(
   private val stateLock = MlnFfiLock()
 
   @Volatile private var loop: MlnFfiMapRuntimeLoop? = null
+
+  @Volatile private var cameraPadding: EdgeInsets = EdgeInsets(0.0, 0.0, 0.0, 0.0)
 
   /** One-shot map actions accepted before this session starts. Guarded by [stateLock]. */
   private class PendingMapAction(val run: (MapHandle) -> Unit, val abandon: () -> Unit)
@@ -492,7 +495,7 @@ internal class MlnFfiMapSession(
     applyRequestedStyle(map)
     // A camera set before this map existed reaches it as a queued jump, which a loop that stopped
     // before running it has already abandoned.
-    requestedCamera?.let { map.jumpTo(it.toCameraOptions(layoutDirection)) }
+    requestedCamera?.let { map.jumpTo(it.toCameraOptions(cameraPadding)) }
   }
 
   private fun ensureAttached(map: MapHandle, frame: MlnFfiMapFrame): Boolean {
@@ -850,8 +853,9 @@ internal class MlnFfiMapSession(
 
   private fun recordCamera(position: CameraPosition) {
     requestedCamera = position
+    val padding = cameraPadding
     configureMap { map ->
-      map.jumpTo(position.toCameraOptions(layoutDirection))
+      map.jumpTo(position.toCameraOptions(padding))
       snapshotViewport(map)
     }
   }
@@ -1009,6 +1013,16 @@ internal class MlnFfiMapSession(
     recordCamera(cameraPosition)
   }
 
+  override fun setCameraPadding(padding: PaddingValues) {
+    val insets = padding.toEdgeInsets(layoutDirection)
+    if (cameraPadding == insets) return
+    cameraPadding = insets
+    configureMap { map ->
+      map.jumpTo(CameraOptions().also { it.padding = insets })
+      snapshotViewport(map)
+    }
+  }
+
   override fun setCameraPosition(
     boundingBox: BoundingBox,
     bearing: Double,
@@ -1034,21 +1048,50 @@ internal class MlnFfiMapSession(
     bearing: Double,
     tilt: Double,
     padding: PaddingValues,
-  ) =
-    map.cameraForLatLngBounds(
-      bounds = boundingBox.toLatLngBounds(),
-      // The padding that comes back describes the computed fit, and must be applied verbatim.
-      fitOptions =
-        CameraFitOptions().also {
-          it.padding = padding.toEdgeInsets(layoutDirection)
-          it.bearing = bearing
-          it.pitch = tilt
-        },
+  ): CameraOptions {
+    val persistent = cameraPadding
+    val fit = padding.toEdgeInsets(layoutDirection)
+    val total = persistent + fit
+    val fitted =
+      map.cameraForLatLngBounds(
+        bounds = boundingBox.toLatLngBounds(),
+        fitOptions =
+          CameraFitOptions().also {
+            it.padding = total
+            it.bearing = bearing
+            it.pitch = tilt
+          },
+      )
+
+    // Native returns the fit padding as persistent camera state. Preserve the fitted transform
+    // while replacing it with the map's declarative padding.
+    map.createProjection().use { projection ->
+      projection.setCamera(fitted)
+      val size = map.size
+      fitted.center =
+        projection.latLngForPixel(
+          ScreenPoint(
+            x = (size.width + persistent.left - persistent.right) / 2.0,
+            y = (size.height + persistent.top - persistent.bottom) / 2.0,
+          )
+        )
+    }
+    fitted.padding = persistent
+    return fitted
+  }
+
+  private operator fun EdgeInsets.plus(other: EdgeInsets): EdgeInsets =
+    EdgeInsets(
+      top = top + other.top,
+      left = left + other.left,
+      bottom = bottom + other.bottom,
+      right = right + other.right,
     )
 
   override suspend fun animateCameraPosition(finalPosition: CameraPosition, duration: Duration) {
+    val padding = cameraPadding
     startTransitionAwaitingRelease(duration) { map, animation ->
-      map.flyTo(finalPosition.toCameraOptions(layoutDirection), animation)
+      map.flyTo(finalPosition.toCameraOptions(padding), animation)
     }
   }
 

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/util/conversions.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/util/conversions.kt
@@ -34,7 +34,14 @@ internal fun LatLngBounds.toBoundingBox(): BoundingBox =
   BoundingBox(southwest = southwest.toPosition(), northeast = northeast.toPosition())
 
 internal fun BoundingBox.toLatLngBounds(): LatLngBounds =
-  LatLngBounds(southwest = southwest.toLatLng(), northeast = northeast.toLatLng())
+  LatLngBounds(
+    southwest = southwest.toLatLng(),
+    northeast =
+      LatLng(
+        latitude = north,
+        longitude = if (east < west) east + 360.0 else east,
+      ),
+  )
 
 internal fun PaddingValues.toEdgeInsets(layoutDirection: LayoutDirection): EdgeInsets =
   EdgeInsets(
@@ -43,9 +50,6 @@ internal fun PaddingValues.toEdgeInsets(layoutDirection: LayoutDirection): EdgeI
     bottom = calculateBottomPadding().value.toDouble(),
     right = calculateRightPadding(layoutDirection).value.toDouble(),
   )
-
-internal fun EdgeInsets.toPaddingValues(): PaddingValues =
-  PaddingValues.Absolute(left = left.dp, top = top.dp, right = right.dp, bottom = bottom.dp)
 
 /**
  * Snapshots a camera into an immutable value. [CameraOptions] is a mutable builder for native
@@ -57,16 +61,15 @@ internal fun CameraOptions.toCameraPosition(): CameraPosition =
     zoom = zoom ?: 0.0,
     bearing = bearing ?: 0.0,
     tilt = pitch ?: 0.0,
-    padding = padding?.toPaddingValues() ?: PaddingValues(0.dp),
   )
 
-internal fun CameraPosition.toCameraOptions(layoutDirection: LayoutDirection): CameraOptions =
+internal fun CameraPosition.toCameraOptions(padding: EdgeInsets): CameraOptions =
   CameraOptions().also {
     it.center = target.toLatLng()
     it.zoom = zoom
     it.bearing = bearing
     it.pitch = tilt
-    it.padding = padding.toEdgeInsets(layoutDirection)
+    it.padding = padding
   }
 
 /** Converts physical Compose pixels to the logical pixels MapLibre projects in. */

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/util/MlnFfiConversionsTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/util/MlnFfiConversionsTest.kt
@@ -1,6 +1,5 @@
 package org.maplibre.compose.util
 
-import androidx.compose.ui.unit.LayoutDirection
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -9,7 +8,6 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
-import org.maplibre.nativeffi.camera.EdgeInsets
 import org.maplibre.nativeffi.query.QueriedFeature
 import org.maplibre.spatialk.geojson.Feature as GeoJsonFeature
 import org.maplibre.spatialk.geojson.GeometryCollection
@@ -45,14 +43,6 @@ class MlnFfiConversionsTest {
 
     assertEquals(Point(Position(1.0, 2.0)), requireNotNull(feature).geometry)
     assertEquals(buildJsonObject { put("name", "a") }, feature.properties)
-  }
-
-  @Test
-  fun native_edge_insets_remain_physical_in_rtl() {
-    val padding = EdgeInsets(top = 1.0, left = 2.0, bottom = 3.0, right = 4.0).toPaddingValues()
-
-    assertEquals(2f, padding.calculateLeftPadding(LayoutDirection.Rtl).value)
-    assertEquals(4f, padding.calculateRightPadding(LayoutDirection.Rtl).value)
   }
 
   @Test


### PR DESCRIPTION
## Description

Adds map-level camera padding with consistent bounds fitting across platforms and updates the demo shell to account for its floating panels.

## Validation

Validated with JS, desktop, and Android tests, a full documentation build, repository checks, and manual testing on JS and desktop.

## AI assistance

Developed and reviewed with OpenAI Codex using GPT-5.