### PR TITLE
Keep the non-Material 3 compass flat by default

### DIFF
--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/CompassButton.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/CompassButton.kt
@@ -193,10 +193,9 @@ public object CompassDefaults {
   /** Reads over both light and dark basemaps, in the absence of a theme to draw colors from. */
   public val ContainerColor: Color = Color.White.copy(alpha = 0.9f)
 
-  public val ShadowElevation: Dp = 1.dp
+  public val ShadowElevation: Dp = 0.dp
 
-  /** Matches the lift that Material's elevated button gives a hovered pointer. */
-  public val HoveredShadowElevation: Dp = 3.dp
+  public val HoveredShadowElevation: Dp = 0.dp
 
   /** Accessibility label for the needle. */
   @Composable public fun contentDescription(): String = stringResource(Res.string.compass)


### PR DESCRIPTION
Resolves #1077 

## Description

Set the Foundation compass shadow elevations to zero by default while preserving the explicit ElevatedButton elevations in the Material 3 wrapper.

## Validation

`mise run check` and `mise run test:android` passed locally.

## AI assistance

OpenAI Codex with GPT-5.
