### PR TITLE
Fix pointer pin placement in inset containers

### DIFF
--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoMap.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoMap.kt
@@ -64,6 +64,16 @@ internal suspend fun CameraState.flyTo(destination: DemoDestination) {
 /** The shared map, the selected demo's overlay, the pointer pin, and the diagnostic overlays. */
 @Composable
 fun DemoMap(state: DemoAppState, viewportInsets: MapViewportInsets) {
+  val scope = rememberCoroutineScope()
+  val selectedDemo = state.selectedDemo
+  val pointerPin = selectedDemo?.pointerPin
+  val placementPadding =
+    PaddingValues.Absolute(
+      left = viewportInsets.left + MapOverlay.Spacing,
+      top = viewportInsets.top + MapOverlay.Spacing,
+      right = viewportInsets.right + MapOverlay.Spacing,
+      bottom = viewportInsets.bottom + MapOverlay.Spacing,
+    )
   Box(Modifier.fillMaxSize()) {
     MaplibreMap(
       baseStyle = state.selectedStyle.base,
@@ -83,7 +93,23 @@ fun DemoMap(state: DemoAppState, viewportInsets: MapViewportInsets) {
           include(
             if (state.settings.useMaterial3Controls) MapOverlay.Material3 else MapOverlay.Default
           )
-          state.selectedDemo?.let { demo -> key(demo) { with(demo) { Overlay(state) } } }
+          selectedDemo?.let { demo ->
+            key(demo) {
+              with(demo) { Overlay(state) }
+              pointerPin?.let {
+                PointerPinButton(
+                  cameraState = cameraState,
+                  targetPosition = it.target,
+                  onClick = { scope.launch { cameraState.flyTo(it.destination) } },
+                ) {
+                  Icon(
+                    vectorResource(Res.drawable.filter_center_focus_24px),
+                    contentDescription = "Fly back to ${demo.name}",
+                  )
+                }
+              }
+            }
+          }
         },
     ) {
       // Keyed: without it, layers and sources are identified by position, so switching demos
@@ -97,9 +123,6 @@ fun DemoMap(state: DemoAppState, viewportInsets: MapViewportInsets) {
       }
     }
 
-    val scope = rememberCoroutineScope()
-    val pointerPin = state.selectedDemo?.pointerPin
-    val placementPadding = viewportInsets.asPaddingValues()
     if (state.settings.showPointerPinDiagnostics && pointerPin != null) {
       PointerPinDestinationOverlay(
         cameraState = state.cameraState,
@@ -112,22 +135,6 @@ fun DemoMap(state: DemoAppState, viewportInsets: MapViewportInsets) {
         placementPadding = placementPadding,
         modifier = Modifier.fillMaxSize(),
       )
-    }
-
-    state.selectedDemo?.let { demo ->
-      pointerPin?.let {
-        PointerPinButton(
-          cameraState = state.cameraState,
-          targetPosition = it.target,
-          placementPadding = placementPadding,
-          onClick = { scope.launch { state.cameraState.flyTo(it.destination) } },
-        ) {
-          Icon(
-            vectorResource(Res.drawable.filter_center_focus_24px),
-            contentDescription = "Fly back to ${demo.name}",
-          )
-        }
-      }
     }
 
     Box(Modifier.fillMaxSize().padding(placementPadding)) {

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoMap.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoMap.kt
@@ -1,5 +1,6 @@
 package org.maplibre.compose.demoapp
 
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -13,11 +14,19 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.key
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.dp
 import kotlin.math.roundToInt
+import kotlin.math.sqrt
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.vectorResource
@@ -30,6 +39,7 @@ import org.maplibre.compose.material3.Material3
 import org.maplibre.compose.material3.PointerPinButton
 import org.maplibre.compose.overlay.MapOverlay
 import org.maplibre.compose.overlay.include
+import org.maplibre.spatialk.geojson.Position
 
 /** How long the camera takes to fly to a newly selected demo. */
 val DemoFlightDuration = 2.seconds
@@ -88,26 +98,196 @@ fun DemoMap(state: DemoAppState, viewportInsets: MapViewportInsets) {
     }
 
     val scope = rememberCoroutineScope()
-    Box(Modifier.fillMaxSize().padding(viewportInsets.asPaddingValues())) {
-      state.selectedDemo?.let { demo ->
-        demo.pointerPin?.let { pointerPin ->
-          // The pin fills this box to place itself; sizing the pin itself is up to its content.
-          PointerPinButton(
-            cameraState = state.cameraState,
-            targetPosition = pointerPin.target,
-            onClick = { scope.launch { state.cameraState.flyTo(pointerPin.destination) } },
-          ) {
-            Icon(
-              vectorResource(Res.drawable.filter_center_focus_24px),
-              contentDescription = "Fly back to ${demo.name}",
-            )
-          }
+    val pointerPin = state.selectedDemo?.pointerPin
+    val placementPadding = viewportInsets.asPaddingValues()
+    if (state.settings.showPointerPinDiagnostics && pointerPin != null) {
+      PointerPinDestinationOverlay(
+        cameraState = state.cameraState,
+        destination = pointerPin.destination,
+        modifier = Modifier.fillMaxSize(),
+      )
+      PointerPinPlacementOverlay(
+        cameraState = state.cameraState,
+        target = pointerPin.target,
+        placementPadding = placementPadding,
+        modifier = Modifier.fillMaxSize(),
+      )
+    }
+
+    state.selectedDemo?.let { demo ->
+      pointerPin?.let {
+        PointerPinButton(
+          cameraState = state.cameraState,
+          targetPosition = it.target,
+          placementPadding = placementPadding,
+          onClick = { scope.launch { state.cameraState.flyTo(it.destination) } },
+        ) {
+          Icon(
+            vectorResource(Res.drawable.filter_center_focus_24px),
+            contentDescription = "Fly back to ${demo.name}",
+          )
         }
       }
+    }
 
+    Box(Modifier.fillMaxSize().padding(placementPadding)) {
       DiagnosticOverlays(state = state, modifier = Modifier.align(Alignment.TopCenter))
     }
   }
+}
+
+@Composable
+private fun PointerPinDestinationOverlay(
+  cameraState: CameraState,
+  destination: DemoDestination,
+  modifier: Modifier = Modifier,
+) {
+  // The viewport read recomputes the projection when the camera changes.
+  val viewport = cameraState.viewport
+  val projected =
+    remember(destination, viewport) {
+      when (destination) {
+        is DemoDestination.ExactCamera ->
+          cameraState.screenLocationFromPosition(destination.position.target)?.let(::listOf)
+        is DemoDestination.FitBounds -> {
+          val bounds = destination.bounds
+          listOf(
+              Position(longitude = bounds.west, latitude = bounds.north),
+              Position(longitude = bounds.east, latitude = bounds.north),
+              Position(longitude = bounds.east, latitude = bounds.south),
+              Position(longitude = bounds.west, latitude = bounds.south),
+            )
+            .mapNotNull(cameraState::screenLocationFromPosition)
+            .takeIf { it.size == 4 }
+        }
+        DemoDestination.None -> null
+      }
+    }
+  val color = Color(0xFFE53935)
+
+  if (projected != null) {
+    Canvas(modifier) {
+      val points = projected.map { Offset(it.x.toPx(), it.y.toPx()) }
+      if (points.size == 1) {
+        drawCircle(
+          color = color,
+          radius = 12.dp.toPx(),
+          center = points.single(),
+          style = Stroke(width = 3.dp.toPx()),
+        )
+      } else {
+        val path =
+          Path().apply {
+            moveTo(points.first().x, points.first().y)
+            points.drop(1).forEach { lineTo(it.x, it.y) }
+            close()
+          }
+        drawPath(path = path, color = color, style = Stroke(width = 3.dp.toPx()))
+      }
+    }
+  }
+}
+
+@Composable
+private fun PointerPinPlacementOverlay(
+  cameraState: CameraState,
+  target: Position,
+  placementPadding: PaddingValues,
+  modifier: Modifier = Modifier,
+) {
+  val viewport = cameraState.viewport
+  val projected = remember(target, viewport) { cameraState.screenLocationFromPosition(target) }
+  val layoutDirection = LocalLayoutDirection.current
+
+  Canvas(modifier) {
+    val geometryColor = Color(0xFF00ACC1)
+    val targetColor = Color(0xFFFFB300)
+    val haloColor = Color.White.copy(alpha = 0.9f)
+    val geometryWidth = 2.dp.toPx()
+    val haloWidth = 5.dp.toPx()
+    val area =
+      Rect(
+        left = placementPadding.calculateLeftPadding(layoutDirection).toPx(),
+        top = placementPadding.calculateTopPadding().toPx(),
+        right = size.width - placementPadding.calculateRightPadding(layoutDirection).toPx(),
+        bottom = size.height - placementPadding.calculateBottomPadding().toPx(),
+      )
+    if (area.width <= 0 || area.height <= 0) return@Canvas
+
+    drawOval(
+      color = haloColor,
+      topLeft = area.topLeft,
+      size = area.size,
+      style = Stroke(width = haloWidth),
+    )
+    drawOval(
+      color = geometryColor,
+      topLeft = area.topLeft,
+      size = area.size,
+      style = Stroke(width = geometryWidth),
+    )
+
+    val projectedTarget = projected?.let { Offset(it.x.toPx(), it.y.toPx()) } ?: return@Canvas
+    val intersection = findEllipseIntersection(area, projectedTarget)
+
+    if (intersection != null) {
+      drawLine(
+        color = haloColor,
+        start = intersection,
+        end = projectedTarget,
+        strokeWidth = haloWidth,
+      )
+      drawLine(
+        color = geometryColor,
+        start = intersection,
+        end = projectedTarget,
+        strokeWidth = geometryWidth,
+      )
+      drawCircle(color = haloColor, radius = 6.dp.toPx(), center = intersection)
+      drawCircle(color = geometryColor, radius = 4.dp.toPx(), center = intersection)
+    }
+
+    val targetRadius = 9.dp.toPx()
+    val targetArm = 13.dp.toPx()
+    drawCircle(
+      color = haloColor,
+      radius = targetRadius,
+      center = projectedTarget,
+      style = Stroke(width = haloWidth),
+    )
+    drawCircle(
+      color = targetColor,
+      radius = targetRadius,
+      center = projectedTarget,
+      style = Stroke(width = geometryWidth),
+    )
+    listOf(haloWidth to haloColor, geometryWidth to targetColor).forEach { (width, color) ->
+      drawLine(
+        color = color,
+        start = Offset(projectedTarget.x - targetArm, projectedTarget.y),
+        end = Offset(projectedTarget.x + targetArm, projectedTarget.y),
+        strokeWidth = width,
+      )
+      drawLine(
+        color = color,
+        start = Offset(projectedTarget.x, projectedTarget.y - targetArm),
+        end = Offset(projectedTarget.x, projectedTarget.y + targetArm),
+        strokeWidth = width,
+      )
+    }
+  }
+}
+
+// Matches the placement calculation in PointerPinButton.
+private fun findEllipseIntersection(area: Rect, target: Offset): Offset? {
+  val delta = target - area.center
+  val horizontalRadius = area.width / 2.0
+  val verticalRadius = area.height / 2.0
+  val normalizedDistance =
+    delta.x * delta.x / (horizontalRadius * horizontalRadius) +
+      delta.y * delta.y / (verticalRadius * verticalRadius)
+  if (normalizedDistance < 1.0) return null
+  return area.center + delta * (1.0 / sqrt(normalizedDistance)).toFloat()
 }
 
 @Composable
@@ -126,6 +306,12 @@ private fun DiagnosticOverlays(state: DemoAppState, modifier: Modifier = Modifie
         .padding(horizontal = 8.dp),
     horizontalAlignment = Alignment.CenterHorizontally,
   ) {
+    if (state.settings.showPointerPinDiagnostics && state.selectedDemo?.pointerPin != null) {
+      Text(
+        text = "Destination: red · target: amber · placement: cyan",
+        style = MaterialTheme.typography.labelMedium,
+      )
+    }
     if (state.settings.showFpsOverlay) {
       Text(
         text = "${state.frameRateState.framesPerSecond.roundToInt()} fps",

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoPanel.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoPanel.kt
@@ -273,6 +273,9 @@ private fun InterfaceSettingsItems(settings: DemoSettings) {
   SectionHeader("Overlays")
   SwitchRow("Frame rate", settings.showFpsOverlay) { settings.showFpsOverlay = it }
   SwitchRow("Camera state", settings.showCameraOverlay) { settings.showCameraOverlay = it }
+  SwitchRow("Pointer pin geometry", settings.showPointerPinDiagnostics) {
+    settings.showPointerPinDiagnostics = it
+  }
 }
 
 @Composable

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoSettings.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoSettings.kt
@@ -20,6 +20,7 @@ class DemoSettings {
   var tileLodOptions by mutableStateOf(TileLodOptions.Standard)
   var showFpsOverlay by mutableStateOf(false)
   var showCameraOverlay by mutableStateOf(false)
+  var showPointerPinDiagnostics by mutableStateOf(false)
   var useMaterial3Controls by mutableStateOf(true)
 }
 

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/org/maplibre/compose/material3/PointerPinButton.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/org/maplibre/compose/material3/PointerPinButton.kt
@@ -29,6 +29,8 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.vector.PathParser
 import androidx.compose.ui.graphics.vector.toPath
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
@@ -48,13 +50,14 @@ import org.maplibre.spatialk.geojson.Position
  * parent layout, pointing towards some [targetPosition] off-screen. Only shown if the
  * [targetPosition] is outside of the ellipsis.
  *
- * Note that this composable should fill the whole area in which the pointer pin button will be
- * **placed**, i.e. usually the whole map screen.
+ * This composable should fill the map. Use [placementPadding] to keep the placement ellipse inside
+ * another overlay or inset.
  *
  * @param onClick called when this button is clicked
  * @param cameraState used to calculate where the given [targetPosition] is in screen coordinates
  * @param targetPosition position (off-screen) the pin should point at
  * @param modifier the [Modifier] to be applied to the layout the button is placed in
+ * @param placementPadding padding between the map edges and the placement ellipse
  * @param enabled controls the enabled state of this button. When `false`, this component will not
  *   respond to user input, and it will appear visually disabled and disabled to accessibility
  *   services.
@@ -77,6 +80,7 @@ public fun PointerPinButton(
   cameraState: CameraState,
   targetPosition: Position,
   modifier: Modifier = Modifier,
+  placementPadding: PaddingValues = PaddingValues(0.dp),
   onClick: () -> Unit = {},
   enabled: Boolean = true,
   colors: ButtonColors = ButtonDefaults.elevatedButtonColors(),
@@ -92,7 +96,11 @@ public fun PointerPinButton(
     remember(targetPosition, viewport) { cameraState.screenLocationFromPosition(targetPosition) }
   val target = dpTarget?.toOffset() ?: return
 
-  PointerPinPlacement(target = target, modifier = modifier) { offset, angle ->
+  PointerPinPlacement(
+    target = target,
+    modifier = modifier,
+    placementPadding = placementPadding,
+  ) { offset, angle ->
     val rotation = angle * 180 / PI
     val dpOffset = offset.toDpOffset()
 
@@ -137,36 +145,31 @@ public fun PointerPinButton(
 internal fun PointerPinPlacement(
   target: Offset,
   modifier: Modifier = Modifier,
+  placementPadding: PaddingValues = PaddingValues(0.dp),
   content: @Composable BoxScope.(offset: Offset, angle: Double) -> Unit,
 ) {
-  var placementSpace by remember { mutableStateOf<PlacementSpace?>(null) }
+  var area by remember { mutableStateOf<Rect?>(null) }
+  val density = LocalDensity.current
+  val layoutDirection = LocalLayoutDirection.current
 
   Box(
     modifier =
       modifier.fillMaxSize().onGloballyPositioned { coordinates ->
-        val parent = coordinates.parentLayoutCoordinates ?: return@onGloballyPositioned
-        val parentToLocal = Matrix()
-        // The projected target uses the parent's coordinates; placement uses this box's.
-        coordinates.transformFrom(parent, parentToLocal)
-        placementSpace =
-          PlacementSpace(
-            area =
-              Rect(0f, 0f, coordinates.size.width.toFloat(), coordinates.size.height.toFloat()),
-            parentToLocal = parentToLocal,
-          )
+        val left = with(density) { placementPadding.calculateLeftPadding(layoutDirection).toPx() }
+        val top = with(density) { placementPadding.calculateTopPadding().toPx() }
+        val right =
+          coordinates.size.width -
+            with(density) { placementPadding.calculateRightPadding(layoutDirection).toPx() }
+        val bottom =
+          coordinates.size.height -
+            with(density) { placementPadding.calculateBottomPadding().toPx() }
+        area = if (left < right && top < bottom) Rect(left, top, right, bottom) else null
       }
   ) {
-    val intersection =
-      remember(target, placementSpace) {
-        placementSpace?.let {
-          findEllipsisIntersection(it.area, it.parentToLocal.map(target))
-        }
-      }
+    val intersection = remember(target, area) { area?.let { findEllipsisIntersection(it, target) } }
     intersection?.let { content(it.position, it.angle) }
   }
 }
-
-private data class PlacementSpace(val area: Rect, val parentToLocal: Matrix)
 
 /** A kind of map-📍 shape, but rotatable */
 private class PointerPinShape(val rotation: Float = 0f) : Shape {

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/org/maplibre/compose/material3/PointerPinButton.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/org/maplibre/compose/material3/PointerPinButton.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Matrix
@@ -90,61 +91,82 @@ public fun PointerPinButton(
   val dpTarget =
     remember(targetPosition, viewport) { cameraState.screenLocationFromPosition(targetPosition) }
   val target = dpTarget?.toOffset() ?: return
-  var area by remember { mutableStateOf<Rect?>(null) }
 
-  Box(
-    modifier =
-      modifier.fillMaxSize().onGloballyPositioned { coordinates ->
-        area =
-          coordinates.parentLayoutCoordinates?.localBoundingBoxOf(
-            coordinates,
-            clipBounds = false,
+  PointerPinPlacement(target = target, modifier = modifier) { offset, angle ->
+    val rotation = angle * 180 / PI
+    val dpOffset = offset.toDpOffset()
+
+    val pointerPinShape = remember(rotation) { PointerPinShape(rotation.toFloat()) }
+
+    ElevatedButton(
+      onClick = onClick,
+      modifier =
+        Modifier
+          // offsetting it to account for the pointy side of the pin depending on the rotation.
+          // (The tip of the pin should be exactly on the ellipsis outline)
+          .proportionalAbsoluteOffset(
+            x = (-sin(angle) / 2.0 - 0.5).toFloat(),
+            y = (cos(angle) / 2.0 - 0.5).toFloat(),
           )
-      }
-  ) {
-    val intersection = remember(target, area) { area?.let { findEllipsisIntersection(it, target) } }
-
-    intersection?.let { (offset, angle) ->
-      val rotation = angle * 180 / PI
-      val dpOffset = offset.toDpOffset()
-
-      val pointerPinShape = remember(rotation) { PointerPinShape(rotation.toFloat()) }
-
-      ElevatedButton(
-        onClick = onClick,
+          // Place the pin tip at the ellipse intersection inside this box.
+          .absoluteOffset(dpOffset.x, dpOffset.y),
+      enabled = enabled,
+      shape = pointerPinShape,
+      colors = colors,
+      elevation = elevation,
+      border = border,
+      contentPadding = PaddingValues(0.dp),
+      interactionSource = interactionSource,
+    ) {
+      Box(
         modifier =
           Modifier
-            // offsetting it to account for the pointy side of the pin depending on the rotation.
-            // (The tip of the pin should be exactly on the ellipsis outline)
-            .proportionalAbsoluteOffset(
-              x = (-sin(angle) / 2.0 - 0.5).toFloat(),
-              y = (cos(angle) / 2.0 - 0.5).toFloat(),
-            )
-            // offsetting the whole pin to place it correctly within the parent layout
-            .absoluteOffset(dpOffset.x, dpOffset.y),
-        enabled = enabled,
-        shape = pointerPinShape,
-        colors = colors,
-        elevation = elevation,
-        border = border,
-        contentPadding = PaddingValues(0.dp),
-        interactionSource = interactionSource,
+            // padding to place the content within the pin correctly, taking into account that the
+            // center of the pointer shape is not the center of to-be-placed icon (due to the
+            // pointy side)
+            .proportionalPadding(PointerPinShape.POINTY_SIZE)
+            .padding(contentPadding)
       ) {
-        Box(
-          modifier =
-            Modifier
-              // padding to place the content within the pin correctly, taking into account that the
-              // center of the pointer shape is not the center of to-be-placed icon (due to the
-              // pointy side)
-              .proportionalPadding(PointerPinShape.POINTY_SIZE)
-              .padding(contentPadding)
-        ) {
-          content()
-        }
+        content()
       }
     }
   }
 }
+
+@Composable
+internal fun PointerPinPlacement(
+  target: Offset,
+  modifier: Modifier = Modifier,
+  content: @Composable BoxScope.(offset: Offset, angle: Double) -> Unit,
+) {
+  var placementSpace by remember { mutableStateOf<PlacementSpace?>(null) }
+
+  Box(
+    modifier =
+      modifier.fillMaxSize().onGloballyPositioned { coordinates ->
+        val parent = coordinates.parentLayoutCoordinates ?: return@onGloballyPositioned
+        val parentToLocal = Matrix()
+        // The projected target uses the parent's coordinates; placement uses this box's.
+        coordinates.transformFrom(parent, parentToLocal)
+        placementSpace =
+          PlacementSpace(
+            area =
+              Rect(0f, 0f, coordinates.size.width.toFloat(), coordinates.size.height.toFloat()),
+            parentToLocal = parentToLocal,
+          )
+      }
+  ) {
+    val intersection =
+      remember(target, placementSpace) {
+        placementSpace?.let {
+          findEllipsisIntersection(it.area, it.parentToLocal.map(target))
+        }
+      }
+    intersection?.let { content(it.position, it.angle) }
+  }
+}
+
+private data class PlacementSpace(val area: Rect, val parentToLocal: Matrix)
 
 /** A kind of map-📍 shape, but rotatable */
 private class PointerPinShape(val rotation: Float = 0f) : Shape {

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/org/maplibre/compose/material3/PointerPinButton.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/org/maplibre/compose/material3/PointerPinButton.kt
@@ -29,8 +29,6 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.vector.PathParser
 import androidx.compose.ui.graphics.vector.toPath
 import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
@@ -50,14 +48,13 @@ import org.maplibre.spatialk.geojson.Position
  * parent layout, pointing towards some [targetPosition] off-screen. Only shown if the
  * [targetPosition] is outside of the ellipsis.
  *
- * This composable should fill the map. Use [placementPadding] to keep the placement ellipse inside
- * another overlay or inset.
+ * Place this composable directly in the map overlay so its parent coordinates match the map's
+ * screen coordinates. The overlay keeps the placement ellipse inside the unobstructed map region.
  *
  * @param onClick called when this button is clicked
  * @param cameraState used to calculate where the given [targetPosition] is in screen coordinates
  * @param targetPosition position (off-screen) the pin should point at
  * @param modifier the [Modifier] to be applied to the layout the button is placed in
- * @param placementPadding padding between the map edges and the placement ellipse
  * @param enabled controls the enabled state of this button. When `false`, this component will not
  *   respond to user input, and it will appear visually disabled and disabled to accessibility
  *   services.
@@ -80,7 +77,6 @@ public fun PointerPinButton(
   cameraState: CameraState,
   targetPosition: Position,
   modifier: Modifier = Modifier,
-  placementPadding: PaddingValues = PaddingValues(0.dp),
   onClick: () -> Unit = {},
   enabled: Boolean = true,
   colors: ButtonColors = ButtonDefaults.elevatedButtonColors(),
@@ -96,11 +92,7 @@ public fun PointerPinButton(
     remember(targetPosition, viewport) { cameraState.screenLocationFromPosition(targetPosition) }
   val target = dpTarget?.toOffset() ?: return
 
-  PointerPinPlacement(
-    target = target,
-    modifier = modifier,
-    placementPadding = placementPadding,
-  ) { offset, angle ->
+  PointerPinPlacement(target = target, modifier = modifier) { offset, angle ->
     val rotation = angle * 180 / PI
     val dpOffset = offset.toDpOffset()
 
@@ -145,31 +137,35 @@ public fun PointerPinButton(
 internal fun PointerPinPlacement(
   target: Offset,
   modifier: Modifier = Modifier,
-  placementPadding: PaddingValues = PaddingValues(0.dp),
   content: @Composable BoxScope.(offset: Offset, angle: Double) -> Unit,
 ) {
-  var area by remember { mutableStateOf<Rect?>(null) }
-  val density = LocalDensity.current
-  val layoutDirection = LocalLayoutDirection.current
+  var placementSpace by remember { mutableStateOf<PlacementSpace?>(null) }
 
   Box(
     modifier =
       modifier.fillMaxSize().onGloballyPositioned { coordinates ->
-        val left = with(density) { placementPadding.calculateLeftPadding(layoutDirection).toPx() }
-        val top = with(density) { placementPadding.calculateTopPadding().toPx() }
-        val right =
-          coordinates.size.width -
-            with(density) { placementPadding.calculateRightPadding(layoutDirection).toPx() }
-        val bottom =
-          coordinates.size.height -
-            with(density) { placementPadding.calculateBottomPadding().toPx() }
-        area = if (left < right && top < bottom) Rect(left, top, right, bottom) else null
+        val parent = coordinates.parentLayoutCoordinates ?: return@onGloballyPositioned
+        val parentToLocal = Matrix()
+        coordinates.transformFrom(parent, parentToLocal)
+        placementSpace =
+          PlacementSpace(
+            area =
+              Rect(0f, 0f, coordinates.size.width.toFloat(), coordinates.size.height.toFloat()),
+            parentToLocal = parentToLocal,
+          )
       }
   ) {
-    val intersection = remember(target, area) { area?.let { findEllipsisIntersection(it, target) } }
+    val intersection =
+      remember(target, placementSpace) {
+        placementSpace?.let {
+          findEllipsisIntersection(it.area, it.parentToLocal.map(target))
+        }
+      }
     intersection?.let { content(it.position, it.angle) }
   }
 }
+
+private data class PlacementSpace(val area: Rect, val parentToLocal: Matrix)
 
 /** A kind of map-📍 shape, but rotatable */
 private class PointerPinShape(val rotation: Float = 0f) : Shape {

--- a/lib/maplibre-compose-material3/src/jvmTest/kotlin/org/maplibre/compose/material3/PointerPinButtonTest.kt
+++ b/lib/maplibre-compose-material3/src/jvmTest/kotlin/org/maplibre/compose/material3/PointerPinButtonTest.kt
@@ -1,9 +1,8 @@
 package org.maplibre.compose.material3
 
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.absoluteOffset
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.Modifier
@@ -21,33 +20,32 @@ import kotlin.test.assertEquals
 @OptIn(ExperimentalTestApi::class)
 class PointerPinButtonTest {
   @Test
-  fun mapProjectedTargetStaysAlignedWithInsetPlacement() = runComposeUiTest {
+  fun mapProjectedTargetIsConvertedToInsetChildCoordinates() = runComposeUiTest {
     setContent {
       MaterialTheme {
         val density = LocalDensity.current
         Box(Modifier.size(300.dp)) {
           PointerPinPlacement(
             target = with(density) { Offset(170.dp.toPx(), (-100).dp.toPx()) },
-            modifier = Modifier.fillMaxSize(),
-            placementPadding = PaddingValues(start = 40.dp, top = 60.dp),
+            modifier = Modifier.offset(40.dp, 60.dp).size(260.dp, 240.dp),
           ) { placement, _ ->
             val placementDp = with(density) { placement.x.toDp() to placement.y.toDp() }
             Box(
               Modifier.absoluteOffset(placementDp.first, placementDp.second)
                 .size(20.dp)
-                .testTag(PADDED_PLACEMENT)
+                .testTag(INSET_PLACEMENT)
             )
           }
         }
       }
     }
 
-    val placement = onNodeWithTag(PADDED_PLACEMENT).getUnclippedBoundsInRoot()
+    val placement = onNodeWithTag(INSET_PLACEMENT).getUnclippedBoundsInRoot()
     assertEquals(170f, placement.left.value, absoluteTolerance = 0.5f)
     assertEquals(60f, placement.top.value, absoluteTolerance = 0.5f)
   }
 
   private companion object {
-    const val PADDED_PLACEMENT = "padded-placement"
+    const val INSET_PLACEMENT = "inset-placement"
   }
 }

--- a/lib/maplibre-compose-material3/src/jvmTest/kotlin/org/maplibre/compose/material3/PointerPinButtonTest.kt
+++ b/lib/maplibre-compose-material3/src/jvmTest/kotlin/org/maplibre/compose/material3/PointerPinButtonTest.kt
@@ -1,0 +1,65 @@
+package org.maplibre.compose.material3
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.absoluteOffset
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalTestApi::class)
+class PointerPinButtonTest {
+  @Test
+  fun parentTranslationMovesThePlacementOnce() = runComposeUiTest {
+    setContent {
+      MaterialTheme {
+        val density = LocalDensity.current
+        Box(Modifier.size(300.dp)) {
+          PointerPinPlacement(
+            target = with(density) { Offset(100.dp.toPx(), (-100).dp.toPx()) },
+            modifier = Modifier.size(200.dp, 100.dp),
+          ) { placement, _ ->
+            val placementDp = with(density) { placement.x.toDp() to placement.y.toDp() }
+            Box(
+              Modifier.absoluteOffset(placementDp.first, placementDp.second)
+                .size(20.dp)
+                .testTag(BASE_PLACEMENT)
+            )
+          }
+          PointerPinPlacement(
+            target = with(density) { Offset(140.dp.toPx(), (-40).dp.toPx()) },
+            modifier = Modifier.offset(40.dp, 60.dp).size(200.dp, 100.dp),
+          ) { placement, _ ->
+            val placementDp = with(density) { placement.x.toDp() to placement.y.toDp() }
+            Box(
+              Modifier.absoluteOffset(placementDp.first, placementDp.second)
+                .size(20.dp)
+                .testTag(TRANSLATED_PLACEMENT)
+            )
+          }
+        }
+      }
+    }
+
+    val base = onNodeWithTag(BASE_PLACEMENT).getUnclippedBoundsInRoot()
+    val translated = onNodeWithTag(TRANSLATED_PLACEMENT).getUnclippedBoundsInRoot()
+
+    assertEquals(40f, (translated.left - base.left).value, absoluteTolerance = 0.5f)
+    assertEquals(60f, (translated.top - base.top).value, absoluteTolerance = 0.5f)
+  }
+
+  private companion object {
+    const val BASE_PLACEMENT = "base-placement"
+    const val TRANSLATED_PLACEMENT = "translated-placement"
+  }
+}

--- a/lib/maplibre-compose-material3/src/jvmTest/kotlin/org/maplibre/compose/material3/PointerPinButtonTest.kt
+++ b/lib/maplibre-compose-material3/src/jvmTest/kotlin/org/maplibre/compose/material3/PointerPinButtonTest.kt
@@ -1,8 +1,9 @@
 package org.maplibre.compose.material3
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.absoluteOffset
-import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.Modifier
@@ -20,46 +21,33 @@ import kotlin.test.assertEquals
 @OptIn(ExperimentalTestApi::class)
 class PointerPinButtonTest {
   @Test
-  fun parentTranslationMovesThePlacementOnce() = runComposeUiTest {
+  fun mapProjectedTargetStaysAlignedWithInsetPlacement() = runComposeUiTest {
     setContent {
       MaterialTheme {
         val density = LocalDensity.current
         Box(Modifier.size(300.dp)) {
           PointerPinPlacement(
-            target = with(density) { Offset(100.dp.toPx(), (-100).dp.toPx()) },
-            modifier = Modifier.size(200.dp, 100.dp),
+            target = with(density) { Offset(170.dp.toPx(), (-100).dp.toPx()) },
+            modifier = Modifier.fillMaxSize(),
+            placementPadding = PaddingValues(start = 40.dp, top = 60.dp),
           ) { placement, _ ->
             val placementDp = with(density) { placement.x.toDp() to placement.y.toDp() }
             Box(
               Modifier.absoluteOffset(placementDp.first, placementDp.second)
                 .size(20.dp)
-                .testTag(BASE_PLACEMENT)
-            )
-          }
-          PointerPinPlacement(
-            target = with(density) { Offset(140.dp.toPx(), (-40).dp.toPx()) },
-            modifier = Modifier.offset(40.dp, 60.dp).size(200.dp, 100.dp),
-          ) { placement, _ ->
-            val placementDp = with(density) { placement.x.toDp() to placement.y.toDp() }
-            Box(
-              Modifier.absoluteOffset(placementDp.first, placementDp.second)
-                .size(20.dp)
-                .testTag(TRANSLATED_PLACEMENT)
+                .testTag(PADDED_PLACEMENT)
             )
           }
         }
       }
     }
 
-    val base = onNodeWithTag(BASE_PLACEMENT).getUnclippedBoundsInRoot()
-    val translated = onNodeWithTag(TRANSLATED_PLACEMENT).getUnclippedBoundsInRoot()
-
-    assertEquals(40f, (translated.left - base.left).value, absoluteTolerance = 0.5f)
-    assertEquals(60f, (translated.top - base.top).value, absoluteTolerance = 0.5f)
+    val placement = onNodeWithTag(PADDED_PLACEMENT).getUnclippedBoundsInRoot()
+    assertEquals(170f, placement.left.value, absoluteTolerance = 0.5f)
+    assertEquals(60f, placement.top.value, absoluteTolerance = 0.5f)
   }
 
   private companion object {
-    const val BASE_PLACEMENT = "base-placement"
-    const val TRANSLATED_PLACEMENT = "translated-placement"
+    const val PADDED_PLACEMENT = "padded-placement"
   }
 }


### PR DESCRIPTION
## Description

Keep pointer targets in map coordinates, place the pin through the map overlay unobstructed bounds, and add toggleable demo diagnostics for the destination, target, and placement geometry.

## Validation

Validated with mise run check, mise run test:desktop, the focused pointer-pin JVM regression test, the desktop distributable build, and a live macOS Metal demo.

## AI assistance

OpenAI Codex (GPT-5) investigated, implemented, and validated this change.