### PR TITLE
Show cluster counts in the JavaScript demo

### DIFF
--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/DataVizDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/DataVizDemo.kt
@@ -13,8 +13,8 @@ import org.maplibre.compose.demoapp.DemoAppState
 import org.maplibre.compose.demoapp.OpenFreeMap
 import org.maplibre.compose.demoapp.design.SegmentedRow
 import org.maplibre.compose.expressions.dsl.asNumber
-import org.maplibre.compose.expressions.dsl.asString
 import org.maplibre.compose.expressions.dsl.const
+import org.maplibre.compose.expressions.dsl.convertToString
 import org.maplibre.compose.expressions.dsl.feature
 import org.maplibre.compose.expressions.dsl.interpolate
 import org.maplibre.compose.expressions.dsl.linear
@@ -124,7 +124,7 @@ object DataVizDemo : Demo {
       id = "earthquake-cluster-counts",
       source = source,
       filter = feature.has("point_count"),
-      textField = feature["point_count_abbreviated"].asString(),
+      textField = feature["point_count_abbreviated"].convertToString(),
       textFont = const(preferredStyle.textFont),
       textColor = const(Color.Black),
     )


### PR DESCRIPTION
## Description

Convert the abbreviated cluster count to text so GL JS accepts its numeric values and renders cluster labels while preserving native string values.

## Validation

Ran `caffeinate -dimsu mise run test:js`, `mise run style-spec:parity -- --check`, and `mise run check`; the pinned GL JS evaluator rejects the numeric value under a strict string assertion and converts the same value to `"3"`.

## AI assistance

Codex (GPT-5) diagnosed, implemented, and validated the change.