### PR TITLE
Expose text variable anchor offsets through SymbolLayer

### DIFF
--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/dsl/literals.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/dsl/literals.kt
@@ -100,12 +100,14 @@ public fun const(list: List<Number>): Literal<VectorValue<Number>, *> =
  * Creates a literal expression for [TextVariableAnchorOffsetValue], used by
  * [SymbolLayer][org.maplibre.compose.layers.SymbolLayer]'s `textVariableAnchorOffset` parameter.
  *
- * The offset is measured in a multipler of the text size (EM). It's in [Offset] instead of [offset]
- * because of technical limitations in MapLibre.
+ * Each [Offset] component is measured in ems. This helper uses [Offset] instead of [offset] because
+ * MapLibre requires the offsets inside a literal array. That array cannot evaluate text-unit
+ * expressions.
  */
 public fun textVariableAnchorOffset(
   vararg pairs: Pair<SymbolAnchor, Offset>
 ): Literal<TextVariableAnchorOffsetValue, List<*>> {
+  // TODO: Replace Offset with a dedicated em offset type that makes the unit explicit.
   val elements = buildList {
     pairs.forEach { (anchor, offset) ->
       add(anchor.literal)

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/SymbolLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/SymbolLayer.kt
@@ -348,31 +348,27 @@ private fun rememberEmCompiler(textSize: Expression<TextUnitValue>): LayerProper
  *   the next location+offset. Use [textJustify] = [TextJustify.Auto] to choose justification based
  *   on anchor position. The expression may use feature properties.
  *
- * Each anchor location is accompanied by a point which defines the offset when the corresponding
- * anchor location is used. Positive offset values indicate right and down, while negative values
- * indicate left and up. Anchor locations may repeat, allowing the renderer to try multiple offsets
- * to try and place a label using the same anchor.
+ * Each anchor location has an [androidx.compose.ui.geometry.Offset] in ems. Positive offset values
+ * indicate right and down, while negative values indicate left and up. Anchor locations may repeat,
+ * which lets the renderer try multiple offsets for the same anchor.
  *
  * When present, this property takes precedence over [textAnchor], [textVariableAnchor],
  * [textOffset] and [textRadialOffset].
  *
  * Example:
  * ```kt
- * listOf(
- *   SymbolAnchor.Top to Point(0, 4),
- *   SymbolAnchor.Left to Point(3, 0),
- *   SymbolAnchor.Bottom to Point(1, 1)
+ * textVariableAnchorOffset(
+ *   SymbolAnchor.Top to Offset(0f, 4f),
+ *   SymbolAnchor.Left to Offset(3f, 0f),
+ *   SymbolAnchor.Bottom to Offset(1f, 1f),
  * )
  * ```
  *
  * When the renderer chooses the top anchor, [0, 4] will be used for [textOffset]; the text will be
  * shifted down by 4 ems. When the renderer chooses the left anchor, [3, 0] will be used for
- * [textOffset]; the text will be shifted right by 3 ems. Etc.
+ * [textOffset]; the text will be shifted right by 3 ems.
  *
  * Ignored if [textField] is not specified.
- *
- * NOTE: This property is currently not usable:
- * https://github.com/maplibre/maplibre-compose/issues/143
  *
  * @param textPadding Size of the additional area in dp around the text bounding box used for
  *   detecting symbol collisions.
@@ -499,8 +495,7 @@ public fun SymbolLayer(
   textOffset: Expression<TextUnitOffsetValue> = offset(0f.em, 0f.em),
   textVariableAnchor: Expression<ListValue<SymbolAnchor>> = nil(),
   textRadialOffset: Expression<TextUnitValue> = const(0f.em),
-  //  textVariableAnchorOffset: Expression<TextVariableAnchorOffsetValue> = nil(),
-  textVariableAnchorOffset: Expression<Nothing> = nil(),
+  textVariableAnchorOffset: Expression<TextVariableAnchorOffsetValue> = nil(),
 
   // text collision
   textPadding: Expression<DpValue> = const(2.dp),

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/layers/LayerPropertyRoundTripTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/layers/LayerPropertyRoundTripTest.kt
@@ -621,11 +621,15 @@ class LayerPropertyRoundTripTest {
         },
         Case(
           "text-variable-anchor-offset",
-          """["top",[0.0,1.0]]""",
-          """["literal",["top",[0.0,1.0]]]""",
+          """["top",[0.0,1.0],"bottom",[0.0,-2.0]]""",
+          """["literal",["top",[0.0,1.0],"bottom",[0.0,-2.0]]]""",
         ) {
           it.setTextVariableAnchorOffset(
-            textVariableAnchorOffset(SymbolAnchor.Top to Offset(0f, 1f)).c()
+            textVariableAnchorOffset(
+                SymbolAnchor.Top to Offset(0f, 1f),
+                SymbolAnchor.Bottom to Offset(0f, -2f),
+              )
+              .c()
           )
         },
         Case("text-anchor", "\"top-left\"") { it.setTextAnchor(const(SymbolAnchor.TopLeft).c()) },

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/layers/SymbolLayerCompositionTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/layers/SymbolLayerCompositionTest.kt
@@ -1,0 +1,96 @@
+package org.maplibre.compose.layers
+
+import androidx.compose.runtime.BroadcastFrameClock
+import androidx.compose.runtime.Composition
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.withRunningRecomposer
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.yield
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.doubleOrNull
+import org.maplibre.compose.expressions.dsl.textVariableAnchorOffset
+import org.maplibre.compose.expressions.value.SymbolAnchor
+import org.maplibre.compose.sources.GeoJsonData
+import org.maplibre.compose.sources.GeoJsonOptions
+import org.maplibre.compose.sources.GeoJsonSource
+import org.maplibre.compose.style.FakeStyle
+import org.maplibre.compose.style.MapNodeApplier
+import org.maplibre.compose.style.SafeStyle
+import org.maplibre.compose.style.StyleContent
+import org.maplibre.compose.style.StyleNode
+import org.maplibre.spatialk.geojson.dsl.featureCollectionOf
+
+class SymbolLayerCompositionTest {
+
+  @Test
+  fun variable_anchor_offsets_reach_the_layer_through_the_public_api() = runTest {
+    val frameClock = BroadcastFrameClock()
+    withContext(frameClock) {
+      withRunningRecomposer { recomposer ->
+        val style = FakeStyle(emptyList(), emptyList(), emptyList())
+        val rootNode = StyleNode(SafeStyle(style), logger = null)
+        val source =
+          GeoJsonSource(
+            "features",
+            GeoJsonData.Features(featureCollectionOf()),
+            GeoJsonOptions(),
+          )
+        val composition = Composition(MapNodeApplier(rootNode), recomposer)
+        try {
+          composition.setContent {
+            CompositionLocalProvider(
+              LocalDensity provides Density(1f),
+              LocalLayoutDirection provides LayoutDirection.Ltr,
+            ) {
+              StyleContent(rootNode) {
+                SymbolLayer(
+                  id = "labels",
+                  source = source,
+                  textVariableAnchorOffset =
+                    textVariableAnchorOffset(
+                      SymbolAnchor.Top to Offset(0f, 1f),
+                      SymbolAnchor.Bottom to Offset(0f, -2f),
+                    ),
+                )
+              }
+            }
+          }
+          while (!frameClock.hasAwaiters) yield()
+          frameClock.sendFrame(0)
+          yield()
+          recomposer.awaitIdle()
+
+          val layer = assertNotNull(style.getLayer("labels"))
+          val layout = assertNotNull(layer.toJson()["layout"] as? JsonObject)
+          assertEquals(
+            Json.parseToJsonElement("""["literal",["top",[0,1],"bottom",[0,-2]]]""")
+              .normalizeNumbers(),
+            assertNotNull(layout["text-variable-anchor-offset"]).normalizeNumbers(),
+          )
+        } finally {
+          composition.dispose()
+        }
+      }
+    }
+  }
+
+  private fun JsonElement.normalizeNumbers(): JsonElement =
+    when (this) {
+      is JsonArray -> JsonArray(map { it.normalizeNumbers() })
+      is JsonObject -> JsonObject(mapValues { (_, value) -> value.normalizeNumbers() })
+      is JsonPrimitive -> doubleOrNull?.let(::JsonPrimitive) ?: this
+    }
+}


### PR DESCRIPTION
## Summary

- Expose `textVariableAnchorOffset` through the public `SymbolLayer` API
- Clarify that offsets are measured in ems
- Add composition coverage proving offsets reach the generated layer layout

## Testing

- Added live-map composition and round-trip tests for multiple variable anchor offsets