### PR TITLE
Fix JS map rendering after Compose context replacement

### DIFF
--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/EmscriptenGl.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/EmscriptenGl.kt
@@ -6,9 +6,16 @@ import web.html.HTMLCanvasElement
 internal const val GL_TEXTURE_2D: Int = 0x0DE1
 internal const val GL_RGBA8: Int = 0x8058
 
+/** The Emscripten context that owns the Compose draw pass currently in progress. */
+internal class EmscriptenGlContext(
+  val handle: Int,
+  val webGlContext: WebGL2RenderingContext,
+)
+
 /**
- * Emscripten's GL bookkeeping, which skiko's loader publishes as a global. It is the only list of
- * the contexts on the page: Compose puts its canvas inside a shadow root.
+ * Emscripten's GL bookkeeping, which Skiko's loader publishes as a global. The current entry
+ * identifies the renderer driving this frame even though Compose puts its canvas inside a shadow
+ * root.
  */
 internal object EmscriptenGl {
   private val registry: dynamic
@@ -20,36 +27,35 @@ internal object EmscriptenGl {
       return gl != null && gl != undefined
     }
 
-  /**
-   * Null before Compose has built its renderer.
-   *
-   * @throws IllegalStateException if the page holds more than one live WebGL context. The Skia
-   *   context this pairs with is whichever was created last, and WebGL shares no resources between
-   *   contexts, so guessing between them would draw a map from a texture another context owns.
-   */
-  fun skikoCanvas(): HTMLCanvasElement? {
+  /** The handle that Skiko made current, including handles from retired renderers. */
+  fun currentHandle(): Int? {
     if (!isAvailable) return null
-    val contexts = registry.contexts ?: return null
-    val length = contexts.length as? Int ?: return null
-    var found: HTMLCanvasElement? = null
-    for (index in 0 until length) {
-      val entry = contexts[index]
-      if (entry == null || entry == undefined) continue
-      val canvas = entry.GLctx?.canvas
-      if (canvas == null || canvas == undefined) continue
-      check(found == null) {
-        "MapLibre Compose supports one Compose renderer per page, and this page has more than one " +
-          "live WebGL context."
-      }
-      found = canvas.unsafeCast<HTMLCanvasElement>()
-    }
-    return found
+    val entry = registry.currentContext
+    if (entry == null || entry == undefined) return null
+    return entry.handle as? Int
   }
 
-  fun contextOf(canvas: HTMLCanvasElement): WebGL2RenderingContext? {
-    val context = canvas.asDynamic().GLctxObject?.GLctx
-    if (context == null || context == undefined) return null
-    return context.unsafeCast<WebGL2RenderingContext>()
+  /**
+   * The context for the Compose draw pass currently in progress.
+   *
+   * Compose can leave one animation frame queued on a renderer that a resize replaced. The canvas
+   * points at the newest Emscripten entry, so a different current entry belongs to a retired frame.
+   */
+  fun currentContext(): EmscriptenGlContext? {
+    if (!isAvailable) return null
+    val entry = registry.currentContext
+    if (entry == null || entry == undefined) return null
+    val handle = entry.handle as? Int ?: return null
+    val context = entry.GLctx
+    if (context == null || context == undefined || context.isContextLost() == true) return null
+    val canvas = context.canvas
+    if (canvas == null || canvas == undefined) return null
+    val typedCanvas = canvas.unsafeCast<HTMLCanvasElement>()
+    if (typedCanvas.asDynamic().GLctxObject !== entry) return null
+    return EmscriptenGlContext(
+      handle = handle,
+      webGlContext = context.unsafeCast<WebGL2RenderingContext>(),
+    )
   }
 
   /** A texture created from JavaScript has no name, and Skia's wasm build addresses it by one. */

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsCompositor.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsCompositor.kt
@@ -3,7 +3,6 @@ package org.maplibre.compose.gljs
 import androidx.compose.runtime.staticCompositionLocalOf
 import co.touchlab.kermit.Logger
 import org.maplibre.compose.map.MapExtent
-import web.html.HTMLCanvasElement
 
 /** What a map should render into for one frame. */
 internal sealed interface GlJsFrameTarget {
@@ -30,49 +29,39 @@ internal val LocalGlJsCompositor =
 /** A target is never resized in place: WebGL cannot resize a texture. */
 internal class ComposeGlJsCompositor(private val logger: Logger?) : GlJsCompositor {
 
-  private var canvas: HTMLCanvasElement? = null
-  private var gl: dynamic = null
   private var target: GlJsRenderTarget? = null
   private var generation = 0L
   private var reportedUnavailable = false
 
-  /** Null before Compose has built its own. */
-  private fun context(): dynamic {
-    if (gl != null) return gl
-    val found = EmscriptenGl.skikoCanvas() ?: return null
-    val context = EmscriptenGl.contextOf(found) ?: return null
-    canvas = found
-    gl = context
-    return context
-  }
-
   override fun acquire(extent: MapExtent): GlJsFrameTarget {
     if (extent.isEmpty) return GlJsFrameTarget.NotReady
-    val current = target
-    if (
-      current != null &&
-        current.widthPx == extent.physicalWidth &&
-        current.heightPx == extent.physicalHeight
-    ) {
-      return GlJsFrameTarget.Composited(current)
-    }
-
-    val context = context()
-    if (context == null || !SkikoGpuBridge.isReady) {
+    val hostContext = EmscriptenGl.currentContext()
+    if (hostContext == null || !SkikoGpuBridge.isReady(hostContext)) {
       if (!reportedUnavailable) {
         reportedUnavailable = true
         logger?.d {
           "Waiting to composite the map: " +
-            if (context == null) "Compose has no WebGL context yet" else SkikoGpuBridge.diagnostic()
+            if (hostContext == null) "Compose has no current WebGL renderer"
+            else SkikoGpuBridge.diagnostic(hostContext)
         }
       }
       return GlJsFrameTarget.NotReady
     }
     reportedUnavailable = false
 
+    val current = target
+    if (
+      current != null &&
+        current.hostContext.handle == hostContext.handle &&
+        current.widthPx == extent.physicalWidth &&
+        current.heightPx == extent.physicalHeight
+    ) {
+      return GlJsFrameTarget.Composited(current)
+    }
+
     val next =
       GlJsRenderTarget(
-        gl = context,
+        hostContext = hostContext,
         widthPx = extent.physicalWidth,
         heightPx = extent.physicalHeight,
         generation = ++generation,

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsRenderTarget.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsRenderTarget.kt
@@ -7,14 +7,17 @@ import org.jetbrains.skia.SurfaceOrigin
 
 /**
  * The texture MapLibre GL JS renders into and Compose draws from, sized in physical pixels and
- * never resized in place. Everything here is allocated in the one context skiko created.
+ * never resized in place. The texture and adopted image belong to one Emscripten and Skia renderer
+ * generation.
  */
 internal class GlJsRenderTarget(
-  val gl: dynamic,
+  val hostContext: EmscriptenGlContext,
   val widthPx: Int,
   val heightPx: Int,
   val generation: Long,
 ) : AutoCloseable {
+
+  val gl: dynamic = hostContext.webGlContext.asDynamic()
 
   private val fragmentTextureUnits =
     (gl.getParameter(gl.MAX_TEXTURE_IMAGE_UNITS) as? Int)
@@ -60,8 +63,8 @@ internal class GlJsRenderTarget(
     }
 
     val context =
-      checkNotNull(SkikoGpuBridge.directContext()) {
-        "Compose's GPU context is not available: ${SkikoGpuBridge.diagnostic()}"
+      checkNotNull(SkikoGpuBridge.directContext(hostContext)) {
+        "Compose's GPU context is not available: ${SkikoGpuBridge.diagnostic(hostContext)}"
       }
     val backendTexture =
       BackendTexture.makeGL(
@@ -88,6 +91,11 @@ internal class GlJsRenderTarget(
    */
   fun unbindSamplerObjects() {
     repeat(fragmentTextureUnits) { unit -> gl.bindSampler(unit, null) }
+  }
+
+  /** Invalidates the Skia state cache for the context that adopted [image]. */
+  fun resetSkiaState() {
+    SkikoGpuBridge.resetGlState(hostContext)
   }
 
   /** The texture is not deleted here: adoption handed it to Skia. */

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/SkikoGpuBridge.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/SkikoGpuBridge.kt
@@ -20,7 +20,8 @@ private const val GL_STATES = 0xffff
  *   [JetBrains/skiko#1219](https://github.com/JetBrains/skiko/pull/1219) or an equivalent lands.
  */
 internal object SkikoGpuBridge {
-  private var contextPointer: dynamic = null
+  /** Skia context pointer for each Emscripten renderer generation. */
+  private val contextPointers = mutableMapOf<Int, Any>()
 
   /** Which mangled property this build keeps a managed object's native pointer in. */
   private var pointerField: String? = null
@@ -28,9 +29,6 @@ internal object SkikoGpuBridge {
   private var managedPrototype: dynamic = null
 
   private var hookInstalled = false
-
-  val isReady: Boolean
-    get() = contextPointer != null && pointerField != null
 
   /**
    * Must run after skiko's wasm module has published its exports and before Compose builds its
@@ -42,7 +40,9 @@ internal object SkikoGpuBridge {
     if (original == null || original == undefined) return false
     browserWindow[MAKE_GL_SYMBOL] = {
       val pointer = original()
-      contextPointer = pointer
+      EmscriptenGl.currentHandle()?.let { handle ->
+        contextPointers[handle] = pointer.unsafeCast<Any>()
+      }
       pointer
     }
     hookInstalled = true
@@ -56,8 +56,8 @@ internal object SkikoGpuBridge {
    * development build goes through its accessor. It frees nothing — the pointer belongs to Compose
    * — and no instance method may dispatch on it.
    */
-  fun directContext(): DirectContext? {
-    val pointer = contextPointer ?: return null
+  fun directContext(context: EmscriptenGlContext): DirectContext? {
+    val pointer = contextPointers[context.handle] ?: return null
     val field = pointerField ?: return null
     val prototype = managedPrototype ?: return null
     val stand: dynamic = js("Object").create(prototype)
@@ -66,18 +66,22 @@ internal object SkikoGpuBridge {
   }
 
   /** `DirectContext.resetGLAll()`, through the export, since that method needs a real instance. */
-  fun resetGlState() {
-    val pointer = contextPointer ?: return
+  fun resetGlState(context: EmscriptenGlContext) {
+    val pointer = contextPointers[context.handle] ?: return
     val reset = browserWindow[RESET_SYMBOL]
     if (reset == null || reset == undefined) return
     reset(pointer, GL_STATES)
   }
 
-  fun diagnostic(): String =
+  fun isReady(context: EmscriptenGlContext): Boolean =
+    pointerField != null && contextPointers.containsKey(context.handle)
+
+  fun diagnostic(context: EmscriptenGlContext): String =
     when {
       !hookInstalled -> "skiko's exports were not on the page when MapLibre Compose initialized"
-      contextPointer == null -> "Compose has not created its GPU context yet"
       pointerField == null -> "skiko's native pointer field could not be identified in this build"
+      !contextPointers.containsKey(context.handle) ->
+        "Compose's Skia context was not captured for Emscripten handle ${context.handle}"
       else -> "ready"
     }
 

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
@@ -42,7 +42,6 @@ import org.maplibre.compose.gljs.Point
 import org.maplibre.compose.gljs.QueryGeometry
 import org.maplibre.compose.gljs.QueryRenderedFeaturesOptions
 import org.maplibre.compose.gljs.SetStyleOptions
-import org.maplibre.compose.gljs.SkikoGpuBridge
 import org.maplibre.compose.gljs.isCameraEasing
 import org.maplibre.compose.gljs.queryBox
 import org.maplibre.compose.gljs.styleJson
@@ -184,7 +183,7 @@ internal class GlJsMapSession(
       GlJsRuntime.withDrawingBufferSize(mapTarget.gl, mapTarget.widthPx, mapTarget.heightPx) {
         map.redraw()
       }
-      SkikoGpuBridge.resetGlState()
+      mapTarget.resetSkiaState()
     } else {
       // GL JS runs style updates, tile loading and every camera ease from inside its own render, so
       // even a map nothing samples has to be asked to draw.
@@ -222,6 +221,17 @@ internal class GlJsMapSession(
    * a context from its own canvas and is never drawn.
    */
   private fun ensureMap(target: GlJsRenderTarget?, extent: MapExtent): MaplibreMap? {
+    val incomingContext = target?.gl?.unsafeCast<WebGL2RenderingContext>()
+    if (
+      map != null &&
+        incomingContext != null &&
+        lentContext != null &&
+        incomingContext !== lentContext
+    ) {
+      // MapLibre may keep its map across a new Skia renderer on the same browser context, but its
+      // resources cannot move to a different browser context.
+      destroyMap()
+    }
     map?.let {
       return it
     }

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
@@ -221,17 +221,6 @@ internal class GlJsMapSession(
    * a context from its own canvas and is never drawn.
    */
   private fun ensureMap(target: GlJsRenderTarget?, extent: MapExtent): MaplibreMap? {
-    val incomingContext = target?.gl?.unsafeCast<WebGL2RenderingContext>()
-    if (
-      map != null &&
-        incomingContext != null &&
-        lentContext != null &&
-        incomingContext !== lentContext
-    ) {
-      // MapLibre may keep its map across a new Skia renderer on the same browser context, but its
-      // resources cannot move to a different browser context.
-      destroyMap()
-    }
     map?.let {
       return it
     }

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserCompositingTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserCompositingTest.kt
@@ -103,7 +103,7 @@ class BrowserCompositingTest {
   @Test
   fun the_map_lands_in_the_callers_framebuffer_and_never_on_the_canvas() = gpuTest { gpu ->
     val gl = gpu.gl.asDynamic()
-    GlJsRenderTarget(gl, FULL, FULL, generation = 1).use { target ->
+    browserRenderTarget(FULL, FULL, generation = 1).use { target ->
       CompositedMap(SPLIT_STYLE).use { map ->
         map.drawTheWholeStyle(target)
 
@@ -133,7 +133,7 @@ class BrowserCompositingTest {
   @Test
   fun the_two_colour_style_splits_the_target_down_the_prime_meridian() = gpuTest { gpu ->
     val gl = gpu.gl.asDynamic()
-    GlJsRenderTarget(gl, FULL, FULL, generation = 1).use { target ->
+    browserRenderTarget(FULL, FULL, generation = 1).use { target ->
       CompositedMap(SPLIT_STYLE).use { map ->
         map.drawTheWholeStyle(target)
         assertEquals(
@@ -148,7 +148,7 @@ class BrowserCompositingTest {
   @Test
   fun a_heatmap_uses_the_map_target_size_instead_of_the_shared_canvas_size() = gpuTest { gpu ->
     val gl = gpu.gl.asDynamic()
-    GlJsRenderTarget(gl, SMALL, SMALL, generation = 1).use { target ->
+    browserRenderTarget(SMALL, SMALL, generation = 1).use { target ->
       CompositedMap(HEATMAP_STYLE, scaleFactor = FRACTIONAL_SCALE).use { map ->
         val extent = MapExtent.fromPhysical(SMALL, SMALL, FRACTIONAL_SCALE)
         map.drawUntil(target, "the heatmap point to reach the render tree") {
@@ -173,47 +173,66 @@ class BrowserCompositingTest {
   @Test
   fun skia_draws_the_adopted_texture_into_a_gpu_surface() = gpuTest { gpu ->
     val gl = gpu.gl.asDynamic()
-    GlJsRenderTarget(gl, FULL, FULL, generation = 1).use { target ->
+    browserRenderTarget(FULL, FULL, generation = 1).use { target ->
       CompositedMap(SPLIT_STYLE).use { map -> map.drawTheWholeStyle(target) }
 
-      val surface =
-        Surface.makeRenderTarget(
-          gpu.skia,
-          false,
-          ImageInfo(FULL, FULL, ColorType.RGBA_8888, ColorAlphaType.PREMUL),
-          0,
-          SurfaceOrigin.TOP_LEFT,
-          null,
-          false,
-        )
-      val bitmap = Bitmap()
-      try {
-        surface.canvas.clear(PAGE_ARGB)
-        surface.canvas.drawImageRect(
-          target.image,
-          Rect.makeWH(FULL.toFloat(), FULL.toFloat()),
-          Rect.makeXYWH(INSET.toFloat(), INSET.toFloat(), SMALL.toFloat(), SMALL.toFloat()),
-          SamplingMode.LINEAR,
-          null,
-          strict = true,
-        )
-        gpu.skia.flush(surface)
-        gpu.skia.submit(true)
+      assertEquals(
+        mapOf(
+          PAGE to FULL * FULL - SMALL * SMALL,
+          RED to SMALL * SMALL / 2,
+          BLUE to SMALL * SMALL / 2,
+        ),
+        drawTargetWithSkia(gpu.skia, target),
+        "Skia should sample MapLibre's texture into exactly the rect it was drawn to",
+      )
+    }
+  }
 
-        bitmap.allocPixels(ImageInfo(FULL, FULL, ColorType.RGBA_8888, ColorAlphaType.UNPREMUL))
-        assertTrue(surface.readPixels(bitmap, 0, 0), "the GPU surface should read back")
-        assertEquals(
-          mapOf(
-            PAGE to FULL * FULL - SMALL * SMALL,
-            RED to SMALL * SMALL / 2,
-            BLUE to SMALL * SMALL / 2,
-          ),
-          histogram(checkNotNull(bitmap.readPixels())),
-          "Skia should sample MapLibre's texture into exactly the rect it was drawn to",
-        )
+  @Test
+  fun a_new_skia_context_replaces_a_same_size_target_and_the_map_keeps_drawing() = gpuTest { gpu ->
+    val gl = gpu.gl.asDynamic()
+    val compositor = ComposeGlJsCompositor(logger = null)
+    CompositedMap(SPLIT_STYLE).use { map ->
+      try {
+        val first =
+          assertIs<GlJsFrameTarget.Composited>(
+              compositor.acquire(MapExtent.fromPhysical(FULL, FULL, 1.0))
+            )
+            .target
+        map.drawTheWholeStyle(first)
+
+        gpu.withRecreatedSkiaContext { nextSkia ->
+          val second =
+            assertIs<GlJsFrameTarget.Composited>(
+                compositor.acquire(MapExtent.fromPhysical(FULL, FULL, 1.0))
+              )
+              .target
+          assertNotEquals(
+            first.generation,
+            second.generation,
+            "a new Skia context should replace a same-size target",
+          )
+          assertTrue(first.gl === second.gl, "the browser WebGL context should stay the same")
+
+          map.drawTheWholeStyle(second)
+          assertEquals(
+            mapOf(RED to FULL * FULL / 2, BLUE to FULL * FULL / 2),
+            histogram(readFramebuffer(gl, second.framebuffer, FULL, FULL)),
+            "the existing map should draw into the replacement target",
+          )
+          assertEquals(
+            mapOf(
+              PAGE to FULL * FULL - SMALL * SMALL,
+              RED to SMALL * SMALL / 2,
+              BLUE to SMALL * SMALL / 2,
+            ),
+            drawTargetWithSkia(nextSkia, second),
+            "the replacement Skia context should draw the replacement image",
+          )
+          compositor.close()
+        }
       } finally {
-        bitmap.close()
-        surface.close()
+        compositor.close()
       }
     }
   }
@@ -221,7 +240,7 @@ class BrowserCompositingTest {
   @Test
   fun map_frames_clear_sampler_objects_left_by_the_shared_renderer() = gpuTest { gpu ->
     val gl = gpu.gl.asDynamic()
-    GlJsRenderTarget(gl, FULL, FULL, generation = 1).use { target ->
+    browserRenderTarget(FULL, FULL, generation = 1).use { target ->
       CompositedMap(SPLIT_STYLE).use { map ->
         map.drawTheWholeStyle(target)
 
@@ -283,7 +302,7 @@ class BrowserCompositingTest {
   @Test
   fun closing_a_composited_map_leaves_the_shared_context_alive() = gpuTest { gpu ->
     val gl = gpu.gl.asDynamic()
-    GlJsRenderTarget(gl, FULL, FULL, generation = 1).use { target ->
+    browserRenderTarget(FULL, FULL, generation = 1).use { target ->
       CompositedMap(SPLIT_STYLE).use { map -> map.drawTheWholeStyle(target) }
       assertFalse(
         gl.isContextLost().unsafeCast<Boolean>(),
@@ -299,5 +318,42 @@ private fun gpuTest(block: suspend (BrowserGpu) -> Unit): Promise<*> =
 private suspend fun CompositedMap.drawTheWholeStyle(target: GlJsRenderTarget) {
   drawUntil(target, "the red polygon to reach the render tree") {
     rendersFeature("shape", target.widthPx / 4, target.heightPx / 2)
+  }
+}
+
+private fun drawTargetWithSkia(
+  skia: org.jetbrains.skia.DirectContext,
+  target: GlJsRenderTarget,
+): Map<String, Int> {
+  val surface =
+    Surface.makeRenderTarget(
+      skia,
+      false,
+      ImageInfo(FULL, FULL, ColorType.RGBA_8888, ColorAlphaType.PREMUL),
+      0,
+      SurfaceOrigin.TOP_LEFT,
+      null,
+      false,
+    )
+  val bitmap = Bitmap()
+  try {
+    surface.canvas.clear(PAGE_ARGB)
+    surface.canvas.drawImageRect(
+      target.image,
+      Rect.makeWH(target.widthPx.toFloat(), target.heightPx.toFloat()),
+      Rect.makeXYWH(INSET.toFloat(), INSET.toFloat(), SMALL.toFloat(), SMALL.toFloat()),
+      SamplingMode.LINEAR,
+      null,
+      strict = true,
+    )
+    skia.flush(surface)
+    skia.submit(true)
+
+    bitmap.allocPixels(ImageInfo(FULL, FULL, ColorType.RGBA_8888, ColorAlphaType.UNPREMUL))
+    assertTrue(surface.readPixels(bitmap, 0, 0), "the GPU surface should read back")
+    return histogram(checkNotNull(bitmap.readPixels()))
+  } finally {
+    bitmap.close()
+    surface.close()
   }
 }

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserGpu.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserGpu.kt
@@ -58,9 +58,43 @@ private fun createGpu(): BrowserGpu {
   // The hook has to be installed before the context is made.
   MapLibre.configure(workerUrl = LOCAL_WORKER_URL)
   val skia = DirectContext.makeGL()
-  check(SkikoGpuBridge.isReady) { SkikoGpuBridge.diagnostic() }
+  val hostContext = checkNotNull(EmscriptenGl.currentContext())
+  check(SkikoGpuBridge.isReady(hostContext)) { SkikoGpuBridge.diagnostic(hostContext) }
 
-  return BrowserGpu(canvas, checkNotNull(EmscriptenGl.contextOf(canvas)), skia)
+  return BrowserGpu(canvas, hostContext.webGlContext, skia)
+}
+
+internal fun browserRenderTarget(width: Int, height: Int, generation: Long): GlJsRenderTarget =
+  GlJsRenderTarget(
+    hostContext = checkNotNull(EmscriptenGl.currentContext()),
+    widthPx = width,
+    heightPx = height,
+    generation = generation,
+  )
+
+/** Repeats Skiko's resize-time context construction on [BrowserGpu.canvas]. */
+internal inline fun <T> BrowserGpu.withRecreatedSkiaContext(block: (DirectContext) -> T): T {
+  val registry: dynamic = js("globalThis").GL
+  val previous = registry.currentContext
+  check(previous != null && previous != undefined) { "the browser GPU has no current context" }
+  val nextHandle = registry.createContext(canvas, previous.attributes)
+  check(nextHandle != null && nextHandle != undefined && nextHandle != 0) {
+    "Emscripten did not recreate the context"
+  }
+  registry.makeContextCurrent(nextHandle)
+  val nextSkia = DirectContext.makeGL()
+  try {
+    val next = checkNotNull(EmscriptenGl.currentContext())
+    check(next.webGlContext === gl) {
+      "Skiko's resize path replaced the browser WebGL context instead of registering a new handle"
+    }
+    return block(nextSkia)
+  } finally {
+    nextSkia.close()
+    registry.deleteContext(nextHandle)
+    canvas.asDynamic().GLctxObject = previous
+    registry.makeContextCurrent(previous.handle)
+  }
 }
 
 /** Reads [framebuffer] — null meaning the canvas itself — as tightly packed RGBA bytes. */


### PR DESCRIPTION
## Description

Track the active Emscripten and Skia renderer generation so JS maps replace stale adopted textures after Compose recreates its renderer while retaining MapLibre across the same browser WebGL context.

## Validation

`mise run test:js` in Chrome Headless 151 manual verification with the demo app.

## AI assistance

Codex, GPT-5.6 Sol