### PR TITLE
Remove deprecated MapLibre.initialize on JS

### DIFF
--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/browser/MapLibre.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/browser/MapLibre.kt
@@ -21,9 +21,4 @@ public object MapLibre {
     }
     GlJsRuntime.pointAtWorker(workerUrl)
   }
-
-  @Deprecated("Renamed to configure", ReplaceWith("configure(workerUrl)"))
-  public fun initialize(workerUrl: String = DEFAULT_WORKER_URL) {
-    configure(workerUrl)
-  }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Removes the deprecated browser `MapLibre.initialize` wrapper that only forwarded to `configure`.

## Validation

`./gradlew :lib:maplibre-compose:compileKotlinJs`, `:demo-app:common:compileKotlinJs`, and `:lib:maplibre-compose:compileTestKotlinJs` succeeded. Demo and docs already call `configure`.

## AI assistance

Cursor Grok 4.6 Cloud Agent.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-14293677-e7a6-4509-8b5f-8c62cb8de7e9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-14293677-e7a6-4509-8b5f-8c62cb8de7e9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

