### PR TITLE
Skip draw passes whose extent does not match the canvas on web

### DIFF
--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsMapSurface.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsMapSurface.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.IntSize
 import co.touchlab.kermit.Logger
+import kotlin.math.abs
 import kotlin.math.roundToInt
 import org.jetbrains.skia.Rect
 import org.jetbrains.skia.SamplingMode
@@ -76,9 +77,12 @@ internal fun GlJsMapSurface(
     // transient measurement (max constraints for one frame) is corrected immediately after.
     // Acquiring a render target for that stale extent can exceed GL limits and kill the map, so
     // skip the frame and wait for recomposition to deliver the extent that matches this canvas.
+    // The layout size and the draw size can round a fractional device pixel ratio differently,
+    // so one physical pixel of disagreement is normal and draws rather than skips; a chronic
+    // one-pixel skip would otherwise blank the map until the next relayout.
     val staleExtent =
-      size.width.roundToInt() != extent.physicalWidth ||
-        size.height.roundToInt() != extent.physicalHeight
+      abs(size.width.roundToInt() - extent.physicalWidth) > 1 ||
+        abs(size.height.roundToInt() - extent.physicalHeight) > 1
     if (staleExtent) surface.requestFrame()
 
     var drew = false

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsMapSurface.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsMapSurface.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.IntSize
 import co.touchlab.kermit.Logger
+import kotlin.math.roundToInt
 import org.jetbrains.skia.Rect
 import org.jetbrains.skia.SamplingMode
 import org.maplibre.compose.map.MapExtent
@@ -71,8 +72,17 @@ internal fun GlJsMapSurface(
     // Load-bearing read: it is what makes requestFrame() reschedule this Canvas.
     frameRequest
 
+    // The draw pass can run with an extent captured before the latest layout pass, e.g. when a
+    // transient measurement (max constraints for one frame) is corrected immediately after.
+    // Acquiring a render target for that stale extent can exceed GL limits and kill the map, so
+    // skip the frame and wait for recomposition to deliver the extent that matches this canvas.
+    val staleExtent =
+      size.width.roundToInt() != extent.physicalWidth ||
+        size.height.roundToInt() != extent.physicalHeight
+    if (staleExtent) surface.requestFrame()
+
     var drew = false
-    if (!extent.isEmpty && !failed) {
+    if (!extent.isEmpty && !failed && !staleExtent) {
       try {
         val acquired = compositor.acquire(extent)
         renderer.render(acquired, extent)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Fixes a permanent map failure on the browser platform: a draw pass could run with an extent captured before the latest layout pass (for example a transient max-constraint measurement in a small iframe, observed as 32766x32766), the compositor allocated a WebGL render target beyond GL limits, the frame threw, and the `failed` latch never let the map draw again; `GlJsMapSurface` now skips a draw pass whose extent does not match the canvas size and requests a new frame instead.

## Validation

Reproduced the failure deterministically with a small iframe embedding the demo app, confirmed via instrumentation that the stale 32766x32766 extent was acquired before the corrected size arrived, and verified after the fix that the same embed renders and the skip fires exactly once; `mise run check` and the JS compilation pass.

## AI assistance

Written by Claude Fable 5 in Cursor Cloud Agents.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba43b33b-e068-4a5a-9e61-b4a2b2dcd02c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba43b33b-e068-4a5a-9e61-b4a2b2dcd02c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

