### PR TITLE
Clear shared WebGL sampler bindings

### DIFF
--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsRenderTarget.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsRenderTarget.kt
@@ -16,6 +16,10 @@ internal class GlJsRenderTarget(
   val generation: Long,
 ) : AutoCloseable {
 
+  private val fragmentTextureUnits =
+    (gl.getParameter(gl.MAX_TEXTURE_IMAGE_UNITS) as? Int)
+      ?: error("WebGL did not report its fragment texture unit count")
+
   private val framebufferObject: dynamic
   private val depthStencil: dynamic
 
@@ -76,6 +80,14 @@ internal class GlJsRenderTarget(
         origin = SurfaceOrigin.BOTTOM_LEFT,
         colorType = ColorType.RGBA_8888,
       )
+  }
+
+  /**
+   * Removes sampler objects left by Skia. A sampler object overrides the filtering and wrapping on
+   * MapLibre's textures, and MapLibre does not track sampler bindings in its WebGL state cache.
+   */
+  fun unbindSamplerObjects() {
+    repeat(fragmentTextureUnits) { unit -> gl.bindSampler(unit, null) }
   }
 
   /** The texture is not deleted here: adoption handed it to Skia. */

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
@@ -171,6 +171,7 @@ internal class GlJsMapSession(
     if (composited != null) {
       // Skia drives this context between MapLibre's frames, so each renderer is told the other
       // moved the state.
+      composited.target.unbindSamplerObjects()
       map.painter.context.setDirty()
       map.redraw()
       SkikoGpuBridge.resetGlState()

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserCompositingTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserCompositingTest.kt
@@ -154,6 +154,38 @@ class BrowserCompositingTest {
   }
 
   @Test
+  fun map_frames_clear_sampler_objects_left_by_the_shared_renderer() = gpuTest { gpu ->
+    val gl = gpu.gl.asDynamic()
+    GlJsRenderTarget(gl, FULL, FULL, generation = 1).use { target ->
+      CompositedMap(SPLIT_STYLE).use { map ->
+        map.drawTheWholeStyle(target)
+
+        val sampler = gl.createSampler()
+        check(sampler != null) { "WebGL did not create a sampler object" }
+        val textureUnits = gl.getParameter(gl.MAX_TEXTURE_IMAGE_UNITS).unsafeCast<Int>()
+        try {
+          repeat(textureUnits) { unit -> gl.bindSampler(unit, sampler) }
+
+          assertTrue(map.drawOnce(target), "the map should have drawn with foreign GL state")
+
+          repeat(textureUnits) { unit ->
+            gl.activeTexture(gl.TEXTURE0 + unit)
+            assertEquals(
+              null,
+              gl.getParameter(gl.SAMPLER_BINDING),
+              "texture unit $unit should not retain the shared renderer's sampler",
+            )
+          }
+        } finally {
+          repeat(textureUnits) { unit -> gl.bindSampler(unit, null) }
+          gl.activeTexture(gl.TEXTURE0)
+          gl.deleteSampler(sampler)
+        }
+      }
+    }
+  }
+
+  @Test
   fun a_resize_allocates_a_new_target_and_the_map_keeps_drawing() = gpuTest { gpu ->
     val gl = gpu.gl.asDynamic()
     ComposeGlJsCompositor(logger = null).use { compositor ->


### PR DESCRIPTION
## Description

Clear sampler objects left by Skia before each composited GL JS frame so MapLibre controls texture filtering and wrapping, including the repeating line-dash atlas.

## Validation

Ran `caffeinate -dimsu mise run test:js` and `mise run check`; the browser regression also failed on retained sampler unit 0 when the production reset was temporarily removed.

## AI assistance

Codex (GPT-5) diagnosed, implemented, and validated the change.