### PR TITLE
Fix JS overdraw inspector rendering

### DIFF
--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsRenderTarget.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsRenderTarget.kt
@@ -85,12 +85,10 @@ internal class GlJsRenderTarget(
       )
   }
 
-  /**
-   * Removes sampler objects left by Skia. A sampler object overrides the filtering and wrapping on
-   * MapLibre's textures, and MapLibre does not track sampler bindings in its WebGL state cache.
-   */
-  fun unbindSamplerObjects() {
+  /** Clears state that Skia uses but MapLibre does not track before MapLibre draws. */
+  fun prepareMapRender() {
     repeat(fragmentTextureUnits) { unit -> gl.bindSampler(unit, null) }
+    gl.disable(gl.SCISSOR_TEST)
   }
 
   /** Invalidates the Skia state cache for the context that adopted [image]. */

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
@@ -177,9 +177,9 @@ internal class GlJsMapSession(
     if (composited != null) {
       // Skia drives this context between MapLibre's frames, so each renderer is told the other
       // moved the state.
-      composited.target.unbindSamplerObjects()
-      map.painter.context.setDirty()
       val mapTarget = composited.target
+      mapTarget.prepareMapRender()
+      map.painter.context.setDirty()
       GlJsRuntime.withDrawingBufferSize(mapTarget.gl, mapTarget.widthPx, mapTarget.heightPx) {
         map.redraw()
       }

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserCompositingTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserCompositingTest.kt
@@ -189,6 +189,34 @@ class BrowserCompositingTest {
   }
 
   @Test
+  fun overdraw_is_rendered_in_the_first_requested_frame() = gpuTest { gpu ->
+    val gl = gpu.gl.asDynamic()
+    browserRenderTarget(FULL, FULL, generation = 1).use { target ->
+      CompositedMap(SPLIT_STYLE).use { map ->
+        map.drawTheWholeStyle(target)
+        val requestsBefore = map.frameRequests
+
+        map.setOverdrawInspector(true)
+        gl.enable(gl.SCISSOR_TEST)
+        gl.scissor(0, 0, 1, 1)
+
+        assertTrue(map.frameRequests > requestsBefore, "the option should request a frame")
+        assertTrue(map.drawOnce(target), "the requested overdraw frame should render")
+        assertFalse(
+          gl.isEnabled(gl.SCISSOR_TEST).unsafeCast<Boolean>(),
+          "MapLibre should not inherit Compose's damage scissor",
+        )
+        val colors = histogram(readFramebuffer(gl, target.framebuffer, FULL, FULL))
+        assertFalse(
+          RED in colors || BLUE in colors,
+          "the first requested frame should use overdraw",
+        )
+        assertTrue(colors.keys.any { it != "#000000" }, "overdraw should record drawn fragments")
+      }
+    }
+  }
+
+  @Test
   fun a_new_skia_context_replaces_a_same_size_target_and_the_map_keeps_drawing() = gpuTest { gpu ->
     val gl = gpu.gl.asDynamic()
     val compositor = ComposeGlJsCompositor(logger = null)

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/CompositedMap.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/CompositedMap.kt
@@ -8,6 +8,7 @@ import org.maplibre.compose.camera.CameraMoveReason
 import org.maplibre.compose.map.GlJsMapSession
 import org.maplibre.compose.map.MapAdapter
 import org.maplibre.compose.map.MapExtent
+import org.maplibre.compose.map.RenderOptions
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.compose.style.Style
 import org.maplibre.spatialk.geojson.Position
@@ -39,6 +40,10 @@ internal class CompositedMap(style: BaseStyle, private val scaleFactor: Double =
   /** Synchronous, so a caller can bracket it with GL of its own. */
   fun drawOnce(target: GlJsRenderTarget): Boolean =
     session.render(GlJsFrameTarget.Composited(target), extentOf(target))
+
+  fun setOverdrawInspector(enabled: Boolean) {
+    session.setRenderSettings(RenderOptions(isOverdrawInspectorEnabled = enabled))
+  }
 
   suspend fun drawUntil(target: GlJsRenderTarget, what: String, condition: suspend () -> Boolean) {
     val deadline = Date.now() + RENDER_TIMEOUT_MS


### PR DESCRIPTION
Resolve #1076 

## Description

Disable the stale Compose damage scissor before MapLibre GL JS renders so rendering options such as the overdraw inspector affect the first requested frame.

## Validation

Ran `mise run check`, forced the complete JS browser suite with `mise run test:js -- --rerun-tasks`, and verified the immediate toggle behavior in the in-app browser.

## AI assistance

Sol in the Codex desktop app assisted with source analysis, browser probes, implementation, and tests.