### PR TITLE
Embed inline demos

### DIFF
--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/snippetdemos/CameraSnippetDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/snippetdemos/CameraSnippetDemo.kt
@@ -1,0 +1,76 @@
+package org.maplibre.compose.snippetdemos
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.launch
+import org.maplibre.compose.camera.CameraPosition
+import org.maplibre.compose.camera.rememberCameraState
+import org.maplibre.compose.map.MaplibreMap
+import org.maplibre.compose.overlay.MapOverlay
+import org.maplibre.compose.overlay.include
+import org.maplibre.compose.style.BaseStyle
+import org.maplibre.spatialk.geojson.BoundingBox
+import org.maplibre.spatialk.geojson.Position
+
+/** Demonstrates the camera guide: animate to a position and fit a bounding box. */
+@Composable
+fun CameraSnippetDemo() {
+  val camera =
+    rememberCameraState(
+      firstPosition =
+        CameraPosition(target = Position(latitude = 45.521, longitude = -122.675), zoom = 10.0)
+    )
+  val scope = rememberCoroutineScope()
+
+  MaplibreMap(
+    baseStyle = BaseStyle.Uri("https://tiles.openfreemap.org/styles/liberty"),
+    cameraState = camera,
+    overlay =
+      MapOverlay {
+        include(MapOverlay.Default)
+        Row(
+          modifier = Modifier.align(Alignment.BottomCenter).padding(bottom = 8.dp),
+          horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+          Button(
+            onClick = {
+              scope.launch {
+                camera.animateTo(
+                  finalPosition =
+                    CameraPosition(
+                      target = Position(latitude = 47.607, longitude = -122.342),
+                      zoom = 11.0,
+                    ),
+                  duration = 3.seconds,
+                )
+              }
+            }
+          ) {
+            Text("Animate to Seattle")
+          }
+          Button(
+            onClick = {
+              scope.launch {
+                camera.animateTo(
+                  boundingBox =
+                    BoundingBox(west = -124.8, south = 45.0, east = -116.9, north = 49.0),
+                  duration = 3.seconds,
+                )
+              }
+            }
+          ) {
+            Text("Fit the Northwest")
+          }
+        }
+      },
+  )
+}

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/snippetdemos/ExpressionsSnippetDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/snippetdemos/ExpressionsSnippetDemo.kt
@@ -1,0 +1,81 @@
+package org.maplibre.compose.snippetdemos
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import org.maplibre.compose.camera.CameraPosition
+import org.maplibre.compose.camera.rememberCameraState
+import org.maplibre.compose.expressions.dsl.asNumber
+import org.maplibre.compose.expressions.dsl.condition
+import org.maplibre.compose.expressions.dsl.const
+import org.maplibre.compose.expressions.dsl.exponential
+import org.maplibre.compose.expressions.dsl.feature
+import org.maplibre.compose.expressions.dsl.gt
+import org.maplibre.compose.expressions.dsl.interpolate
+import org.maplibre.compose.expressions.dsl.switch
+import org.maplibre.compose.expressions.dsl.zoom
+import org.maplibre.compose.layers.CircleLayer
+import org.maplibre.compose.map.MaplibreMap
+import org.maplibre.compose.overlay.MapOverlay
+import org.maplibre.compose.overlay.include
+import org.maplibre.compose.sources.GeoJsonData
+import org.maplibre.compose.sources.rememberGeoJsonSource
+import org.maplibre.compose.style.BaseStyle
+import org.maplibre.spatialk.geojson.Position
+
+/**
+ * Demonstrates the expressions guide: zoom the map and watch the earthquake circles resize with the
+ * zoom interpolation, colored by magnitude.
+ */
+@Composable
+fun ExpressionsSnippetDemo() {
+  val camera =
+    rememberCameraState(
+      firstPosition =
+        CameraPosition(target = Position(latitude = 37.0, longitude = -150.0), zoom = 2.0)
+    )
+
+  MaplibreMap(
+    baseStyle = BaseStyle.Uri("https://tiles.openfreemap.org/styles/liberty"),
+    cameraState = camera,
+    overlay =
+      MapOverlay {
+        include(MapOverlay.Default)
+        Surface(
+          modifier = Modifier.align(Alignment.BottomCenter).padding(bottom = 8.dp),
+          shape = MaterialTheme.shapes.small,
+          tonalElevation = 2.dp,
+        ) {
+          Text(
+            "Zoom ${(cameraState.position.zoom * 10).toInt() / 10.0}:" +
+              " circles grow with zoom, red above magnitude 5",
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+          )
+        }
+      },
+  ) {
+    val earthquakes =
+      rememberGeoJsonSource(
+        GeoJsonData.Uri("https://maplibre.org/maplibre-gl-js/docs/assets/earthquakes.geojson")
+      )
+
+    CircleLayer(
+      id = "earthquakes",
+      source = earthquakes,
+      radius =
+        interpolate(type = exponential(2f), input = zoom(), 2 to const(3.dp), 10 to const(24.dp)),
+      color =
+        switch(
+          condition(test = feature["mag"].asNumber() gt const(5), output = const(Color.Red)),
+          fallback = const(Color(0xFFFFB300)),
+        ),
+      opacity = const(0.7f),
+    )
+  }
+}

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/snippetdemos/SnippetDemos.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/snippetdemos/SnippetDemos.kt
@@ -1,0 +1,24 @@
+package org.maplibre.compose.snippetdemos
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+
+/**
+ * Inline demos that the documentation site embeds next to code snippets. The browser entry point
+ * composes [SnippetDemoHost] instead of the demo app when the page URL carries a `snippet` query
+ * parameter, e.g. `/demo/?snippet=camera`.
+ *
+ * Each demo stays close to the size of the docsnippet region it demonstrates, and draws its
+ * controls as map overlay children rather than in a panel, because the embedded surface is small.
+ */
+val snippetDemos: Map<String, @Composable () -> Unit> =
+  mapOf("camera" to { CameraSnippetDemo() }, "expressions" to { ExpressionsSnippetDemo() })
+
+@Composable
+fun SnippetDemoHost(id: String) {
+  MaterialTheme {
+    val demo = snippetDemos[id]
+    if (demo != null) demo() else Text("Unknown snippet demo: $id")
+  }
+}

--- a/demo-app/common/src/jsMain/kotlin/org/maplibre/compose/demoapp/main.kt
+++ b/demo-app/common/src/jsMain/kotlin/org/maplibre/compose/demoapp/main.kt
@@ -3,17 +3,24 @@ package org.maplibre.compose.demoapp
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.window.ComposeViewport
 import kotlinx.browser.document
+import kotlinx.browser.window
 import org.jetbrains.skiko.wasm.onWasmReady
 import org.maplibre.compose.browser.MapLibre
+import org.maplibre.compose.snippetdemos.SnippetDemoHost
+import org.w3c.dom.url.URLSearchParams
 
 @OptIn(ExperimentalComposeUiApi::class)
 fun main() {
   // Reachable use so production DCE keeps @js-joda/timezone. See JsJodaTimeZone.kt.
   @Suppress("UNUSED_VARIABLE") val keepJsJodaTimeZone = jsJodaTz
+  // The documentation site embeds single demos next to code snippets.
+  val snippet = URLSearchParams(window.location.search).get("snippet")
   onWasmReady {
     // Must run before Compose builds its renderer, which creates the GPU context maps composite
     // into.
     MapLibre.configure()
-    ComposeViewport(document.body!!) { DemoApp() }
+    ComposeViewport(document.body!!) {
+      if (snippet != null) SnippetDemoHost(snippet) else DemoApp()
+    }
   }
 }

--- a/docs/src/components/SnippetDemo.astro
+++ b/docs/src/components/SnippetDemo.astro
@@ -1,0 +1,71 @@
+---
+/**
+ * Embeds an inline demo from the browser demo app next to a code snippet.
+ *
+ * Renders a framed placeholder with a button, and swaps in an iframe of
+ * `/demo/?snippet=<id>` when the reader clicks it. Loading on click keeps the
+ * demo app's bundle and tile requests off the initial page load.
+ */
+import { snippetDemoIds } from "../snippet-demos";
+
+interface Props {
+  id: (typeof snippetDemoIds)[number];
+}
+
+const { id } = Astro.props;
+
+if (!snippetDemoIds.includes(id)) {
+  throw new Error(`<SnippetDemo id="${id}"> is not a registered inline demo`);
+}
+
+const base = import.meta.env.BASE_URL.replace(/\/$/, "");
+const src = `${base}/demo/?snippet=${id}`;
+---
+
+<div class="snippet-demo not-content" data-src={src}>
+  <button>Run this example</button>
+</div>
+
+<script>
+for (const container of document.querySelectorAll<HTMLElement>(".snippet-demo")) {
+    const button = container.querySelector("button");
+    button?.addEventListener("click", () => {
+      const iframe = document.createElement("iframe");
+      iframe.src = container.dataset.src ?? "";
+      iframe.title = "Live example";
+      container.replaceChildren(iframe);
+    });
+  }
+</script>
+
+<style>
+.snippet-demo {
+  aspect-ratio: 16 / 9;
+  border: 1px solid var(--sl-color-gray-5);
+  border-radius: 0.5rem;
+  overflow: hidden;
+  display: grid;
+  place-items: center;
+  background-color: var(--sl-color-gray-7, var(--sl-color-gray-6));
+}
+
+.snippet-demo button {
+  font: inherit;
+  color: var(--sl-color-white);
+  background-color: var(--sl-color-gray-5);
+  border: 1px solid var(--sl-color-gray-4);
+  border-radius: 0.5rem;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+}
+
+.snippet-demo button:hover {
+  background-color: var(--sl-color-gray-4);
+}
+
+.snippet-demo iframe {
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+</style>

--- a/docs/src/components/SnippetDemo.astro
+++ b/docs/src/components/SnippetDemo.astro
@@ -33,6 +33,11 @@ for (const container of document.querySelectorAll<HTMLElement>(".snippet-demo"))
       const iframe = document.createElement("iframe");
       iframe.src = container.dataset.src ?? "";
       iframe.title = "Live example";
+      // Astro's scoped styles cannot match an element created after render,
+      // so size the iframe inline.
+      iframe.style.width = "100%";
+      iframe.style.height = "100%";
+      iframe.style.border = "0";
       container.replaceChildren(iframe);
     });
   }
@@ -61,11 +66,5 @@ for (const container of document.querySelectorAll<HTMLElement>(".snippet-demo"))
 
 .snippet-demo button:hover {
   background-color: var(--sl-color-gray-4);
-}
-
-.snippet-demo iframe {
-  width: 100%;
-  height: 100%;
-  border: 0;
 }
 </style>

--- a/docs/src/content/docs/camera.mdx
+++ b/docs/src/content/docs/camera.mdx
@@ -5,6 +5,7 @@ description: Set the initial position, animate the camera, fit bounds, and conve
 
 import { Code } from "@astrojs/starlight/components";
 import Api from "../../components/Api.astro";
+import SnippetDemo from "../../components/SnippetDemo.astro";
 import { region } from "../../snippets";
 
 import camera from "../../../../demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Camera.kt?raw";
@@ -35,6 +36,8 @@ map:
 
 <Api of="CameraState.jumpTo" /> fits the same bounding box without an
 animation.
+
+<SnippetDemo id="camera" />
 
 ## Read the visible area
 

--- a/docs/src/content/docs/expressions.mdx
+++ b/docs/src/content/docs/expressions.mdx
@@ -5,6 +5,7 @@ description: The expression DSL that computes layer properties from feature data
 
 import { Code } from "@astrojs/starlight/components";
 import Api from "../../components/Api.astro";
+import SnippetDemo from "../../components/SnippetDemo.astro";
 import { region } from "../../snippets";
 
 import expressions from "../../../../demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Expressions.kt?raw";
@@ -43,6 +44,8 @@ radius and a color computed from its own magnitude.
 a smooth value between stops:
 
 <Code code={region(expressions, "zoom")} lang="kotlin" title="App.kt" />
+
+<SnippetDemo id="expressions" />
 
 ## Filter features
 

--- a/docs/src/snippet-demos.ts
+++ b/docs/src/snippet-demos.ts
@@ -1,0 +1,7 @@
+/**
+ * The inline demos that the browser demo app serves, by `snippet` query
+ * parameter. Mirrors `snippetDemos` in
+ * `demo-app/common/src/commonMain/kotlin/org/maplibre/compose/snippetdemos/SnippetDemos.kt`;
+ * an id listed here but missing there renders an error in the embedded frame.
+ */
+export const snippetDemoIds = ["camera", "expressions"] as const;


### PR DESCRIPTION
todo: some odd bugs with embedding, figure out which bits of the docs should have a demo, perhaps expression tweakables from outside that affect the code snippet and the demo content?

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description



## Validation



## AI assistance

Written by Claude Fable 5 in Cursor Cloud Agents.

<a href="https://cursor.com/agents/bc-ba43b33b-e068-4a5a-9e61-b4a2b2dcd02c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Finline-demos-demo.mp4"><img src="https://cursor.com/artifacts/c/art-e3ea6900-9156-4431-a60b-72f0caf4dd3b" alt="inline-demos-demo.mp4" /></a>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba43b33b-e068-4a5a-9e61-b4a2b2dcd02c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba43b33b-e068-4a5a-9e61-b4a2b2dcd02c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

