### PR TITLE
Make Android emulator windowed by default

### DIFF
--- a/.mise/bin/boot-android-emulator
+++ b/.mise/bin/boot-android-emulator
@@ -1,8 +1,25 @@
 #!/usr/bin/env bash
-# Boots a headless Android emulator and waits until it is ready. Idempotent.
+# Boots an Android emulator and waits until it is ready. Idempotent.
 set -euo pipefail
 
-api_level=${1:?usage: boot-android-emulator <api-level>}
+usage() {
+  echo "Usage: boot-android-emulator <api-level> [--headless]" >&2
+  exit 2
+}
+
+api_level=
+headless=false
+for arg in "$@"; do
+  case "$arg" in
+    --headless) headless=true ;;
+    -*) usage ;;
+    *)
+      [[ -z "$api_level" ]] || usage
+      api_level=$arg
+      ;;
+  esac
+done
+[[ -n "$api_level" ]] || usage
 
 # An arm64 host needs an arm64 image to use its native accelerator.
 case "$(uname -m)" in
@@ -18,6 +35,7 @@ project_root="${MISE_PROJECT_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." &
 state_dir="$project_root/build/android-emulator"
 pid_file="$state_dir/emulator.pid"
 log_file="$state_dir/emulator.log"
+launchd_label=org.maplibre.compose.android-emulator
 # In the build tree, not ~/.android: removing the tree removes the device.
 export ANDROID_AVD_HOME="$state_dir/avd"
 
@@ -62,13 +80,31 @@ booted_avd() {
 }
 
 running_avd="$(booted_avd || true)"
-if [[ "$running_avd" == "$avd_name" ]]; then
+running_mode=
+if [[ -f "$pid_file" ]]; then
+  running_pid=$(<"$pid_file")
+  if [[ "$running_pid" =~ ^[0-9]+$ ]] &&
+    kill -0 "$running_pid" 2>/dev/null &&
+    ps -p "$running_pid" -o args= | grep -q "$avd_name"; then
+    if ps -p "$running_pid" -o args= | grep -q -- ' -no-window'; then
+      running_mode=headless
+    else
+      running_mode=visible
+    fi
+  fi
+fi
+desired_mode=visible
+if [[ "$headless" == true ]]; then
+  desired_mode=headless
+fi
+
+if [[ "$running_avd" == "$avd_name" && "$running_mode" == "$desired_mode" ]]; then
   echo "Android emulator for API $api_level ($abi) is ready at $serial."
   exit 0
 fi
 if [[ -n "$running_avd" ]] ||
   { [[ -x "$adb" ]] && adb_probe 20 devices | grep -q "^$serial"; }; then
-  echo "Replacing the emulator on $serial with $avd_name."
+  echo "Replacing the emulator on $serial with $avd_name in $desired_mode mode."
   "$project_root/.mise/bin/stop-android-emulator"
 fi
 
@@ -127,7 +163,6 @@ if [[ ! -f "$pid_file" ]]; then
     -avd "$avd_name"
     # Fixed, so $serial always names this emulator rather than the next free port.
     -port "${serial#emulator-}"
-    -no-window
     -no-audio
     -no-boot-anim
     -no-snapshot
@@ -136,17 +171,46 @@ if [[ ! -f "$pid_file" ]]; then
     -camera-back none
     -camera-front none
   )
+  if [[ "$headless" == true ]]; then
+    launcher+=(-no-window)
+  fi
   # No -accel: the default finds KVM here, Hypervisor.framework on macOS, and
   # WHPX on Windows. Only a missing /dev/kvm is worth warning about.
   if [[ "$(uname -s)" == "Linux" && ! (-r /dev/kvm && -w /dev/kvm) ]]; then
     echo "KVM is inaccessible; falling back to software emulation." >&2
   fi
-  if command -v setsid >/dev/null 2>&1; then
+  if [[ "$(uname -s)" == Darwin && "$headless" == false ]]; then
+    # launchd keeps the macOS GUI process outside the invoking task's process
+    # group, which lets the window remain open after mise exits.
+    launchctl remove "$launchd_label" 2>/dev/null || true
+    launchctl submit \
+      -l "$launchd_label" \
+      -o "$log_file" \
+      -e "$log_file" \
+      -- /usr/bin/env "ANDROID_AVD_HOME=$ANDROID_AVD_HOME" "${launcher[@]}"
+
+    pid=
+    for ((attempt = 0; attempt < 30; attempt++)); do
+      pid=$(launchctl print "gui/$(id -u)/$launchd_label" 2>/dev/null |
+        awk '/pid =/ { print $3; exit }')
+      if [[ "$pid" =~ ^[0-9]+$ ]] && kill -0 "$pid" 2>/dev/null; then
+        break
+      fi
+      sleep 1
+    done
+    if [[ ! "$pid" =~ ^[0-9]+$ ]] || ! kill -0 "$pid" 2>/dev/null; then
+      echo "Android emulator did not start under launchd." >&2
+      launchctl remove "$launchd_label" 2>/dev/null || true
+      tail -100 "$log_file" >&2
+      exit 1
+    fi
+  elif command -v setsid >/dev/null 2>&1; then
     nohup setsid "${launcher[@]}" </dev/null >"$log_file" 2>&1 &
+    pid=$!
   else
     nohup "${launcher[@]}" </dev/null >"$log_file" 2>&1 &
+    pid=$!
   fi
-  pid=$!
   printf '%s\n' "$pid" >"$pid_file"
   echo "Started Android emulator process $pid."
 fi

--- a/.mise/bin/run-android-device-tests
+++ b/.mise/bin/run-android-device-tests
@@ -40,7 +40,7 @@ fi
 
 echo "Android session install hung; rebooting the emulator and retrying once."
 "$project_root/.mise/bin/stop-android-emulator"
-"$project_root/.mise/bin/boot-android-emulator" "$api_level"
+"$project_root/.mise/bin/boot-android-emulator" "$api_level" --headless
 
 set +e
 {

--- a/.mise/bin/stop-android-emulator
+++ b/.mise/bin/stop-android-emulator
@@ -7,6 +7,13 @@ project_root="${MISE_PROJECT_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." &
 state_dir="$project_root/build/android-emulator"
 pid_file="$state_dir/emulator.pid"
 adb="$("$(dirname "${BASH_SOURCE[0]}")/android-sdk-root")/platform-tools/adb"
+launchd_label=org.maplibre.compose.android-emulator
+
+# A submitted launchd job restarts its process after `adb emu kill`, so remove
+# the job before asking the emulator to shut down.
+if [[ "$(uname -s)" == Darwin ]]; then
+  launchctl remove "$launchd_label" 2>/dev/null || true
+fi
 
 # Unconditional: the port must be free before another AVD can claim it.
 if [[ -x "$adb" ]]; then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,7 +95,7 @@ For a machine with no SDK, install the pinned SDK with
 
 - **Android host:** `mise run test:android`
 - **Android device:** `mise run test:android:device [api-level]` (boots its own
-  headless emulator; `android-emulator:boot`/`:stop` drive it directly)
+  headless emulator; `android-emulator:boot` opens a window by default)
 - **iOS:** `mise run test:ios` (boots its own simulator)
 - **Web:** `mise run test:js`
 - **Desktop:** `mise run test:desktop` (add `--backend <name>` to package a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,11 +156,13 @@ You can drive the emulator on its own:
 
 ```bash
 mise run android-emulator:boot 24
+mise run android-emulator:boot 24 --headless
 mise run android-emulator:stop
 ```
 
-The AVD lives under `build/android-emulator`, so removing the build tree removes
-the device.
+The boot task opens the emulator window by default. Pass `--headless` to run it
+without a window. The AVD lives under `build/android-emulator`, so removing the
+build tree removes the device.
 
 ## Building documentation
 

--- a/mise.toml
+++ b/mise.toml
@@ -123,10 +123,19 @@ description = "Run the Android host (JVM) test suite."
 run = "./gradlew testDebugUnitTest testAndroidHostTest"
 
 [tasks."android-emulator:boot"]
-description = "Boot a headless Android emulator and wait until it is ready."
-usage = 'arg "[api_level]" default="{{vars.android_api_level}}"'
+description = "Boot an Android emulator and wait until it is ready."
+usage = '''
+flag "--headless" help="Run the emulator without a window."
+arg "[api_level]" default="{{vars.android_api_level}}"
+'''
 tools = { "core:java" = "{{vars.java_version}}" }
-run = '.mise/bin/boot-android-emulator "$usage_api_level"'
+run = '''
+args=("$usage_api_level")
+if [[ "$usage_headless" == "true" ]]; then
+  args+=(--headless)
+fi
+.mise/bin/boot-android-emulator "${args[@]}"
+'''
 
 [tasks."android-emulator:stop"]
 description = "Stop the Android emulator started by mise."
@@ -139,7 +148,9 @@ run = ".mise/bin/capture-android-emulator-diagnostics"
 [tasks."test:android:device"]
 description = "Run the Android instrumented test suite on an emulator."
 usage = 'arg "[api_level]" default="{{vars.android_api_level}}"'
-depends = [{ task = "android-emulator:boot", args = ["{{usage.api_level}}"] }]
+depends = [
+  { task = "android-emulator:boot", args = ["{{usage.api_level}}", "--headless"] },
+]
 # One task name per Android plugin; see test:android.
 run = '.mise/bin/run-android-device-tests "$usage_api_level"'
 


### PR DESCRIPTION
## Description

Make the standalone Android emulator open a window by default, keep device-test launches headless through an explicit flag, and preserve the visible macOS process through launchd.

## Validation

Ran `mise run check`, shell syntax and mise task validation, then booted the API 36 emulator in visible mode and confirmed repeated ADB readiness plus idempotent boot behavior.

## AI assistance

Implemented and validated with OpenAI Codex using GPT-5.6.