### PR TITLE
Start the demo app camera over New York City

### DIFF
--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoAppState.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoAppState.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.camera.CameraState
 import org.maplibre.compose.camera.rememberCameraState
 import org.maplibre.compose.demoapp.benchmark.BenchmarkScenario
@@ -13,6 +14,11 @@ import org.maplibre.compose.demoapp.benchmark.BenchmarkUiState
 import org.maplibre.compose.demoapp.benchmark.allBenchmarkScenarios
 import org.maplibre.compose.style.StyleState
 import org.maplibre.compose.style.rememberStyleState
+import org.maplibre.spatialk.geojson.Position
+
+/** New York City at a metro-area zoom, so every demo's fly-in has somewhere to go. */
+private val StartPosition =
+  CameraPosition(target = Position(longitude = -74.006, latitude = 40.7128), zoom = 9.5)
 
 /** Whether the shell is showing the shared demo map or the isolated benchmark map. */
 enum class DemoShell {
@@ -37,7 +43,7 @@ class DemoAppState(
 
 @Composable
 fun rememberDemoAppState(): DemoAppState {
-  val cameraState = rememberCameraState()
+  val cameraState = rememberCameraState(firstPosition = StartPosition)
   val styleState = rememberStyleState()
   val settings = rememberDemoSettings()
   val frameRateState = remember { FrameRateState() }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

The shared demo map now starts over New York City at zoom 9.5 instead of the whole world, broad enough that the Manhattan demos still fly in.

## Validation

Compiled the desktop demo app and ran the shell hygiene checks; ran the desktop demo to confirm the start position.

## AI assistance

Claude Fable 5 via Cursor Cloud Agent.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-548b43cc-c5eb-4bff-b60f-427051a3547a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-548b43cc-c5eb-4bff-b60f-427051a3547a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

