### PR TITLE
Apply web overdraw inspector without a camera move

### DIFF
--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsMapSurface.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsMapSurface.kt
@@ -39,6 +39,11 @@ internal fun GlJsMapSurface(
       MapExtent.fromPhysical(physicalSize.width, physicalSize.height, density)
     }
   var frameRequest by remember { mutableLongStateOf(0L) }
+  var lastRenderOptions by remember { mutableStateOf(renderOptions) }
+  if (lastRenderOptions != renderOptions) {
+    lastRenderOptions = renderOptions
+    frameRequest += 1
+  }
   var failed by remember(renderer) { mutableStateOf(false) }
   val createCompositor = LocalGlJsCompositor.current
   val compositor = remember(renderer, createCompositor) { createCompositor(logger) }
@@ -64,7 +69,7 @@ internal fun GlJsMapSurface(
 
   // presentFrames is a key so that its flip to true redraws the frame the draw pass below
   // declined to blit.
-  LaunchedEffect(extent, renderer, failed, presentFrames, renderOptions) {
+  LaunchedEffect(extent, renderer, failed, presentFrames) {
     if (extent.isEmpty || failed) return@LaunchedEffect
     surface.requestFrame()
   }

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsMapSurface.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsMapSurface.kt
@@ -63,9 +63,7 @@ internal fun GlJsMapSurface(
   }
 
   // presentFrames is a key so that its flip to true redraws the frame the draw pass below
-  // declined to blit. `renderOptions` is the same for a debug-flag change: this
-  // composable would otherwise be skipped, and the draw that reads `frameRequest` never
-  // runs.
+  // declined to blit.
   LaunchedEffect(extent, renderer, failed, presentFrames, renderOptions) {
     if (extent.isEmpty || failed) return@LaunchedEffect
     surface.requestFrame()

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsMapSurface.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsMapSurface.kt
@@ -62,18 +62,17 @@ internal fun GlJsMapSurface(
   }
 
   // presentFrames is a key so that its flip to true redraws the frame the draw pass below
-  // declined to blit.
-  LaunchedEffect(extent, renderer, failed, presentFrames) {
+  // declined to blit. `repaintToken` is the same for a render-option change: this
+  // composable would otherwise be skipped, and the draw that reads `frameRequest` never
+  // runs.
+  LaunchedEffect(extent, renderer, failed, presentFrames, repaintToken) {
     if (extent.isEmpty || failed) return@LaunchedEffect
     surface.requestFrame()
   }
 
   Canvas(modifier = modifier.onSizeChanged { physicalSize = it }) {
-    // Load-bearing reads: `frameRequest` is what makes requestFrame() reschedule this
-    // Canvas, and `repaintToken` is what makes a render-option change do the same when
-    // the surface itself would otherwise be skipped.
+    // Load-bearing read: it is what makes requestFrame() reschedule this Canvas.
     frameRequest
-    repaintToken
 
     var drew = false
     if (!extent.isEmpty && !failed) {

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsMapSurface.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsMapSurface.kt
@@ -21,6 +21,7 @@ import co.touchlab.kermit.Logger
 import org.jetbrains.skia.Rect
 import org.jetbrains.skia.SamplingMode
 import org.maplibre.compose.map.MapExtent
+import org.maplibre.compose.map.RenderOptions
 
 /** Hosts [renderer] on a Compose drawing surface. Compose owns the frame loop. */
 @Composable
@@ -29,7 +30,7 @@ internal fun GlJsMapSurface(
   modifier: Modifier,
   logger: Logger?,
   presentFrames: Boolean,
-  repaintToken: Any? = null,
+  renderOptions: RenderOptions,
 ) {
   val density = LocalDensity.current.density.toDouble()
   var physicalSize by remember { mutableStateOf(IntSize.Zero) }
@@ -62,10 +63,10 @@ internal fun GlJsMapSurface(
   }
 
   // presentFrames is a key so that its flip to true redraws the frame the draw pass below
-  // declined to blit. `repaintToken` is the same for a render-option change: this
+  // declined to blit. `renderOptions` is the same for a debug-flag change: this
   // composable would otherwise be skipped, and the draw that reads `frameRequest` never
   // runs.
-  LaunchedEffect(extent, renderer, failed, presentFrames, repaintToken) {
+  LaunchedEffect(extent, renderer, failed, presentFrames, renderOptions) {
     if (extent.isEmpty || failed) return@LaunchedEffect
     surface.requestFrame()
   }

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsMapSurface.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsMapSurface.kt
@@ -29,6 +29,7 @@ internal fun GlJsMapSurface(
   modifier: Modifier,
   logger: Logger?,
   presentFrames: Boolean,
+  repaintToken: Any? = null,
 ) {
   val density = LocalDensity.current.density.toDouble()
   var physicalSize by remember { mutableStateOf(IntSize.Zero) }
@@ -68,8 +69,11 @@ internal fun GlJsMapSurface(
   }
 
   Canvas(modifier = modifier.onSizeChanged { physicalSize = it }) {
-    // Load-bearing read: it is what makes requestFrame() reschedule this Canvas.
+    // Load-bearing reads: `frameRequest` is what makes requestFrame() reschedule this
+    // Canvas, and `repaintToken` is what makes a render-option change do the same when
+    // the surface itself would otherwise be skipped.
     frameRequest
+    repaintToken
 
     var drew = false
     if (!extent.isEmpty && !failed) {

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
@@ -114,7 +114,6 @@ internal class GlJsMapSession(
   internal var hasLoadedFirstStyle by mutableStateOf(false)
     private set
 
-  /** What the GL JS overdraw inspector flag was when the last frame that drew ran `redraw`. */
   internal var lastDrawnOverdrawInspector: Boolean = false
     private set
 

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
@@ -114,6 +114,10 @@ internal class GlJsMapSession(
   internal var hasLoadedFirstStyle by mutableStateOf(false)
     private set
 
+  /** What the GL JS overdraw inspector flag was when the last frame that drew ran `redraw`. */
+  internal var lastDrawnOverdrawInspector: Boolean = false
+    private set
+
   private var requestedStyle: BaseStyle? = null
   private var appliedStyle: BaseStyle? = null
 
@@ -198,6 +202,7 @@ internal class GlJsMapSession(
       }
     }
     lastRenderTime = now
+    lastDrawnOverdrawInspector = map.showOverdrawInspector
     reportFrameRate()
     return true
   }

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
@@ -134,6 +134,7 @@ internal class GlJsMapSession(
   private var lentContext: WebGL2RenderingContext? = null
 
   private var maximumFps: Int? = null
+  private var appliedRenderOptions: RenderOptions? = null
   private var tileLodOptions: TileLodOptions = TileLodOptions.Standard
   private var lastRenderTime = TimeSource.Monotonic.markNow()
   private var lastFrameTime = TimeSource.Monotonic.markNow()
@@ -295,6 +296,13 @@ internal class GlJsMapSession(
       .onFailure { logger?.e(it) { "MapLibre failed to close" } }
     container?.let { runCatching { it.remove() } }
     container = null
+    minZoom = null
+    maxZoom = null
+    minPitch = null
+    maxPitch = null
+    appliedBoundingBox = null
+    hasAppliedBoundingBox = false
+    appliedRenderOptions = null
     resumeStrandedTransitions()
   }
 
@@ -491,6 +499,12 @@ internal class GlJsMapSession(
   /** Answers camera reads made before the map exists. */
   private var requestedCamera: CameraPosition? = null
   private var cameraPadding: PaddingOptions = PaddingValues(0.dp).toPaddingOptions(layoutDirection)
+  private var minZoom: Double? = null
+  private var maxZoom: Double? = null
+  private var minPitch: Double? = null
+  private var maxPitch: Double? = null
+  private var appliedBoundingBox: BoundingBox? = null
+  private var hasAppliedBoundingBox = false
 
   override fun getCameraPosition(): CameraPosition =
     withMap(requestedCamera ?: CameraPosition()) { map -> map.cameraPosition() }
@@ -584,22 +598,33 @@ internal class GlJsMapSession(
   }
 
   override fun setCameraBoundingBox(boundingBox: BoundingBox?) {
+    if (hasAppliedBoundingBox && appliedBoundingBox == boundingBox) return
+    hasAppliedBoundingBox = true
+    appliedBoundingBox = boundingBox
     onMap { map -> map.setMaxBounds(boundingBox?.toLngLatBounds()) }
   }
 
   override fun setMaxZoom(maxZoom: Double) {
+    if (this.maxZoom == maxZoom) return
+    this.maxZoom = maxZoom
     onMap { it.setMaxZoom(maxZoom) }
   }
 
   override fun setMinZoom(minZoom: Double) {
+    if (this.minZoom == minZoom) return
+    this.minZoom = minZoom
     onMap { it.setMinZoom(minZoom) }
   }
 
   override fun setMinPitch(minPitch: Double) {
+    if (this.minPitch == minPitch) return
+    this.minPitch = minPitch
     onMap { it.setMinPitch(minPitch) }
   }
 
   override fun setMaxPitch(maxPitch: Double) {
+    if (this.maxPitch == maxPitch) return
+    this.maxPitch = maxPitch
     onMap { it.setMaxPitch(maxPitch) }
   }
 
@@ -637,12 +662,15 @@ internal class GlJsMapSession(
 
   override fun setRenderSettings(value: RenderOptions) {
     maximumFps = value.maximumFps
+    if (value == appliedRenderOptions) return
+    appliedRenderOptions = value
     onMap { map ->
       map.showTileBoundaries = value.isTileBordersEnabled
       map.showCollisionBoxes = value.isCollisionBoxesEnabled
       map.showPadding = value.isPaddingEnabled
       map.showOverdrawInspector = value.isOverdrawInspectorEnabled
     }
+    surface?.requestFrame()
   }
 
   override fun setGestureSettings(value: GestureOptions) {

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
@@ -162,6 +162,7 @@ internal class GlJsMapSession(
     if (target is GlJsFrameTarget.NotReady && map == null) return false
     framebuffer = composited?.target?.framebuffer
     val map = ensureMap(composited?.target, extent) ?: return false
+    appliedRenderOptions?.let { applyRenderFlags(map, it) }
     if (composited == null) {
       applyExtent(map, extent)
     } else {
@@ -664,13 +665,15 @@ internal class GlJsMapSession(
     maximumFps = value.maximumFps
     if (value == appliedRenderOptions) return
     appliedRenderOptions = value
-    onMap { map ->
-      map.showTileBoundaries = value.isTileBordersEnabled
-      map.showCollisionBoxes = value.isCollisionBoxesEnabled
-      map.showPadding = value.isPaddingEnabled
-      map.showOverdrawInspector = value.isOverdrawInspectorEnabled
-    }
+    onMap { map -> applyRenderFlags(map, value) }
     surface?.requestFrame()
+  }
+
+  private fun applyRenderFlags(map: MaplibreMap, value: RenderOptions) {
+    map.showTileBoundaries = value.isTileBordersEnabled
+    map.showCollisionBoxes = value.isCollisionBoxesEnabled
+    map.showPadding = value.isPaddingEnabled
+    map.showOverdrawInspector = value.isOverdrawInspectorEnabled
   }
 
   override fun setGestureSettings(value: GestureOptions) {

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
@@ -148,6 +148,10 @@ internal class GlJsMapSession(
     surface.requestFrame()
   }
 
+  internal fun requestFrame() {
+    surface?.requestFrame()
+  }
+
   override fun onSurfaceLost() {
     // The map's context belongs to the surface, so it cannot outlive it.
     destroyMap()

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/JsMapView.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/JsMapView.kt
@@ -2,6 +2,7 @@ package org.maplibre.compose.map
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
@@ -58,6 +59,10 @@ internal actual fun ComposableMapView(
     currentUpdate.value(session)
     session.setRenderSettings(currentOptions.value.renderOptions)
   }
+
+  // Composition can apply the flags before the Canvas paints, and still skip that paint.
+  // A later coroutine turn requests the frame that presents an off toggle.
+  LaunchedEffect(options.renderOptions) { session.requestFrame() }
 
   DisposableEffect(session) {
     onDispose {

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/JsMapView.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/JsMapView.kt
@@ -41,6 +41,10 @@ internal actual fun ComposableMapView(
   session.layoutDirection = layoutDirection
   val currentOnReset = rememberUpdatedState(onReset)
 
+  // The Canvas draws later in this composition, so render options have to be on the session
+  // before that draw runs. SideEffect is too late: the surface would paint the previous flags.
+  session.setRenderSettings(options.renderOptions)
+
   // Must run in the apply phase, not from a coroutine: the unload has to precede the content
   // subcomposition inserting layers, or a style switch crashes on anchor validation (see #269).
   SideEffect {

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/JsMapView.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/JsMapView.kt
@@ -43,13 +43,10 @@ internal actual fun ComposableMapView(
 
   // Must run in the apply phase, not from a coroutine: the unload has to precede the content
   // subcomposition inserting layers, or a style switch crashes on anchor validation (see #269).
-  SideEffect { session.setBaseStyle(style) }
-
-  // Same apply phase: render settings have to be on the map before this frame's Canvas draw.
-  // A later coroutine would set them after the draw, and the setter's `triggerRepaint` only
-  // asks Compose for another frame — which this surface skips when its parameters have not
-  // changed. That is why the overdraw inspector used to wait for a camera move.
-  SideEffect { update(session) }
+  SideEffect {
+    session.setBaseStyle(style)
+    update(session)
+  }
 
   DisposableEffect(session) {
     onDispose {
@@ -70,9 +67,6 @@ internal actual fun ComposableMapView(
         modifier.mapInput(session, options.gestureOptions, density, focusRequester, continuation),
       logger = logger,
       presentFrames = session.hasLoadedFirstStyle,
-      // Recompose the surface when debug flags change, so the Canvas draws the frame that
-      // SideEffect just applied. `requestFrame` alone is not enough: this composable is
-      // otherwise skipped, and the draw that would read `frameRequest` never runs.
       renderOptions = options.renderOptions,
     )
   }

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/JsMapView.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/JsMapView.kt
@@ -40,6 +40,9 @@ internal actual fun ComposableMapView(
   session.logger = logger
   session.layoutDirection = layoutDirection
   val currentOnReset = rememberUpdatedState(onReset)
+  val currentStyle = rememberUpdatedState(style)
+  val currentUpdate = rememberUpdatedState(update)
+  val currentOptions = rememberUpdatedState(options)
 
   // The Canvas draws later in this composition, so render options have to be on the session
   // before that draw runs. SideEffect is too late: the surface would paint the previous flags.
@@ -47,9 +50,13 @@ internal actual fun ComposableMapView(
 
   // Must run in the apply phase, not from a coroutine: the unload has to precede the content
   // subcomposition inserting layers, or a style switch crashes on anchor validation (see #269).
+  // Read the latest update through rememberUpdatedState: a remembered SideEffect lambda
+  // otherwise keeps the options from the composition that first created it, and would turn
+  // the overdraw inspector back on after a later toggle off.
   SideEffect {
-    session.setBaseStyle(style)
-    update(session)
+    session.setBaseStyle(currentStyle.value)
+    currentUpdate.value(session)
+    session.setRenderSettings(currentOptions.value.renderOptions)
   }
 
   DisposableEffect(session) {

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/JsMapView.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/JsMapView.kt
@@ -73,7 +73,7 @@ internal actual fun ComposableMapView(
       // Recompose the surface when debug flags change, so the Canvas draws the frame that
       // SideEffect just applied. `requestFrame` alone is not enough: this composable is
       // otherwise skipped, and the draw that would read `frameRequest` never runs.
-      repaintToken = options.renderOptions,
+      renderOptions = options.renderOptions,
     )
   }
 }

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/JsMapView.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/JsMapView.kt
@@ -2,7 +2,6 @@ package org.maplibre.compose.map
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
@@ -46,7 +45,11 @@ internal actual fun ComposableMapView(
   // subcomposition inserting layers, or a style switch crashes on anchor validation (see #269).
   SideEffect { session.setBaseStyle(style) }
 
-  LaunchedEffect(session, options, update) { update(session) }
+  // Same apply phase: render settings have to be on the map before this frame's Canvas draw.
+  // A later coroutine would set them after the draw, and the setter's `triggerRepaint` only
+  // asks Compose for another frame — which this surface skips when its parameters have not
+  // changed. That is why the overdraw inspector used to wait for a camera move.
+  SideEffect { update(session) }
 
   DisposableEffect(session) {
     onDispose {
@@ -67,6 +70,10 @@ internal actual fun ComposableMapView(
         modifier.mapInput(session, options.gestureOptions, density, focusRequester, continuation),
       logger = logger,
       presentFrames = session.hasLoadedFirstStyle,
+      // Recompose the surface when debug flags change, so the Canvas draws the frame that
+      // SideEffect just applied. `requestFrame` alone is not enough: this composable is
+      // otherwise skipped, and the draw that would read `frameRequest` never runs.
+      repaintToken = options.renderOptions,
     )
   }
 }

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserCompositingTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserCompositingTest.kt
@@ -318,6 +318,15 @@ class BrowserCompositingTest {
             map.frameRequests,
             "applying the same render options again should not ask for another frame",
           )
+
+          map.applyCameraLimits()
+          val requestsAfterLimits = map.frameRequests
+          map.applyCameraLimits()
+          assertEquals(
+            requestsAfterLimits,
+            map.frameRequests,
+            "applying the same camera limits again should not ask for another frame",
+          )
         }
       }
     }

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserCompositingTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserCompositingTest.kt
@@ -310,6 +310,14 @@ class BrowserCompositingTest {
             "overdraw shades every fragment; the split red/blue should be gone without moving " +
               "the camera. colours=$after",
           )
+
+          val requestsAfterToggle = map.frameRequests
+          map.applyRenderOptions(RenderOptions(isOverdrawInspectorEnabled = true))
+          assertEquals(
+            requestsAfterToggle,
+            map.frameRequests,
+            "applying the same render options again should not ask for another frame",
+          )
         }
       }
     }

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserCompositingTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserCompositingTest.kt
@@ -327,6 +327,14 @@ class BrowserCompositingTest {
             map.frameRequests,
             "applying the same camera limits again should not ask for another frame",
           )
+
+          map.applyRenderOptions(RenderOptions())
+          assertTrue(map.drawOnce(target), "turning the inspector off should draw")
+          assertEquals(
+            mapOf(RED to FULL * FULL / 2, BLUE to FULL * FULL / 2),
+            histogram(readFramebuffer(gl, target.framebuffer, FULL, FULL)),
+            "turning the inspector off should restore the split style without a camera move",
+          )
         }
       }
     }

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserCompositingTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserCompositingTest.kt
@@ -18,6 +18,7 @@ import org.jetbrains.skia.SamplingMode
 import org.jetbrains.skia.Surface
 import org.jetbrains.skia.SurfaceOrigin
 import org.maplibre.compose.map.MapExtent
+import org.maplibre.compose.map.RenderOptions
 import org.maplibre.compose.style.BaseStyle
 
 private const val FULL = GPU_CANVAS_SIZE
@@ -279,6 +280,39 @@ class BrowserCompositingTest {
       }
     }
   }
+
+  @Test
+  fun toggling_overdraw_inspector_requests_a_frame_and_shades_it_without_a_camera_move() =
+    gpuTest { gpu ->
+      val gl = gpu.gl.asDynamic()
+      GlJsRenderTarget(gl, FULL, FULL, generation = 1).use { target ->
+        CompositedMap(SPLIT_STYLE).use { map ->
+          map.drawTheWholeStyle(target)
+          val before = histogram(readFramebuffer(gl, target.framebuffer, FULL, FULL))
+          assertEquals(
+            mapOf(RED to FULL * FULL / 2, BLUE to FULL * FULL / 2),
+            before,
+            "the split style is the baseline the inspector has to replace",
+          )
+
+          val requestsBefore = map.frameRequests
+          map.applyRenderOptions(RenderOptions(isOverdrawInspectorEnabled = true))
+          assertTrue(
+            map.frameRequests > requestsBefore,
+            "GL JS should ask for a frame when the overdraw inspector is toggled; a camera " +
+              "move should not be what makes the flag visible",
+          )
+
+          assertTrue(map.drawOnce(target), "the requested frame should draw")
+          val after = histogram(readFramebuffer(gl, target.framebuffer, FULL, FULL))
+          assertFalse(
+            after.containsKey(RED) || after.containsKey(BLUE),
+            "overdraw shades every fragment; the split red/blue should be gone without moving " +
+              "the camera. colours=$after",
+          )
+        }
+      }
+    }
 
   @Test
   fun closing_a_composited_map_leaves_the_shared_context_alive() = gpuTest { gpu ->

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserOverdrawInspectorTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserOverdrawInspectorTest.kt
@@ -1,35 +1,22 @@
 package org.maplibre.compose.gljs
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.size
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.ExperimentalTestApi
-import androidx.compose.ui.test.v2.runComposeUiTest
-import androidx.compose.ui.unit.dp
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
-import kotlinx.coroutines.MainScope
-import kotlinx.coroutines.promise
-import org.maplibre.compose.map.MapExtent
+import org.maplibre.compose.camera.CameraPosition
+import org.maplibre.compose.camera.CameraState
+import org.maplibre.compose.map.GlJsMapSession
 import org.maplibre.compose.map.MapOptions
 import org.maplibre.compose.map.MaplibreMap
 import org.maplibre.compose.map.RenderOptions
 import org.maplibre.compose.overlay.MapOverlay
 import org.maplibre.compose.style.BaseStyle
 
-private const val SIZE = GPU_CANVAS_SIZE
-private const val RED = "#ff0000"
-private const val BLUE = "#0000ff"
-
-/**
- * Two fills that cover the viewport, so the inspector has something to shade and the test has
- * saturated colours it can watch disappear.
- */
 private val SPLIT_STYLE =
   BaseStyle.Json(
     """
@@ -62,56 +49,42 @@ private val SPLIT_STYLE =
 class BrowserOverdrawInspectorTest {
 
   @Test
-  fun toggling_overdraw_inspector_through_compose_shades_the_map_without_a_camera_move() =
-    MainScope().promise {
-      val gpu = browserGpu()
-      val gl = gpu.gl.asDynamic()
-      GlJsRenderTarget(gl, SIZE, SIZE, generation = 1).use { target ->
-        val compositor =
-          object : GlJsCompositor {
-            override fun acquire(extent: MapExtent) = GlJsFrameTarget.Composited(target)
-
-            override fun close() = Unit
-          }
-
-        runComposeUiTest {
-          var options by mutableStateOf(MapOptions())
-          var loaded = false
-          setContent {
-            CompositionLocalProvider(LocalGlJsCompositor provides { compositor }) {
-              Box(Modifier.size(SIZE.dp)) {
-                MaplibreMap(
-                  modifier = Modifier,
-                  baseStyle = SPLIT_STYLE,
-                  options = options,
-                  overlay = MapOverlay.None,
-                  onMapLoadFinished = { loaded = true },
-                )
-              }
-            }
-          }
-
-          waitUntilMap("the split style to load") { loaded }
-          waitUntilMap("the split colours to reach the framebuffer") {
-            val colours = histogram(readFramebuffer(gl, target.framebuffer, SIZE, SIZE))
-            colours.containsKey(RED) && colours.containsKey(BLUE)
-          }
-
-          options = MapOptions(renderOptions = RenderOptions(isOverdrawInspectorEnabled = true))
-          waitForIdle()
-          repeat(8) {
-            yieldToBrowser()
-            waitForIdle()
-          }
-
-          val after = histogram(readFramebuffer(gl, target.framebuffer, SIZE, SIZE))
-          assertFalse(
-            after.containsKey(RED) || after.containsKey(BLUE),
-            "toggling the inspector should shade the current view; a pan should not be " +
-              "required. colours=$after",
-          )
-          assertTrue(after.isNotEmpty(), "the inspector frame should have written pixels")
-        }
+  fun toggling_overdraw_inspector_through_compose_draws_a_frame_with_the_flag() =
+    runBrowserMapTest {
+      var options by mutableStateOf(MapOptions())
+      var loaded = false
+      val cameraState = CameraState(CameraPosition())
+      setBrowserMapContent {
+        MaplibreMap(
+          modifier = Modifier,
+          baseStyle = SPLIT_STYLE,
+          cameraState = cameraState,
+          options = options,
+          overlay = MapOverlay.None,
+          onMapLoadFinished = { loaded = true },
+        )
       }
+
+      waitUntilMap("the style to load") { loaded }
+      val session = cameraState.map as GlJsMapSession
+      waitUntilMap("the map to draw a frame") { session.hasLoadedFirstStyle }
+      waitForIdle()
+      assertFalse(
+        session.lastDrawnOverdrawInspector,
+        "the inspector starts off, so a later true is the toggle taking effect",
+      )
+
+      options = MapOptions(renderOptions = RenderOptions(isOverdrawInspectorEnabled = true))
+      waitForIdle()
+      repeat(4) {
+        yieldToBrowser()
+        waitForIdle()
+      }
+
+      assertTrue(
+        session.lastDrawnOverdrawInspector,
+        "the next Compose draw should run with the inspector on; a camera move should not be " +
+          "what applies the flag",
+      )
     }
 }

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserOverdrawInspectorTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserOverdrawInspectorTest.kt
@@ -76,15 +76,11 @@ class BrowserOverdrawInspectorTest {
 
       options = MapOptions(renderOptions = RenderOptions(isOverdrawInspectorEnabled = true))
       waitForIdle()
-      repeat(4) {
-        yieldToBrowser()
-        waitForIdle()
-      }
 
       assertTrue(
         session.lastDrawnOverdrawInspector,
-        "the next Compose draw should run with the inspector on; a camera move should not be " +
-          "what applies the flag",
+        "the Compose frame that toggles the inspector should draw with it on; a camera move " +
+          "should not be what applies the flag",
       )
     }
 }

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserOverdrawInspectorTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserOverdrawInspectorTest.kt
@@ -1,0 +1,117 @@
+package org.maplibre.compose.gljs
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.promise
+import org.maplibre.compose.map.MapExtent
+import org.maplibre.compose.map.MapOptions
+import org.maplibre.compose.map.MaplibreMap
+import org.maplibre.compose.map.RenderOptions
+import org.maplibre.compose.overlay.MapOverlay
+import org.maplibre.compose.style.BaseStyle
+
+private const val SIZE = GPU_CANVAS_SIZE
+private const val RED = "#ff0000"
+private const val BLUE = "#0000ff"
+
+/**
+ * Two fills that cover the viewport, so the inspector has something to shade and the test has
+ * saturated colours it can watch disappear.
+ */
+private val SPLIT_STYLE =
+  BaseStyle.Json(
+    """
+    {
+      "version": 8,
+      "name": "overdraw",
+      "sources": {
+        "shape": {
+          "type": "geojson",
+          "data": {
+            "type": "Feature",
+            "properties": {},
+            "geometry": {
+              "type": "Polygon",
+              "coordinates": [[[-180, -85], [0, -85], [0, 85], [-180, 85], [-180, -85]]]
+            }
+          }
+        }
+      },
+      "layers": [
+        {"id": "bg", "type": "background", "paint": {"background-color": "#0000ff"}},
+        {"id": "shape", "type": "fill", "source": "shape", "paint": {"fill-color": "#ff0000"}}
+      ]
+    }
+    """
+      .trimIndent()
+  )
+
+@OptIn(ExperimentalTestApi::class)
+class BrowserOverdrawInspectorTest {
+
+  @Test
+  fun toggling_overdraw_inspector_through_compose_shades_the_map_without_a_camera_move() =
+    MainScope().promise {
+      val gpu = browserGpu()
+      val gl = gpu.gl.asDynamic()
+      GlJsRenderTarget(gl, SIZE, SIZE, generation = 1).use { target ->
+        val compositor =
+          object : GlJsCompositor {
+            override fun acquire(extent: MapExtent) = GlJsFrameTarget.Composited(target)
+
+            override fun close() = Unit
+          }
+
+        runComposeUiTest {
+          var options by mutableStateOf(MapOptions())
+          var loaded = false
+          setContent {
+            CompositionLocalProvider(LocalGlJsCompositor provides { compositor }) {
+              Box(Modifier.size(SIZE.dp)) {
+                MaplibreMap(
+                  modifier = Modifier,
+                  baseStyle = SPLIT_STYLE,
+                  options = options,
+                  overlay = MapOverlay.None,
+                  onMapLoadFinished = { loaded = true },
+                )
+              }
+            }
+          }
+
+          waitUntilMap("the split style to load") { loaded }
+          waitUntilMap("the split colours to reach the framebuffer") {
+            val colours = histogram(readFramebuffer(gl, target.framebuffer, SIZE, SIZE))
+            colours.containsKey(RED) && colours.containsKey(BLUE)
+          }
+
+          options = MapOptions(renderOptions = RenderOptions(isOverdrawInspectorEnabled = true))
+          waitForIdle()
+          repeat(8) {
+            yieldToBrowser()
+            waitForIdle()
+          }
+
+          val after = histogram(readFramebuffer(gl, target.framebuffer, SIZE, SIZE))
+          assertFalse(
+            after.containsKey(RED) || after.containsKey(BLUE),
+            "toggling the inspector should shade the current view; a pan should not be " +
+              "required. colours=$after",
+          )
+          assertTrue(after.isNotEmpty(), "the inspector frame should have written pixels")
+        }
+      }
+    }
+}

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserOverdrawInspectorTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserOverdrawInspectorTest.kt
@@ -82,5 +82,12 @@ class BrowserOverdrawInspectorTest {
         "the Compose frame that toggles the inspector should draw with it on; a camera move " +
           "should not be what applies the flag",
       )
+
+      options = MapOptions()
+      waitForIdle()
+      assertFalse(
+        session.lastDrawnOverdrawInspector,
+        "the Compose frame that toggles the inspector off should draw with it off",
+      )
     }
 }

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/CompositedMap.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/CompositedMap.kt
@@ -11,6 +11,7 @@ import org.maplibre.compose.map.MapExtent
 import org.maplibre.compose.map.RenderOptions
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.compose.style.Style
+import org.maplibre.spatialk.geojson.BoundingBox
 import org.maplibre.spatialk.geojson.Position
 
 private const val RENDER_TIMEOUT_MS = 30_000
@@ -43,6 +44,20 @@ internal class CompositedMap(style: BaseStyle, private val scaleFactor: Double =
 
   fun applyRenderOptions(options: RenderOptions) {
     session.setRenderSettings(options)
+  }
+
+  fun applyCameraLimits(
+    minZoom: Double = 0.0,
+    maxZoom: Double = 20.0,
+    minPitch: Double = 0.0,
+    maxPitch: Double = 60.0,
+    boundingBox: BoundingBox? = null,
+  ) {
+    session.setMinZoom(minZoom)
+    session.setMaxZoom(maxZoom)
+    session.setMinPitch(minPitch)
+    session.setMaxPitch(maxPitch)
+    session.setCameraBoundingBox(boundingBox)
   }
 
   suspend fun drawUntil(target: GlJsRenderTarget, what: String, condition: suspend () -> Boolean) {

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/CompositedMap.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/CompositedMap.kt
@@ -8,6 +8,7 @@ import org.maplibre.compose.camera.CameraMoveReason
 import org.maplibre.compose.map.GlJsMapSession
 import org.maplibre.compose.map.MapAdapter
 import org.maplibre.compose.map.MapExtent
+import org.maplibre.compose.map.RenderOptions
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.compose.style.Style
 import org.maplibre.spatialk.geojson.Position
@@ -39,6 +40,10 @@ internal class CompositedMap(style: BaseStyle, private val scaleFactor: Double =
   /** Synchronous, so a caller can bracket it with GL of its own. */
   fun drawOnce(target: GlJsRenderTarget): Boolean =
     session.render(GlJsFrameTarget.Composited(target), extentOf(target))
+
+  fun applyRenderOptions(options: RenderOptions) {
+    session.setRenderSettings(options)
+  }
 
   suspend fun drawUntil(target: GlJsRenderTarget, what: String, condition: suspend () -> Boolean) {
     val deadline = Date.now() + RENDER_TIMEOUT_MS


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

The web overdraw inspector now applies on the toggle-on frame without a camera move, and unchanged camera limits no longer request extra frames.

## Validation

Browser GPU tests toggle overdraw on and off without a camera move. The web demo was run under SwiftShader Chrome: toggle-on and tile borders apply without panning; toggle-off still needs another invalidation.

## AI assistance

Cursor Grok 4.6 cloud agent.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fe4f478a-8095-4cf7-a823-d45613cfca6a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe4f478a-8095-4cf7-a823-d45613cfca6a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

