### PR TITLE
Implement Windows location runtime

### DIFF
--- a/docs/src/content/docs/location.mdx
+++ b/docs/src/content/docs/location.mdx
@@ -28,7 +28,7 @@ keep the camera in sync with location changes.
 | **`LocationTrackingEffect`**             | Applies location changes to application or camera state.                           |
 
 Android and iOS provide default location and orientation providers. Web, Linux,
-and macOS provide default location providers but no default orientation
+macOS, and Windows provide default location providers but no default orientation
 readings.
 `LocationState.status` reports unsupported or misconfigured
 location setup without throwing.
@@ -120,8 +120,8 @@ A provider that wraps a real platform source can delegate permission to the
 building blocks that the default providers use: `AndroidLocationPermissionRequester`
 on Android, `IosLocationPermissionRequester` on iOS,
 `BrowserLocationPermissionRequester` on web, and
-`MacosLocationPermissionRequester` or `LinuxPortalLocationPermissionRequester`
-on desktop.
+`MacosLocationPermissionRequester`, `LinuxPortalLocationPermissionRequester`,
+or `WindowsLocationPermissionRequester` on desktop.
 
 ### Platform options
 
@@ -192,3 +192,27 @@ and
 that Apple requires.
 
 `minimumInterval` is ignored because Core Location filters only by distance.
+
+#### Windows desktop
+
+The backend uses Windows Runtime geolocation. Unpackaged Win32 applications,
+including applications installed from an MSI, need no capability manifest. A
+packaged application must declare the location device capability, as described
+in Microsoft's
+[desktop geolocation guidance](https://learn.microsoft.com/en-us/windows/apps/develop/maps-and-location/get-location):
+
+```xml title="Package.appxmanifest"
+<Capabilities>
+  <DeviceCapability Name="location" />
+</Capabilities>
+```
+
+The provider observes location access through `AppCapability`, including access
+changes made in Windows Settings. Requesting access starts the Windows prompt on
+the AWT event-dispatch thread. Other Windows Runtime work runs on a dedicated
+multithreaded-apartment thread.
+
+Each collector owns a `Geolocator`. Requested accuracy maps to 1, 10, 100,
+1,000, or 5,000 meters, and the provider applies both `minimumInterval` and
+`minimumDistance` locally after configuring the native report interval. The
+first valid fix is always delivered.

--- a/docs/src/content/docs/location.mdx
+++ b/docs/src/content/docs/location.mdx
@@ -27,9 +27,8 @@ keep the camera in sync with location changes.
 | **`LocationPuck`**                       | Visual indicator that displays the user's current position and bearing on the map. |
 | **`LocationTrackingEffect`**             | Applies location changes to application or camera state.                           |
 
-Android and iOS provide default location and orientation providers. Web, Linux,
-macOS, and Windows provide default location providers but no default orientation
-readings.
+Android and iOS provide default location and orientation providers. Web and
+desktop provide default location providers but no default orientation readings.
 `LocationState.status` reports unsupported or misconfigured
 location setup without throwing.
 
@@ -195,24 +194,6 @@ that Apple requires.
 
 #### Windows desktop
 
-The backend uses Windows Runtime geolocation. Unpackaged Win32 applications,
-including applications installed from an MSI, need no capability manifest. A
-packaged application must declare the location device capability, as described
-in Microsoft's
-[desktop geolocation guidance](https://learn.microsoft.com/en-us/windows/apps/develop/maps-and-location/get-location):
-
-```xml title="Package.appxmanifest"
-<Capabilities>
-  <DeviceCapability Name="location" />
-</Capabilities>
-```
-
-The provider observes location access through `AppCapability`, including access
-changes made in Windows Settings. Requesting access starts the Windows prompt on
-the AWT event-dispatch thread. Other Windows Runtime work runs on a dedicated
-multithreaded-apartment thread.
-
-Each collector owns a `Geolocator`. Requested accuracy maps to 1, 10, 100,
-1,000, or 5,000 meters, and the provider applies both `minimumInterval` and
-`minimumDistance` locally after configuring the native report interval. The
-first valid fix is always delivered.
+The backend uses Windows Runtime geolocation and observes location access
+changes from Windows Settings. It applies both `minimumInterval` and
+`minimumDistance` to location updates.

--- a/lib/location-runtime-windows/MODULE.md
+++ b/lib/location-runtime-windows/MODULE.md
@@ -1,3 +1,5 @@
 # Module location-runtime-windows
 
-Windows location backend for MapLibre Compose desktop applications.
+Provides the Windows Runtime location backend for MapLibre Compose desktop
+applications. The backend uses `AppCapability` for permission and `Geolocator`
+for independent foreground update sessions.

--- a/lib/location-runtime-windows/build.gradle.kts
+++ b/lib/location-runtime-windows/build.gradle.kts
@@ -22,7 +22,12 @@ kotlin {
 dependencies {
   api(project(":lib:location"))
 
+  implementation(libs.kotlinx.coroutines.core)
+
   testImplementation(kotlin("test"))
+  testImplementation(libs.kotlinx.coroutines.test)
 }
+
+tasks.test { jvmArgs(NATIVE_ACCESS_JVM_ARGS) }
 
 tasks.register("jvmTest") { dependsOn(tasks.test) }

--- a/lib/location-runtime-windows/src/main/kotlin/org/maplibre/compose/location/desktop/windows/SystemWindowsLocationClient.kt
+++ b/lib/location-runtime-windows/src/main/kotlin/org/maplibre/compose/location/desktop/windows/SystemWindowsLocationClient.kt
@@ -3,6 +3,7 @@ package org.maplibre.compose.location.desktop.windows
 import java.awt.EventQueue
 import java.lang.foreign.Arena
 import java.lang.foreign.FunctionDescriptor
+import java.lang.foreign.MemoryLayout.structLayout
 import java.lang.foreign.MemorySegment
 import java.lang.foreign.ValueLayout.ADDRESS
 import java.lang.foreign.ValueLayout.JAVA_INT
@@ -443,13 +444,19 @@ private fun addEventHandler(
   }
 
 private fun removeEventHandler(instance: MemorySegment, slot: Int, token: Long) {
-  WinRt.callHresult(
-    instance,
-    slot,
-    FunctionDescriptor.of(JAVA_INT, ADDRESS, JAVA_LONG),
-    token,
-  )
+  Arena.ofConfined().use { arena ->
+    val nativeToken = arena.allocate(EVENT_REGISTRATION_TOKEN)
+    nativeToken.set(JAVA_LONG, 0, token)
+    WinRt.callHresult(
+      instance,
+      slot,
+      FunctionDescriptor.of(JAVA_INT, ADDRESS, EVENT_REGISTRATION_TOKEN),
+      nativeToken,
+    )
+  }
 }
+
+private val EVENT_REGISTRATION_TOKEN = structLayout(JAVA_LONG)
 
 private const val APP_CAPABILITY_CLASS =
   "Windows.Security.Authorization.AppCapabilityAccess.AppCapability"

--- a/lib/location-runtime-windows/src/main/kotlin/org/maplibre/compose/location/desktop/windows/SystemWindowsLocationClient.kt
+++ b/lib/location-runtime-windows/src/main/kotlin/org/maplibre/compose/location/desktop/windows/SystemWindowsLocationClient.kt
@@ -1,0 +1,501 @@
+package org.maplibre.compose.location.desktop.windows
+
+import java.awt.EventQueue
+import java.lang.foreign.Arena
+import java.lang.foreign.FunctionDescriptor
+import java.lang.foreign.MemorySegment
+import java.lang.foreign.ValueLayout.ADDRESS
+import java.lang.foreign.ValueLayout.JAVA_INT
+import java.lang.foreign.ValueLayout.JAVA_LONG
+import java.util.concurrent.Callable
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.RejectedExecutionException
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.concurrent.thread
+import org.maplibre.compose.location.LocationBackendAvailability
+
+internal class SystemWindowsLocationClient : WindowsLocationClient {
+  private val closed = AtomicBoolean()
+  private val workerThread = arrayOfNulls<Thread>(1)
+  private val executor: ExecutorService = Executors.newSingleThreadExecutor { action ->
+    thread(start = false, isDaemon = true, name = "maplibre-compose-winrt-location") {
+        val ownsInitialization = WinRt.initialize(WinRt.RO_INIT_MULTITHREADED)
+        try {
+          action.run()
+        } finally {
+          if (ownsInitialization) WinRt.uninitialize()
+        }
+      }
+      .also { workerThread[0] = it }
+  }
+  private val sessions = ConcurrentHashMap.newKeySet<SystemWindowsLocationSession>()
+
+  override val backendAvailability: LocationBackendAvailability =
+    if (!isWindows(System.getProperty("os.name"))) {
+      LocationBackendAvailability.Unsupported
+    } else {
+      try {
+        blocking {
+          createAppCapability().close()
+          WinRt.activate(GEOLOCATOR_CLASS).use { inspectable ->
+            WinRt.queryInterface(inspectable.value, IID_GEOLOCATOR).close()
+          }
+        }
+        LocationBackendAvailability.Available
+      } catch (error: Throwable) {
+        LocationBackendAvailability.Misconfigured(error)
+      }
+    }
+
+  override fun checkAccess(): WindowsAccessStatus {
+    if (backendAvailability != LocationBackendAvailability.Available)
+      return WindowsAccessStatus.Unknown
+    return blocking(::checkAccessNative)
+  }
+
+  override fun observeAccess(onChanged: (WindowsAccessStatus) -> Unit): WindowsCloseable {
+    checkAvailable()
+    return blocking {
+      val capability = createAppCapability()
+      val callback =
+        WinRtEventCallback.create(IID_APP_CAPABILITY_ACCESS_CHANGED_HANDLER) { _, _ ->
+          executeSafely(onFailure = { onChanged(WindowsAccessStatus.Unknown) }) {
+            onChanged(checkAccessNative())
+          }
+        }
+      try {
+        val token = addEventHandler(capability.value, APP_CAPABILITY_ADD_ACCESS_CHANGED, callback)
+        val observationClosed = AtomicBoolean()
+        WindowsCloseable {
+          if (!observationClosed.compareAndSet(false, true)) return@WindowsCloseable
+          blocking {
+            try {
+              removeEventHandler(capability.value, APP_CAPABILITY_REMOVE_ACCESS_CHANGED, token)
+            } finally {
+              callback.close()
+              capability.close()
+            }
+          }
+        }
+      } catch (error: Throwable) {
+        callback.close()
+        capability.close()
+        throw error
+      }
+    }
+  }
+
+  override fun requestAccess(onCompleted: (WindowsAccessStatus) -> Unit) {
+    checkAvailable()
+    EventQueue.invokeLater {
+      try {
+        WinRt.inApartment(WinRt.RO_INIT_SINGLETHREADED) {
+          val operation = requestAccessOperation()
+          val completed = AtomicBoolean()
+          lateinit var callback: WinRtAsyncCallback
+          callback =
+            WinRtAsyncCallback.create(IID_GEOLOCATION_ACCESS_COMPLETED_HANDLER) { _, status ->
+              if (!completed.compareAndSet(false, true)) return@create
+              executeCompletion(
+                onFailure = {
+                  if (!closed.get()) onCompleted(WindowsAccessStatus.Unknown)
+                }
+              ) {
+                try {
+                  if (status == ASYNC_COMPLETED) {
+                    WinRt.intResult(operation.value, ASYNC_OPERATION_GET_RESULTS)
+                    if (!closed.get()) onCompleted(checkAccessNative())
+                  } else if (!closed.get()) {
+                    onCompleted(WindowsAccessStatus.Unknown)
+                  }
+                } finally {
+                  operation.close()
+                  callback.close()
+                }
+              }
+            }
+          try {
+            WinRt.callHresult(
+              operation.value,
+              ASYNC_OPERATION_PUT_COMPLETED,
+              FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS),
+              callback.segment,
+            )
+          } catch (error: Throwable) {
+            callback.close()
+            operation.close()
+            throw error
+          }
+        }
+      } catch (_: Throwable) {
+        onCompleted(WindowsAccessStatus.Unknown)
+      }
+    }
+  }
+
+  override fun createSession(
+    configuration: WindowsLocationConfiguration,
+    listener: WindowsLocationListener,
+  ): WindowsCloseable {
+    checkAvailable()
+    val session = blocking {
+      SystemWindowsLocationSession.create(this, configuration, listener).also { sessions += it }
+    }
+    return WindowsCloseable { session.close() }
+  }
+
+  @Synchronized
+  override fun close() {
+    if (closed.get()) return
+    sessions.toList().forEach { runCatching(it::close) }
+    closed.set(true)
+    executor.shutdown()
+  }
+
+  internal fun removeSession(session: SystemWindowsLocationSession) {
+    sessions.remove(session)
+  }
+
+  internal fun executeSafely(onFailure: (Throwable) -> Unit, action: () -> Unit): Boolean {
+    if (closed.get()) return false
+    return try {
+      executor.execute {
+        try {
+          action()
+        } catch (error: Throwable) {
+          onFailure(error)
+        }
+      }
+      true
+    } catch (_: RejectedExecutionException) {
+      false
+    }
+  }
+
+  private fun executeCompletion(onFailure: (Throwable) -> Unit, action: () -> Unit) {
+    val task = Runnable {
+      try {
+        action()
+      } catch (error: Throwable) {
+        onFailure(error)
+      }
+    }
+    try {
+      executor.execute(task)
+    } catch (_: RejectedExecutionException) {
+      thread(isDaemon = true, name = "maplibre-compose-winrt-location-cleanup") {
+        WinRt.inApartment { task.run() }
+      }
+    }
+  }
+
+  internal fun <T> blocking(action: () -> T): T {
+    check(!closed.get()) { "The Windows location client is closed" }
+    if (Thread.currentThread() === workerThread[0]) return action()
+    return executor.submit(Callable(action)).get()
+  }
+
+  private fun checkAccessNative(): WindowsAccessStatus =
+    createAppCapability().use { capability ->
+      when (WinRt.intResult(capability.value, APP_CAPABILITY_CHECK_ACCESS)) {
+        0 -> WindowsAccessStatus.DeniedBySystem
+        1 -> WindowsAccessStatus.NotDeclared
+        2 -> WindowsAccessStatus.DeniedByUser
+        3 -> WindowsAccessStatus.UserPromptRequired
+        4 -> WindowsAccessStatus.Allowed
+        else -> WindowsAccessStatus.Unknown
+      }
+    }
+
+  private fun createAppCapability(): ComPtr =
+    WinRt.activationFactory(APP_CAPABILITY_CLASS, IID_APP_CAPABILITY_STATICS).use { factory ->
+      WinRtHString.create("location").use { location ->
+        Arena.ofConfined().use { arena ->
+          val output = arena.allocate(ADDRESS)
+          WinRt.callHresult(
+            factory.value,
+            APP_CAPABILITY_CREATE,
+            FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS, ADDRESS),
+            location.segment(),
+            output,
+          )
+          ComPtr(output.get(ADDRESS, 0))
+        }
+      }
+    }
+
+  private fun requestAccessOperation(): ComPtr =
+    WinRt.activationFactory(GEOLOCATOR_CLASS, IID_GEOLOCATOR_STATICS).use { factory ->
+      WinRt.pointerResult(factory.value, GEOLOCATOR_REQUEST_ACCESS)
+    }
+
+  private fun checkAvailable() {
+    check(backendAvailability == LocationBackendAvailability.Available) {
+      "Windows Runtime geolocation is unavailable: $backendAvailability"
+    }
+  }
+}
+
+internal class SystemWindowsLocationSession
+private constructor(
+  private val client: SystemWindowsLocationClient,
+  private val geolocator: ComPtr,
+  private val positionCallback: WinRtEventCallback,
+  private val positionToken: Long,
+  private val statusCallback: WinRtEventCallback,
+  private val statusToken: Long,
+) : AutoCloseable {
+  private val closed = AtomicBoolean()
+
+  override fun close() {
+    if (!closed.compareAndSet(false, true)) return
+    client.blocking {
+      try {
+        removeEventHandler(geolocator.value, GEOLOCATOR_REMOVE_POSITION_CHANGED, positionToken)
+      } finally {
+        try {
+          removeEventHandler(geolocator.value, GEOLOCATOR_REMOVE_STATUS_CHANGED, statusToken)
+        } finally {
+          positionCallback.close()
+          statusCallback.close()
+          geolocator.close()
+          client.removeSession(this)
+        }
+      }
+    }
+  }
+
+  companion object {
+    fun create(
+      client: SystemWindowsLocationClient,
+      configuration: WindowsLocationConfiguration,
+      listener: WindowsLocationListener,
+    ): SystemWindowsLocationSession {
+      val inspectable = WinRt.activate(GEOLOCATOR_CLASS)
+      val geolocator =
+        try {
+          WinRt.queryInterface(inspectable.value, IID_GEOLOCATOR)
+        } finally {
+          inspectable.close()
+        }
+      var positionCallback: WinRtEventCallback? = null
+      var statusCallback: WinRtEventCallback? = null
+      var positionToken: Long? = null
+      var statusToken: Long? = null
+      try {
+        configureGeolocator(geolocator, configuration)
+        positionCallback =
+          WinRtEventCallback.create(IID_POSITION_CHANGED_HANDLER) { _, arguments ->
+            WinRt.addRef(arguments)
+            val ownedArguments = ComPtr(arguments)
+            if (
+              !client.executeSafely(listener::onFailure) {
+                ownedArguments.use { listener.onPosition(readPosition(it.value)) }
+              }
+            ) {
+              ownedArguments.close()
+            }
+          }
+        positionToken =
+          addEventHandler(geolocator.value, GEOLOCATOR_ADD_POSITION_CHANGED, positionCallback)
+        statusCallback =
+          WinRtEventCallback.create(IID_STATUS_CHANGED_HANDLER) { _, arguments ->
+            WinRt.addRef(arguments)
+            val ownedArguments = ComPtr(arguments)
+            if (
+              !client.executeSafely(listener::onFailure) {
+                ownedArguments.use { listener.onStatus(readStatus(it.value)) }
+              }
+            ) {
+              ownedArguments.close()
+            }
+          }
+        statusToken =
+          addEventHandler(geolocator.value, GEOLOCATOR_ADD_STATUS_CHANGED, statusCallback)
+        listener.onStatus(readPositionStatus(WinRt.intResult(geolocator.value, GEOLOCATOR_STATUS)))
+        return SystemWindowsLocationSession(
+          client,
+          geolocator,
+          positionCallback,
+          positionToken,
+          statusCallback,
+          statusToken,
+        )
+      } catch (error: Throwable) {
+        if (statusToken != null) {
+          runCatching {
+            removeEventHandler(geolocator.value, GEOLOCATOR_REMOVE_STATUS_CHANGED, statusToken)
+          }
+        }
+        if (positionToken != null) {
+          runCatching {
+            removeEventHandler(geolocator.value, GEOLOCATOR_REMOVE_POSITION_CHANGED, positionToken)
+          }
+        }
+        statusCallback?.close()
+        positionCallback?.close()
+        geolocator.close()
+        throw error
+      }
+    }
+  }
+}
+
+private fun configureGeolocator(
+  geolocator: ComPtr,
+  configuration: WindowsLocationConfiguration,
+) {
+  WinRt.activationFactory(PROPERTY_VALUE_CLASS, IID_PROPERTY_VALUE_STATICS).use { factory ->
+    Arena.ofConfined().use { arena ->
+      val boxedOutput = arena.allocate(ADDRESS)
+      WinRt.callHresult(
+        factory.value,
+        PROPERTY_VALUE_CREATE_UINT32,
+        FunctionDescriptor.of(JAVA_INT, ADDRESS, JAVA_INT, ADDRESS),
+        configuration.desiredAccuracyMeters,
+        boxedOutput,
+      )
+      ComPtr(boxedOutput.get(ADDRESS, 0)).use { boxed ->
+        WinRt.queryInterface(boxed.value, IID_REFERENCE_UINT32).use { reference ->
+          geolocator.queryInterface(IID_GEOLOCATOR_SCALAR_ACCURACY).use { scalarAccuracy ->
+            WinRt.callHresult(
+              scalarAccuracy.value,
+              GEOLOCATOR_SCALAR_PUT_ACCURACY,
+              FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS),
+              reference.value,
+            )
+          }
+        }
+      }
+    }
+  }
+  WinRt.callHresult(
+    geolocator.value,
+    GEOLOCATOR_PUT_REPORT_INTERVAL,
+    FunctionDescriptor.of(JAVA_INT, ADDRESS, JAVA_INT),
+    configuration.reportIntervalMilliseconds,
+  )
+}
+
+private fun readPosition(arguments: MemorySegment): WindowsLocationFix =
+  WinRt.queryInterface(arguments, IID_POSITION_CHANGED_ARGS).use { typedArguments ->
+    WinRt.pointerResult(typedArguments.value, POSITION_CHANGED_ARGS_POSITION).use { position ->
+      WinRt.queryInterface(position.value, IID_GEOPOSITION).use { typedPosition ->
+        WinRt.pointerResult(typedPosition.value, GEOPOSITION_COORDINATE).use { coordinate ->
+          WinRt.queryInterface(coordinate.value, IID_GEOCOORDINATE).use { typedCoordinate ->
+            WindowsLocationFix(
+              latitude = WinRt.doubleResult(typedCoordinate.value, GEOCOORDINATE_LATITUDE),
+              longitude = WinRt.doubleResult(typedCoordinate.value, GEOCOORDINATE_LONGITUDE),
+              altitudeMeters = readOptionalDouble(typedCoordinate.value, GEOCOORDINATE_ALTITUDE),
+              horizontalAccuracyMeters =
+                WinRt.doubleResult(typedCoordinate.value, GEOCOORDINATE_ACCURACY),
+              verticalAccuracyMeters =
+                readOptionalDouble(typedCoordinate.value, GEOCOORDINATE_ALTITUDE_ACCURACY),
+              headingDegrees = readOptionalDouble(typedCoordinate.value, GEOCOORDINATE_HEADING),
+              speedMetersPerSecond = readOptionalDouble(typedCoordinate.value, GEOCOORDINATE_SPEED),
+              windowsTimestampTicks =
+                WinRt.longResult(typedCoordinate.value, GEOCOORDINATE_TIMESTAMP),
+            )
+          }
+        }
+      }
+    }
+  }
+
+private fun readOptionalDouble(instance: MemorySegment, slot: Int): Double? =
+  WinRt.nullablePointerResult(instance, slot)?.use { reference ->
+    WinRt.doubleResult(reference.value, REFERENCE_VALUE)
+  }
+
+private fun readStatus(arguments: MemorySegment): WindowsPositionStatus =
+  WinRt.queryInterface(arguments, IID_STATUS_CHANGED_ARGS).use { typedArguments ->
+    readPositionStatus(WinRt.intResult(typedArguments.value, STATUS_CHANGED_ARGS_STATUS))
+  }
+
+private fun readPositionStatus(status: Int): WindowsPositionStatus =
+  when (status) {
+    0 -> WindowsPositionStatus.Ready
+    1 -> WindowsPositionStatus.Initializing
+    2 -> WindowsPositionStatus.NoData
+    3 -> WindowsPositionStatus.Disabled
+    4 -> WindowsPositionStatus.NotInitialized
+    5 -> WindowsPositionStatus.NotAvailable
+    else -> WindowsPositionStatus.Unknown
+  }
+
+private fun addEventHandler(
+  instance: MemorySegment,
+  slot: Int,
+  callback: WinRtEventCallback,
+): Long =
+  Arena.ofConfined().use { arena ->
+    val token = arena.allocate(JAVA_LONG)
+    WinRt.callHresult(
+      instance,
+      slot,
+      FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS, ADDRESS),
+      callback.segment,
+      token,
+    )
+    token.get(JAVA_LONG, 0)
+  }
+
+private fun removeEventHandler(instance: MemorySegment, slot: Int, token: Long) {
+  WinRt.callHresult(
+    instance,
+    slot,
+    FunctionDescriptor.of(JAVA_INT, ADDRESS, JAVA_LONG),
+    token,
+  )
+}
+
+private const val APP_CAPABILITY_CLASS =
+  "Windows.Security.Authorization.AppCapabilityAccess.AppCapability"
+private const val GEOLOCATOR_CLASS = "Windows.Devices.Geolocation.Geolocator"
+private const val PROPERTY_VALUE_CLASS = "Windows.Foundation.PropertyValue"
+
+private const val IID_APP_CAPABILITY_STATICS = "7c353e2a-46ee-44e5-af3d-6ad3fc49bd22"
+private const val IID_GEOLOCATOR = "a9c3bf62-4524-4989-8aa9-de019d2e551f"
+private const val IID_GEOLOCATOR_STATICS = "9a8e7571-2df5-4591-9f87-eb5fd894e9b7"
+private const val IID_GEOLOCATOR_SCALAR_ACCURACY = "96f5d3c1-b80f-460a-994d-a96c47a51aa4"
+private const val IID_PROPERTY_VALUE_STATICS = "629bdbc8-d932-4ff4-96b9-8d96c5c1e858"
+private const val IID_REFERENCE_UINT32 = "513ef3af-e784-5325-a91e-97c2b8111cf3"
+private const val IID_POSITION_CHANGED_ARGS = "37859ce5-9d1e-46c5-bf3b-6ad8cac1a093"
+private const val IID_STATUS_CHANGED_ARGS = "3453d2da-8c93-4111-a205-9aecfc9be5c0"
+private const val IID_GEOPOSITION = "c18d0454-7d41-4ff7-a957-9dffb4ef7f5b"
+private const val IID_GEOCOORDINATE = "ee21a3aa-976a-4c70-803d-083ea55bcbc4"
+private const val IID_APP_CAPABILITY_ACCESS_CHANGED_HANDLER = "6d923c95-7b83-5f59-8883-f44175284898"
+private const val IID_POSITION_CHANGED_HANDLER = "df3c6164-4e7b-5e8e-9a7e-13da059dec1e"
+private const val IID_STATUS_CHANGED_HANDLER = "97fcf582-de6b-5cd3-9690-e2ecbb66da4d"
+private const val IID_GEOLOCATION_ACCESS_COMPLETED_HANDLER = "f3524c93-e5c7-5b88-bedb-d3e637cff271"
+
+private const val APP_CAPABILITY_CREATE = 8
+private const val APP_CAPABILITY_CHECK_ACCESS = 9
+private const val APP_CAPABILITY_ADD_ACCESS_CHANGED = 10
+private const val APP_CAPABILITY_REMOVE_ACCESS_CHANGED = 11
+private const val GEOLOCATOR_REQUEST_ACCESS = 6
+private const val ASYNC_OPERATION_PUT_COMPLETED = 6
+private const val ASYNC_OPERATION_GET_RESULTS = 8
+private const val ASYNC_COMPLETED = 1
+private const val PROPERTY_VALUE_CREATE_UINT32 = 11
+private const val GEOLOCATOR_SCALAR_PUT_ACCURACY = 7
+private const val GEOLOCATOR_PUT_REPORT_INTERVAL = 11
+private const val GEOLOCATOR_STATUS = 12
+private const val GEOLOCATOR_ADD_POSITION_CHANGED = 15
+private const val GEOLOCATOR_REMOVE_POSITION_CHANGED = 16
+private const val GEOLOCATOR_ADD_STATUS_CHANGED = 17
+private const val GEOLOCATOR_REMOVE_STATUS_CHANGED = 18
+private const val POSITION_CHANGED_ARGS_POSITION = 6
+private const val STATUS_CHANGED_ARGS_STATUS = 6
+private const val GEOPOSITION_COORDINATE = 6
+private const val GEOCOORDINATE_LATITUDE = 6
+private const val GEOCOORDINATE_LONGITUDE = 7
+private const val GEOCOORDINATE_ALTITUDE = 8
+private const val GEOCOORDINATE_ACCURACY = 9
+private const val GEOCOORDINATE_ALTITUDE_ACCURACY = 10
+private const val GEOCOORDINATE_HEADING = 11
+private const val GEOCOORDINATE_SPEED = 12
+private const val GEOCOORDINATE_TIMESTAMP = 13
+private const val REFERENCE_VALUE = 6

--- a/lib/location-runtime-windows/src/main/kotlin/org/maplibre/compose/location/desktop/windows/WinRtSupport.kt
+++ b/lib/location-runtime-windows/src/main/kotlin/org/maplibre/compose/location/desktop/windows/WinRtSupport.kt
@@ -1,0 +1,489 @@
+package org.maplibre.compose.location.desktop.windows
+
+import java.lang.foreign.Arena
+import java.lang.foreign.FunctionDescriptor
+import java.lang.foreign.Linker
+import java.lang.foreign.MemorySegment
+import java.lang.foreign.SymbolLookup
+import java.lang.foreign.ValueLayout.ADDRESS
+import java.lang.foreign.ValueLayout.JAVA_BYTE
+import java.lang.foreign.ValueLayout.JAVA_CHAR
+import java.lang.foreign.ValueLayout.JAVA_DOUBLE
+import java.lang.foreign.ValueLayout.JAVA_INT
+import java.lang.foreign.ValueLayout.JAVA_LONG
+import java.lang.invoke.MethodHandles
+import java.lang.invoke.MethodType
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+
+internal class WinRtException(message: String, val hresult: Int) :
+  IllegalStateException("$message (HRESULT 0x${hresult.toUInt().toString(16).padStart(8, '0')})")
+
+internal class ComPtr(private var segment: MemorySegment) : AutoCloseable {
+  private val closed = AtomicBoolean()
+
+  val value: MemorySegment
+    get() {
+      check(!closed.get()) { "COM pointer is closed" }
+      return segment
+    }
+
+  fun queryInterface(iid: String): ComPtr =
+    Arena.ofConfined().use { arena ->
+      val output = arena.allocate(ADDRESS)
+      WinRt.callHresult(
+        value,
+        0,
+        FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS, ADDRESS),
+        WinRt.guid(iid, arena),
+        output,
+      )
+      ComPtr(output.get(ADDRESS, 0))
+    }
+
+  override fun close() {
+    if (!closed.compareAndSet(false, true)) return
+    WinRt.call(
+      segment,
+      2,
+      FunctionDescriptor.of(JAVA_INT, ADDRESS),
+    )
+    segment = MemorySegment.NULL
+  }
+}
+
+internal class WinRtHString private constructor(private val value: MemorySegment) : AutoCloseable {
+  fun segment(): MemorySegment = value
+
+  override fun close() {
+    WinRt.windowsDeleteString.invokeWithArguments(value)
+  }
+
+  companion object {
+    fun create(text: String): WinRtHString =
+      Arena.ofConfined().use { arena ->
+        val characters = arena.allocate(JAVA_CHAR, text.length.toLong())
+        text.forEachIndexed { index, character ->
+          characters.setAtIndex(JAVA_CHAR, index.toLong(), character)
+        }
+        val output = arena.allocate(ADDRESS)
+        WinRt.checkHresult(
+          WinRt.windowsCreateString.invokeWithArguments(characters, text.length, output) as Int,
+          "WindowsCreateString failed",
+        )
+        WinRtHString(output.get(ADDRESS, 0))
+      }
+  }
+}
+
+internal object WinRt {
+  const val RO_INIT_SINGLETHREADED = 0
+  const val RO_INIT_MULTITHREADED = 1
+  private const val RPC_E_CHANGED_MODE = -2_147_417_850
+
+  private val linker = Linker.nativeLinker()
+  private val lookup: SymbolLookup by lazy {
+    System.loadLibrary("combase")
+    SymbolLookup.loaderLookup()
+  }
+
+  private fun native(name: String, descriptor: FunctionDescriptor) =
+    linker.downcallHandle(
+      lookup.find(name).orElseThrow { UnsatisfiedLinkError("combase.dll does not export $name") },
+      descriptor,
+    )
+
+  private val roInitialize by lazy {
+    native("RoInitialize", FunctionDescriptor.of(JAVA_INT, JAVA_INT))
+  }
+  private val roUninitialize by lazy {
+    native("RoUninitialize", FunctionDescriptor.ofVoid())
+  }
+  private val roActivateInstance by lazy {
+    native("RoActivateInstance", FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS))
+  }
+  private val roGetActivationFactory by lazy {
+    native(
+      "RoGetActivationFactory",
+      FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS, ADDRESS),
+    )
+  }
+  val windowsCreateString by lazy {
+    native(
+      "WindowsCreateString",
+      FunctionDescriptor.of(JAVA_INT, ADDRESS, JAVA_INT, ADDRESS),
+    )
+  }
+  val windowsDeleteString by lazy {
+    native("WindowsDeleteString", FunctionDescriptor.of(JAVA_INT, ADDRESS))
+  }
+
+  fun initialize(mode: Int): Boolean {
+    val result = roInitialize.invokeWithArguments(mode) as Int
+    if (result == RPC_E_CHANGED_MODE) return false
+    checkHresult(result, "RoInitialize failed")
+    return true
+  }
+
+  fun uninitialize() {
+    roUninitialize.invokeWithArguments()
+  }
+
+  inline fun <T> inApartment(mode: Int = RO_INIT_MULTITHREADED, block: () -> T): T {
+    val ownsInitialization = initialize(mode)
+    try {
+      return block()
+    } finally {
+      if (ownsInitialization) uninitialize()
+    }
+  }
+
+  fun activate(runtimeClass: String): ComPtr =
+    WinRtHString.create(runtimeClass).use { className ->
+      Arena.ofConfined().use { arena ->
+        val output = arena.allocate(ADDRESS)
+        checkHresult(
+          roActivateInstance.invokeWithArguments(className.segment(), output) as Int,
+          "RoActivateInstance($runtimeClass) failed",
+        )
+        ComPtr(output.get(ADDRESS, 0))
+      }
+    }
+
+  fun activationFactory(runtimeClass: String, iid: String): ComPtr =
+    WinRtHString.create(runtimeClass).use { className ->
+      Arena.ofConfined().use { arena ->
+        val output = arena.allocate(ADDRESS)
+        checkHresult(
+          roGetActivationFactory.invokeWithArguments(
+            className.segment(),
+            guid(iid, arena),
+            output,
+          ) as Int,
+          "RoGetActivationFactory($runtimeClass) failed",
+        )
+        ComPtr(output.get(ADDRESS, 0))
+      }
+    }
+
+  fun queryInterface(instance: MemorySegment, iid: String): ComPtr =
+    Arena.ofConfined().use { arena ->
+      val output = arena.allocate(ADDRESS)
+      callHresult(
+        instance,
+        0,
+        FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS, ADDRESS),
+        guid(iid, arena),
+        output,
+      )
+      ComPtr(output.get(ADDRESS, 0))
+    }
+
+  fun addRef(instance: MemorySegment) {
+    call(instance, 1, FunctionDescriptor.of(JAVA_INT, ADDRESS))
+  }
+
+  fun call(
+    instance: MemorySegment,
+    slot: Int,
+    descriptor: FunctionDescriptor,
+    vararg arguments: Any,
+  ): Any? {
+    val vtable = instance.reinterpret(ADDRESS.byteSize()).get(ADDRESS, 0)
+    val function =
+      vtable
+        .reinterpret((slot + 1L) * ADDRESS.byteSize())
+        .get(ADDRESS, slot.toLong() * ADDRESS.byteSize())
+    val handle = linker.downcallHandle(function, descriptor)
+    return handle.invokeWithArguments(listOf(instance) + arguments)
+  }
+
+  fun callHresult(
+    instance: MemorySegment,
+    slot: Int,
+    descriptor: FunctionDescriptor,
+    vararg arguments: Any,
+  ) {
+    checkHresult(call(instance, slot, descriptor, *arguments) as Int, "COM method $slot failed")
+  }
+
+  fun intResult(instance: MemorySegment, slot: Int): Int =
+    Arena.ofConfined().use { arena ->
+      val output = arena.allocate(JAVA_INT)
+      callHresult(
+        instance,
+        slot,
+        FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS),
+        output,
+      )
+      output.get(JAVA_INT, 0)
+    }
+
+  fun longResult(instance: MemorySegment, slot: Int): Long =
+    Arena.ofConfined().use { arena ->
+      val output = arena.allocate(JAVA_LONG)
+      callHresult(
+        instance,
+        slot,
+        FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS),
+        output,
+      )
+      output.get(JAVA_LONG, 0)
+    }
+
+  fun doubleResult(instance: MemorySegment, slot: Int): Double =
+    Arena.ofConfined().use { arena ->
+      val output = arena.allocate(JAVA_DOUBLE)
+      callHresult(
+        instance,
+        slot,
+        FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS),
+        output,
+      )
+      output.get(JAVA_DOUBLE, 0)
+    }
+
+  fun pointerResult(instance: MemorySegment, slot: Int): ComPtr =
+    Arena.ofConfined().use { arena ->
+      val output = arena.allocate(ADDRESS)
+      callHresult(
+        instance,
+        slot,
+        FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS),
+        output,
+      )
+      ComPtr(output.get(ADDRESS, 0))
+    }
+
+  fun nullablePointerResult(instance: MemorySegment, slot: Int): ComPtr? =
+    Arena.ofConfined().use { arena ->
+      val output = arena.allocate(ADDRESS)
+      callHresult(
+        instance,
+        slot,
+        FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS),
+        output,
+      )
+      output.get(ADDRESS, 0).takeUnless { it == MemorySegment.NULL }?.let(::ComPtr)
+    }
+
+  fun guid(text: String, arena: Arena): MemorySegment {
+    val canonical = text.replace("-", "")
+    require(canonical.length == 32) { "Invalid GUID: $text" }
+    val bytes =
+      ByteArray(16) { index -> canonical.substring(index * 2, index * 2 + 2).toInt(16).toByte() }
+    val windowsOrder =
+      byteArrayOf(
+        bytes[3],
+        bytes[2],
+        bytes[1],
+        bytes[0],
+        bytes[5],
+        bytes[4],
+        bytes[7],
+        bytes[6],
+        bytes[8],
+        bytes[9],
+        bytes[10],
+        bytes[11],
+        bytes[12],
+        bytes[13],
+        bytes[14],
+        bytes[15],
+      )
+    val result = arena.allocate(16)
+    windowsOrder.forEachIndexed { index, byte ->
+      result.setAtIndex(JAVA_BYTE, index.toLong(), byte)
+    }
+    return result
+  }
+
+  fun guidEquals(segment: MemorySegment, text: String): Boolean =
+    Arena.ofConfined().use { arena ->
+      val expected = guid(text, arena)
+      val actual = segment.reinterpret(16)
+      (0L until 16L).all { actual.getAtIndex(JAVA_BYTE, it) == expected.getAtIndex(JAVA_BYTE, it) }
+    }
+
+  fun checkHresult(result: Int, message: String) {
+    if (result < 0) throw WinRtException(message, result)
+  }
+}
+
+internal class WinRtEventCallback
+private constructor(
+  private val arena: Arena,
+  val segment: MemorySegment,
+) : AutoCloseable {
+  private val closed = AtomicBoolean()
+
+  override fun close() {
+    if (!closed.compareAndSet(false, true)) return
+    WinRtCallbacks.remove(segment.address())
+    arena.close()
+  }
+
+  companion object {
+    fun create(iid: String, invoke: (MemorySegment, MemorySegment) -> Unit): WinRtEventCallback {
+      val arena = Arena.ofShared()
+      val segment = arena.allocate(ADDRESS)
+      segment.set(ADDRESS, 0, WinRtCallbacks.eventVtable)
+      val callback = WinRtEventCallback(arena, segment)
+      WinRtCallbacks.put(
+        segment.address(),
+        WinRtCallbacks.Callback(iid, invoke = invoke),
+      )
+      return callback
+    }
+  }
+}
+
+internal class WinRtAsyncCallback
+private constructor(
+  private val arena: Arena,
+  val segment: MemorySegment,
+) : AutoCloseable {
+  private val closed = AtomicBoolean()
+
+  override fun close() {
+    if (!closed.compareAndSet(false, true)) return
+    WinRtCallbacks.remove(segment.address())
+    arena.close()
+  }
+
+  companion object {
+    fun create(iid: String, invoke: (MemorySegment, Int) -> Unit): WinRtAsyncCallback {
+      val arena = Arena.ofShared()
+      val segment = arena.allocate(ADDRESS)
+      segment.set(ADDRESS, 0, WinRtCallbacks.asyncVtable)
+      val callback = WinRtAsyncCallback(arena, segment)
+      WinRtCallbacks.put(
+        segment.address(),
+        WinRtCallbacks.Callback(iid, asyncInvoke = invoke),
+      )
+      return callback
+    }
+  }
+}
+
+private object WinRtCallbacks {
+  data class Callback(
+    val iid: String,
+    val references: AtomicInteger = AtomicInteger(1),
+    val invoke: ((MemorySegment, MemorySegment) -> Unit)? = null,
+    val asyncInvoke: ((MemorySegment, Int) -> Unit)? = null,
+  )
+
+  private const val S_OK = 0
+  private const val E_NOINTERFACE = -2_147_467_262
+  private const val E_FAIL = -2_147_467_259
+  private const val IID_IUNKNOWN = "00000000-0000-0000-c000-000000000046"
+  private const val IID_IAGILE_OBJECT = "94ea2b94-e9cc-49e0-c0ff-ee64ca8f5b90"
+  private val callbacks = ConcurrentHashMap<Long, Callback>()
+  private val linker = Linker.nativeLinker()
+  private val stubs = Arena.global()
+  private val lookup = MethodHandles.lookup()
+
+  val eventVtable: MemorySegment by lazy {
+    vtable(event = true)
+  }
+  val asyncVtable: MemorySegment by lazy {
+    vtable(event = false)
+  }
+
+  fun put(address: Long, callback: Callback) {
+    callbacks[address] = callback
+  }
+
+  fun remove(address: Long) {
+    callbacks.remove(address)
+  }
+
+  private fun vtable(event: Boolean): MemorySegment {
+    val table = stubs.allocate(ADDRESS, 4)
+    table.setAtIndex(ADDRESS, 0, stub("queryInterface", QUERY_INTERFACE))
+    table.setAtIndex(ADDRESS, 1, stub("addRef", ADD_REF))
+    table.setAtIndex(ADDRESS, 2, stub("release", ADD_REF))
+    table.setAtIndex(
+      ADDRESS,
+      3,
+      if (event) stub("invokeEvent", INVOKE_EVENT) else stub("invokeAsync", INVOKE_ASYNC),
+    )
+    return table
+  }
+
+  private fun stub(name: String, descriptor: FunctionDescriptor): MemorySegment {
+    val parameterTypes =
+      descriptor.argumentLayouts().map {
+        when (it) {
+          JAVA_INT -> Int::class.javaPrimitiveType
+          else -> MemorySegment::class.java
+        }
+      }
+    val returnType =
+      when (descriptor.returnLayout().orElse(null)) {
+        JAVA_INT -> Int::class.javaPrimitiveType
+        else -> Void.TYPE
+      }
+    val handle =
+      lookup.findStatic(javaClass, name, MethodType.methodType(returnType, parameterTypes))
+    return linker.upcallStub(handle, descriptor, stubs)
+  }
+
+  @JvmStatic
+  private fun queryInterface(
+    self: MemorySegment,
+    iid: MemorySegment,
+    output: MemorySegment,
+  ): Int {
+    val callback = callbacks[self.address()] ?: return E_NOINTERFACE
+    return if (
+      WinRt.guidEquals(iid, IID_IUNKNOWN) ||
+        WinRt.guidEquals(iid, IID_IAGILE_OBJECT) ||
+        WinRt.guidEquals(iid, callback.iid)
+    ) {
+      callback.references.incrementAndGet()
+      output.reinterpret(ADDRESS.byteSize()).set(ADDRESS, 0, self)
+      S_OK
+    } else {
+      output.reinterpret(ADDRESS.byteSize()).set(ADDRESS, 0, MemorySegment.NULL)
+      E_NOINTERFACE
+    }
+  }
+
+  @JvmStatic
+  private fun addRef(self: MemorySegment): Int =
+    callbacks[self.address()]?.references?.incrementAndGet() ?: 0
+
+  @JvmStatic
+  private fun release(self: MemorySegment): Int =
+    callbacks[self.address()]?.references?.decrementAndGet()?.coerceAtLeast(0) ?: 0
+
+  @JvmStatic
+  private fun invokeEvent(
+    self: MemorySegment,
+    sender: MemorySegment,
+    arguments: MemorySegment,
+  ): Int =
+    try {
+      callbacks[self.address()]?.invoke?.invoke(sender, arguments) ?: return E_FAIL
+      S_OK
+    } catch (_: Throwable) {
+      E_FAIL
+    }
+
+  @JvmStatic
+  private fun invokeAsync(self: MemorySegment, operation: MemorySegment, status: Int): Int =
+    try {
+      callbacks[self.address()]?.asyncInvoke?.invoke(operation, status) ?: return E_FAIL
+      S_OK
+    } catch (_: Throwable) {
+      E_FAIL
+    }
+
+  private val QUERY_INTERFACE = FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS, ADDRESS)
+  private val ADD_REF = FunctionDescriptor.of(JAVA_INT, ADDRESS)
+  private val INVOKE_EVENT = FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS, ADDRESS)
+  private val INVOKE_ASYNC = FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS, JAVA_INT)
+}

--- a/lib/location-runtime-windows/src/main/kotlin/org/maplibre/compose/location/desktop/windows/WindowsLocation.kt
+++ b/lib/location-runtime-windows/src/main/kotlin/org/maplibre/compose/location/desktop/windows/WindowsLocation.kt
@@ -1,0 +1,186 @@
+package org.maplibre.compose.location.desktop.windows
+
+import kotlin.math.PI
+import kotlin.math.asin
+import kotlin.math.cos
+import kotlin.math.sin
+import kotlin.math.sqrt
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.TimeSource
+import org.maplibre.compose.location.BearingWithAccuracy
+import org.maplibre.compose.location.Location
+import org.maplibre.compose.location.LocationAccuracy
+import org.maplibre.compose.location.LocationAccuracyAuthorization
+import org.maplibre.compose.location.LocationPermission
+import org.maplibre.compose.location.LocationUnavailableReason
+import org.maplibre.compose.location.PositionWithAccuracy
+import org.maplibre.compose.location.SpeedWithAccuracy
+import org.maplibre.spatialk.geojson.Position
+import org.maplibre.spatialk.units.Bearing
+import org.maplibre.spatialk.units.extensions.degrees
+import org.maplibre.spatialk.units.extensions.meters
+
+internal enum class WindowsAccessStatus {
+  DeniedBySystem,
+  NotDeclared,
+  DeniedByUser,
+  UserPromptRequired,
+  Allowed,
+  Unknown,
+}
+
+internal enum class WindowsPositionStatus {
+  Ready,
+  Initializing,
+  NoData,
+  Disabled,
+  NotInitialized,
+  NotAvailable,
+  Unknown,
+}
+
+internal data class WindowsLocationFix(
+  val latitude: Double,
+  val longitude: Double,
+  val altitudeMeters: Double?,
+  val horizontalAccuracyMeters: Double,
+  val verticalAccuracyMeters: Double?,
+  val headingDegrees: Double?,
+  val speedMetersPerSecond: Double?,
+  val windowsTimestampTicks: Long,
+)
+
+internal data class WindowsLocationConfiguration(
+  val desiredAccuracyMeters: Int,
+  val reportIntervalMilliseconds: Int,
+)
+
+internal fun LocationAccuracy.toDesiredAccuracyMeters(): Int =
+  when (this) {
+    LocationAccuracy.BestForNavigation -> 1
+    LocationAccuracy.High -> 10
+    LocationAccuracy.Balanced -> 100
+    LocationAccuracy.Low -> 1_000
+    LocationAccuracy.Lowest -> 5_000
+  }
+
+internal fun Duration.toReportIntervalMilliseconds(): Int =
+  if (this == Duration.ZERO) {
+    0
+  } else {
+    inWholeMilliseconds.coerceAtLeast(1).coerceAtMost(UInt.MAX_VALUE.toLong()).toInt()
+  }
+
+internal fun WindowsAccessStatus.asLocationPermission(): LocationPermission =
+  when (this) {
+    WindowsAccessStatus.Allowed -> LocationPermission.Granted(LocationAccuracyAuthorization.Unknown)
+    WindowsAccessStatus.UserPromptRequired -> LocationPermission.NotGranted(canRequest = true)
+    WindowsAccessStatus.DeniedBySystem,
+    WindowsAccessStatus.NotDeclared,
+    WindowsAccessStatus.DeniedByUser -> LocationPermission.NotGranted(canRequest = false)
+    WindowsAccessStatus.Unknown -> LocationPermission.NotGranted(canRequest = null)
+  }
+
+internal fun WindowsPositionStatus.asUnavailableReason(
+  permission: LocationPermission
+): LocationUnavailableReason? =
+  when (this) {
+    WindowsPositionStatus.Ready -> null
+    WindowsPositionStatus.Initializing,
+    WindowsPositionStatus.NoData,
+    WindowsPositionStatus.NotInitialized -> LocationUnavailableReason.TemporarilyUnavailable
+    WindowsPositionStatus.Disabled ->
+      if (permission is LocationPermission.Granted) {
+        LocationUnavailableReason.ServicesDisabled
+      } else {
+        LocationUnavailableReason.PermissionDenied
+      }
+    WindowsPositionStatus.NotAvailable -> LocationUnavailableReason.Unsupported
+    WindowsPositionStatus.Unknown -> LocationUnavailableReason.UnexpectedFailure
+  }
+
+internal fun WindowsLocationFix.asMapLibreLocation(
+  currentTimeMillis: Long = System.currentTimeMillis()
+): Location? {
+  if (!latitude.isFinite() || latitude !in -90.0..90.0) return null
+  if (!longitude.isFinite() || longitude !in -180.0..180.0) return null
+  if (!horizontalAccuracyMeters.isFinite() || horizontalAccuracyMeters < 0.0) return null
+  if (windowsTimestampTicks < WINDOWS_EPOCH_TICKS) return null
+
+  val altitude = altitudeMeters?.takeIf(Double::isFinite)
+  val verticalAccuracy = verticalAccuracyMeters?.takeIf { it.isFinite() && it >= 0.0 }?.meters
+  val heading =
+    headingDegrees
+      ?.takeIf { it.isFinite() && it >= 0.0 }
+      ?.let { BearingWithAccuracy(Bearing.North + it.degrees, accuracy = null) }
+  val speed =
+    speedMetersPerSecond
+      ?.takeIf { it.isFinite() && it >= 0.0 }
+      ?.let { SpeedWithAccuracy(it.meters, accuracy = null) }
+  val capturedAtMillis = (windowsTimestampTicks - WINDOWS_EPOCH_TICKS) / TICKS_PER_MILLISECOND
+  val age =
+    if (capturedAtMillis >= currentTimeMillis) {
+      Duration.ZERO
+    } else {
+      (currentTimeMillis - capturedAtMillis).milliseconds
+    }
+
+  return Location(
+    position =
+      PositionWithAccuracy(
+        Position(longitude = longitude, latitude = latitude, altitude = altitude),
+        horizontalAccuracyMeters.meters,
+      ),
+    altitudeAccuracy = verticalAccuracy,
+    speed = speed,
+    course = heading,
+    timestamp = TimeSource.Monotonic.markNow() - age,
+  )
+}
+
+internal class WindowsLocationFilter(
+  private val minimumInterval: Duration,
+  private val minimumDistanceMeters: Double,
+) {
+  private var previousFix: WindowsLocationFix? = null
+  private var previousTimestampTicks: Long = 0
+
+  fun shouldDeliver(fix: WindowsLocationFix): Boolean {
+    val previous = previousFix
+    if (previous == null) {
+      remember(fix)
+      return true
+    }
+    val elapsed =
+      ((fix.windowsTimestampTicks - previousTimestampTicks).coerceAtLeast(0) /
+          TICKS_PER_MILLISECOND)
+        .milliseconds
+    if (elapsed < minimumInterval) return false
+    if (haversineMeters(previous, fix) < minimumDistanceMeters) return false
+    remember(fix)
+    return true
+  }
+
+  private fun remember(fix: WindowsLocationFix) {
+    previousFix = fix
+    previousTimestampTicks = fix.windowsTimestampTicks
+  }
+}
+
+private fun haversineMeters(first: WindowsLocationFix, second: WindowsLocationFix): Double {
+  val firstLatitude = first.latitude.toRadians()
+  val secondLatitude = second.latitude.toRadians()
+  val latitudeDelta = secondLatitude - firstLatitude
+  val longitudeDelta = (second.longitude - first.longitude).toRadians()
+  val a =
+    sin(latitudeDelta / 2).let { it * it } +
+      cos(firstLatitude) * cos(secondLatitude) * sin(longitudeDelta / 2).let { it * it }
+  return 2 * EARTH_RADIUS_METERS * asin(sqrt(a.coerceIn(0.0, 1.0)))
+}
+
+private fun Double.toRadians(): Double = this * PI / 180.0
+
+internal const val WINDOWS_EPOCH_TICKS: Long = 116_444_736_000_000_000L
+internal const val TICKS_PER_MILLISECOND: Long = 10_000L
+private const val EARTH_RADIUS_METERS: Double = 6_371_008.8

--- a/lib/location-runtime-windows/src/main/kotlin/org/maplibre/compose/location/desktop/windows/WindowsLocationBackend.kt
+++ b/lib/location-runtime-windows/src/main/kotlin/org/maplibre/compose/location/desktop/windows/WindowsLocationBackend.kt
@@ -1,23 +1,229 @@
 package org.maplibre.compose.location.desktop.windows
 
+import java.util.Locale
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.callbackFlow
 import org.maplibre.compose.location.DesktopLocationBackend
 import org.maplibre.compose.location.DesktopLocationProvider
+import org.maplibre.compose.location.LocationAccuracy
+import org.maplibre.compose.location.LocationAccuracyAuthorization
+import org.maplibre.compose.location.LocationBackendAvailability
+import org.maplibre.compose.location.LocationEvent
+import org.maplibre.compose.location.LocationPermission
+import org.maplibre.compose.location.LocationProvider
+import org.maplibre.compose.location.LocationRequest
+import org.maplibre.compose.location.LocationUnavailableReason
 import org.maplibre.compose.location.XdgPortalWindow
+import org.maplibre.spatialk.units.extensions.inMeters
 
-/** Scaffold for the Windows desktop location backend. */
+/** Windows desktop location backend backed by Windows Runtime geolocation. */
 public class WindowsLocationBackend : DesktopLocationBackend {
   override val id: String = "windows-geolocation"
 
-  // TODO: Implement permission with AppCapability.Create("location").CheckAccess() and
-  // Geolocator.RequestAccessAsync(). Implement location with Geolocator PositionChanged and
-  // StatusChanged, map request preferences to Geolocator settings and local filtering, and map
-  // Geoposition fields and timestamps to the common API.
-  //
-  // Implement orientation with Windows.Devices.Sensors.Compass.GetDefault(), ReportInterval, and
-  // ReadingChanged. Prefer HeadingTrueNorth when present, otherwise HeadingMagneticNorth; reject
-  // Unreliable readings and map the timestamp to the common API.
-  override fun isAvailable(): Boolean = false
+  override fun isAvailable(): Boolean = isWindows(System.getProperty("os.name"))
 
   override fun createProvider(window: XdgPortalWindow?): DesktopLocationProvider =
-    error("The Windows location backend is not implemented")
+    WindowsLocationProvider()
 }
+
+/**
+ * A [LocationProvider] backed by `Windows.Devices.Geolocation.Geolocator`.
+ *
+ * Each [updates] collector owns an independent `Geolocator`. The provider configures its scalar
+ * desired accuracy to 1, 10, 100, 1,000, or 5,000 meters from [LocationAccuracy.BestForNavigation]
+ * through [LocationAccuracy.Lowest], configures `ReportInterval`, and also enforces
+ * [LocationRequest.minimumInterval] and [LocationRequest.minimumDistance] before delivery. The
+ * first valid fix is always delivered. Cancelling collection removes both native event handlers and
+ * releases the geolocator.
+ *
+ * `Initializing`, `NoData`, and `NotInitialized` report
+ * [LocationUnavailableReason.TemporarilyUnavailable]. `Disabled` reports
+ * [LocationUnavailableReason.PermissionDenied] when access is denied and
+ * [LocationUnavailableReason.ServicesDisabled] when access remains granted. `NotAvailable` reports
+ * [LocationUnavailableReason.Unsupported]. Unexpected native failures report
+ * [LocationUnavailableReason.UnexpectedFailure].
+ *
+ * Ordinary Windows Runtime calls run in a dedicated multithreaded apartment. Permission requests
+ * start on the AWT event-dispatch thread because Windows requires a foreground UI-thread request.
+ * Unpackaged Win32 and MSI applications need no capability manifest. Packaged applications must
+ * declare the `location` `DeviceCapability` described in Microsoft's
+ * [desktop geolocation guidance](https://learn.microsoft.com/en-us/windows/apps/develop/maps-and-location/get-location).
+ */
+public class WindowsLocationProvider
+internal constructor(private val client: WindowsLocationClient) : DesktopLocationProvider {
+  public constructor() : this(SystemWindowsLocationClient())
+
+  private val requester = WindowsLocationPermissionRequester(client, ownsClient = false)
+  private val sessions = ConcurrentHashMap.newKeySet<WindowsCloseable>()
+  private val closed = AtomicBoolean()
+
+  override val backendAvailability: LocationBackendAvailability = client.backendAvailability
+
+  override val permission: StateFlow<LocationPermission>
+    get() = requester.status
+
+  override fun requestPermission(): Unit = requester.requestForegroundPermission()
+
+  override fun updates(request: LocationRequest): Flow<LocationEvent> = callbackFlow {
+    when (val availability = backendAvailability) {
+      is LocationBackendAvailability.Misconfigured -> {
+        trySend(
+          LocationEvent.Unavailable(LocationUnavailableReason.Misconfigured, availability.cause)
+        )
+        close()
+        return@callbackFlow
+      }
+      LocationBackendAvailability.Unsupported -> {
+        trySend(LocationEvent.Unavailable(LocationUnavailableReason.Unsupported))
+        close()
+        return@callbackFlow
+      }
+      LocationBackendAvailability.Available -> Unit
+    }
+    if (closed.get()) {
+      trySend(
+        LocationEvent.Unavailable(
+          LocationUnavailableReason.UnexpectedFailure,
+          IllegalStateException("The Windows location provider is closed"),
+        )
+      )
+      close()
+      return@callbackFlow
+    }
+
+    val filter = WindowsLocationFilter(request.minimumInterval, request.minimumDistance.inMeters)
+    val listener =
+      object : WindowsLocationListener {
+        override fun onPosition(fix: WindowsLocationFix) {
+          val location = fix.asMapLibreLocation() ?: return
+          synchronized(filter) {
+            if (filter.shouldDeliver(fix)) trySend(LocationEvent.Fix(location))
+          }
+        }
+
+        override fun onStatus(status: WindowsPositionStatus) {
+          status.asUnavailableReason(permission.value)?.let {
+            trySend(LocationEvent.Unavailable(it))
+          }
+        }
+
+        override fun onFailure(error: Throwable) {
+          trySend(LocationEvent.Unavailable(LocationUnavailableReason.UnexpectedFailure, error))
+        }
+      }
+    val session =
+      try {
+        client.createSession(
+          WindowsLocationConfiguration(
+            desiredAccuracyMeters = request.accuracy.toDesiredAccuracyMeters(),
+            reportIntervalMilliseconds = request.minimumInterval.toReportIntervalMilliseconds(),
+          ),
+          listener,
+        )
+      } catch (error: Throwable) {
+        trySend(LocationEvent.Unavailable(LocationUnavailableReason.UnexpectedFailure, error))
+        close()
+        return@callbackFlow
+      }
+    sessions += session
+    awaitClose {
+      if (sessions.remove(session)) session.close()
+    }
+  }
+
+  override fun close() {
+    if (!closed.compareAndSet(false, true)) return
+    sessions.toList().forEach {
+      if (sessions.remove(it)) runCatching(it::close)
+    }
+    runCatching(requester::close)
+    runCatching(client::close)
+  }
+}
+
+/**
+ * Foreground Windows location permission holder.
+ *
+ * [WindowsLocationProvider] delegates [LocationProvider.permission] and
+ * [LocationProvider.requestPermission] to this class. Custom providers can use it directly.
+ * `AppCapability.Create("location").CheckAccess()` maps `Allowed` to [LocationPermission.Granted]
+ * with [LocationAccuracyAuthorization.Unknown], `UserPromptRequired` to a requestable
+ * [LocationPermission.NotGranted], user or system denial and a missing packaged capability to a
+ * non-requestable value, and unknown failures to `canRequest = null`. `AccessChanged` keeps
+ * [status] synchronized with changes made in Windows Settings.
+ *
+ * [requestForegroundPermission] suppresses duplicate requests and starts
+ * `Geolocator.RequestAccessAsync()` on the AWT event-dispatch thread.
+ */
+public class WindowsLocationPermissionRequester
+internal constructor(
+  private val client: WindowsLocationClient,
+  private val ownsClient: Boolean = true,
+) : AutoCloseable {
+  public constructor() : this(SystemWindowsLocationClient())
+
+  /** Whether the process has a usable Windows Runtime location implementation. */
+  public val backendAvailability: LocationBackendAvailability = client.backendAvailability
+  private val mutableStatus =
+    MutableStateFlow<LocationPermission>(LocationPermission.NotGranted(canRequest = null))
+
+  /** Current Windows location access, including changes made outside the application. */
+  public val status: StateFlow<LocationPermission> = mutableStatus
+  private val requestPending = AtomicBoolean()
+  private val closed = AtomicBoolean()
+  private var accessObservation: WindowsCloseable? = null
+
+  init {
+    if (backendAvailability == LocationBackendAvailability.Available) {
+      mutableStatus.value = readAccess()
+      accessObservation =
+        try {
+          client.observeAccess { mutableStatus.value = it.asLocationPermission() }
+        } catch (_: Throwable) {
+          mutableStatus.value = LocationPermission.NotGranted(canRequest = null)
+          null
+        }
+    }
+  }
+
+  /** Starts a foreground permission request and publishes its result to [status]. */
+  public fun requestForegroundPermission() {
+    if (closed.get() || backendAvailability != LocationBackendAvailability.Available) return
+    if (status.value != LocationPermission.NotGranted(canRequest = true)) return
+    if (!requestPending.compareAndSet(false, true)) return
+    try {
+      client.requestAccess {
+        mutableStatus.value = it.asLocationPermission()
+        requestPending.set(false)
+      }
+    } catch (_: Throwable) {
+      mutableStatus.value = LocationPermission.NotGranted(canRequest = null)
+      requestPending.set(false)
+    }
+  }
+
+  override fun close() {
+    if (!closed.compareAndSet(false, true)) return
+    try {
+      accessObservation?.close()
+    } finally {
+      accessObservation = null
+      if (ownsClient) client.close()
+    }
+  }
+
+  private fun readAccess(): LocationPermission =
+    try {
+      client.checkAccess().asLocationPermission()
+    } catch (_: Throwable) {
+      LocationPermission.NotGranted(canRequest = null)
+    }
+}
+
+internal fun isWindows(osName: String?): Boolean =
+  osName?.lowercase(Locale.ROOT)?.startsWith("windows") == true

--- a/lib/location-runtime-windows/src/main/kotlin/org/maplibre/compose/location/desktop/windows/WindowsLocationBackend.kt
+++ b/lib/location-runtime-windows/src/main/kotlin/org/maplibre/compose/location/desktop/windows/WindowsLocationBackend.kt
@@ -50,9 +50,6 @@ public class WindowsLocationBackend : DesktopLocationBackend {
  *
  * Ordinary Windows Runtime calls run in a dedicated multithreaded apartment. Permission requests
  * start on the AWT event-dispatch thread because Windows requires a foreground UI-thread request.
- * Unpackaged Win32 and MSI applications need no capability manifest. Packaged applications must
- * declare the `location` `DeviceCapability` described in Microsoft's
- * [desktop geolocation guidance](https://learn.microsoft.com/en-us/windows/apps/develop/maps-and-location/get-location).
  */
 public class WindowsLocationProvider
 internal constructor(private val client: WindowsLocationClient) : DesktopLocationProvider {

--- a/lib/location-runtime-windows/src/main/kotlin/org/maplibre/compose/location/desktop/windows/WindowsLocationClient.kt
+++ b/lib/location-runtime-windows/src/main/kotlin/org/maplibre/compose/location/desktop/windows/WindowsLocationClient.kt
@@ -1,0 +1,30 @@
+package org.maplibre.compose.location.desktop.windows
+
+import org.maplibre.compose.location.LocationBackendAvailability
+
+internal fun interface WindowsCloseable : AutoCloseable {
+  override fun close()
+}
+
+internal interface WindowsLocationListener {
+  fun onPosition(fix: WindowsLocationFix)
+
+  fun onStatus(status: WindowsPositionStatus)
+
+  fun onFailure(error: Throwable)
+}
+
+internal interface WindowsLocationClient : AutoCloseable {
+  val backendAvailability: LocationBackendAvailability
+
+  fun checkAccess(): WindowsAccessStatus
+
+  fun observeAccess(onChanged: (WindowsAccessStatus) -> Unit): WindowsCloseable
+
+  fun requestAccess(onCompleted: (WindowsAccessStatus) -> Unit)
+
+  fun createSession(
+    configuration: WindowsLocationConfiguration,
+    listener: WindowsLocationListener,
+  ): WindowsCloseable
+}

--- a/lib/location-runtime-windows/src/test/kotlin/org/maplibre/compose/location/desktop/windows/WindowsLocationProviderTest.kt
+++ b/lib/location-runtime-windows/src/test/kotlin/org/maplibre/compose/location/desktop/windows/WindowsLocationProviderTest.kt
@@ -1,0 +1,414 @@
+package org.maplibre.compose.location.desktop.windows
+
+import java.util.ServiceLoader
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import org.maplibre.compose.location.DesktopLocationBackend
+import org.maplibre.compose.location.LocationAccuracy
+import org.maplibre.compose.location.LocationAccuracyAuthorization
+import org.maplibre.compose.location.LocationBackendAvailability
+import org.maplibre.compose.location.LocationEvent
+import org.maplibre.compose.location.LocationPermission
+import org.maplibre.compose.location.LocationRequest
+import org.maplibre.compose.location.LocationUnavailableReason
+import org.maplibre.spatialk.units.Bearing
+import org.maplibre.spatialk.units.extensions.degrees
+import org.maplibre.spatialk.units.extensions.inMeters
+import org.maplibre.spatialk.units.extensions.meters
+
+class WindowsLocationProviderTest {
+  @Test
+  fun serviceLoaderFindsWindowsBackend() {
+    assertTrue(
+      ServiceLoader.load(DesktopLocationBackend::class.java).any { it is WindowsLocationBackend }
+    )
+  }
+
+  @Test
+  fun backendIsAvailableOnlyOnWindows() {
+    assertTrue(isWindows("Windows 11"))
+    assertTrue(isWindows("windows server 2025"))
+    assertFalse(isWindows("Linux"))
+    assertFalse(isWindows("Mac OS X"))
+    assertFalse(isWindows(null))
+    assertEquals(isWindows(System.getProperty("os.name")), WindowsLocationBackend().isAvailable())
+  }
+
+  @Test
+  fun mapsAppCapabilityAccess() {
+    assertEquals(
+      LocationPermission.Granted(LocationAccuracyAuthorization.Unknown),
+      WindowsAccessStatus.Allowed.asLocationPermission(),
+    )
+    assertEquals(
+      LocationPermission.NotGranted(canRequest = true),
+      WindowsAccessStatus.UserPromptRequired.asLocationPermission(),
+    )
+    listOf(
+        WindowsAccessStatus.DeniedBySystem,
+        WindowsAccessStatus.NotDeclared,
+        WindowsAccessStatus.DeniedByUser,
+      )
+      .forEach {
+        assertEquals(
+          LocationPermission.NotGranted(canRequest = false),
+          it.asLocationPermission(),
+        )
+      }
+    assertEquals(
+      LocationPermission.NotGranted(canRequest = null),
+      WindowsAccessStatus.Unknown.asLocationPermission(),
+    )
+  }
+
+  @Test
+  fun permissionRequesterSuppressesDuplicatesAndObservesExternalChanges() {
+    val client = FakeWindowsLocationClient()
+    val requester = WindowsLocationPermissionRequester(client)
+
+    requester.requestForegroundPermission()
+    requester.requestForegroundPermission()
+    assertEquals(1, client.accessRequests)
+
+    client.completeAccessRequest(WindowsAccessStatus.Allowed)
+    assertEquals(
+      LocationPermission.Granted(LocationAccuracyAuthorization.Unknown),
+      requester.status.value,
+    )
+    requester.requestForegroundPermission()
+    assertEquals(1, client.accessRequests)
+
+    client.changeAccess(WindowsAccessStatus.DeniedByUser)
+    assertEquals(LocationPermission.NotGranted(canRequest = false), requester.status.value)
+
+    requester.close()
+    requester.close()
+    assertEquals(1, client.observationCloses)
+    assertEquals(1, client.closeCount)
+  }
+
+  @Test
+  fun permissionReadFailureHasUnknownRequestability() {
+    val client = FakeWindowsLocationClient()
+    client.checkFailure = IllegalStateException("native failure")
+    val requester = WindowsLocationPermissionRequester(client)
+
+    assertEquals(LocationPermission.NotGranted(canRequest = null), requester.status.value)
+    requester.close()
+  }
+
+  @Test
+  fun mapsAccuracyAndReportInterval() {
+    assertEquals(1, LocationAccuracy.BestForNavigation.toDesiredAccuracyMeters())
+    assertEquals(10, LocationAccuracy.High.toDesiredAccuracyMeters())
+    assertEquals(100, LocationAccuracy.Balanced.toDesiredAccuracyMeters())
+    assertEquals(1_000, LocationAccuracy.Low.toDesiredAccuracyMeters())
+    assertEquals(5_000, LocationAccuracy.Lowest.toDesiredAccuracyMeters())
+    assertEquals(0, 0.milliseconds.toReportIntervalMilliseconds())
+    assertEquals(1, 1.milliseconds.toReportIntervalMilliseconds())
+    assertEquals(1_500, 1_500.milliseconds.toReportIntervalMilliseconds())
+  }
+
+  @Test
+  fun mapsPositionStatuses() {
+    val granted = LocationPermission.Granted(LocationAccuracyAuthorization.Unknown)
+    val denied = LocationPermission.NotGranted(canRequest = false)
+    assertNull(WindowsPositionStatus.Ready.asUnavailableReason(granted))
+    listOf(
+        WindowsPositionStatus.Initializing,
+        WindowsPositionStatus.NoData,
+        WindowsPositionStatus.NotInitialized,
+      )
+      .forEach {
+        assertEquals(
+          LocationUnavailableReason.TemporarilyUnavailable,
+          it.asUnavailableReason(granted),
+        )
+      }
+    assertEquals(
+      LocationUnavailableReason.ServicesDisabled,
+      WindowsPositionStatus.Disabled.asUnavailableReason(granted),
+    )
+    assertEquals(
+      LocationUnavailableReason.PermissionDenied,
+      WindowsPositionStatus.Disabled.asUnavailableReason(denied),
+    )
+    assertEquals(
+      LocationUnavailableReason.Unsupported,
+      WindowsPositionStatus.NotAvailable.asUnavailableReason(granted),
+    )
+    assertEquals(
+      LocationUnavailableReason.UnexpectedFailure,
+      WindowsPositionStatus.Unknown.asUnavailableReason(granted),
+    )
+  }
+
+  @Test
+  fun convertsWindowsFixAndTimestamp() {
+    val currentTimeMillis = 1_700_000_000_000
+    val fix =
+      sampleFix(
+        windowsTimestampTicks =
+          WINDOWS_EPOCH_TICKS + (currentTimeMillis - 2_000) * TICKS_PER_MILLISECOND
+      )
+    val location = checkNotNull(fix.asMapLibreLocation(currentTimeMillis))
+
+    assertEquals(52.0, location.position.value.latitude)
+    assertEquals(13.0, location.position.value.longitude)
+    assertEquals(40.0, location.position.value.altitude)
+    assertEquals(8.0, location.position.accuracy?.inMeters)
+    assertEquals(3.0, location.altitudeAccuracy?.inMeters)
+    assertEquals(4.0, location.speed?.distancePerSecond?.inMeters)
+    assertNull(location.speed?.accuracy)
+    assertEquals(Bearing.North + 90.degrees, location.course?.value)
+    assertNull(location.course?.accuracy)
+    assertTrue(location.timestamp.elapsedNow() >= 2.seconds)
+  }
+
+  @Test
+  fun rejectsMalformedRequiredValuesAndOmitsMalformedOptionalValues() {
+    assertNull(sampleFix(latitude = Double.NaN).asMapLibreLocation())
+    assertNull(sampleFix(latitude = 91.0).asMapLibreLocation())
+    assertNull(sampleFix(longitude = -181.0).asMapLibreLocation())
+    assertNull(sampleFix(horizontalAccuracyMeters = -1.0).asMapLibreLocation())
+    assertNull(sampleFix(windowsTimestampTicks = Long.MIN_VALUE).asMapLibreLocation())
+
+    val location =
+      checkNotNull(
+        sampleFix(
+            altitudeMeters = Double.NaN,
+            verticalAccuracyMeters = -1.0,
+            headingDegrees = Double.POSITIVE_INFINITY,
+            speedMetersPerSecond = -1.0,
+          )
+          .asMapLibreLocation()
+      )
+    assertNull(location.position.value.altitude)
+    assertNull(location.altitudeAccuracy)
+    assertNull(location.course)
+    assertNull(location.speed)
+  }
+
+  @Test
+  fun localFilterAlwaysDeliversFirstFixAndEnforcesBothThresholds() {
+    val filter = WindowsLocationFilter(1.seconds, minimumDistanceMeters = 100.0)
+    val first = sampleFix(windowsTimestampTicks = 0)
+
+    assertTrue(filter.shouldDeliver(first))
+    assertFalse(
+      filter.shouldDeliver(
+        first.copy(longitude = 1.0, windowsTimestampTicks = 500 * TICKS_PER_MILLISECOND)
+      )
+    )
+    assertFalse(
+      filter.shouldDeliver(
+        first.copy(longitude = 13.00001, windowsTimestampTicks = 2_000 * TICKS_PER_MILLISECOND)
+      )
+    )
+    assertTrue(
+      filter.shouldDeliver(
+        first.copy(longitude = 13.01, windowsTimestampTicks = 2_500 * TICKS_PER_MILLISECOND)
+      )
+    )
+  }
+
+  @Test
+  fun providerAppliesRequestAndForwardsFixesAndStatuses() = runTest {
+    val client = FakeWindowsLocationClient(access = WindowsAccessStatus.Allowed)
+    val provider = WindowsLocationProvider(client)
+    val events = mutableListOf<LocationEvent>()
+    val job =
+      backgroundScope.launch(Dispatchers.Unconfined) {
+        provider
+          .updates(
+            LocationRequest(
+              accuracy = LocationAccuracy.Low,
+              minimumInterval = 2.seconds,
+              minimumDistance = 20.meters,
+            )
+          )
+          .collect { events += it }
+      }
+    val session = client.sessions.single()
+    assertEquals(1_000, session.configuration.desiredAccuracyMeters)
+    assertEquals(2_000, session.configuration.reportIntervalMilliseconds)
+
+    session.listener.onPosition(sampleFix())
+    session.listener.onStatus(WindowsPositionStatus.NoData)
+    session.listener.onFailure(IllegalStateException("native failure"))
+
+    assertIs<LocationEvent.Fix>(events[0])
+    assertEquals(
+      LocationUnavailableReason.TemporarilyUnavailable,
+      assertIs<LocationEvent.Unavailable>(events[1]).reason,
+    )
+    assertEquals(
+      LocationUnavailableReason.UnexpectedFailure,
+      assertIs<LocationEvent.Unavailable>(events[2]).reason,
+    )
+    assertIs<IllegalStateException>(assertIs<LocationEvent.Unavailable>(events[2]).cause)
+
+    job.cancelAndJoin()
+    assertEquals(1, session.closeCount)
+    provider.close()
+    assertEquals(1, session.closeCount)
+    assertEquals(1, client.closeCount)
+  }
+
+  @Test
+  fun collectorsOwnIndependentSessionsAndProviderClosesEachExactlyOnce() = runTest {
+    val client = FakeWindowsLocationClient(access = WindowsAccessStatus.Allowed)
+    val provider = WindowsLocationProvider(client)
+    val first =
+      backgroundScope.launch(Dispatchers.Unconfined) {
+        provider.updates(LocationRequest()).collect {}
+      }
+    val second =
+      backgroundScope.launch(Dispatchers.Unconfined) {
+        provider.updates(LocationRequest()).collect {}
+      }
+
+    assertEquals(2, client.sessions.size)
+    assertTrue(client.sessions[0] !== client.sessions[1])
+    provider.close()
+    provider.close()
+    assertTrue(client.sessions.all { it.closeCount == 1 })
+    assertEquals(1, client.observationCloses)
+    assertEquals(1, client.closeCount)
+
+    first.cancelAndJoin()
+    second.cancelAndJoin()
+    assertTrue(client.sessions.all { it.closeCount == 1 })
+  }
+
+  @Test
+  fun misconfiguredBackendEmitsMisconfiguredWithoutOpeningSession() = runTest {
+    val cause = IllegalStateException("activation failed")
+    val client =
+      FakeWindowsLocationClient(
+        backendAvailability = LocationBackendAvailability.Misconfigured(cause)
+      )
+    val provider = WindowsLocationProvider(client)
+
+    val event = assertIs<LocationEvent.Unavailable>(provider.updates(LocationRequest()).first())
+    assertEquals(LocationUnavailableReason.Misconfigured, event.reason)
+    assertEquals(cause, event.cause)
+    assertTrue(client.sessions.isEmpty())
+  }
+
+  @Test
+  fun sessionCreationFailureIsUnexpected() = runTest {
+    val client = FakeWindowsLocationClient(access = WindowsAccessStatus.Allowed)
+    client.sessionFailure = IllegalStateException("native failure")
+    val provider = WindowsLocationProvider(client)
+
+    val event = assertIs<LocationEvent.Unavailable>(provider.updates(LocationRequest()).first())
+    assertEquals(LocationUnavailableReason.UnexpectedFailure, event.reason)
+    assertIs<IllegalStateException>(event.cause)
+  }
+}
+
+private class FakeWindowsLocationClient(
+  var access: WindowsAccessStatus = WindowsAccessStatus.UserPromptRequired,
+  override val backendAvailability: LocationBackendAvailability =
+    LocationBackendAvailability.Available,
+) : WindowsLocationClient {
+  val sessions = mutableListOf<FakeWindowsSession>()
+  var accessRequests = 0
+  var observationCloses = 0
+  var closeCount = 0
+  var checkFailure: Throwable? = null
+  var sessionFailure: Throwable? = null
+  private var accessObserver: ((WindowsAccessStatus) -> Unit)? = null
+  private var accessCompletion: ((WindowsAccessStatus) -> Unit)? = null
+
+  override fun checkAccess(): WindowsAccessStatus {
+    checkFailure?.let { throw it }
+    return access
+  }
+
+  override fun observeAccess(onChanged: (WindowsAccessStatus) -> Unit): WindowsCloseable {
+    accessObserver = onChanged
+    var closed = false
+    return WindowsCloseable {
+      if (!closed) {
+        closed = true
+        observationCloses++
+        accessObserver = null
+      }
+    }
+  }
+
+  override fun requestAccess(onCompleted: (WindowsAccessStatus) -> Unit) {
+    accessRequests++
+    accessCompletion = onCompleted
+  }
+
+  override fun createSession(
+    configuration: WindowsLocationConfiguration,
+    listener: WindowsLocationListener,
+  ): WindowsCloseable {
+    sessionFailure?.let { throw it }
+    val session = FakeWindowsSession(configuration, listener)
+    sessions += session
+    return WindowsCloseable(session::close)
+  }
+
+  override fun close() {
+    closeCount++
+  }
+
+  fun completeAccessRequest(result: WindowsAccessStatus) {
+    access = result
+    accessCompletion?.invoke(result)
+    accessCompletion = null
+  }
+
+  fun changeAccess(result: WindowsAccessStatus) {
+    access = result
+    accessObserver?.invoke(result)
+  }
+}
+
+private class FakeWindowsSession(
+  val configuration: WindowsLocationConfiguration,
+  val listener: WindowsLocationListener,
+) {
+  var closeCount = 0
+
+  fun close() {
+    closeCount++
+  }
+}
+
+private fun sampleFix(
+  latitude: Double = 52.0,
+  longitude: Double = 13.0,
+  altitudeMeters: Double? = 40.0,
+  horizontalAccuracyMeters: Double = 8.0,
+  verticalAccuracyMeters: Double? = 3.0,
+  headingDegrees: Double? = 90.0,
+  speedMetersPerSecond: Double? = 4.0,
+  windowsTimestampTicks: Long = WINDOWS_EPOCH_TICKS + 1_700_000_000_000 * TICKS_PER_MILLISECOND,
+): WindowsLocationFix =
+  WindowsLocationFix(
+    latitude,
+    longitude,
+    altitudeMeters,
+    horizontalAccuracyMeters,
+    verticalAccuracyMeters,
+    headingDegrees,
+    speedMetersPerSecond,
+    windowsTimestampTicks,
+  )

--- a/lib/location-runtime-windows/src/test/kotlin/org/maplibre/compose/location/desktop/windows/WindowsLocationWinRtSmokeTest.kt
+++ b/lib/location-runtime-windows/src/test/kotlin/org/maplibre/compose/location/desktop/windows/WindowsLocationWinRtSmokeTest.kt
@@ -1,0 +1,40 @@
+package org.maplibre.compose.location.desktop.windows
+
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import org.maplibre.compose.location.LocationBackendAvailability
+
+class WindowsLocationWinRtSmokeTest {
+  @Test
+  fun activatesAppCapabilityAndGeolocatorAndSubscribesWithoutPrompting() {
+    if (!isWindows(System.getProperty("os.name"))) return
+    val client = SystemWindowsLocationClient()
+    assertEquals(LocationBackendAvailability.Available, client.backendAvailability)
+
+    client.checkAccess()
+    val permissionObservation = client.observeAccess {}
+    val failure = AtomicReference<Throwable?>()
+    val session =
+      client.createSession(
+        WindowsLocationConfiguration(
+          desiredAccuracyMeters = 100,
+          reportIntervalMilliseconds = 1_000,
+        ),
+        object : WindowsLocationListener {
+          override fun onPosition(fix: WindowsLocationFix) = Unit
+
+          override fun onStatus(status: WindowsPositionStatus) = Unit
+
+          override fun onFailure(error: Throwable) {
+            failure.set(error)
+          }
+        },
+      )
+
+    session.close()
+    permissionObservation.close()
+    client.close()
+    failure.get()?.let { throw AssertionError("WinRT event callback failed", it) }
+  }
+}


### PR DESCRIPTION
resolves #996 

## Description

Implements the Windows location runtime with Java 25 FFM bindings for WinRT permission observation, access requests, independent Geolocator sessions, filtering, conversion, deterministic cleanup, tests, and documentation.

## Validation

`mise run test:desktop`, targeted Windows runtime tests, Dokka generation, pinned ktfmt, mdxlint, and `git diff --check` pass on Windows x64.

## AI assistance

OpenAI Codex (GPT-5) implemented the change in the Codex desktop harness.