### PR TITLE
Wait for touch momentum before checking settled camera in pitched flings

### DIFF
--- a/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MlnFfiMapInputTest.kt
+++ b/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MlnFfiMapInputTest.kt
@@ -816,6 +816,7 @@ class MlnFfiMapInputTest {
   ): Double {
     val before = camera.position.target.latitude
     onRoot().performTouchInput { swipe(center, center + Offset(0f, swipeY), durationMillis = 100) }
+    awaitReleasedTouchMomentum(camera)
     waitUntil(timeoutMillis = TIMEOUT) { !camera.isCameraMoving }
     return camera.position.target.latitude - before
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Wait for released touch momentum before waiting for camera motion to end in `verticalFlingLatitudeDelta`. Extends the previous flaky test fix to this test that was missed. See #1033 

## Validation

Verified with `mise run check` and Kotlin test compilation.

## AI assistance

Cursor Cloud Agent using Gemini 3.7 Flash.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8c61fd08-33bd-4176-bbb9-c4c55ae97b5b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8c61fd08-33bd-4176-bbb9-c4c55ae97b5b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

