### PR TITLE
Avoid LWJGL stack exhaustion during Vulkan extension queries

### DIFF
--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/bridge/VulkanSupport.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/bridge/VulkanSupport.kt
@@ -38,12 +38,13 @@ internal fun MemoryStack.vulkanInstanceExtensions(): Set<String> {
     vkEnumerateInstanceExtensionProperties(null as String?, count, null),
     "vkEnumerateInstanceExtensionProperties(count)",
   )
-  val props = VkExtensionProperties.calloc(count[0], this)
-  checkVulkan(
-    vkEnumerateInstanceExtensionProperties(null as String?, count, props),
-    "vkEnumerateInstanceExtensionProperties",
-  )
-  return buildSet { props.forEach { add(it.extensionNameString()) } }
+  return VkExtensionProperties.calloc(count[0]).use { props ->
+    checkVulkan(
+      vkEnumerateInstanceExtensionProperties(null as String?, count, props),
+      "vkEnumerateInstanceExtensionProperties",
+    )
+    buildSet { props.forEach { add(it.extensionNameString()) } }
+  }
 }
 
 internal fun MemoryStack.vulkanDeviceExtensions(device: VkPhysicalDevice): Set<String> {
@@ -52,12 +53,13 @@ internal fun MemoryStack.vulkanDeviceExtensions(device: VkPhysicalDevice): Set<S
     vkEnumerateDeviceExtensionProperties(device, null as String?, count, null),
     "vkEnumerateDeviceExtensionProperties(count)",
   )
-  val props = VkExtensionProperties.calloc(count[0], this)
-  checkVulkan(
-    vkEnumerateDeviceExtensionProperties(device, null as String?, count, props),
-    "vkEnumerateDeviceExtensionProperties",
-  )
-  return buildSet { props.forEach { add(it.extensionNameString()) } }
+  return VkExtensionProperties.calloc(count[0]).use { props ->
+    checkVulkan(
+      vkEnumerateDeviceExtensionProperties(device, null as String?, count, props),
+      "vkEnumerateDeviceExtensionProperties",
+    )
+    buildSet { props.forEach { add(it.extensionNameString()) } }
+  }
 }
 
 internal fun MemoryStack.vulkanStringBuffer(values: Set<String>): PointerBuffer {


### PR DESCRIPTION
## Description

Allocate Vulkan extension-property buffers outside LWJGL's fixed thread-local stack so that nested Windows Direct3D probes cannot exhaust it.

## Validation

`mise run test:desktop` passed 405 tests on Windows with 0 failures, and the changed Kotlin file passed the targeted ktfmt check.

## AI assistance

OpenAI Codex (GPT-5) diagnosed the failure, implemented the change, and ran validation.