### PR TITLE
revise demo map style selection with a theme mode

### DIFF
--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/Demo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/Demo.kt
@@ -26,7 +26,14 @@ interface Demo {
   val description: String
   val destination: DemoDestination
 
-  /** Replaces the user's chosen style while this demo is selected. See [DemoStyle]. */
+  /**
+   * Replaces the user's chosen style while this demo is selected. See [DemoStyle].
+   *
+   * Declare this only when the demo genuinely depends on its base style: it reads the style's own
+   * data or glyph endpoint, or its data visualization only reads against a deliberately muted
+   * canvas. Demos whose content is self-contained should stay agnostic and honor the user's chosen
+   * style and theme.
+   */
   val preferredStyle: DemoStyle?
     get() = null
 

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/Demo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/Demo.kt
@@ -26,7 +26,7 @@ interface Demo {
   val description: String
   val destination: DemoDestination
 
-  /** Applied once when the demo is selected; a later choice by the user wins. */
+  /** Replaces the user's chosen style while this demo is selected. See [DemoStyle]. */
   val preferredStyle: DemoStyle?
     get() = null
 

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoApp.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoApp.kt
@@ -47,7 +47,7 @@ fun DemoApp() {
   val state = rememberDemoAppState()
   val dark =
     if (state.shell == DemoShell.Benchmarks) state.selectedScenario.style.isDark
-    else state.selectedStyle.isDark
+    else state.appliedStyle.isDark
   val colorScheme = if (dark) darkColorScheme() else lightColorScheme()
   val sheetState = rememberBottomSheetScaffoldState()
   // One composition for the panel, so the NavHost keeps its back stack when the viewport crosses

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoAppState.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoAppState.kt
@@ -1,5 +1,6 @@
 package org.maplibre.compose.demoapp
 
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
@@ -35,7 +36,31 @@ class DemoAppState(
   val frameRateState: FrameRateState,
 ) {
   var selectedDemo by mutableStateOf<Demo?>(null)
-  var selectedStyle by mutableStateOf(DemoStyle.Default)
+
+  /** The style applied when [ThemeMode] resolves to light. */
+  var chosenLightStyle by mutableStateOf<DemoStyle>(Protomaps.Light)
+
+  /** The style applied when [ThemeMode] resolves to dark. */
+  var chosenDarkStyle by mutableStateOf<DemoStyle>(Protomaps.Dark)
+
+  /**
+   * The style applied to the map: the selected demo's if it provides one, else the chosen style for
+   * the current [ThemeMode].
+   */
+  val appliedStyle: DemoStyle
+    @Composable
+    get() {
+      selectedDemo?.preferredStyle?.let {
+        return it
+      }
+      val systemDark = isSystemInDarkTheme()
+      return when (settings.themeMode) {
+        ThemeMode.System -> if (systemDark) chosenDarkStyle else chosenLightStyle
+        ThemeMode.Light -> chosenLightStyle
+        ThemeMode.Dark -> chosenDarkStyle
+      }
+    }
+
   var shell by mutableStateOf(DemoShell.Demos)
   var selectedScenario by mutableStateOf<BenchmarkScenario>(allBenchmarkScenarios.first())
   val benchmark = BenchmarkUiState()

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoMap.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoMap.kt
@@ -76,7 +76,7 @@ fun DemoMap(state: DemoAppState, viewportInsets: MapViewportInsets) {
     )
   Box(Modifier.fillMaxSize()) {
     MaplibreMap(
-      baseStyle = state.selectedStyle.base,
+      baseStyle = state.appliedStyle.base,
       cameraState = state.cameraState,
       cameraPadding = viewportInsets.asPaddingValues(),
       styleState = state.styleState,

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoPanel.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoPanel.kt
@@ -265,13 +265,13 @@ private fun SettingsScreen(
     )
     StyleSelector(
       label = "Light style",
-      styles = DemoStyle.all.filter { !it.isDark },
+      styles = allDemoStyles.filter { !it.isDark },
       selected = state.chosenLightStyle,
       onSelect = { state.chosenLightStyle = it },
     )
     StyleSelector(
       label = "Dark style",
-      styles = DemoStyle.all.filter { it.isDark },
+      styles = allDemoStyles.filter { it.isDark },
       selected = state.chosenDarkStyle,
       onSelect = { state.chosenDarkStyle = it },
     )

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoPanel.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoPanel.kt
@@ -47,6 +47,7 @@ import androidx.navigation.compose.rememberNavController
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.vectorResource
 import org.maplibre.compose.demoapp.design.SectionHeader
+import org.maplibre.compose.demoapp.design.SegmentedRow
 import org.maplibre.compose.demoapp.design.SwitchRow
 import org.maplibre.compose.demoapp.generated.Res
 import org.maplibre.compose.demoapp.generated.arrow_back_24px
@@ -94,7 +95,6 @@ fun DemoPanel(
         onOpenDemo = { demo ->
           scope.launch {
             revealMap()
-            demo.preferredStyle?.let { state.selectedStyle = it }
             state.selectedDemo = demo
             navController.navigate("demo")
             state.cameraState.flyTo(demo.destination)
@@ -142,6 +142,7 @@ fun DemoPanel(
     }
     composable("settings") {
       SettingsScreen(
+        state,
         onBack = { navController.popBackStack() },
         onOpen = { navController.navigate("settings/$it") },
       )
@@ -203,8 +204,6 @@ private fun DemosScreen(
       colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Transparent),
     )
     Column(Modifier.verticalScroll(rememberScrollState()).padding(bottom = 16.dp)) {
-      StyleSelector(state)
-
       SectionHeader("Demos")
       allDemos.forEach { demo ->
         SubmenuRow(demo.name, demo.description) { onOpenDemo(demo) }
@@ -214,7 +213,12 @@ private fun DemosScreen(
 }
 
 @Composable
-private fun StyleSelector(state: DemoAppState) {
+private fun StyleSelector(
+  label: String,
+  styles: List<DemoStyle>,
+  selected: DemoStyle,
+  onSelect: (DemoStyle) -> Unit,
+) {
   var expanded by remember { mutableStateOf(false) }
   ExposedDropdownMenuBox(
     expanded = expanded,
@@ -222,20 +226,20 @@ private fun StyleSelector(state: DemoAppState) {
     modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
   ) {
     OutlinedTextField(
-      value = state.selectedStyle.displayName,
+      value = selected.displayName,
       onValueChange = {},
       readOnly = true,
-      label = { Text("Map style") },
+      label = { Text(label) },
       trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
       modifier =
         Modifier.fillMaxWidth().menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable),
     )
     ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
-      DemoStyle.all.forEach { style ->
+      styles.forEach { style ->
         DropdownMenuItem(
           text = { Text(style.displayName) },
           onClick = {
-            state.selectedStyle = style
+            onSelect(style)
             expanded = false
           },
         )
@@ -245,8 +249,34 @@ private fun StyleSelector(state: DemoAppState) {
 }
 
 @Composable
-private fun SettingsScreen(onBack: () -> Unit, onOpen: (route: String) -> Unit) {
+private fun SettingsScreen(
+  state: DemoAppState,
+  onBack: () -> Unit,
+  onOpen: (route: String) -> Unit,
+) {
   SettingsSubScreen("Settings", onBack) {
+    SectionHeader("Map style")
+    SegmentedRow(
+      label = "Theme",
+      options = ThemeMode.entries,
+      selected = state.settings.themeMode,
+      optionLabel = { it.name },
+      onSelect = { state.settings.themeMode = it },
+    )
+    StyleSelector(
+      label = "Light style",
+      styles = DemoStyle.all.filter { !it.isDark },
+      selected = state.chosenLightStyle,
+      onSelect = { state.chosenLightStyle = it },
+    )
+    StyleSelector(
+      label = "Dark style",
+      styles = DemoStyle.all.filter { it.isDark },
+      selected = state.chosenDarkStyle,
+      onSelect = { state.chosenDarkStyle = it },
+    )
+
+    SectionHeader("Options")
     SubmenuRow("Gestures", "Which inputs move the camera") { onOpen("gestures") }
     SubmenuRow("Rendering", "Frame rate cap, tile detail, and debug views") { onOpen("rendering") }
     SubmenuRow("Interface", "Map controls and diagnostic overlays") { onOpen("interface") }

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoSettings.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoSettings.kt
@@ -12,9 +12,17 @@ import org.maplibre.compose.map.GestureOptions
 import org.maplibre.compose.map.RenderOptions
 import org.maplibre.compose.map.TileLodOptions
 
+/** Which of the two chosen map styles applies: the system's, or a forced light or dark one. */
+enum class ThemeMode {
+  System,
+  Light,
+  Dark,
+}
+
 /** App-wide diagnostics and toggles, available regardless of which demo is open. */
 @Stable
 class DemoSettings {
+  var themeMode by mutableStateOf(ThemeMode.System)
   var gestureOptions by mutableStateOf(GestureOptions.Standard)
   var renderOptions by mutableStateOf(RenderOptions.Standard)
   var tileLodOptions by mutableStateOf(TileLodOptions.Standard)

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoStyle.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoStyle.kt
@@ -21,10 +21,12 @@ interface DemoStyle {
   val anchorBelowSymbols: Anchor
 
   companion object {
-    val Default: DemoStyle = OpenFreeMap.Liberty
-
-    val all: List<DemoStyle> =
+    // Lazy because an enum can be the first touchpoint of this interface (e.g. Protomaps.Light as
+    // a property initializer). The enum's <clinit> initializes this companion, and reading
+    // `entries` here would re-enter the enum before its entries array is assigned.
+    val all: List<DemoStyle> by lazy {
       OpenFreeMap.entries + Protomaps.entries + Versatiles.entries + OtherStyles.entries
+    }
   }
 }
 

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoStyle.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoStyle.kt
@@ -19,16 +19,17 @@ interface DemoStyle {
 
   /** An anchor that keeps a demo's layers below the style's labels. */
   val anchorBelowSymbols: Anchor
-
-  companion object {
-    // Lazy because an enum can be the first touchpoint of this interface (e.g. Protomaps.Light as
-    // a property initializer). The enum's <clinit> initializes this companion, and reading
-    // `entries` here would re-enter the enum before its entries array is assigned.
-    val all: List<DemoStyle> by lazy {
-      OpenFreeMap.entries + Protomaps.entries + Versatiles.entries + OtherStyles.entries
-    }
-  }
 }
+
+/**
+ * The styles the user can pick from, in picker order.
+ *
+ * Top-level rather than on [DemoStyle] because a list of implementors must not live on the type
+ * they implement: initializing an enum entry first initializes the interface, and reading `entries`
+ * there would re-enter the enum before its entries array is assigned.
+ */
+val allDemoStyles: List<DemoStyle> =
+  OpenFreeMap.entries + Protomaps.entries + Versatiles.entries + OtherStyles.entries
 
 enum class OpenFreeMap(override val isDark: Boolean = false) : DemoStyle {
   Bright,

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/CastelloPlanDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/CastelloPlanDemo.kt
@@ -17,7 +17,6 @@ import org.maplibre.compose.demoapp.Demo
 import org.maplibre.compose.demoapp.DemoAppState
 import org.maplibre.compose.demoapp.DemoDestination
 import org.maplibre.compose.demoapp.DemoPointerPin
-import org.maplibre.compose.demoapp.OpenFreeMap
 import org.maplibre.compose.demoapp.center
 import org.maplibre.compose.demoapp.generated.Res
 import org.maplibre.compose.expressions.dsl.const
@@ -30,7 +29,6 @@ import org.maplibre.spatialk.geojson.Position
 object CastelloPlanDemo : Demo {
   override val name = "Castello Plan"
   override val description = "The 1660 map of New Amsterdam draped over lower Manhattan."
-  override val preferredStyle = OpenFreeMap.Liberty
 
   private val imageRegion =
     BoundingBox(west = -74.018, south = 40.7005, east = -74.006, north = 40.710)

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/DragDropDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/DragDropDemo.kt
@@ -28,7 +28,6 @@ import org.maplibre.compose.camera.CameraState
 import org.maplibre.compose.demoapp.Demo
 import org.maplibre.compose.demoapp.DemoAppState
 import org.maplibre.compose.demoapp.DemoDestination
-import org.maplibre.compose.demoapp.OpenFreeMap
 import org.maplibre.compose.demoapp.design.SegmentedRow
 import org.maplibre.compose.expressions.dsl.const
 import org.maplibre.compose.layers.FillLayer
@@ -51,7 +50,6 @@ private val DragColor = Color(0xFF00695C)
 object DragDropDemo : Demo {
   override val name = "Drag & drop"
   override val description = "Drag a location-picker pin or the corner handles of a bounding box."
-  override val preferredStyle = OpenFreeMap.Liberty
 
   // A neighborhood view gives both modes room to drag in without a detour through the camera.
   override val destination =

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/LiveTrackingDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/LiveTrackingDemo.kt
@@ -18,7 +18,6 @@ import org.maplibre.compose.demoapp.Demo
 import org.maplibre.compose.demoapp.DemoAppState
 import org.maplibre.compose.demoapp.DemoDestination
 import org.maplibre.compose.demoapp.DemoPointerPin
-import org.maplibre.compose.demoapp.OpenFreeMap
 import org.maplibre.compose.demoapp.center
 import org.maplibre.compose.demoapp.design.SwitchRow
 import org.maplibre.compose.expressions.dsl.const
@@ -39,7 +38,6 @@ object LiveTrackingDemo : Demo {
     BoundingBox(west = -122.5195, south = 47.5925, east = -122.3298, north = 47.6321)
   override val destination = DemoDestination.FitBounds(routeRegion)
   override val pointerPin = DemoPointerPin(routeRegion.center, destination)
-  override val preferredStyle = OpenFreeMap.Liberty
 
   // The Seattle-Bainbridge ferry crossing, traced from OpenStreetMap (ODbL).
   private val route =

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/LocationDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/LocationDemo.kt
@@ -20,7 +20,6 @@ import org.maplibre.compose.demoapp.DemoAppState
 import org.maplibre.compose.demoapp.DemoDestination
 import org.maplibre.compose.demoapp.DemoFlightDuration
 import org.maplibre.compose.demoapp.DemoPointerPin
-import org.maplibre.compose.demoapp.OpenFreeMap
 import org.maplibre.compose.demoapp.design.ButtonRow
 import org.maplibre.compose.demoapp.design.SegmentedRow
 import org.maplibre.compose.demoapp.design.SwitchRow
@@ -42,7 +41,6 @@ object LocationDemo : Demo {
   override val name = "My location"
   override val description =
     "The location puck, device heading, and a camera-follow toggle on the real device."
-  override val preferredStyle = OpenFreeMap.Liberty
   override val destination = DemoDestination.None
 
   override val pointerPin: DemoPointerPin?

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/MagnifyingLensDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/MagnifyingLensDemo.kt
@@ -39,7 +39,6 @@ import org.maplibre.compose.demoapp.Demo
 import org.maplibre.compose.demoapp.DemoAppState
 import org.maplibre.compose.demoapp.DemoDestination
 import org.maplibre.compose.demoapp.DemoPointerPin
-import org.maplibre.compose.demoapp.OpenFreeMap
 import org.maplibre.compose.demoapp.center
 import org.maplibre.compose.demoapp.design.SectionHeader
 import org.maplibre.compose.demoapp.design.SegmentedRow
@@ -66,7 +65,6 @@ import org.maplibre.spatialk.geojson.BoundingBox
 object MagnifyingLensDemo : Demo {
   override val name = "Magnifying lens"
   override val description = "A second map composited into a draggable lens with Compose modifiers."
-  override val preferredStyle = OpenFreeMap.Liberty
 
   private val lensRegion =
     BoundingBox(west = -74.002, south = 40.748, east = -73.968, north = 40.768)

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/MagnifyingLensDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/MagnifyingLensDemo.kt
@@ -138,7 +138,7 @@ object MagnifyingLensDemo : Demo {
           } else {
             Modifier.fillMaxSize()
           },
-        baseStyle = state.selectedStyle.base,
+        baseStyle = state.appliedStyle.base,
         cameraState = lensCamera,
         options =
           MapOptions(


### PR DESCRIPTION
## Description

Splits style state into per-theme chosen styles and a derived applied style, moves the picker from the demo list into Settings with a System/Light/Dark theme switch and a style picker per theme, and changes the defaults to Protomaps Light and Dark.

## Validation

Ran the desktop demo and switched themes and styles manually; `:demo-app:common:compileKotlinJvm` passes.

## AI assistance

Written with Kimi Code; the human drove the app manually and reported a startup crash that led to moving the style list off DemoStyle to allDemoStyles.
