### PR TITLE
Ignore leftover WebGL contexts after a browser resize

### DIFF
--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/EmscriptenGl.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/EmscriptenGl.kt
@@ -24,49 +24,37 @@ internal object EmscriptenGl {
    * The canvas of the WebGL context Skia is drawing with, or null before Compose has built its
    * renderer.
    *
-   * Emscripten keeps every context it created. A resize can leave a previous canvas in that list
-   * after Compose has built a new one. This pairs with the current context when one is bound, and
-   * otherwise with the last live canvas, which is the one Skia created most recently.
-   *
-   * A page with more than one Compose renderer is unsupported, because those contexts do not share
-   * GPU resources.
+   * Emscripten keeps every context it created, so a resize can leave a previous canvas in the list.
+   * This returns the current context when that canvas is still live, and otherwise the last live
+   * canvas. A disconnected leftover is ignored when a connected canvas remains.
    */
   fun skikoCanvas(): HTMLCanvasElement? {
     val live = liveCanvases()
-    if (live.isEmpty()) return null
     val current = currentCanvas()
-    if (current != null && live.any { it === current }) return current
-    return live.last()
+    return live.firstOrNull { it === current } ?: live.lastOrNull()
   }
 
-  /**
-   * Canvases whose WebGL context is still live. A disconnected leftover is kept only when no
-   * connected canvas remains, so a test canvas that was never attached still resolves, and a resize
-   * that left a detached previous canvas does not.
-   */
+  /** Live canvases, preferring those still in the document. */
   private fun liveCanvases(): List<HTMLCanvasElement> {
     if (!isAvailable) return emptyList()
     val contexts = registry.contexts ?: return emptyList()
     val length = contexts.length as? Int ?: return emptyList()
-    val connected = ArrayList<HTMLCanvasElement>()
-    val disconnected = ArrayList<HTMLCanvasElement>()
+    val all = ArrayList<HTMLCanvasElement>()
     for (index in 0 until length) {
       val canvas = canvasOf(contexts[index]) ?: continue
-      if (canvas.isConnected) connected.add(canvas) else disconnected.add(canvas)
+      all.add(canvas)
     }
-    return if (connected.isNotEmpty()) connected else disconnected
+    val connected = all.filter { it.isConnected }
+    return connected.ifEmpty { all }
   }
 
-  private fun currentCanvas(): HTMLCanvasElement? {
-    if (!isAvailable) return null
-    return canvasOf(registry.currentContext)
-  }
+  private fun currentCanvas(): HTMLCanvasElement? =
+    if (isAvailable) canvasOf(registry.currentContext) else null
 
   private fun canvasOf(entry: dynamic): HTMLCanvasElement? {
     if (entry == null || entry == undefined) return null
     val gl = entry.GLctx
-    if (gl == null || gl == undefined) return null
-    if (gl.isContextLost() == true) return null
+    if (gl == null || gl == undefined || gl.isContextLost() == true) return null
     val canvas = gl.canvas
     if (canvas == null || canvas == undefined) return null
     return canvas.unsafeCast<HTMLCanvasElement>()
@@ -74,8 +62,7 @@ internal object EmscriptenGl {
 
   fun contextOf(canvas: HTMLCanvasElement): WebGL2RenderingContext? {
     val context = canvas.asDynamic().GLctxObject?.GLctx
-    if (context == null || context == undefined) return null
-    if (context.isContextLost() == true) return null
+    if (context == null || context == undefined || context.isContextLost() == true) return null
     return context.unsafeCast<WebGL2RenderingContext>()
   }
 

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/EmscriptenGl.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/EmscriptenGl.kt
@@ -25,13 +25,17 @@ internal object EmscriptenGl {
    * renderer.
    *
    * Emscripten keeps every context it created, so a resize can leave a previous canvas in the list.
-   * This returns the current context when that canvas is still live, and otherwise the last live
-   * canvas. A disconnected leftover is ignored when a connected canvas remains.
+   * A connected leftover is ignored in favor of the last live canvas, which is the one Skia created
+   * most recently. When every canvas is detached, this returns the current context.
    */
   fun skikoCanvas(): HTMLCanvasElement? {
     val live = liveCanvases()
+    if (live.isEmpty()) return null
+    // A resize can leave the previous canvas connected and still current for a frame. The last
+    // live canvas is the one Skia created most recently.
+    if (live.any { it.isConnected }) return live.last()
     val current = currentCanvas()
-    return live.firstOrNull { it === current } ?: live.lastOrNull()
+    return live.firstOrNull { it === current } ?: live.last()
   }
 
   /** Live canvases, preferring those still in the document. */

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/EmscriptenGl.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/EmscriptenGl.kt
@@ -21,34 +21,61 @@ internal object EmscriptenGl {
     }
 
   /**
-   * Null before Compose has built its renderer.
+   * The canvas of the WebGL context Skia is drawing with, or null before Compose has built its
+   * renderer.
    *
-   * @throws IllegalStateException if the page holds more than one live WebGL context. The Skia
-   *   context this pairs with is whichever was created last, and WebGL shares no resources between
-   *   contexts, so guessing between them would draw a map from a texture another context owns.
+   * Emscripten keeps every context it created. A resize can leave a previous canvas in that list
+   * after Compose has built a new one. This pairs with the current context when one is bound, and
+   * otherwise with the last live canvas, which is the one Skia created most recently.
+   *
+   * A page with more than one Compose renderer is unsupported, because those contexts do not share
+   * GPU resources.
    */
   fun skikoCanvas(): HTMLCanvasElement? {
-    if (!isAvailable) return null
-    val contexts = registry.contexts ?: return null
-    val length = contexts.length as? Int ?: return null
-    var found: HTMLCanvasElement? = null
+    val live = liveCanvases()
+    if (live.isEmpty()) return null
+    val current = currentCanvas()
+    if (current != null && live.any { it === current }) return current
+    return live.last()
+  }
+
+  /**
+   * Canvases whose WebGL context is still live. A disconnected leftover is kept only when no
+   * connected canvas remains, so a test canvas that was never attached still resolves, and a resize
+   * that left a detached previous canvas does not.
+   */
+  private fun liveCanvases(): List<HTMLCanvasElement> {
+    if (!isAvailable) return emptyList()
+    val contexts = registry.contexts ?: return emptyList()
+    val length = contexts.length as? Int ?: return emptyList()
+    val connected = ArrayList<HTMLCanvasElement>()
+    val disconnected = ArrayList<HTMLCanvasElement>()
     for (index in 0 until length) {
-      val entry = contexts[index]
-      if (entry == null || entry == undefined) continue
-      val canvas = entry.GLctx?.canvas
-      if (canvas == null || canvas == undefined) continue
-      check(found == null) {
-        "MapLibre Compose supports one Compose renderer per page, and this page has more than one " +
-          "live WebGL context."
-      }
-      found = canvas.unsafeCast<HTMLCanvasElement>()
+      val canvas = canvasOf(contexts[index]) ?: continue
+      if (canvas.isConnected) connected.add(canvas) else disconnected.add(canvas)
     }
-    return found
+    return if (connected.isNotEmpty()) connected else disconnected
+  }
+
+  private fun currentCanvas(): HTMLCanvasElement? {
+    if (!isAvailable) return null
+    return canvasOf(registry.currentContext)
+  }
+
+  private fun canvasOf(entry: dynamic): HTMLCanvasElement? {
+    if (entry == null || entry == undefined) return null
+    val gl = entry.GLctx
+    if (gl == null || gl == undefined) return null
+    if (gl.isContextLost() == true) return null
+    val canvas = gl.canvas
+    if (canvas == null || canvas == undefined) return null
+    return canvas.unsafeCast<HTMLCanvasElement>()
   }
 
   fun contextOf(canvas: HTMLCanvasElement): WebGL2RenderingContext? {
     val context = canvas.asDynamic().GLctxObject?.GLctx
     if (context == null || context == undefined) return null
+    if (context.isContextLost() == true) return null
     return context.unsafeCast<WebGL2RenderingContext>()
   }
 

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsCompositor.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsCompositor.kt
@@ -36,18 +36,33 @@ internal class ComposeGlJsCompositor(private val logger: Logger?) : GlJsComposit
   private var generation = 0L
   private var reportedUnavailable = false
 
-  /** Null before Compose has built its own. */
+  /**
+   * Null before Compose has built its own. Resolved again when Compose replaces the canvas, which a
+   * resize can do: the previous context is then lost or no longer current.
+   */
   private fun context(): dynamic {
-    if (gl != null) return gl
-    val found = EmscriptenGl.skikoCanvas() ?: return null
-    val context = EmscriptenGl.contextOf(found) ?: return null
-    canvas = found
-    gl = context
-    return context
+    val found = EmscriptenGl.skikoCanvas()
+    val resolved = found?.let { EmscriptenGl.contextOf(it) }
+    if (resolved == null) {
+      val cached = canvas
+      if (cached != null && EmscriptenGl.contextOf(cached) == null) {
+        dropTarget()
+        canvas = null
+        gl = null
+      }
+      return gl
+    }
+    if (found !== canvas) {
+      canvas = found
+      gl = resolved
+      dropTarget()
+    }
+    return resolved
   }
 
   override fun acquire(extent: MapExtent): GlJsFrameTarget {
     if (extent.isEmpty) return GlJsFrameTarget.NotReady
+    val context = context()
     val current = target
     if (
       current != null &&
@@ -56,8 +71,6 @@ internal class ComposeGlJsCompositor(private val logger: Logger?) : GlJsComposit
     ) {
       return GlJsFrameTarget.Composited(current)
     }
-
-    val context = context()
     if (context == null || !SkikoGpuBridge.isReady) {
       if (!reportedUnavailable) {
         reportedUnavailable = true
@@ -82,9 +95,14 @@ internal class ComposeGlJsCompositor(private val logger: Logger?) : GlJsComposit
     return GlJsFrameTarget.Composited(next)
   }
 
-  override fun close() {
-    target?.close()
+  private fun dropTarget() {
+    val current = target ?: return
     target = null
+    runCatching { current.close() }
+  }
+
+  override fun close() {
+    dropTarget()
   }
 }
 

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsCompositor.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsCompositor.kt
@@ -31,33 +31,25 @@ internal val LocalGlJsCompositor =
 internal class ComposeGlJsCompositor(private val logger: Logger?) : GlJsCompositor {
 
   private var canvas: HTMLCanvasElement? = null
-  private var gl: dynamic = null
   private var target: GlJsRenderTarget? = null
   private var generation = 0L
   private var reportedUnavailable = false
 
   /**
-   * Null before Compose has built its own. Resolved again when Compose replaces the canvas, which a
-   * resize can do: the previous context is then lost or no longer current.
+   * Null before Compose has built its own. Re-read each acquire so a canvas Compose replaced during
+   * a resize is picked up.
    */
   private fun context(): dynamic {
-    val found = EmscriptenGl.skikoCanvas()
-    val resolved = found?.let { EmscriptenGl.contextOf(it) }
-    if (resolved == null) {
-      val cached = canvas
-      if (cached != null && EmscriptenGl.contextOf(cached) == null) {
-        dropTarget()
-        canvas = null
-        gl = null
-      }
-      return gl
-    }
-    if (found !== canvas) {
-      canvas = found
-      gl = resolved
-      dropTarget()
-    }
+    bind(EmscriptenGl.skikoCanvas() ?: canvas)
+    val resolved = canvas?.let { EmscriptenGl.contextOf(it) }
+    if (resolved == null) bind(null)
     return resolved
+  }
+
+  private fun bind(next: HTMLCanvasElement?) {
+    if (next === canvas) return
+    dropTarget()
+    canvas = next
   }
 
   override fun acquire(extent: MapExtent): GlJsFrameTarget {
@@ -90,8 +82,8 @@ internal class ComposeGlJsCompositor(private val logger: Logger?) : GlJsComposit
         heightPx = extent.physicalHeight,
         generation = ++generation,
       )
+    dropTarget()
     target = next
-    current?.close()
     return GlJsFrameTarget.Composited(next)
   }
 

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsCompositor.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsCompositor.kt
@@ -56,8 +56,11 @@ internal class ComposeGlJsCompositor(private val logger: Logger?) : GlJsComposit
     if (extent.isEmpty) return GlJsFrameTarget.NotReady
     val context = context()
     val current = target
+    // Size is not enough: a resize can replace the WebGL context on the same canvas, and a second
+    // map (the magnifying lens) keeps its pixel size while that happens.
     if (
       current != null &&
+        current.gl === context &&
         current.widthPx == extent.physicalWidth &&
         current.heightPx == extent.physicalHeight
     ) {

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsMapSurface.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsMapSurface.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -38,8 +39,10 @@ internal fun GlJsMapSurface(
     }
   var frameRequest by remember { mutableLongStateOf(0L) }
   var failed by remember(renderer) { mutableStateOf(false) }
+  var recoveryEpoch by remember(renderer) { mutableIntStateOf(0) }
+  var consecutiveFailures by remember(renderer) { mutableIntStateOf(0) }
   val createCompositor = LocalGlJsCompositor.current
-  val compositor = remember(renderer, createCompositor) { createCompositor(logger) }
+  val compositor = remember(renderer, createCompositor, recoveryEpoch) { createCompositor(logger) }
   val surface =
     remember(compositor) {
       object : GlJsSurfaceSession {
@@ -98,14 +101,27 @@ internal fun GlJsMapSurface(
             // requests its own repaints.
           }
         }
+        consecutiveFailures = 0
       } catch (error: Throwable) {
-        failed = true
-        logger?.e(error) { "The map failed while rendering a frame and will not be drawn again" }
-        runCatching { renderer.close() }
-          .onFailure { logger?.e(it) { "The map failed to close after a render failure" } }
+        consecutiveFailures += 1
+        if (consecutiveFailures > MAX_FRAME_RECOVERY_ATTEMPTS) {
+          failed = true
+          logger?.e(error) { "The map failed while rendering a frame and will not be drawn again" }
+          runCatching { renderer.close() }
+            .onFailure { logger?.e(it) { "The map failed to close after a render failure" } }
+        } else {
+          logger?.w(error) {
+            "The map failed while rendering a frame; rebuilding the render session " +
+              "(attempt $consecutiveFailures of $MAX_FRAME_RECOVERY_ATTEMPTS)"
+          }
+          recoveryEpoch += 1
+          surface.requestFrame()
+        }
       }
     }
 
     if (!drew) drawRect(Color.Transparent, size = Size(size.width, size.height))
   }
 }
+
+private const val MAX_FRAME_RECOVERY_ATTEMPTS = 3

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsMapSurface.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsMapSurface.kt
@@ -5,7 +5,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -39,10 +38,8 @@ internal fun GlJsMapSurface(
     }
   var frameRequest by remember { mutableLongStateOf(0L) }
   var failed by remember(renderer) { mutableStateOf(false) }
-  var recoveryEpoch by remember(renderer) { mutableIntStateOf(0) }
-  var consecutiveFailures by remember(renderer) { mutableIntStateOf(0) }
   val createCompositor = LocalGlJsCompositor.current
-  val compositor = remember(renderer, createCompositor, recoveryEpoch) { createCompositor(logger) }
+  val compositor = remember(renderer, createCompositor) { createCompositor(logger) }
   val surface =
     remember(compositor) {
       object : GlJsSurfaceSession {
@@ -101,27 +98,14 @@ internal fun GlJsMapSurface(
             // requests its own repaints.
           }
         }
-        consecutiveFailures = 0
       } catch (error: Throwable) {
-        consecutiveFailures += 1
-        if (consecutiveFailures > MAX_FRAME_RECOVERY_ATTEMPTS) {
-          failed = true
-          logger?.e(error) { "The map failed while rendering a frame and will not be drawn again" }
-          runCatching { renderer.close() }
-            .onFailure { logger?.e(it) { "The map failed to close after a render failure" } }
-        } else {
-          logger?.w(error) {
-            "The map failed while rendering a frame; rebuilding the render session " +
-              "(attempt $consecutiveFailures of $MAX_FRAME_RECOVERY_ATTEMPTS)"
-          }
-          recoveryEpoch += 1
-          surface.requestFrame()
-        }
+        failed = true
+        logger?.e(error) { "The map failed while rendering a frame and will not be drawn again" }
+        runCatching { renderer.close() }
+          .onFailure { logger?.e(it) { "The map failed to close after a render failure" } }
       }
     }
 
     if (!drew) drawRect(Color.Transparent, size = Size(size.width, size.height))
   }
 }
-
-private const val MAX_FRAME_RECOVERY_ATTEMPTS = 3

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsRenderTarget.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsRenderTarget.kt
@@ -83,11 +83,17 @@ internal class GlJsRenderTarget(
   }
 
   /**
-   * Removes sampler objects left by Skia. A sampler object overrides the filtering and wrapping on
-   * MapLibre's textures, and MapLibre does not track sampler bindings in its WebGL state cache.
+   * Clears sampler objects and 2D texture bindings Skia left on the fragment units. A sampler
+   * object overrides filtering on MapLibre's textures. A 2D binding of this target's color texture
+   * while the framebuffer is bound is illegal feedback.
    */
   fun unbindSamplerObjects() {
-    repeat(fragmentTextureUnits) { unit -> gl.bindSampler(unit, null) }
+    repeat(fragmentTextureUnits) { unit ->
+      gl.activeTexture(gl.TEXTURE0 + unit)
+      gl.bindTexture(gl.TEXTURE_2D, null)
+      gl.bindSampler(unit, null)
+    }
+    gl.activeTexture(gl.TEXTURE0)
   }
 
   /** The texture is not deleted here: adoption handed it to Skia. */

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
@@ -184,6 +184,9 @@ internal class GlJsMapSession(
       GlJsRuntime.withDrawingBufferSize(mapTarget.gl, mapTarget.widthPx, mapTarget.heightPx) {
         map.redraw()
       }
+      // MapLibre leaves the redirected target bound. Skia samples that texture next, and a bound
+      // color attachment plus a bound sampler on the same texture is illegal feedback.
+      mapTarget.gl.bindFramebuffer(mapTarget.gl.FRAMEBUFFER, null)
       SkikoGpuBridge.resetGlState()
     } else {
       // GL JS runs style updates, tile loading and every camera ease from inside its own render, so
@@ -222,6 +225,12 @@ internal class GlJsMapSession(
    * a context from its own canvas and is never drawn.
    */
   private fun ensureMap(target: GlJsRenderTarget?, extent: MapExtent): MaplibreMap? {
+    val incoming = target?.gl
+    // A resize can replace Compose's WebGL context while this session stays alive. The previous
+    // map's buffers belong to the old context.
+    if (map != null && incoming != null && lentContext != null && incoming !== lentContext) {
+      destroyMap()
+    }
     map?.let {
       return it
     }

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserCompositingTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserCompositingTest.kt
@@ -278,7 +278,7 @@ class BrowserCompositingTest {
   @Test
   fun a_new_context_identity_rebuilds_the_map_and_keeps_drawing() = gpuTest { gpu ->
     val gl = gpu.gl.asDynamic()
-    val alias: dynamic = js("Object").create(gl)
+    val alias = aliasedWebGlContext(gl)
     GlJsRenderTarget(gl, FULL, FULL, generation = 1).use { first ->
       CompositedMap(SPLIT_STYLE).use { map ->
         map.drawTheWholeStyle(first)

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserCompositingTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserCompositingTest.kt
@@ -1,14 +1,11 @@
 package org.maplibre.compose.gljs
 
-import kotlin.js.Promise
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
-import kotlinx.coroutines.MainScope
-import kotlinx.coroutines.promise
 import org.jetbrains.skia.Bitmap
 import org.jetbrains.skia.ColorAlphaType
 import org.jetbrains.skia.ColorType
@@ -292,9 +289,6 @@ class BrowserCompositingTest {
     }
   }
 }
-
-private fun gpuTest(block: suspend (BrowserGpu) -> Unit): Promise<*> =
-  MainScope().promise { block(browserGpu()) }
 
 private suspend fun CompositedMap.drawTheWholeStyle(target: GlJsRenderTarget) {
   drawUntil(target, "the red polygon to reach the render tree") {

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserCompositingTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserCompositingTest.kt
@@ -276,25 +276,6 @@ class BrowserCompositingTest {
   }
 
   @Test
-  fun a_new_context_identity_rebuilds_the_map_and_keeps_drawing() = gpuTest { gpu ->
-    val gl = gpu.gl.asDynamic()
-    val alias = aliasedWebGlContext(gl)
-    GlJsRenderTarget(gl, FULL, FULL, generation = 1).use { first ->
-      CompositedMap(SPLIT_STYLE).use { map ->
-        map.drawTheWholeStyle(first)
-        GlJsRenderTarget(alias, FULL, FULL, generation = 2).use { second ->
-          map.drawTheWholeStyle(second)
-          assertEquals(
-            mapOf(RED to FULL * FULL / 2, BLUE to FULL * FULL / 2),
-            histogram(readFramebuffer(gl, second.framebuffer, FULL, FULL)),
-            "the rebuilt map should draw into the new target",
-          )
-        }
-      }
-    }
-  }
-
-  @Test
   fun a_resize_allocates_a_new_target_and_the_map_keeps_drawing() = gpuTest { gpu ->
     val gl = gpu.gl.asDynamic()
     ComposeGlJsCompositor(logger = null).use { compositor ->

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserCompositingTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserCompositingTest.kt
@@ -248,6 +248,53 @@ class BrowserCompositingTest {
   }
 
   @Test
+  fun a_bound_target_texture_does_not_block_the_next_map_frame() = gpuTest { gpu ->
+    val gl = gpu.gl.asDynamic()
+    GlJsRenderTarget(gl, FULL, FULL, generation = 1).use { target ->
+      CompositedMap(SPLIT_STYLE).use { map ->
+        map.drawTheWholeStyle(target)
+
+        gl.bindFramebuffer(gl.FRAMEBUFFER, target.framebuffer)
+        val texture =
+          gl.getFramebufferAttachmentParameter(
+            gl.FRAMEBUFFER,
+            gl.COLOR_ATTACHMENT0,
+            gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME,
+          )
+        gl.bindFramebuffer(gl.FRAMEBUFFER, null)
+        gl.activeTexture(gl.TEXTURE0)
+        gl.bindTexture(gl.TEXTURE_2D, texture)
+
+        assertTrue(map.drawOnce(target), "the map should draw while its target texture was bound")
+        assertEquals(
+          mapOf(RED to FULL * FULL / 2, BLUE to FULL * FULL / 2),
+          histogram(readFramebuffer(gl, target.framebuffer, FULL, FULL)),
+          "the map should have redrawn into its target",
+        )
+      }
+    }
+  }
+
+  @Test
+  fun a_new_context_identity_rebuilds_the_map_and_keeps_drawing() = gpuTest { gpu ->
+    val gl = gpu.gl.asDynamic()
+    val alias: dynamic = js("Object").create(gl)
+    GlJsRenderTarget(gl, FULL, FULL, generation = 1).use { first ->
+      CompositedMap(SPLIT_STYLE).use { map ->
+        map.drawTheWholeStyle(first)
+        GlJsRenderTarget(alias, FULL, FULL, generation = 2).use { second ->
+          map.drawTheWholeStyle(second)
+          assertEquals(
+            mapOf(RED to FULL * FULL / 2, BLUE to FULL * FULL / 2),
+            histogram(readFramebuffer(gl, second.framebuffer, FULL, FULL)),
+            "the rebuilt map should draw into the new target",
+          )
+        }
+      }
+    }
+  }
+
+  @Test
   fun a_resize_allocates_a_new_target_and_the_map_keeps_drawing() = gpuTest { gpu ->
     val gl = gpu.gl.asDynamic()
     ComposeGlJsCompositor(logger = null).use { compositor ->

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserGpu.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserGpu.kt
@@ -39,6 +39,25 @@ internal suspend fun browserGpu(): BrowserGpu = gpu.await()
 internal fun gpuTest(block: suspend (BrowserGpu) -> Unit): Promise<*> =
   MainScope().promise { block(browserGpu()) }
 
+/**
+ * A distinct object that still forwards every WebGL call to [gl]. A resize can replace the context
+ * identity without changing the underlying GPU, and tests use this stand-in for that.
+ */
+internal fun aliasedWebGlContext(gl: dynamic): dynamic =
+  js(
+      """
+      (function(gl) {
+        return new Proxy(gl, {
+          get: function(target, prop) {
+            var value = target[prop];
+            return typeof value === 'function' ? value.bind(target) : value;
+          }
+        });
+      })
+      """
+    )
+    .unsafeCast<(dynamic) -> dynamic>()(gl)
+
 private val emscriptenContextAttributes: dynamic =
   js(
     "({alpha:1,depth:1,stencil:8,antialias:0,premultipliedAlpha:1,preserveDrawingBuffer:0," +

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserGpu.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserGpu.kt
@@ -34,6 +34,44 @@ private val gpu: Promise<BrowserGpu> by lazy {
 
 internal suspend fun browserGpu(): BrowserGpu = gpu.await()
 
+private val emscriptenContextAttributes: dynamic =
+  js(
+    "({alpha:1,depth:1,stencil:8,antialias:0,premultipliedAlpha:1,preserveDrawingBuffer:0," +
+      "preferLowPowerToHighPerformance:0,failIfMajorPerformanceCaveat:0," +
+      "enableExtensionsByDefault:1,explicitSwapControl:0,renderViaOffscreenBackBuffer:0," +
+      "majorVersion:2})"
+  )
+
+/**
+ * Registers one more Emscripten context, the leftover a resize leaves in `GL.contexts`, then
+ * restores the suite's current context.
+ */
+internal fun withExtraEmscriptenContext(
+  connected: Boolean = false,
+  block: (HTMLCanvasElement) -> Unit,
+) {
+  val registry: dynamic = js("globalThis").GL
+  val previous = registry.currentContext?.handle
+  val canvas = document.createElement("canvas").unsafeCast<HTMLCanvasElement>()
+  canvas.width = 8
+  canvas.height = 8
+  if (connected) {
+    document.body.asDynamic().appendChild(canvas)
+  }
+  val handle = registry.createContext(canvas, emscriptenContextAttributes)
+  check(handle != null && handle != undefined && handle != 0) {
+    "no extra WebGL2 context in this browser"
+  }
+  try {
+    if (previous != null && previous != undefined) registry.makeContextCurrent(previous)
+    block(canvas)
+  } finally {
+    registry.deleteContext(handle)
+    canvas.remove()
+    if (previous != null && previous != undefined) registry.makeContextCurrent(previous)
+  }
+}
+
 private fun createGpu(): BrowserGpu {
   val canvas = document.createElement("canvas").unsafeCast<HTMLCanvasElement>()
   canvas.width = GPU_CANVAS_SIZE
@@ -42,14 +80,7 @@ private fun createGpu(): BrowserGpu {
   // Emscripten's registry, not canvas.getContext: skia addresses a context by the integer name only
   // this registers.
   val registry: dynamic = js("globalThis").GL
-  val attributes =
-    js(
-      "({alpha:1,depth:1,stencil:8,antialias:0,premultipliedAlpha:1,preserveDrawingBuffer:0," +
-        "preferLowPowerToHighPerformance:0,failIfMajorPerformanceCaveat:0," +
-        "enableExtensionsByDefault:1,explicitSwapControl:0,renderViaOffscreenBackBuffer:0," +
-        "majorVersion:2})"
-    )
-  val handle = registry.createContext(canvas, attributes)
+  val handle = registry.createContext(canvas, emscriptenContextAttributes)
   check(handle != null && handle != undefined && handle != 0) {
     "no WebGL2 context in this browser"
   }

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserGpu.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserGpu.kt
@@ -2,7 +2,9 @@ package org.maplibre.compose.gljs
 
 import kotlin.js.Promise
 import kotlinx.browser.document
+import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.await
+import kotlinx.coroutines.promise
 import org.jetbrains.skia.DirectContext
 import org.jetbrains.skiko.wasm.onWasmReady
 import org.khronos.webgl.Uint8Array
@@ -34,6 +36,9 @@ private val gpu: Promise<BrowserGpu> by lazy {
 
 internal suspend fun browserGpu(): BrowserGpu = gpu.await()
 
+internal fun gpuTest(block: suspend (BrowserGpu) -> Unit): Promise<*> =
+  MainScope().promise { block(browserGpu()) }
+
 private val emscriptenContextAttributes: dynamic =
   js(
     "({alpha:1,depth:1,stencil:8,antialias:0,premultipliedAlpha:1,preserveDrawingBuffer:0," +
@@ -41,6 +46,9 @@ private val emscriptenContextAttributes: dynamic =
       "enableExtensionsByDefault:1,explicitSwapControl:0,renderViaOffscreenBackBuffer:0," +
       "majorVersion:2})"
   )
+
+private val emscriptenRegistry: dynamic
+  get() = js("globalThis").GL
 
 /**
  * Registers one more Emscripten context, the leftover a resize leaves in `GL.contexts`, then
@@ -50,41 +58,46 @@ internal fun withExtraEmscriptenContext(
   connected: Boolean = false,
   block: (HTMLCanvasElement) -> Unit,
 ) {
-  val registry: dynamic = js("globalThis").GL
+  val registry = emscriptenRegistry
   val previous = registry.currentContext?.handle
-  val canvas = document.createElement("canvas").unsafeCast<HTMLCanvasElement>()
-  canvas.width = 8
-  canvas.height = 8
-  if (connected) {
-    document.body.asDynamic().appendChild(canvas)
-  }
-  val handle = registry.createContext(canvas, emscriptenContextAttributes)
-  check(handle != null && handle != undefined && handle != 0) {
-    "no extra WebGL2 context in this browser"
+  val canvas = newCanvas(8)
+  if (connected) document.body.asDynamic().appendChild(canvas)
+  val handle = createEmscriptenContext(canvas)
+  fun restore() {
+    if (previous != null && previous != undefined) registry.makeContextCurrent(previous)
   }
   try {
-    if (previous != null && previous != undefined) registry.makeContextCurrent(previous)
+    restore()
     block(canvas)
   } finally {
     registry.deleteContext(handle)
     canvas.remove()
-    if (previous != null && previous != undefined) registry.makeContextCurrent(previous)
+    restore()
   }
 }
 
-private fun createGpu(): BrowserGpu {
+private fun newCanvas(size: Int): HTMLCanvasElement {
   val canvas = document.createElement("canvas").unsafeCast<HTMLCanvasElement>()
-  canvas.width = GPU_CANVAS_SIZE
-  canvas.height = GPU_CANVAS_SIZE
+  canvas.width = size
+  canvas.height = size
+  return canvas
+}
 
-  // Emscripten's registry, not canvas.getContext: skia addresses a context by the integer name only
-  // this registers.
-  val registry: dynamic = js("globalThis").GL
-  val handle = registry.createContext(canvas, emscriptenContextAttributes)
+private fun createEmscriptenContext(canvas: HTMLCanvasElement): dynamic {
+  val handle = emscriptenRegistry.createContext(canvas, emscriptenContextAttributes)
   check(handle != null && handle != undefined && handle != 0) {
     "no WebGL2 context in this browser"
   }
-  registry.makeContextCurrent(handle)
+  return handle
+}
+
+private fun createGpu(): BrowserGpu {
+  val canvas = newCanvas(GPU_CANVAS_SIZE)
+
+  // Emscripten's registry, not canvas.getContext: skia addresses a context by the integer name only
+  // this registers.
+  val handle = createEmscriptenContext(canvas)
+  emscriptenRegistry.makeContextCurrent(handle)
 
   // The hook has to be installed before the context is made.
   MapLibre.configure(workerUrl = LOCAL_WORKER_URL)

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/EmscriptenGlTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/EmscriptenGlTest.kt
@@ -74,7 +74,7 @@ class EmscriptenGlTest {
           )
           .target
       val replacement: dynamic = js("({})")
-      replacement.GLctx = js("Object").create(original.GLctx)
+      replacement.GLctx = aliasedWebGlContext(original.GLctx)
       holder.GLctxObject = replacement
       try {
         val again =

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/EmscriptenGlTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/EmscriptenGlTest.kt
@@ -3,7 +3,9 @@ package org.maplibre.compose.gljs
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertNotEquals
 import kotlin.test.assertSame
+import kotlinx.browser.document
 import org.maplibre.compose.map.MapExtent
 
 class EmscriptenGlTest {
@@ -45,6 +47,48 @@ class EmscriptenGlTest {
             .target
         assertEquals(SMALL, resized.widthPx)
         assertEquals(FULL, gl.drawingBufferWidth.unsafeCast<Int>(), "the leftover is not current")
+      }
+    }
+  }
+
+  @Test
+  fun the_newest_connected_canvas_wins_over_a_connected_leftover() = gpuTest { gpu ->
+    document.body.asDynamic().appendChild(gpu.canvas)
+    try {
+      withExtraEmscriptenContext(connected = true) { extra ->
+        assertSame(extra, EmscriptenGl.skikoCanvas(), "the last connected canvas")
+      }
+    } finally {
+      gpu.canvas.remove()
+    }
+  }
+
+  @Test
+  fun a_replaced_context_on_the_same_canvas_mints_a_new_target() = gpuTest { gpu ->
+    val holder = gpu.canvas.asDynamic()
+    val original = holder.GLctxObject
+    ComposeGlJsCompositor(logger = null).use { compositor ->
+      val first =
+        assertIs<GlJsFrameTarget.Composited>(
+            compositor.acquire(MapExtent.fromPhysical(FULL, FULL, 1.0))
+          )
+          .target
+      val replacement: dynamic = js("({})")
+      replacement.GLctx = js("Object").create(original.GLctx)
+      holder.GLctxObject = replacement
+      try {
+        val again =
+          assertIs<GlJsFrameTarget.Composited>(
+              compositor.acquire(MapExtent.fromPhysical(FULL, FULL, 1.0))
+            )
+            .target
+        assertNotEquals(
+          first.generation,
+          again.generation,
+          "a new context should mint a new target at the same size",
+        )
+      } finally {
+        holder.GLctxObject = original
       }
     }
   }

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/EmscriptenGlTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/EmscriptenGlTest.kt
@@ -1,38 +1,24 @@
 package org.maplibre.compose.gljs
 
-import kotlin.js.Promise
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertIs
 import kotlin.test.assertSame
-import kotlin.test.assertTrue
-import kotlinx.coroutines.MainScope
-import kotlinx.coroutines.promise
 import org.maplibre.compose.map.MapExtent
 
 class EmscriptenGlTest {
 
   @Test
   fun a_disconnected_leftover_context_does_not_hide_the_current_canvas() = gpuTest { gpu ->
-    withExtraEmscriptenContext(connected = false) {
-      assertSame(
-        gpu.canvas,
-        EmscriptenGl.skikoCanvas(),
-        "a leftover registry entry should not replace the current Skia canvas",
-      )
+    withExtraEmscriptenContext {
+      assertSame(gpu.canvas, EmscriptenGl.skikoCanvas(), "the current Skia canvas")
     }
   }
 
   @Test
-  fun a_connected_canvas_is_preferred_over_a_disconnected_leftover() = gpuTest { gpu ->
+  fun a_connected_canvas_is_preferred_over_a_disconnected_leftover() = gpuTest {
     withExtraEmscriptenContext(connected = true) { extra ->
-      val found = EmscriptenGl.skikoCanvas()
-      assertSame(
-        extra,
-        found,
-        "a resize leftover that left the document should lose to the new canvas",
-      )
-      assertTrue(extra.isConnected, "the extra canvas should still be in the document")
-      assertTrue(!gpu.canvas.isConnected, "the suite canvas is never attached")
+      assertSame(extra, EmscriptenGl.skikoCanvas(), "the canvas still in the document")
     }
   }
 
@@ -41,19 +27,24 @@ class EmscriptenGlTest {
     val gl = gpu.gl.asDynamic()
     ComposeGlJsCompositor(logger = null).use { compositor ->
       val first =
-        assertIsComposited(compositor.acquire(MapExtent.fromPhysical(FULL, FULL, 1.0))).target
-      withExtraEmscriptenContext(connected = false) {
+        assertIs<GlJsFrameTarget.Composited>(
+            compositor.acquire(MapExtent.fromPhysical(FULL, FULL, 1.0))
+          )
+          .target
+      withExtraEmscriptenContext {
         val again =
-          assertIsComposited(compositor.acquire(MapExtent.fromPhysical(FULL, FULL, 1.0))).target
+          assertIs<GlJsFrameTarget.Composited>(
+              compositor.acquire(MapExtent.fromPhysical(FULL, FULL, 1.0))
+            )
+            .target
         assertEquals(first.generation, again.generation, "the same target should be reused")
         val resized =
-          assertIsComposited(compositor.acquire(MapExtent.fromPhysical(SMALL, SMALL, 1.0))).target
+          assertIs<GlJsFrameTarget.Composited>(
+              compositor.acquire(MapExtent.fromPhysical(SMALL, SMALL, 1.0))
+            )
+            .target
         assertEquals(SMALL, resized.widthPx)
-        assertEquals(
-          FULL,
-          gl.drawingBufferWidth.unsafeCast<Int>(),
-          "the leftover context should not have become current",
-        )
+        assertEquals(FULL, gl.drawingBufferWidth.unsafeCast<Int>(), "the leftover is not current")
       }
     }
   }
@@ -61,11 +52,3 @@ class EmscriptenGlTest {
 
 private const val FULL = GPU_CANVAS_SIZE
 private const val SMALL = FULL / 2
-
-private fun gpuTest(block: suspend (BrowserGpu) -> Unit): Promise<*> =
-  MainScope().promise { block(browserGpu()) }
-
-private fun assertIsComposited(target: GlJsFrameTarget): GlJsFrameTarget.Composited {
-  assertTrue(target is GlJsFrameTarget.Composited, "expected a composited target, got $target")
-  return target
-}

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/EmscriptenGlTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/EmscriptenGlTest.kt
@@ -1,0 +1,71 @@
+package org.maplibre.compose.gljs
+
+import kotlin.js.Promise
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.promise
+import org.maplibre.compose.map.MapExtent
+
+class EmscriptenGlTest {
+
+  @Test
+  fun a_disconnected_leftover_context_does_not_hide_the_current_canvas() = gpuTest { gpu ->
+    withExtraEmscriptenContext(connected = false) {
+      assertSame(
+        gpu.canvas,
+        EmscriptenGl.skikoCanvas(),
+        "a leftover registry entry should not replace the current Skia canvas",
+      )
+    }
+  }
+
+  @Test
+  fun a_connected_canvas_is_preferred_over_a_disconnected_leftover() = gpuTest { gpu ->
+    withExtraEmscriptenContext(connected = true) { extra ->
+      val found = EmscriptenGl.skikoCanvas()
+      assertSame(
+        extra,
+        found,
+        "a resize leftover that left the document should lose to the new canvas",
+      )
+      assertTrue(extra.isConnected, "the extra canvas should still be in the document")
+      assertTrue(!gpu.canvas.isConnected, "the suite canvas is never attached")
+    }
+  }
+
+  @Test
+  fun the_compositor_keeps_drawing_when_the_registry_holds_a_leftover() = gpuTest { gpu ->
+    val gl = gpu.gl.asDynamic()
+    ComposeGlJsCompositor(logger = null).use { compositor ->
+      val first =
+        assertIsComposited(compositor.acquire(MapExtent.fromPhysical(FULL, FULL, 1.0))).target
+      withExtraEmscriptenContext(connected = false) {
+        val again =
+          assertIsComposited(compositor.acquire(MapExtent.fromPhysical(FULL, FULL, 1.0))).target
+        assertEquals(first.generation, again.generation, "the same target should be reused")
+        val resized =
+          assertIsComposited(compositor.acquire(MapExtent.fromPhysical(SMALL, SMALL, 1.0))).target
+        assertEquals(SMALL, resized.widthPx)
+        assertEquals(
+          FULL,
+          gl.drawingBufferWidth.unsafeCast<Int>(),
+          "the leftover context should not have become current",
+        )
+      }
+    }
+  }
+}
+
+private const val FULL = GPU_CANVAS_SIZE
+private const val SMALL = FULL / 2
+
+private fun gpuTest(block: suspend (BrowserGpu) -> Unit): Promise<*> =
+  MainScope().promise { block(browserGpu()) }
+
+private fun assertIsComposited(target: GlJsFrameTarget): GlJsFrameTarget.Composited {
+  assertTrue(target is GlJsFrameTarget.Composited, "expected a composited target, got $target")
+  return target
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

A window resize can replace Compose's WebGL context while the magnifying lens keeps its pixel size, so the compositor remints that target and rebuilds the lent map instead of reusing a framebuffer from the old context.

## Validation

`:lib:maplibre-compose:jsBrowserTest` passed after dropping the retry path.

## AI assistance

Cursor Grok 4.6 in a Cloud Agent.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cc99ec6d-4fdd-4c09-8af8-da055b6586b2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cc99ec6d-4fdd-4c09-8af8-da055b6586b2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

