### PR TITLE
Fix JS heatmap framebuffer scaling

### DIFF
--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsRuntime.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsRuntime.kt
@@ -90,6 +90,45 @@ internal object GlJsRuntime {
   }
 
   /**
+   * Runs [draw] while [gl] reports [width] and [height] as its drawing buffer size.
+   *
+   * MapLibre normally renders into its context's canvas, so some fullscreen passes read the canvas
+   * drawing buffer instead of the current framebuffer. The Compose compositor redirects that
+   * framebuffer to a map-sized texture inside a larger shared canvas.
+   */
+  fun <T> withDrawingBufferSize(
+    gl: WebGL2RenderingContext,
+    width: Int,
+    height: Int,
+    draw: () -> T,
+  ): T {
+    val target = gl.asDynamic()
+    val objects = js("Object")
+    val previousWidth = objects.getOwnPropertyDescriptor(target, "drawingBufferWidth")
+    val previousHeight = objects.getOwnPropertyDescriptor(target, "drawingBufferHeight")
+    val widthDescriptor = js("({configurable: true})")
+    val heightDescriptor = js("({configurable: true})")
+    widthDescriptor.value = width
+    heightDescriptor.value = height
+    try {
+      objects.defineProperty(target, "drawingBufferWidth", widthDescriptor)
+      objects.defineProperty(target, "drawingBufferHeight", heightDescriptor)
+      return draw()
+    } finally {
+      restoreOwnProperty(objects, target, "drawingBufferWidth", previousWidth)
+      restoreOwnProperty(objects, target, "drawingBufferHeight", previousHeight)
+    }
+  }
+
+  private fun restoreOwnProperty(objects: dynamic, target: dynamic, name: String, value: dynamic) {
+    if (value == null || value == undefined) {
+      js("Reflect").deleteProperty(target, name)
+    } else {
+      objects.defineProperty(target, name, value)
+    }
+  }
+
+  /**
    * `bindFramebuffer.set(null)` is the one place in MapLibre's renderer that means "the screen".
    * [target] is read per call, because a resize replaces the framebuffer while the map renders.
    */

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
@@ -158,7 +158,14 @@ internal class GlJsMapSession(
     if (target is GlJsFrameTarget.NotReady && map == null) return false
     framebuffer = composited?.target?.framebuffer
     val map = ensureMap(composited?.target, extent) ?: return false
-    applyExtent(map, extent)
+    if (composited == null) {
+      applyExtent(map, extent)
+    } else {
+      val mapTarget = composited.target
+      GlJsRuntime.withDrawingBufferSize(mapTarget.gl, mapTarget.widthPx, mapTarget.heightPx) {
+        applyExtent(map, extent)
+      }
+    }
     if (target is GlJsFrameTarget.NotReady) return false
 
     val now = TimeSource.Monotonic.markNow()
@@ -172,7 +179,10 @@ internal class GlJsMapSession(
       // Skia drives this context between MapLibre's frames, so each renderer is told the other
       // moved the state.
       map.painter.context.setDirty()
-      map.redraw()
+      val mapTarget = composited.target
+      GlJsRuntime.withDrawingBufferSize(mapTarget.gl, mapTarget.widthPx, mapTarget.heightPx) {
+        map.redraw()
+      }
       SkikoGpuBridge.resetGlState()
     } else {
       // GL JS runs style updates, tile loading and every camera ease from inside its own render, so
@@ -243,7 +253,9 @@ internal class GlJsMapSession(
       else {
         val context = target.gl.unsafeCast<WebGL2RenderingContext>()
         lentContext = context
-        GlJsRuntime.lendingContext(context) { MaplibreMap(options) }
+        GlJsRuntime.withDrawingBufferSize(context, target.widthPx, target.heightPx) {
+          GlJsRuntime.lendingContext(context) { MaplibreMap(options) }
+        }
       }
 
     // Before the style resolves: any render before the redirect lands on Compose's canvas.

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserCompositingTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserCompositingTest.kt
@@ -23,6 +23,7 @@ import org.maplibre.compose.style.BaseStyle
 private const val FULL = GPU_CANVAS_SIZE
 private const val SMALL = FULL / 2
 private const val INSET = FULL / 4
+private const val FRACTIONAL_SCALE = 1.7
 
 private const val RED = "#ff0000"
 private const val BLUE = "#0000ff"
@@ -52,6 +53,45 @@ private val SPLIT_STYLE =
       "layers": [
         {"id": "bg", "type": "background", "paint": {"background-color": "#0000ff"}},
         {"id": "shape", "type": "fill", "source": "shape", "paint": {"fill-color": "#ff0000"}}
+      ]
+    }
+    """
+      .trimIndent()
+  )
+
+private val HEATMAP_STYLE =
+  BaseStyle.Json(
+    """
+    {
+      "version": 8,
+      "name": "heatmap compositing",
+      "sources": {
+        "point": {
+          "type": "geojson",
+          "data": {
+            "type": "Point",
+            "coordinates": [0, 0]
+          }
+        }
+      },
+      "layers": [
+        {"id": "bg", "type": "background", "paint": {"background-color": "#0000ff"}},
+        {
+          "id": "heatmap",
+          "type": "heatmap",
+          "source": "point",
+          "paint": {
+            "heatmap-radius": 20,
+            "heatmap-color": [
+              "interpolate",
+              ["linear"],
+              ["heatmap-density"],
+              0, "rgba(0, 0, 0, 0)",
+              0.01, "#ff0000",
+              1, "#ff0000"
+            ]
+          }
+        }
       ]
     }
     """
@@ -100,6 +140,31 @@ class BrowserCompositingTest {
           mapOf(RED to FULL * FULL / 2, BLUE to FULL * FULL / 2),
           histogram(readFramebuffer(gl, target.framebuffer, FULL, FULL)),
           "the world should fill the target, red west of the prime meridian and blue east",
+        )
+      }
+    }
+  }
+
+  @Test
+  fun a_heatmap_uses_the_map_target_size_instead_of_the_shared_canvas_size() = gpuTest { gpu ->
+    val gl = gpu.gl.asDynamic()
+    GlJsRenderTarget(gl, SMALL, SMALL, generation = 1).use { target ->
+      CompositedMap(HEATMAP_STYLE, scaleFactor = FRACTIONAL_SCALE).use { map ->
+        val extent = MapExtent.fromPhysical(SMALL, SMALL, FRACTIONAL_SCALE)
+        map.drawUntil(target, "the heatmap point to reach the render tree") {
+          map.rendersFeature("heatmap", extent.width / 2, extent.height / 2)
+        }
+
+        val pixels = readFramebuffer(gl, target.framebuffer, SMALL, SMALL)
+        val center = (SMALL / 2 * SMALL + SMALL / 2) * 4
+        assertTrue(
+          pixels[center].toInt() and 0xff > pixels[center + 2].toInt() and 0xff,
+          "the central heatmap point should be red rather than the blue background",
+        )
+        assertEquals(
+          FULL,
+          gl.drawingBufferWidth.unsafeCast<Int>(),
+          "the map draw should restore the shared canvas drawing buffer size",
         )
       }
     }

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/CompositedMap.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/CompositedMap.kt
@@ -14,7 +14,8 @@ import org.maplibre.spatialk.geojson.Position
 
 private const val RENDER_TIMEOUT_MS = 30_000
 
-internal class CompositedMap(style: BaseStyle) : AutoCloseable {
+internal class CompositedMap(style: BaseStyle, private val scaleFactor: Double = 1.0) :
+  AutoCloseable {
 
   private var loadFailure: String? = null
   private var styleLoaded = false
@@ -60,7 +61,7 @@ internal class CompositedMap(style: BaseStyle) : AutoCloseable {
   override fun close() = session.close()
 
   private fun extentOf(target: GlJsRenderTarget) =
-    MapExtent.fromPhysical(target.widthPx, target.heightPx, 1.0)
+    MapExtent.fromPhysical(target.widthPx, target.heightPx, scaleFactor)
 
   private inner class Callbacks : MapAdapter.Callbacks {
     override fun onStyleChanged(map: MapAdapter, style: Style?) = Unit


### PR DESCRIPTION
## Description

Report the map target dimensions to MapLibre while it creates, resizes, and draws into the Compose framebuffer so fullscreen JS passes such as heatmaps remain aligned at fractional display scales.

## Validation

mise run test:js and mise run check pass on macOS, including a headless-Chrome WebGL regression at 1.7x scaling.

## AI assistance

Codex with GPT-5 in the Codex harness diagnosed the framebuffer mismatch, implemented the fix, and added the regression test.