### PR TITLE
Fix JS point queries that ignored the query location

### DIFF
--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsTypes.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsTypes.kt
@@ -110,7 +110,7 @@ internal external interface PaddingOptions {
   var right: Double
 }
 
-/** A point, or the two corners of a box; see [queryBox]. */
+/** A point, or the two corners of a box; see [queryPoint] and [queryBox]. */
 internal external interface QueryGeometry
 
 internal external interface Point : QueryGeometry {
@@ -219,6 +219,13 @@ internal fun MaplibreMap.isCameraEasing(): Boolean {
   }
   return camera.isEasing() as Boolean
 }
+
+/**
+ * A `[x, y]` number pair. GL JS only treats an `Array` or a `Point` instance as query geometry; a
+ * plain `{x, y}` object is read as options and the query covers the whole viewport.
+ */
+internal fun queryPoint(x: Double, y: Double): QueryGeometry =
+  arrayOf(x, y).unsafeCast<QueryGeometry>()
 
 /** MapLibre tells a box from a point by shape, a box being a two-element array. */
 internal fun queryBox(first: Point, second: Point): QueryGeometry =

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsTypes.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsTypes.kt
@@ -110,10 +110,10 @@ internal external interface PaddingOptions {
   var right: Double
 }
 
-/** A point, or the two corners of a box; see [queryPoint] and [queryBox]. */
+/** Geometry for [org.maplibre.compose.gljs.MaplibreMap.queryRenderedFeatures]. */
 internal external interface QueryGeometry
 
-internal external interface Point : QueryGeometry {
+internal external interface Point {
   var x: Double
   var y: Double
 }
@@ -221,8 +221,8 @@ internal fun MaplibreMap.isCameraEasing(): Boolean {
 }
 
 /**
- * A `[x, y]` number pair. GL JS only treats an `Array` or a `Point` instance as query geometry; a
- * plain `{x, y}` object is read as options and the query covers the whole viewport.
+ * Returns `[x, y]`. GL JS treats only an `Array` or a `Point` instance as query geometry. A plain
+ * `{x, y}` object is not geometry, so the query uses the whole viewport.
  */
 internal fun queryPoint(x: Double, y: Double): QueryGeometry =
   arrayOf(x, y).unsafeCast<QueryGeometry>()

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
@@ -44,6 +44,7 @@ import org.maplibre.compose.gljs.QueryRenderedFeaturesOptions
 import org.maplibre.compose.gljs.SetStyleOptions
 import org.maplibre.compose.gljs.isCameraEasing
 import org.maplibre.compose.gljs.queryBox
+import org.maplibre.compose.gljs.queryPoint
 import org.maplibre.compose.gljs.styleJson
 import org.maplibre.compose.gljs.styleUrl
 import org.maplibre.compose.gljs.subscribe
@@ -672,7 +673,8 @@ internal class GlJsMapSession(
     offset: DpOffset,
     layerIds: Set<String>?,
     predicate: CompiledExpression<BooleanValue>?,
-  ): List<Feature<Geometry, JsonObject?>> = query(offset.toPoint(), layerIds, predicate)
+  ): List<Feature<Geometry, JsonObject?>> =
+    query(queryPoint(offset.x.value.toDouble(), offset.y.value.toDouble()), layerIds, predicate)
 
   override suspend fun queryRenderedFeatures(
     rect: DpRect,

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/util/GlJsConversions.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/util/GlJsConversions.kt
@@ -19,6 +19,7 @@ internal fun LngLat.toPosition(): Position = Position(longitude = lng, latitude 
 
 internal fun Position.toLngLat(): LngLat = LngLat(lng = longitude, lat = latitude)
 
+/** A plain `{x, y}`. `Point.convert` accepts this; `queryRenderedFeatures` does not. */
 internal fun DpOffset.toPoint(): Point = unsafeJso {
   x = this@toPoint.x.value.toDouble()
   y = this@toPoint.y.value.toDouble()

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/MapQueryTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/MapQueryTest.kt
@@ -183,6 +183,7 @@ class MapQueryTest {
   fun a_query_at_an_off_center_point_returns_only_the_feature_there(): MapTestResult = runMapTest {
     createMapFixture().use {
       it.loadStyle(BaseStyle.Json(TWO_HALVES_STYLE))
+      // Zoom 0 keeps ±90 inside the 512 px viewport.
       it.session.setCameraPosition(CameraPosition(target = Position(0.0, 0.0), zoom = 0.0))
       it.pump(frames = 30)
 
@@ -196,12 +197,12 @@ class MapQueryTest {
       assertEquals(
         setOf("west"),
         westHits.names(),
-        "A point in the west half. Hits: ${westHits.names()}",
+        "Expected only west. Hits: ${westHits.names()}",
       )
       assertEquals(
         setOf("east"),
         eastHits.names(),
-        "A point in the east half. Hits: ${eastHits.names()}",
+        "Expected only east. Hits: ${eastHits.names()}",
       )
     }
   }
@@ -234,8 +235,8 @@ class MapQueryTest {
       .toSet()
 
     /**
-     * Two non-overlapping fills, one on each side of the prime meridian. A point query at
-     * [WEST_POINT] or [EAST_POINT] must hit only that half.
+     * Two non-overlapping fills, one west and one east of the prime meridian. A point query at
+     * [WEST_POINT] or [EAST_POINT] hits only that half.
      */
     val TWO_HALVES_STYLE =
       """

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/MapQueryTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/MapQueryTest.kt
@@ -7,11 +7,14 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
+import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.expressions.ast.ExpressionContext
 import org.maplibre.compose.expressions.dsl.Feature
 import org.maplibre.compose.expressions.dsl.const
@@ -22,6 +25,9 @@ import org.maplibre.compose.testing.MapFixture
 import org.maplibre.compose.testing.MapTestResult
 import org.maplibre.compose.testing.createMapFixture
 import org.maplibre.compose.testing.runMapTest
+import org.maplibre.spatialk.geojson.Feature as GeoJsonFeature
+import org.maplibre.spatialk.geojson.Geometry
+import org.maplibre.spatialk.geojson.Position
 
 class MapQueryTest {
 
@@ -174,6 +180,33 @@ class MapQueryTest {
   }
 
   @Test
+  fun a_query_at_an_off_center_point_returns_only_the_feature_there(): MapTestResult = runMapTest {
+    createMapFixture().use {
+      it.loadStyle(BaseStyle.Json(TWO_HALVES_STYLE))
+      it.session.setCameraPosition(CameraPosition(target = Position(0.0, 0.0), zoom = 0.0))
+      it.pump(frames = 30)
+
+      val westAt = assertNotNull(it.session.screenLocationFromPosition(WEST_POINT))
+      val eastAt = assertNotNull(it.session.screenLocationFromPosition(EAST_POINT))
+      val westHits =
+        it.session.queryRenderedFeatures(offset = westAt, layerIds = null, predicate = null)
+      val eastHits =
+        it.session.queryRenderedFeatures(offset = eastAt, layerIds = null, predicate = null)
+
+      assertEquals(
+        setOf("west"),
+        westHits.names(),
+        "A point in the west half. Hits: ${westHits.names()}",
+      )
+      assertEquals(
+        setOf("east"),
+        eastHits.names(),
+        "A point in the east half. Hits: ${eastHits.names()}",
+      )
+    }
+  }
+
+  @Test
   fun a_queried_feature_keeps_its_geojson_id(): MapTestResult = runMapTest {
     createMapFixture().use {
       it.loadStyle(BaseStyle.Json(WORLD_POLYGON_STYLE))
@@ -190,6 +223,63 @@ class MapQueryTest {
   private companion object {
     /** The center of [MapFixture.DEFAULT_EXTENT], in the logical pixels a query takes. */
     val CENTER = DpOffset(256.dp, 256.dp)
+
+    val WEST_POINT = Position(longitude = -90.0, latitude = 0.0)
+
+    val EAST_POINT = Position(longitude = 90.0, latitude = 0.0)
+
+    fun List<GeoJsonFeature<Geometry, JsonObject?>>.names(): Set<String?> = map { feature ->
+      feature.properties?.get("name")?.jsonPrimitive?.content
+    }
+      .toSet()
+
+    /**
+     * Two non-overlapping fills, one on each side of the prime meridian. A point query at
+     * [WEST_POINT] or [EAST_POINT] must hit only that half.
+     */
+    val TWO_HALVES_STYLE =
+      """
+      {
+        "version": 8,
+        "name": "query-halves-test",
+        "sources": {
+          "test": {
+            "type": "geojson",
+            "data": {
+              "type": "FeatureCollection",
+              "features": [
+                {
+                  "type": "Feature",
+                  "id": 1,
+                  "properties": { "name": "west" },
+                  "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [
+                      [[-170, -80], [-10, -80], [-10, 80], [-170, 80], [-170, -80]]
+                    ]
+                  }
+                },
+                {
+                  "type": "Feature",
+                  "id": 2,
+                  "properties": { "name": "east" },
+                  "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [
+                      [[10, -80], [170, -80], [170, 80], [10, 80], [10, -80]]
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        },
+        "layers": [
+          { "id": "test-fill", "type": "fill", "source": "test", "paint": { "fill-color": "#ff0000" } }
+        ]
+      }
+      """
+        .trimIndent()
 
     /** A polygon covering most of the world, so the viewport center is a hit at any zoom. */
     val WORLD_POLYGON_STYLE =


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

GL JS treats a plain `{x, y}` as missing geometry, so a point `queryRenderedFeatures` searched the whole viewport; this change passes `[x, y]` and adds an off-center halves test. Resolve #1112 

## Validation

The new test failed on JS with both halves (`[east, west]`), then passed on JS ChromeHeadless and desktop Vulkan after the geometry fix.

## AI assistance

Cursor Grok 4.6 (Cloud Agent).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2b849568-97a6-427e-ace1-042f40198bf9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2b849568-97a6-427e-ace1-042f40198bf9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

