### PR TITLE
Publish docs previews with Cloudflare Pages

### DIFF
--- a/.github/workflows/action-pins.yml
+++ b/.github/workflows/action-pins.yml
@@ -37,6 +37,7 @@ jobs:
         with:
           path: pins
       - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+      - uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
       - uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
       - uses: jakoch/install-vulkan-sdk-action@37effcfa045411f8bfbbda26df2fd1b3bf3436fa # v1.6.0
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,9 +280,6 @@ jobs:
     environment:
       name: cloudflare-pages
       url: ${{ steps.deploy-cloudflare.outputs.pages-deployment-alias-url }}
-    permissions:
-      contents: read
-      deployments: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -315,7 +312,6 @@ jobs:
             pages deploy build/cloudflare-pages
             --project-name=maplibre-compose
             --branch=${{ env.CLOUDFLARE_BRANCH }}
-          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
           packageManager: pnpm
           wranglerVersion: "4.125.0"
       - name: Report the Cloudflare Pages preview

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,6 +280,13 @@ jobs:
     environment:
       name: cloudflare-pages
       url: ${{ steps.deploy-cloudflare.outputs.pages-deployment-alias-url }}
+      deployment: >-
+        ${{
+          github.event_name == 'push'
+          || (github.event_name == 'pull_request'
+          && github.actor != 'dependabot[bot]'
+          && github.event.pull_request.head.repo.full_name == github.repository)
+        }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -298,6 +305,7 @@ jobs:
         if: >-
           github.event_name == 'push'
           || (github.event_name == 'pull_request'
+          && github.actor != 'dependabot[bot]'
           && github.event.pull_request.head.repo.full_name == github.repository)
         uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,6 +277,12 @@ jobs:
   docs:
     timeout-minutes: 30
     runs-on: ubuntu-24.04
+    environment:
+      name: cloudflare-pages
+      url: ${{ steps.deploy-cloudflare.outputs.pages-deployment-alias-url }}
+    permissions:
+      contents: read
+      deployments: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -290,6 +296,36 @@ jobs:
       - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: docs/dist
+      - name: Deploy the Cloudflare Pages preview
+        id: deploy-cloudflare
+        if: >-
+          github.event_name == 'push'
+          || (github.event_name == 'pull_request'
+          && github.event.pull_request.head.repo.full_name == github.repository)
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
+        env:
+          CLOUDFLARE_BRANCH: >-
+            ${{ github.event_name == 'pull_request'
+            && format('pr-{0}', github.event.number)
+            || 'main' }}
+        with:
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          command: >-
+            pages deploy build/cloudflare-pages
+            --project-name=maplibre-compose
+            --branch=${{ env.CLOUDFLARE_BRANCH }}
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+          packageManager: pnpm
+          wranglerVersion: "4.125.0"
+      - name: Report the Cloudflare Pages preview
+        if: steps.deploy-cloudflare.outcome == 'success'
+        env:
+          DEPLOYMENT_URL: ${{ steps.deploy-cloudflare.outputs.deployment-url }}
+          PREVIEW_URL: ${{ steps.deploy-cloudflare.outputs.pages-deployment-alias-url }}
+        run: |
+          url="${PREVIEW_URL:-$DEPLOYMENT_URL}"
+          echo "Cloudflare Pages: ${url}/maplibre-compose/" >> "$GITHUB_STEP_SUMMARY"
 
   # Branch protection requires this job. always() still runs it after a needed
   # job fails; GitHub otherwise skips it and treats that skip as a passing check.

--- a/docs/cloudflare-pages/_redirects
+++ b/docs/cloudflare-pages/_redirects
@@ -1,0 +1,1 @@
+/ /maplibre-compose/ 302

--- a/mise.toml
+++ b/mise.toml
@@ -201,6 +201,17 @@ mise run build:docs
 mise run build:js-app
 mkdir -p docs/dist/demo
 cp -a demo-app/common/build/dist/js/productionExecutable/. docs/dist/demo/
+mise run package:cloudflare-pages
+'''
+
+[tasks."package:cloudflare-pages"]
+description = "Package the complete site for Cloudflare Pages."
+run = '''
+test -d docs/dist
+rm -rf build/cloudflare-pages
+mkdir -p build/cloudflare-pages/maplibre-compose
+cp -a docs/dist/. build/cloudflare-pages/maplibre-compose/
+cp docs/cloudflare-pages/_redirects build/cloudflare-pages/_redirects
 '''
 
 [tasks."test:pages"]

--- a/mise.toml
+++ b/mise.toml
@@ -215,7 +215,7 @@ cp docs/cloudflare-pages/_redirects build/cloudflare-pages/_redirects
 '''
 
 [tasks."test:pages"]
-description = "Load the browser demo from the complete GitHub Pages build."
+description = "Load the browser demo from the packaged Cloudflare Pages site."
 depends = ["build:pages"]
 run = '''
 pages_test_dir="$(mktemp -d)"
@@ -230,7 +230,14 @@ cleanup() {
 }
 trap cleanup EXIT
 
-pnpm --dir docs exec astro preview --host 127.0.0.1 --port 4321 >"$pages_test_dir/preview.log" 2>&1 &
+grep --fixed-strings --line-regexp --quiet \
+  "/ /maplibre-compose/ 302" \
+  build/cloudflare-pages/_redirects
+
+python -m http.server 4321 \
+  --bind 127.0.0.1 \
+  --directory build/cloudflare-pages \
+  >"$pages_test_dir/preview.log" 2>&1 &
 pages_preview_pid=$!
 
 for _ in {1..30}; do


### PR DESCRIPTION
## Description

Publish the documentation site, API reference, and live demo to Cloudflare Pages for `main` and same-repository pull requests.

## Validation

Ran `mise run check` and `mise run test:pages`, verified the packaged site with Wrangler, and loaded the deployed documentation, API reference, and demo in Chromium.

## AI assistance

Codex desktop app with GPT-5.
