### PR TITLE
Add queryRenderedFeatures tests for predicate, z-order, and feature id

### DIFF
--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/MapQueryTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/MapQueryTest.kt
@@ -235,8 +235,8 @@ class MapQueryTest {
       )
 
     /**
-     * Two world-covering fills from different sources. The second layer is the one in front, so an
-     * unfiltered query at the centre should list `front` before `back`.
+     * Two world-covering fills from different sources. The second layer is the one in front. The
+     * query API promises that order: front first, then back.
      */
     val OVERLAPPING_FILL_STYLE =
       """

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/MapQueryTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/MapQueryTest.kt
@@ -5,10 +5,18 @@ import androidx.compose.ui.unit.DpRect
 import androidx.compose.ui.unit.dp
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
 import kotlin.test.assertTrue
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
+import org.maplibre.compose.expressions.ast.ExpressionContext
+import org.maplibre.compose.expressions.dsl.Feature
+import org.maplibre.compose.expressions.dsl.const
+import org.maplibre.compose.expressions.dsl.eq
+import org.maplibre.compose.expressions.value.StringValue
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.compose.testing.MapFixture
 import org.maplibre.compose.testing.MapTestResult
@@ -119,6 +127,66 @@ class MapQueryTest {
     }
   }
 
+  @Test
+  fun a_predicate_keeps_only_matching_features(): MapTestResult = runMapTest {
+    createMapFixture().use {
+      it.loadStyle(BaseStyle.Json(WORLD_POLYGON_STYLE))
+      it.pump(frames = 30)
+
+      val matching =
+        (Feature["name"].cast<StringValue>() eq const("world")).compile(ExpressionContext.None)
+      val misses =
+        (Feature["name"].cast<StringValue>() eq const("other")).compile(ExpressionContext.None)
+
+      val kept =
+        it.session.queryRenderedFeatures(offset = CENTER, layerIds = null, predicate = matching)
+      assertTrue(kept.isNotEmpty(), "Expected the matching predicate to keep the feature")
+      assertEquals("world", kept.first().properties?.get("name")?.jsonPrimitive?.content)
+
+      val dropped =
+        it.session.queryRenderedFeatures(offset = CENTER, layerIds = null, predicate = misses)
+      assertTrue(dropped.isEmpty(), "Expected the non-matching predicate to drop the feature")
+    }
+  }
+
+  @Test
+  fun a_query_returns_the_front_layer_first(): MapTestResult = runMapTest {
+    createMapFixture().use {
+      it.loadStyle(BaseStyle.Json(OVERLAPPING_FILL_STYLE))
+      it.pump(frames = 30)
+
+      val features =
+        it.session.queryRenderedFeatures(offset = CENTER, layerIds = null, predicate = null)
+      val names = features.map { feature ->
+        feature.properties?.get("name")?.jsonPrimitive?.content
+      }
+
+      assertTrue(
+        names.contains("front") && names.contains("back"),
+        "Expected both layers. Got $names",
+      )
+      assertEquals("front", names.first(), "The feature in front should be first. Got $names")
+      assertTrue(
+        names.indexOf("front") < names.indexOf("back"),
+        "Front should precede back in render order. Got $names",
+      )
+    }
+  }
+
+  @Test
+  fun a_queried_feature_keeps_its_geojson_id(): MapTestResult = runMapTest {
+    createMapFixture().use {
+      it.loadStyle(BaseStyle.Json(WORLD_POLYGON_STYLE))
+      it.pump(frames = 30)
+
+      val feature =
+        it.session.queryRenderedFeatures(offset = CENTER, layerIds = null, predicate = null).first()
+      val id = assertIs<JsonPrimitive>(feature.id)
+      assertFalse(id.isString, "Expected the GeoJSON id to stay a number, not a string")
+      assertEquals("42", id.content)
+    }
+  }
+
   private companion object {
     /** The center of [MapFixture.DEFAULT_EXTENT], in the logical pixels a query takes. */
     val CENTER = DpOffset(256.dp, 256.dp)
@@ -165,5 +233,50 @@ class MapQueryTest {
         """"properties": { "name": "world" }""",
         """"properties": {"name":"world","${'$'}source":"original-source","${'$'}sourceLayer":"original-source-layer","${'$'}state":"original-state"}""",
       )
+
+    /**
+     * Two world-covering fills from different sources. The second layer is the one in front, so an
+     * unfiltered query at the centre should list `front` before `back`.
+     */
+    val OVERLAPPING_FILL_STYLE =
+      """
+      {
+        "version": 8,
+        "name": "query-order-test",
+        "sources": {
+          "back": {
+            "type": "geojson",
+            "data": {
+              "type": "Feature",
+              "properties": { "name": "back" },
+              "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                  [[-170, -80], [170, -80], [170, 80], [-170, 80], [-170, -80]]
+                ]
+              }
+            }
+          },
+          "front": {
+            "type": "geojson",
+            "data": {
+              "type": "Feature",
+              "properties": { "name": "front" },
+              "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                  [[-170, -80], [170, -80], [170, 80], [-170, 80], [-170, -80]]
+                ]
+              }
+            }
+          }
+        },
+        "layers": [
+          { "id": "back-fill", "type": "fill", "source": "back", "paint": { "fill-color": "#0000ff" } },
+          { "id": "front-fill", "type": "fill", "source": "front", "paint": { "fill-color": "#ff0000" } }
+        ]
+      }
+      """
+        .trimIndent()
   }
 }

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -1390,6 +1390,9 @@ internal class MlnFfiMapSession(
           session
             .queryRenderedFeatures(geometry, renderedQueryOptions(layerIds, predicate))
             .toGeoJsonFeatures()
+            // Native walks style layers from the bottom. CameraState and GL JS put
+            // the feature in front first.
+            .asReversed()
         }
       )
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Adds live-map coverage for a query filter, front-to-back layer order, and a numeric GeoJSON id, and reverses Native query results so they match GL JS.

## Validation

Ran `MapQueryTest` on desktop JVM after the Native order fix.

## AI assistance

Cursor Grok 4.6 (Cloud Agent).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2b849568-97a6-427e-ace1-042f40198bf9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2b849568-97a6-427e-ace1-042f40198bf9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

