### PR TITLE
Allow negative style padding with DpPadding

### DIFF
--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/ast/DpPaddingLiteral.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/ast/DpPaddingLiteral.kt
@@ -1,18 +1,17 @@
 package org.maplibre.compose.expressions.ast
 
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.ui.unit.dp
 import org.maplibre.compose.expressions.value.DpPaddingValue
+import org.maplibre.compose.util.DpPadding
 
-/** A [Literal] representing a [PaddingValues] value. */
-public data class DpPaddingLiteral private constructor(override val value: PaddingValues.Absolute) :
-  CompiledLiteral<DpPaddingValue, PaddingValues.Absolute> {
+/** A [Literal] representing a [DpPadding] value. */
+public data class DpPaddingLiteral private constructor(override val value: DpPadding) :
+  CompiledLiteral<DpPaddingValue, DpPadding> {
   override fun visit(block: (Expression<*>) -> Unit): Unit = block(this)
 
   public companion object {
-    private val zero = DpPaddingLiteral(PaddingValues.Absolute(0.dp, 0.dp, 0.dp, 0.dp))
+    private val zero = DpPaddingLiteral(DpPadding.Zero)
 
-    public fun of(value: PaddingValues.Absolute): DpPaddingLiteral =
-      if (value == zero.value) zero else DpPaddingLiteral(value)
+    public fun of(value: DpPadding): DpPaddingLiteral =
+      if (value == DpPadding.Zero) zero else DpPaddingLiteral(value)
   }
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/dsl/literals.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/dsl/literals.kt
@@ -34,6 +34,8 @@ import org.maplibre.compose.expressions.value.SymbolAnchor
 import org.maplibre.compose.expressions.value.TextUnitOffsetValue
 import org.maplibre.compose.expressions.value.TextVariableAnchorOffsetValue
 import org.maplibre.compose.expressions.value.VectorValue
+import org.maplibre.compose.util.DpPadding
+import org.maplibre.compose.util.toDpPadding
 
 /** Creates a literal expression for a [String] value. */
 public fun const(string: String): StringLiteral = StringLiteral.of(string)
@@ -75,8 +77,11 @@ public fun const(offset: Offset): OffsetLiteral = OffsetLiteral.of(offset)
 /** Creates a literal expression for a [DpOffset] value. */
 public fun const(dpOffset: DpOffset): DpOffsetLiteral = DpOffsetLiteral.of(dpOffset)
 
-/** Creates a literal expression for a [PaddingValues.Absolute] value. */
-public fun const(padding: PaddingValues.Absolute): DpPaddingLiteral = DpPaddingLiteral.of(padding)
+/** Creates a literal expression for a [DpPadding] value. */
+public fun const(padding: DpPadding): DpPaddingLiteral = DpPaddingLiteral.of(padding)
+
+/** Creates a literal expression from Compose [PaddingValues.Absolute]. */
+public fun const(padding: PaddingValues.Absolute): DpPaddingLiteral = const(padding.toDpPadding())
 
 /** Creates a literal expression for a list. */
 public fun <T : ExpressionValue> const(list: List<Literal<T, *>>): ListLiteral<T> =
@@ -131,11 +136,9 @@ public fun offset(x: Dp, y: Dp): DpOffsetLiteral = DpOffsetLiteral.of(DpOffset(x
 public fun offset(x: TextUnit, y: TextUnit): Expression<TextUnitOffsetValue> =
   TextUnitOffsetCalculation.of(x, y)
 
-/** Creates a literal expression for a [PaddingValues.Absolute] value. */
+/** Creates a literal expression for a [DpPadding] value. */
 public fun padding(left: Dp, top: Dp, right: Dp, bottom: Dp): Expression<DpPaddingValue> =
-  DpPaddingLiteral.of(
-    PaddingValues.Absolute(left = left, top = top, right = right, bottom = bottom)
-  )
+  const(DpPadding(left = left, top = top, right = right, bottom = bottom))
 
 /**
  * Creates a literal expression for a `null` value.

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/dsl/literals.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/dsl/literals.kt
@@ -1,6 +1,5 @@
 package org.maplibre.compose.expressions.dsl
 
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
@@ -35,7 +34,6 @@ import org.maplibre.compose.expressions.value.TextUnitOffsetValue
 import org.maplibre.compose.expressions.value.TextVariableAnchorOffsetValue
 import org.maplibre.compose.expressions.value.VectorValue
 import org.maplibre.compose.util.DpPadding
-import org.maplibre.compose.util.toDpPadding
 
 /** Creates a literal expression for a [String] value. */
 public fun const(string: String): StringLiteral = StringLiteral.of(string)
@@ -79,9 +77,6 @@ public fun const(dpOffset: DpOffset): DpOffsetLiteral = DpOffsetLiteral.of(dpOff
 
 /** Creates a literal expression for a [DpPadding] value. */
 public fun const(padding: DpPadding): DpPaddingLiteral = DpPaddingLiteral.of(padding)
-
-/** Creates a literal expression from Compose [PaddingValues.Absolute]. */
-public fun const(padding: PaddingValues.Absolute): DpPaddingLiteral = const(padding.toDpPadding())
 
 /** Creates a literal expression for a list. */
 public fun <T : ExpressionValue> const(list: List<Literal<T, *>>): ListLiteral<T> =

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/value/values.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/value/values.kt
@@ -1,6 +1,5 @@
 package org.maplibre.compose.expressions.value
 
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
@@ -8,6 +7,7 @@ import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.TextUnit
 import kotlin.time.Duration
 import org.maplibre.compose.expressions.ast.StringLiteral
+import org.maplibre.compose.util.DpPadding
 
 /**
  * Represents a value that an [Expression] can resolve to. Many of these types are never actually
@@ -147,8 +147,8 @@ public typealias DpOffsetValue = OffsetValue<Dp>
 public typealias TextUnitOffsetValue = OffsetValue<TextUnit>
 
 /**
- * Represents an [ExpressionValue] that resolves to an absolute (layout direction unaware) padding
- * applied along the edges inside a box ([PaddingValues.Absolute]). See [const].
+ * Represents an [ExpressionValue] that resolves to four-sided padding in device-independent pixels
+ * ([DpPadding]). See [const] and [padding].
  */
 public sealed interface DpPaddingValue : VectorValue<Dp>
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/SymbolLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/SymbolLayer.kt
@@ -1,6 +1,5 @@
 package org.maplibre.compose.layers
 
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
@@ -44,6 +43,7 @@ import org.maplibre.compose.expressions.value.TextWritingMode
 import org.maplibre.compose.expressions.value.TranslateAnchor
 import org.maplibre.compose.sources.Source
 import org.maplibre.compose.sources.SourceReferenceEffect
+import org.maplibre.compose.util.DpPadding
 import org.maplibre.compose.util.FeaturesClickHandler
 import org.maplibre.compose.util.MaplibreComposable
 
@@ -145,7 +145,7 @@ private fun rememberEmCompiler(textSize: Expression<TextUnitValue>): LayerProper
  *   Ignored if not both [iconImage] and [textField] are specified.
  *
  * @param iconTextFitPadding Size of the additional area added to dimensions determined by
- *   [iconTextFit].
+ *   [iconTextFit]. A negative value shrinks that side.
  *
  *   Only applicable when if [iconTextFit] is not [IconTextFit.None]. Ignored if not both
  *   [iconImage] and [textField] are specified.
@@ -176,7 +176,7 @@ private fun rememberEmCompiler(textSize: Expression<TextUnitValue>): LayerProper
  *   Ignored if [iconImage] is not specified.
  *
  * @param iconPadding Size of additional area round the icon bounding box used for detecting symbol
- *   collisions. The expression may use feature properties.
+ *   collisions. A negative value shrinks that side. The expression may use feature properties.
  *
  *   Ignored if [iconImage] is not specified.
  *
@@ -444,7 +444,7 @@ public fun SymbolLayer(
   iconRotationAlignment: Expression<IconRotationAlignment> = const(IconRotationAlignment.Auto),
   iconPitchAlignment: Expression<IconPitchAlignment> = const(IconPitchAlignment.Auto),
   iconTextFit: Expression<IconTextFit> = const(IconTextFit.None),
-  iconTextFitPadding: Expression<DpPaddingValue> = const(PaddingValues.Absolute(0.dp)),
+  iconTextFitPadding: Expression<DpPaddingValue> = const(DpPadding.Zero),
   iconKeepUpright: Expression<BooleanValue> = const(false),
   iconRotate: Expression<FloatValue> = const(0f),
 
@@ -453,7 +453,7 @@ public fun SymbolLayer(
   iconOffset: Expression<DpOffsetValue> = const(DpOffset.Zero),
 
   // icon collision
-  iconPadding: Expression<DpPaddingValue> = const(PaddingValues.Absolute(2.dp, 2.dp, 2.dp, 2.dp)),
+  iconPadding: Expression<DpPaddingValue> = const(DpPadding(2.dp, 2.dp, 2.dp, 2.dp)),
   iconAllowOverlap: Expression<BooleanValue> = const(false),
   iconOverlap: Expression<StringValue> = nil(),
   iconIgnorePlacement: Expression<BooleanValue> = const(false),

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/util/DpPadding.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/util/DpPadding.kt
@@ -7,8 +7,7 @@ import androidx.compose.ui.unit.dp
 /**
  * Four-sided padding in device-independent pixels.
  *
- * Style-spec padding uses physical sides: left, top, right, and bottom. A negative value shrinks
- * that side of the box.
+ * A negative value shrinks that side of the box.
  */
 @Immutable
 public data class DpPadding(

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/util/DpPadding.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/util/DpPadding.kt
@@ -1,0 +1,34 @@
+package org.maplibre.compose.util
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+
+/**
+ * Four-sided padding in device-independent pixels.
+ *
+ * Style-spec padding uses physical sides: left, top, right, and bottom. A negative value shrinks
+ * that side of the box.
+ */
+@Immutable
+public data class DpPadding(
+  val left: Dp = 0.dp,
+  val top: Dp = 0.dp,
+  val right: Dp = 0.dp,
+  val bottom: Dp = 0.dp,
+) {
+  public companion object {
+    public val Zero: DpPadding = DpPadding()
+  }
+}
+
+/** Copies the four physical sides of [this] into a [DpPadding]. */
+public fun PaddingValues.Absolute.toDpPadding(): DpPadding =
+  DpPadding(
+    left = calculateLeftPadding(LayoutDirection.Ltr),
+    top = calculateTopPadding(),
+    right = calculateRightPadding(LayoutDirection.Ltr),
+    bottom = calculateBottomPadding(),
+  )

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/util/DpPadding.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/util/DpPadding.kt
@@ -4,11 +4,7 @@ import androidx.compose.runtime.Immutable
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
-/**
- * Four-sided padding in device-independent pixels.
- *
- * A negative value shrinks that side of the box.
- */
+/** Four-sided padding in device-independent pixels. */
 @Immutable
 public data class DpPadding(
   val left: Dp = 0.dp,

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/util/DpPadding.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/util/DpPadding.kt
@@ -1,9 +1,7 @@
 package org.maplibre.compose.util
 
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 
 /**
@@ -23,12 +21,3 @@ public data class DpPadding(
     public val Zero: DpPadding = DpPadding()
   }
 }
-
-/** Copies the four physical sides of [this] into a [DpPadding]. */
-public fun PaddingValues.Absolute.toDpPadding(): DpPadding =
-  DpPadding(
-    left = calculateLeftPadding(LayoutDirection.Ltr),
-    top = calculateTopPadding(),
-    right = calculateRightPadding(LayoutDirection.Ltr),
-    bottom = calculateBottomPadding(),
-  )

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/util/ExpressionJson.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/util/ExpressionJson.kt
@@ -1,7 +1,6 @@
 package org.maplibre.compose.util
 
 import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.unit.LayoutDirection
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNull
@@ -48,14 +47,14 @@ private fun CompiledExpression<*>.normalizeJsonLike(inLiteral: Boolean): JsonEle
       )
 
     is DpPaddingLiteral ->
-      // Style order is top, right, bottom, left — not the order PaddingValues reads in.
+      // Style order is top, right, bottom, left — not the order DpPadding stores.
       literalArray(
         inLiteral,
         listOf(
-          JsonPrimitive(value.calculateTopPadding().value),
-          JsonPrimitive(value.calculateRightPadding(LayoutDirection.Ltr).value),
-          JsonPrimitive(value.calculateBottomPadding().value),
-          JsonPrimitive(value.calculateLeftPadding(LayoutDirection.Ltr).value),
+          JsonPrimitive(value.top.value),
+          JsonPrimitive(value.right.value),
+          JsonPrimitive(value.bottom.value),
+          JsonPrimitive(value.left.value),
         ),
       )
 

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/util/ExpressionJsonTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/util/ExpressionJsonTest.kt
@@ -95,7 +95,7 @@ class ExpressionJsonTest {
 
   @Test
   fun encodes_negative_padding_sides() {
-    val padding = padding(left = 2.5.dp, top = (-2.5).dp, right = 0.dp, bottom = (-7).dp)
-    assertEquals("""["literal",[-2.5,0.0,-7.0,2.5]]""", json(compiled(padding)))
+    val padding = padding(left = 2.5.dp, top = (-2.5).dp, right = 0.1.dp, bottom = (-7.1).dp)
+    assertEquals("""["literal",[-2.5,0.1,-7.1,2.5]]""", json(compiled(padding)))
   }
 }

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/util/ExpressionJsonTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/util/ExpressionJsonTest.kt
@@ -1,6 +1,5 @@
 package org.maplibre.compose.util
 
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
@@ -16,7 +15,6 @@ import org.maplibre.compose.expressions.ast.FloatLiteral
 import org.maplibre.compose.expressions.ast.NullLiteral
 import org.maplibre.compose.expressions.ast.OffsetLiteral
 import org.maplibre.compose.expressions.ast.StringLiteral
-import org.maplibre.compose.expressions.dsl.const
 import org.maplibre.compose.expressions.dsl.padding
 
 /**
@@ -99,12 +97,5 @@ class ExpressionJsonTest {
   fun encodes_negative_padding_sides() {
     val padding = padding(left = 2.5.dp, top = (-2.5).dp, right = 0.dp, bottom = (-7).dp)
     assertEquals("""["literal",[-2.5,0.0,-7.0,2.5]]""", json(compiled(padding)))
-  }
-
-  @Test
-  fun copies_compose_absolute_padding_into_a_literal() {
-    val padding =
-      const(PaddingValues.Absolute(left = 4.5.dp, top = 1.5.dp, right = 2.5.dp, bottom = 3.5.dp))
-    assertEquals("""["literal",[1.5,2.5,3.5,4.5]]""", json(padding))
   }
 }

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/util/ExpressionJsonTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/util/ExpressionJsonTest.kt
@@ -16,6 +16,8 @@ import org.maplibre.compose.expressions.ast.FloatLiteral
 import org.maplibre.compose.expressions.ast.NullLiteral
 import org.maplibre.compose.expressions.ast.OffsetLiteral
 import org.maplibre.compose.expressions.ast.StringLiteral
+import org.maplibre.compose.expressions.dsl.const
+import org.maplibre.compose.expressions.dsl.padding
 
 /**
  * Written against values, not rendered text, wherever a whole number is involved: Kotlin renders
@@ -88,11 +90,21 @@ class ExpressionJsonTest {
 
   @Test
   fun encodes_padding_in_the_style_spec_s_top_right_bottom_left_order() {
-    // PaddingValues reads start/top/end/bottom, so the order has to be rebuilt rather than copied.
     val padding =
-      DpPaddingLiteral.of(
-        PaddingValues.Absolute(left = 4.5.dp, top = 1.5.dp, right = 2.5.dp, bottom = 3.5.dp)
-      )
+      DpPaddingLiteral.of(DpPadding(left = 4.5.dp, top = 1.5.dp, right = 2.5.dp, bottom = 3.5.dp))
+    assertEquals("""["literal",[1.5,2.5,3.5,4.5]]""", json(padding))
+  }
+
+  @Test
+  fun encodes_negative_padding_sides() {
+    val padding = padding(left = 2.5.dp, top = (-2.5).dp, right = 0.dp, bottom = (-7).dp)
+    assertEquals("""["literal",[-2.5,0.0,-7.0,2.5]]""", json(compiled(padding)))
+  }
+
+  @Test
+  fun copies_compose_absolute_padding_into_a_literal() {
+    val padding =
+      const(PaddingValues.Absolute(left = 4.5.dp, top = 1.5.dp, right = 2.5.dp, bottom = 3.5.dp))
     assertEquals("""["literal",[1.5,2.5,3.5,4.5]]""", json(padding))
   }
 }

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/layers/LayerPropertyRoundTripTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/layers/LayerPropertyRoundTripTest.kt
@@ -1,6 +1,5 @@
 package org.maplibre.compose.layers
 
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.DpOffset
@@ -67,6 +66,7 @@ import org.maplibre.compose.testing.MapTestResult
 import org.maplibre.compose.testing.createMapFixture
 import org.maplibre.compose.testing.mapLibreFlavor
 import org.maplibre.compose.testing.runMapTest
+import org.maplibre.compose.util.DpPadding
 import org.maplibre.spatialk.geojson.FeatureCollection
 import org.maplibre.spatialk.geojson.Geometry
 
@@ -554,14 +554,17 @@ class LayerPropertyRoundTripTest {
         },
         Case("icon-size", "1.5") { it.setIconSize(const(1.5f).c()) },
         Case("icon-text-fit", "\"both\"") { it.setIconTextFit(const(IconTextFit.Both).c()) },
-        // Style order is top, right, bottom, left, which is not the order PaddingValues reads in.
+        // Style order is top, right, bottom, left, which is not the order DpPadding stores.
         Case("icon-text-fit-padding", "[2.0,3.0,4.0,1.0]", """["literal",[2.0,3.0,4.0,1.0]]""") {
-          it.setIconTextFitPadding(const(PaddingValues.Absolute(1.dp, 2.dp, 3.dp, 4.dp)).c())
+          it.setIconTextFitPadding(const(DpPadding(1.dp, 2.dp, 3.dp, 4.dp)).c())
         },
         Case("icon-image", """["image","marker"]""") { it.setIconImage(image("marker").c()) },
         Case("icon-rotate", "45.0") { it.setIconRotate(const(45f).c()) },
         Case("icon-padding", "[2.0,3.0,4.0,1.0]", """["literal",[2.0,3.0,4.0,1.0]]""") {
-          it.setIconPadding(const(PaddingValues.Absolute(1.dp, 2.dp, 3.dp, 4.dp)).c())
+          it.setIconPadding(const(DpPadding(1.dp, 2.dp, 3.dp, 4.dp)).c())
+        },
+        Case("icon-padding", "[-2.5,0.0,-7.0,2.5]", """["literal",[-2.5,0.0,-7.0,2.5]]""") {
+          it.setIconPadding(const(DpPadding(2.5.dp, (-2.5).dp, 0.dp, (-7).dp)).c())
         },
         Case("icon-keep-upright", "true") { it.setIconKeepUpright(const(true).c()) },
         Case("icon-offset", "[3.0,4.0]", """["literal",[3.0,4.0]]""") {

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/layers/LayerPropertyRoundTripTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/layers/LayerPropertyRoundTripTest.kt
@@ -560,18 +560,18 @@ class LayerPropertyRoundTripTest {
         },
         Case(
           "icon-text-fit-padding",
-          "[-2.5,0.0,-7.0,2.5]",
-          """["literal",[-2.5,0.0,-7.0,2.5]]""",
+          "[-2.5,0.1,-7.1,2.5]",
+          """["literal",[-2.5,0.1,-7.1,2.5]]""",
         ) {
-          it.setIconTextFitPadding(const(DpPadding(2.5.dp, (-2.5).dp, 0.dp, (-7).dp)).c())
+          it.setIconTextFitPadding(const(DpPadding(2.5.dp, (-2.5).dp, 0.1.dp, (-7.1).dp)).c())
         },
         Case("icon-image", """["image","marker"]""") { it.setIconImage(image("marker").c()) },
         Case("icon-rotate", "45.0") { it.setIconRotate(const(45f).c()) },
         Case("icon-padding", "[2.0,3.0,4.0,1.0]", """["literal",[2.0,3.0,4.0,1.0]]""") {
           it.setIconPadding(const(DpPadding(1.dp, 2.dp, 3.dp, 4.dp)).c())
         },
-        Case("icon-padding", "[-2.5,0.0,-7.0,2.5]", """["literal",[-2.5,0.0,-7.0,2.5]]""") {
-          it.setIconPadding(const(DpPadding(2.5.dp, (-2.5).dp, 0.dp, (-7).dp)).c())
+        Case("icon-padding", "[-2.5,0.1,-7.1,2.5]", """["literal",[-2.5,0.1,-7.1,2.5]]""") {
+          it.setIconPadding(const(DpPadding(2.5.dp, (-2.5).dp, 0.1.dp, (-7.1).dp)).c())
         },
         Case("icon-keep-upright", "true") { it.setIconKeepUpright(const(true).c()) },
         Case("icon-offset", "[3.0,4.0]", """["literal",[3.0,4.0]]""") {

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/layers/LayerPropertyRoundTripTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/layers/LayerPropertyRoundTripTest.kt
@@ -558,6 +558,13 @@ class LayerPropertyRoundTripTest {
         Case("icon-text-fit-padding", "[2.0,3.0,4.0,1.0]", """["literal",[2.0,3.0,4.0,1.0]]""") {
           it.setIconTextFitPadding(const(DpPadding(1.dp, 2.dp, 3.dp, 4.dp)).c())
         },
+        Case(
+          "icon-text-fit-padding",
+          "[-2.5,0.0,-7.0,2.5]",
+          """["literal",[-2.5,0.0,-7.0,2.5]]""",
+        ) {
+          it.setIconTextFitPadding(const(DpPadding(2.5.dp, (-2.5).dp, 0.dp, (-7).dp)).c())
+        },
         Case("icon-image", """["image","marker"]""") { it.setIconImage(image("marker").c()) },
         Case("icon-rotate", "45.0") { it.setIconRotate(const(45f).c()) },
         Case("icon-padding", "[2.0,3.0,4.0,1.0]", """["literal",[2.0,3.0,4.0,1.0]]""") {


### PR DESCRIPTION
Resolve #1091 

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Replace Compose `PaddingValues.Absolute` with a `DpPadding` type so `icon-padding` and `icon-text-fit-padding` can be negative, which MapLibre Native already accepts.

## Validation

`ExpressionJsonTest` and `LayerPropertyRoundTripTest` passed on JVM, including a negative `icon-padding` round-trip through MapLibre Native (Vulkan).

## AI assistance

Cursor Grok 4.6 (cloud agent).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ef9d5544-69a6-44bc-a9dd-81161b9d5a78?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ef9d5544-69a6-44bc-a9dd-81161b9d5a78&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

