### PR TITLE
Add a local HTTP agent driver to the demo app

### DIFF
--- a/.agents/skills/demo-app-driver/SKILL.md
+++ b/.agents/skills/demo-app-driver/SKILL.md
@@ -17,11 +17,13 @@ Nucleus, `/screenshot` returns 501. Drive the browser app with Playwright.
 
 ```sh
 mise run demo:desktop    # desktop; window may stay in the background
-mise run demo:android    # then: adb reverse tcp:8765 tcp:8765
+mise run demo:android    # then: adb -s <serial> reverse tcp:8765 tcp:8765
 ```
 
-On Android, `adb reverse` makes the device's port reachable on the host. Wait
-for startup, then confirm:
+On Android, `adb reverse` makes the device's port reachable on the host. When
+several devices are connected, `adb devices` lists their serials and
+`adb -s <serial>` targets the one that `demo:android` launched on. Wait for
+startup, then confirm:
 
 ```sh
 curl -s http://127.0.0.1:8765/health
@@ -51,7 +53,7 @@ curl -s localhost:8765/state                   # demo, camera, fps, style, setti
 
 - `POST /camera/animate` suspends until the animation ends or another camera
   command supersedes it. Await its response before calling `/wait/idle`.
-- `POST /wait/idle` waits for a completed style load and a still camera.
+- `POST /wait/idle` waits for style loads to finish and the camera to be still.
 - `PUT /style` takes a style name from the error message's valid list or the
   demo's `preferredStyle`. A demo that pins its style answers 409; select
   another demo first.

--- a/.agents/skills/demo-app-driver/SKILL.md
+++ b/.agents/skills/demo-app-driver/SKILL.md
@@ -17,10 +17,10 @@ Nucleus, `/screenshot` returns 501. Drive the browser app with Playwright.
 
 ```sh
 mise run demo:desktop    # desktop; window may stay in the background
-mise run demo:android    # then: adb -s <serial> reverse tcp:8765 tcp:8765
+mise run demo:android    # then: adb -s <serial> forward tcp:8765 tcp:8765
 ```
 
-On Android, `adb reverse` makes the device's port reachable on the host. When
+On Android, `adb forward` makes the device's port reachable on the host. When
 several devices are connected, `adb devices` lists their serials and
 `adb -s <serial>` targets the one that `demo:android` launched on. Wait for
 startup, then confirm:
@@ -93,7 +93,7 @@ modes by hand when a check needs one.
 ## If the API does not answer
 
 - Check `/health`. Connection refused means the app is not running or, on
-  Android, `adb reverse` is missing.
+  Android, `adb forward` is missing.
 - A port conflict disables the driver; the app logs "agent driver disabled" and
   continues without it.
 - A 503 on `/screenshot` means the app's frame pipeline stalled; retry after a

--- a/.agents/skills/demo-app-driver/SKILL.md
+++ b/.agents/skills/demo-app-driver/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: demo-app-driver
+description: Drive the demo app over its local HTTP API to reproduce bugs, move the camera, switch demos and styles, and capture screenshots and state. Use when reproducing behavior in the demo app, verifying a fix there, or gathering evidence from a running demo.
+---
+
+# Demo app driver
+
+The demo app hosts an HTTP JSON API on `127.0.0.1:8765` while it runs. It
+exposes the live app state: demos, camera, style, rendered features, and
+screenshots. There is no authentication; the API exists for local development.
+Set `MAPLIBRE_DEMO_AGENT_PORT` to change the port.
+
+The desktop (AWT, GLFW, Nucleus) and Android apps serve the API. On GLFW and
+Nucleus, `/screenshot` returns 501. Drive the browser app with Playwright.
+
+## Start the app
+
+```sh
+mise run demo:desktop    # desktop; window may stay in the background
+mise run demo:android    # then: adb reverse tcp:8765 tcp:8765
+```
+
+On Android, `adb reverse` makes the device's port reachable on the host. Wait
+for startup, then confirm:
+
+```sh
+curl -s http://127.0.0.1:8765/health
+```
+
+## Learn the API from the app
+
+`GET /` returns the route index: every route with its method, body fields, and
+query parameters, plus usage notes. Read it rather than guessing paths; it is
+the reference for this API. Every response is JSON except `/screenshot`, which
+returns PNG bytes. Every error is JSON `{"error": "..."}` with a 4xx or 5xx
+status, and 400 messages list valid values or ranges.
+
+## Reproduce and capture
+
+A typical evidence-gathering flow:
+
+```sh
+curl -s -X POST localhost:8765/demos/select -H 'Content-Type: application/json' \
+  -d '{"name": "Data visualization"}'      # names from GET /demos; case-insensitive
+curl -s -X PUT localhost:8765/camera -H 'Content-Type: application/json' \
+  -d '{"latitude": 40.71, "longitude": -74.0, "zoom": 12, "bearing": 30, "tilt": 45}'
+curl -s -X POST localhost:8765/wait/idle -d '{}'
+curl -s localhost:8765/screenshot -o shot.png   # view the PNG to confirm
+curl -s localhost:8765/state                   # demo, camera, fps, style, settings
+```
+
+- `POST /camera/animate` suspends until the animation ends or another camera
+  command supersedes it. Await its response before calling `/wait/idle`.
+- `POST /wait/idle` waits for a completed style load and a still camera.
+- `PUT /style` takes a style name from the error message's valid list or the
+  demo's `preferredStyle`. A demo that pins its style answers 409; select
+  another demo first.
+- A 408 from `/demos/select` still applies the demo and flies the camera; only
+  the style wait timed out.
+- Camera, style, and demo operations switch the app out of the Benchmarks shell
+  back to the Demos shell.
+
+## Coordinates and assertions
+
+`/features`, `/gestures/pan`, and `/gestures/zoom` take screen coordinates in
+physical pixels: the same coordinate space as the screenshot PNG, so a point you
+pick in a captured image works unchanged in API calls. The gesture endpoints
+move the camera through the map's projection math.
+
+Use `GET /features?x=…&y=…` to assert what the map renders at a point instead of
+judging pixels: it returns the rendered features as GeoJSON, filterable with
+`layerIds`. Find the layer IDs a demo uses in its layer composables under
+`demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/`. An
+empty result is ambiguous: the layer may be absent from the style, or the point
+may miss its features. The demos panel covers the left part of the window, so
+pick query points in the visible map area.
+
+Map a latitude/longitude to screen coordinates by setting the camera so the
+point sits at the center, then query at half the screenshot's width and height.
+
+## Demo panel state
+
+The driver operates demo selection, camera, and style. Demos keep further state
+in their panel controls: the Data visualization demo gates its heatmap and
+cluster layers behind a "Render as" control, so those layers exist only after a
+manual selection. A demo can also swap its whole layer set per mode, so a layer
+ID from the source may be absent from the live style. Read the demo's `Panel`
+composable before you promise to verify mode-dependent behavior, and switch
+modes by hand when a check needs one.
+
+## If the API does not answer
+
+- Check `/health`. Connection refused means the app is not running or, on
+  Android, `adb reverse` is missing.
+- A port conflict disables the driver; the app logs "agent driver disabled" and
+  continues without it.
+- A 503 on `/screenshot` means the app's frame pipeline stalled; retry after a
+  camera move.

--- a/demo-app/common/build.gradle.kts
+++ b/demo-app/common/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
   id("module-conventions")
   id("android-library-conventions")
   id(libs.plugins.kotlin.multiplatform.get().pluginId)
+  id(libs.plugins.kotlin.serialization.get().pluginId)
   id(libs.plugins.android.library.get().pluginId)
   id(libs.plugins.kotlin.composeCompiler.get().pluginId)
   id(libs.plugins.compose.get().pluginId)
@@ -73,12 +74,20 @@ kotlin {
       implementation(libs.materialKolor)
       implementation(libs.androidx.navigation.compose)
       implementation(libs.kotlin.dsv)
+      implementation(libs.kotlinx.serialization.json)
       implementation(libs.ktor.client.core)
       implementation(libs.mobilityData.gtfsSchedule)
       implementation(libs.spatialk.geojson)
 
       api(project(":lib:maplibre-compose"))
       implementation(project(":lib:maplibre-compose-material3"))
+    }
+
+    // ktor-server only ships JVM and Android artifacts, so the agent driver server lives in this
+    // source set; iOS and the browser get no-op actuals.
+    androidJvmMain.dependencies {
+      implementation(libs.ktor.server.cio)
+      implementation(libs.ktor.server.statusPages)
     }
 
     androidMain {

--- a/demo-app/common/src/androidJvmMain/kotlin/org/maplibre/compose/demoapp/agent/AgentDriverServer.kt
+++ b/demo-app/common/src/androidJvmMain/kotlin/org/maplibre/compose/demoapp/agent/AgentDriverServer.kt
@@ -1,0 +1,168 @@
+package org.maplibre.compose.demoapp.agent
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalDensity
+import co.touchlab.kermit.Logger
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.application.install
+import io.ktor.server.cio.CIO
+import io.ktor.server.engine.EmbeddedServer
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.plugins.statuspages.StatusPages
+import io.ktor.server.request.receiveText
+import io.ktor.server.response.respondBytes
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import io.ktor.server.routing.put
+import io.ktor.server.routing.routing
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import org.maplibre.compose.demoapp.DemoAppState
+
+private val logger = Logger.withTag("AgentDriver")
+
+private val json = Json { ignoreUnknownKeys = true }
+
+private const val DEFAULT_PORT = 8765
+
+/** The platform the agent driver reports in `/health`. */
+internal expect val agentPlatformName: String
+
+/** A capture of the app window as PNG bytes, or null where screenshots are unsupported. */
+@Composable internal expect fun rememberAgentScreenshotCapture(): (suspend () -> ByteArray)?
+
+@Composable
+internal actual fun StartAgentDriver(state: DemoAppState) {
+  val density = LocalDensity.current
+  val screenshotCapture = rememberAgentScreenshotCapture()
+  val driver =
+    remember(state, density, screenshotCapture) {
+      AgentDriver(state, density, screenshotCapture, agentPlatformName)
+    }
+  DisposableEffect(driver) {
+    val server =
+      try {
+        startAgentServer(driver)
+      } catch (e: Exception) {
+        logger.w(e) { "agent driver disabled: ${e.message}" }
+        null
+      }
+    onDispose { server?.stop(gracePeriodMillis = 500, timeoutMillis = 1_000) }
+  }
+}
+
+private fun startAgentServer(driver: AgentDriver): EmbeddedServer<*, *> {
+  val port = System.getenv("MAPLIBRE_DEMO_AGENT_PORT")?.toIntOrNull() ?: DEFAULT_PORT
+  val server =
+    embeddedServer(CIO, host = "127.0.0.1", port = port) {
+      install(StatusPages) {
+        status(HttpStatusCode.NotFound) { call, status ->
+          call.respondText(
+            json.encodeToString(ErrorDto("unknown route; GET / returns the route index")),
+            ContentType.Application.Json,
+            status,
+          )
+        }
+      }
+      routing {
+        get("/") { call.respondResult { driver.routeIndex() } }
+        get("/health") { call.respondResult { driver.health() } }
+        get("/demos") { call.respondResult { driver.demos() } }
+        post("/demos/select") { call.respondResult { driver.selectDemo(call.jsonBody()) } }
+        get("/camera") { call.respondResult { driver.camera() } }
+        put("/camera") { call.respondResult { driver.jumpCamera(call.jsonBody()) } }
+        post("/camera/animate") { call.respondResult { driver.animateCamera(call.jsonBody()) } }
+        get("/style") { call.respondResult { driver.style() } }
+        put("/style") { call.respondResult { driver.setStyle(call.jsonBody()) } }
+        get("/state") { call.respondResult { driver.fullState() } }
+        post("/wait/idle") {
+          call.respondResult {
+            val text = call.receiveText()
+            driver.waitIdle(if (text.isBlank()) WaitIdleRequest() else decode(text))
+          }
+        }
+        get("/features") {
+          call.respondResult {
+            val x = call.requiredQueryParam("x")
+            val y = call.requiredQueryParam("y")
+            val layerIds =
+              call.request.queryParameters["layerIds"]
+                ?.split(",")
+                ?.filter { it.isNotBlank() }
+                ?.toSet()
+            driver.featuresJson(x, y, layerIds)
+          }
+        }
+        get("/screenshot") { call.respondResult { driver.screenshot() } }
+        post("/gestures/pan") { call.respondResult { driver.pan(call.jsonBody()) } }
+        post("/gestures/zoom") { call.respondResult { driver.zoom(call.jsonBody()) } }
+      }
+    }
+  server.start(wait = false)
+  logger.i { "agent driver listening on http://127.0.0.1:$port" }
+  return server
+}
+
+private fun ApplicationCall.requiredQueryParam(name: String): Float {
+  val raw =
+    request.queryParameters[name]
+      ?: throw AgentException(400, "query parameter '$name' (pixels) is required")
+  return raw.toFloatOrNull()?.takeIf { it.isFinite() }
+    ?: throw AgentException(400, "query parameter '$name' must be a number in pixels, got '$raw'")
+}
+
+private suspend inline fun <reified T> decode(text: String): T =
+  try {
+    json.decodeFromString<T>(text)
+  } catch (e: Exception) {
+    throw AgentException(400, "invalid JSON body: ${e.message}")
+  }
+
+private suspend inline fun <reified T> ApplicationCall.jsonBody(): T {
+  val text = receiveText()
+  if (text.isBlank()) throw AgentException(400, "a JSON request body is required")
+  return decode(text)
+}
+
+private suspend fun ApplicationCall.respondError(e: AgentException) {
+  respondText(
+    json.encodeToString(ErrorDto(e.message ?: "error")),
+    ContentType.Application.Json,
+    HttpStatusCode.fromValue(e.statusCode),
+  )
+}
+
+/**
+ * Runs [block] on the main dispatcher and responds with its result: serialized JSON for DTOs, raw
+ * JSON for a [String], PNG for a [ByteArray]. Every route maps [AgentException] to its status with
+ * an [ErrorDto] body, and any other failure to a 500 [ErrorDto].
+ */
+private suspend inline fun <reified T> ApplicationCall.respondResult(
+  crossinline block: suspend () -> T
+) {
+  try {
+    when (val result = withContext(Dispatchers.Main) { block() }) {
+      is ByteArray -> respondBytes(result, ContentType.Image.PNG)
+      is String -> respondText(result, ContentType.Application.Json)
+      else -> respondText(json.encodeToString(result), ContentType.Application.Json)
+    }
+  } catch (e: CancellationException) {
+    throw e
+  } catch (e: AgentException) {
+    respondError(e)
+  } catch (e: Exception) {
+    logger.w(e) { "agent driver request failed" }
+    respondText(
+      json.encodeToString(ErrorDto(e.message ?: "internal error")),
+      ContentType.Application.Json,
+      HttpStatusCode.InternalServerError,
+    )
+  }
+}

--- a/demo-app/common/src/androidMain/AndroidManifest.xml
+++ b/demo-app/common/src/androidMain/AndroidManifest.xml
@@ -3,4 +3,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+  <uses-permission android:name="android.permission.INTERNET" />
 </manifest>

--- a/demo-app/common/src/androidMain/kotlin/org/maplibre/compose/demoapp/agent/AgentDriverAndroid.kt
+++ b/demo-app/common/src/androidMain/kotlin/org/maplibre/compose/demoapp/agent/AgentDriverAndroid.kt
@@ -1,0 +1,76 @@
+package org.maplibre.compose.demoapp.agent
+
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import android.view.PixelCopy
+import android.view.View
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalView
+import java.io.ByteArrayOutputStream
+import kotlin.coroutines.resume
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withTimeout
+
+internal actual val agentPlatformName: String = "android"
+
+private const val PIXEL_COPY_TIMEOUT_MS = 10_000L
+
+@Composable
+internal actual fun rememberAgentScreenshotCapture(): (suspend () -> ByteArray)? {
+  val view = LocalView.current
+  return remember(view) { { captureView(view) } }
+}
+
+/**
+ * Captures [view] as PNG bytes. PixelCopy (API 26+) includes the map's hardware surface; older
+ * devices fall back to a software draw, which may miss it.
+ */
+private suspend fun captureView(view: View): ByteArray {
+  val bitmap = runCatching {
+    Bitmap.createBitmap(view.width, view.height, Bitmap.Config.ARGB_8888)
+  }
+    .getOrElse { throw AgentException(503, "the view has no size yet") }
+  val window = view.context.findActivity()?.window
+  val copied =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && window != null) {
+      try {
+        withTimeout(PIXEL_COPY_TIMEOUT_MS) {
+          suspendCancellableCoroutine { continuation ->
+            // A synchronous throw here (e.g. an inactive window) falls through to the draw below.
+            runCatching {
+              PixelCopy.request(
+                window,
+                bitmap,
+                { result -> if (continuation.isActive) continuation.resume(result) },
+                Handler(Looper.getMainLooper()),
+              )
+            }
+              .onFailure { if (continuation.isActive) continuation.resume(PixelCopy.ERROR_UNKNOWN) }
+          }
+        } == PixelCopy.SUCCESS
+      } catch (e: TimeoutCancellationException) {
+        false
+      }
+    } else {
+      false
+    }
+  if (!copied) view.draw(Canvas(bitmap))
+  val out = ByteArrayOutputStream()
+  bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)
+  return out.toByteArray()
+}
+
+private tailrec fun Context.findActivity(): Activity? =
+  when (this) {
+    is Activity -> this
+    is ContextWrapper -> baseContext.findActivity()
+    else -> null
+  }

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoApp.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoApp.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.unit.lerp
 import androidx.window.core.layout.WindowSizeClass
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.vectorResource
+import org.maplibre.compose.demoapp.agent.StartAgentDriver
 import org.maplibre.compose.demoapp.benchmark.BenchmarkMap
 import org.maplibre.compose.demoapp.generated.Res
 import org.maplibre.compose.demoapp.generated.chevron_left_24px
@@ -46,6 +47,7 @@ import org.maplibre.compose.demoapp.generated.chevron_right_24px
 @Composable
 fun DemoApp() {
   val state = rememberDemoAppState()
+  StartAgentDriver(state)
   val dark =
     if (state.shell == DemoShell.Benchmarks) state.selectedScenario.style.isDark
     else state.appliedStyle.isDark

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoAppState.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoAppState.kt
@@ -79,8 +79,15 @@ class DemoAppState(
   internal var lastStyleLoad by mutableStateOf(StyleLoad(count = 0, base = null))
     private set
 
+  /**
+   * The base style the map has applied but not yet finished or failed loading, if any. Set by the
+   * map composition and cleared by [noteStyleLoad].
+   */
+  internal var pendingStyleLoad by mutableStateOf<BaseStyle?>(null)
+
   internal fun noteStyleLoad(base: BaseStyle) {
     lastStyleLoad = StyleLoad(lastStyleLoad.count + 1, base)
+    if (pendingStyleLoad == base) pendingStyleLoad = null
   }
 
   /**

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoAppState.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoAppState.kt
@@ -64,6 +64,13 @@ class DemoAppState(
       }
     }
 
+  /**
+   * The style the map composition most recently applied. Kept as plain state because [appliedStyle]
+   * is composable, so non-composition readers like the agent driver cannot call it. Goes stale
+   * while the Benchmarks shell is showing, where the demo map is not composed.
+   */
+  internal var appliedStyleSnapshot by mutableStateOf<DemoStyle?>(null)
+
   var shell by mutableStateOf(DemoShell.Demos)
   var selectedScenario by mutableStateOf<BenchmarkScenario>(allBenchmarkScenarios.first())
   val benchmark = BenchmarkUiState()

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoAppState.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoAppState.kt
@@ -72,6 +72,12 @@ class DemoAppState(
   internal var appliedStyleSnapshot by mutableStateOf<DemoStyle?>(null)
 
   var shell by mutableStateOf(DemoShell.Demos)
+
+  /**
+   * Bumped by the agent driver when it selects a demo, so the demo panel navigates from the list to
+   * the demo's controls. The panel owns its NavController; this is the driver's only hook.
+   */
+  internal var panelNavGeneration by mutableStateOf(0)
   var selectedScenario by mutableStateOf<BenchmarkScenario>(allBenchmarkScenarios.first())
   val benchmark = BenchmarkUiState()
 

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoAppState.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoAppState.kt
@@ -38,7 +38,20 @@ class DemoAppState(
   val settings: DemoSettings,
   val frameRateState: FrameRateState,
 ) {
+  /**
+   * The demo shown on the map. Select demos through [selectDemo] so the panel can align its
+   * destination.
+   */
   var selectedDemo by mutableStateOf<Demo?>(null)
+
+  /**
+   * Selects [demo] in the Demos shell. The one selection path for both the panel's demo list and
+   * the agent driver; the panel observes [selectedDemo] and navigates to the demo's controls.
+   */
+  fun selectDemo(demo: Demo) {
+    selectedDemo = demo
+    shell = DemoShell.Demos
+  }
 
   /** The style applied when [MapStyleMode] resolves to light. */
   var chosenLightStyle by mutableStateOf<DemoStyle>(Protomaps.Light)
@@ -73,11 +86,6 @@ class DemoAppState(
 
   var shell by mutableStateOf(DemoShell.Demos)
 
-  /**
-   * Bumped by the agent driver when it selects a demo, so the demo panel navigates from the list to
-   * the demo's controls. The panel owns its NavController; this is the driver's only hook.
-   */
-  internal var panelNavGeneration by mutableStateOf(0)
   var selectedScenario by mutableStateOf<BenchmarkScenario>(allBenchmarkScenarios.first())
   val benchmark = BenchmarkUiState()
 

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoMap.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoMap.kt
@@ -13,6 +13,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -65,7 +66,9 @@ internal suspend fun CameraState.flyTo(destination: DemoDestination) {
 @Composable
 fun DemoMap(state: DemoAppState, viewportInsets: MapViewportInsets) {
   val scope = rememberCoroutineScope()
-  val appliedBase = state.appliedStyle.base
+  val appliedStyle = state.appliedStyle
+  SideEffect { state.appliedStyleSnapshot = appliedStyle }
+  val appliedBase = appliedStyle.base
   val selectedDemo = state.selectedDemo
   val pointerPin = selectedDemo?.pointerPin
   val placementPadding =
@@ -301,9 +304,8 @@ private fun findEllipseIntersection(area: Rect, target: Offset): Offset? {
 
 @Composable
 private fun DiagnosticOverlays(state: DemoAppState, modifier: Modifier = Modifier) {
-  if (state.settings.showFpsOverlay) {
-    LaunchedEffect(state.frameRateState) { state.frameRateState.track() }
-  }
+  // Track frames whether or not the overlay shows; the agent driver reports fps in /state.
+  LaunchedEffect(state.frameRateState) { state.frameRateState.track() }
   Column(
     modifier =
       modifier

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoMap.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoMap.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.key
@@ -67,8 +68,15 @@ internal suspend fun CameraState.flyTo(destination: DemoDestination) {
 fun DemoMap(state: DemoAppState, viewportInsets: MapViewportInsets) {
   val scope = rememberCoroutineScope()
   val appliedStyle = state.appliedStyle
-  SideEffect { state.appliedStyleSnapshot = appliedStyle }
   val appliedBase = appliedStyle.base
+  SideEffect { state.appliedStyleSnapshot = appliedStyle }
+  // Composing the map with a base means its load is in flight until noteStyleLoad clears it.
+  DisposableEffect(appliedBase) {
+    state.pendingStyleLoad = appliedBase
+    onDispose {
+      if (state.pendingStyleLoad == appliedBase) state.pendingStyleLoad = null
+    }
+  }
   val selectedDemo = state.selectedDemo
   val pointerPin = selectedDemo?.pointerPin
   val placementPadding =

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoPanel.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoPanel.kt
@@ -62,10 +62,10 @@ fun DemoPanel(
   val appliedStyle = state.appliedStyle
   var flightJob by remember { mutableStateOf<Job?>(null) }
   val route = navController.currentBackStackEntryAsState().value?.destination?.route
-  // The agent driver selects demos without touching this NavController; a bump of the generation
-  // asks the panel to show the selected demo's controls.
-  LaunchedEffect(state.panelNavGeneration) {
-    if (state.panelNavGeneration > 0 && route != "demo") navController.navigate("demo")
+  // Align the panel destination with the selection: the agent driver selects demos through
+  // DemoAppState, without touching this NavController.
+  LaunchedEffect(state.selectedDemo) {
+    if (state.selectedDemo != null && route != "demo") navController.navigate("demo")
   }
   // selectedDemo drives the map overlay. Keep it aligned with this destination so
   // system and predictive back clear the overlay too.
@@ -97,8 +97,7 @@ fun DemoPanel(
           flightJob = scope.launch {
             val newBase = demo.preferredStyle?.base?.takeIf { it != appliedStyle.base }
             val styleLoadsSeen = state.lastStyleLoad.count
-            state.selectedDemo = demo
-            navController.navigate("demo")
+            state.selectDemo(demo)
             if (collapseOnSelection) {
               collapsePanel()
               // One frame so the settled viewport insets reach the camera before the flight.

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoPanel.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoPanel.kt
@@ -62,6 +62,11 @@ fun DemoPanel(
   val appliedStyle = state.appliedStyle
   var flightJob by remember { mutableStateOf<Job?>(null) }
   val route = navController.currentBackStackEntryAsState().value?.destination?.route
+  // The agent driver selects demos without touching this NavController; a bump of the generation
+  // asks the panel to show the selected demo's controls.
+  LaunchedEffect(state.panelNavGeneration) {
+    if (state.panelNavGeneration > 0 && route != "demo") navController.navigate("demo")
+  }
   // selectedDemo drives the map overlay. Keep it aligned with this destination so
   // system and predictive back clear the overlay too.
   LaunchedEffect(route) {

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/agent/AgentDriver.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/agent/AgentDriver.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.DpOffset
 import kotlin.math.log2
+import kotlin.math.pow
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.TimeSource
 import kotlinx.coroutines.TimeoutCancellationException
@@ -172,15 +173,27 @@ internal class AgentDriver(
           400,
           "unknown demo '${request.name}'. Valid demos: ${allDemos.joinToString { it.name }}",
         )
+    val wasBenchmarks = state.shell == DemoShell.Benchmarks
     val preferred = demo.preferredStyle
     val newBase = preferred?.base?.takeIf { it != state.appliedStyleSnapshot?.base }
     val styleLoadsSeen = state.lastStyleLoad.count
     markDemoMapReload()
     state.selectedDemo = demo
+    state.panelNavGeneration++
+    // The demo map reloads from scratch when leaving the Benchmarks shell, so await its base even
+    // when this demo has no preferred style of its own.
+    val baseToAwait =
+      if (preferred != null && newBase != null) preferred.base
+      else if (wasBenchmarks) preferred?.base ?: state.appliedStyleSnapshot?.base else null
     val styleTimedOut =
-      if (preferred != null && newBase != null) {
+      if (baseToAwait != null) {
         try {
-          awaitStyleLoad(styleLoadsSeen, newBase, preferred.displayName, request.timeoutMs)
+          awaitStyleLoad(
+            styleLoadsSeen,
+            baseToAwait,
+            preferred?.displayName ?: "the applied style",
+            request.timeoutMs,
+          )
           false
         } catch (e: AgentException) {
           true
@@ -365,9 +378,11 @@ internal class AgentDriver(
       } else {
         null
       }
+    val newZoom = (current.zoom + log2(request.factor)).coerceIn(0.0, 25.5)
+    // Base the anchor shift on the zoom that survives clamping, not the requested factor.
+    val fraction = 1.0 - 2.0.pow(current.zoom - newZoom)
     val target =
       anchor?.let {
-        val fraction = 1.0 - 1.0 / request.factor
         // The projection wraps longitude to ±180; take the short way across the antimeridian.
         val deltaLng = shortLongitudeDelta(from = current.target.longitude, to = it.longitude)
         Position(
@@ -375,11 +390,7 @@ internal class AgentDriver(
           latitude = current.target.latitude + (it.latitude - current.target.latitude) * fraction,
         )
       } ?: current.target
-    state.cameraState.position =
-      current.copy(
-        target = target,
-        zoom = (current.zoom + log2(request.factor)).coerceIn(0.0, 25.5),
-      )
+    state.cameraState.position = current.copy(target = target, zoom = newZoom)
     return camera()
   }
 
@@ -406,7 +417,7 @@ internal class AgentDriver(
     longitude?.let { requireInRange("longitude", it, -180.0..180.0) }
     zoom?.let { requireInRange("zoom", it, 0.0..25.5) }
     bearing?.let { requireFinite("bearing", it) }
-    tilt?.let { requireFinite("tilt", it) }
+    tilt?.let { requireInRange("tilt", it, 0.0..60.0) }
   }
 
   private fun requireInRange(name: String, value: Double, range: ClosedFloatingPointRange<Double>) {
@@ -538,6 +549,8 @@ internal class AgentDriver(
               "command; await the animate response before calling /wait/idle.",
             "A 408 from /demos/select still applies the demo and flies the camera; only the " +
               "style wait timed out.",
+            "Camera reads report the Demos-shell camera while the Benchmarks shell is showing; " +
+              "camera, style, and demo mutations switch back to the Demos shell first.",
           ),
       )
   }

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/agent/AgentDriver.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/agent/AgentDriver.kt
@@ -178,8 +178,7 @@ internal class AgentDriver(
     val newBase = preferred?.base?.takeIf { it != state.appliedStyleSnapshot?.base }
     val styleLoadsSeen = state.lastStyleLoad.count
     markDemoMapReload()
-    state.selectedDemo = demo
-    state.panelNavGeneration++
+    state.selectDemo(demo)
     // The demo map reloads from scratch when leaving the Benchmarks shell, so await its base even
     // when this demo has no preferred style of its own.
     val baseToAwait =

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/agent/AgentDriver.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/agent/AgentDriver.kt
@@ -175,7 +175,7 @@ internal class AgentDriver(
     val preferred = demo.preferredStyle
     val newBase = preferred?.base?.takeIf { it != state.appliedStyleSnapshot?.base }
     val styleLoadsSeen = state.lastStyleLoad.count
-    state.shell = DemoShell.Demos
+    markDemoMapReload()
     state.selectedDemo = demo
     val styleTimedOut =
       if (preferred != null && newBase != null) {
@@ -203,7 +203,7 @@ internal class AgentDriver(
 
   fun jumpCamera(request: CameraUpdateRequest): CameraDto {
     request.validateRanges()
-    state.shell = DemoShell.Demos
+    markDemoMapReload()
     state.cameraState.position = state.cameraState.position.merged(request)
     return camera()
   }
@@ -212,12 +212,24 @@ internal class AgentDriver(
     request.validateRanges()
     val durationMs = request.durationMs ?: DEFAULT_ANIMATION_MS
     if (durationMs < 0) throw AgentException(400, "'durationMs' must be >= 0, got $durationMs")
-    state.shell = DemoShell.Demos
+    markDemoMapReload()
     state.cameraState.animateTo(
       finalPosition = state.cameraState.position.merged(request),
       duration = durationMs.milliseconds,
     )
     return camera()
+  }
+
+  /**
+   * Switches back to the Demos shell. The demo map loads its style from scratch when it recomposes,
+   * so mark that load in flight eagerly; a wait/idle that lands before recomposition must not
+   * report idle.
+   */
+  private fun markDemoMapReload() {
+    if (state.shell == DemoShell.Benchmarks) {
+      state.appliedStyleSnapshot?.let { state.pendingStyleLoad = it.base }
+    }
+    state.shell = DemoShell.Demos
   }
 
   fun style(): StyleDto {
@@ -242,14 +254,15 @@ internal class AgentDriver(
         )
       }
     }
-    state.shell = DemoShell.Demos
+    val wasBenchmarks = state.shell == DemoShell.Benchmarks
+    markDemoMapReload()
     val styleLoadsSeen = state.lastStyleLoad.count
     // Set both so the style applies regardless of how MapStyleMode resolves.
     state.chosenLightStyle = style
     state.chosenDarkStyle = style
-    // appliedStyleSnapshot goes stale while the Benchmarks shell is showing, so this can skip the
-    // await when the demo map still has to load the style on recomposition; /wait/idle covers it.
-    if (state.appliedStyleSnapshot != style) {
+    // appliedStyleSnapshot goes stale while the Benchmarks shell is showing, and the demo map
+    // loads from scratch on recomposition, so a snapshot match does not mean the load finished.
+    if (wasBenchmarks || state.appliedStyleSnapshot != style) {
       awaitStyleLoad(styleLoadsSeen, style.base, style.displayName, request.timeoutMs)
     }
     return style()
@@ -275,15 +288,18 @@ internal class AgentDriver(
     )
 
   /**
-   * Waits for a completed style load and a still camera. Only observes *completed* style loads; a
-   * style load currently in flight is invisible to it, and no signal exists for one yet.
+   * Waits for any in-flight style load to finish, at least one completed load, and a still camera.
    */
   suspend fun waitIdle(request: WaitIdleRequest): WaitIdleResponse {
     requireValidTimeout(request.timeoutMs)
     val start = TimeSource.Monotonic.markNow()
     try {
       withTimeout(request.timeoutMs) {
-        snapshotFlow { state.lastStyleLoad.count > 0 && !state.cameraState.isCameraMoving }
+        snapshotFlow {
+          state.lastStyleLoad.count > 0 &&
+            state.pendingStyleLoad == null &&
+            !state.cameraState.isCameraMoving
+        }
           .first { it }
       }
     } catch (e: TimeoutCancellationException) {
@@ -315,11 +331,13 @@ internal class AgentDriver(
     val atCenter = state.cameraState.positionFromScreenLocation(center) ?: return camera()
     val atMoved = state.cameraState.positionFromScreenLocation(moved) ?: return camera()
     val current = state.cameraState.position
+    // The projection wraps longitude to ±180; take the short way across the antimeridian.
+    val deltaLng = shortLongitudeDelta(from = atMoved.longitude, to = atCenter.longitude)
     state.cameraState.position =
       current.copy(
         target =
           Position(
-            longitude = current.target.longitude + (atCenter.longitude - atMoved.longitude),
+            longitude = current.target.longitude + deltaLng,
             latitude = current.target.latitude + (atCenter.latitude - atMoved.latitude),
           )
       )
@@ -350,9 +368,10 @@ internal class AgentDriver(
     val target =
       anchor?.let {
         val fraction = 1.0 - 1.0 / request.factor
+        // The projection wraps longitude to ±180; take the short way across the antimeridian.
+        val deltaLng = shortLongitudeDelta(from = current.target.longitude, to = it.longitude)
         Position(
-          longitude =
-            current.target.longitude + (it.longitude - current.target.longitude) * fraction,
+          longitude = current.target.longitude + deltaLng * fraction,
           latitude = current.target.latitude + (it.latitude - current.target.latitude) * fraction,
         )
       } ?: current.target
@@ -410,6 +429,11 @@ internal class AgentDriver(
   private fun requireValidTimeout(timeoutMs: Long) {
     if (timeoutMs <= 0) throw AgentException(400, "'timeoutMs' must be > 0, got $timeoutMs")
   }
+
+  /**
+   * The shortest signed longitude delta from [from] to [to], across the antimeridian if shorter.
+   */
+  private fun shortLongitudeDelta(from: Double, to: Double) = (to - from + 540.0) % 360.0 - 180.0
 
   private fun CameraPosition.merged(request: CameraUpdateRequest) =
     copy(
@@ -484,7 +508,7 @@ internal class AgentDriver(
             RouteDto(
               "POST",
               "/wait/idle",
-              "wait for a completed style load and a still camera",
+              "wait for style loads to finish and the camera to be still",
               body = "{timeoutMs?}",
             ),
             RouteDto("GET", "/screenshot", "PNG bytes of the app window"),

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/agent/AgentDriver.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/agent/AgentDriver.kt
@@ -1,0 +1,520 @@
+package org.maplibre.compose.demoapp.agent
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.DpOffset
+import kotlin.math.log2
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.TimeSource
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withTimeout
+import kotlinx.serialization.Serializable
+import org.maplibre.compose.camera.CameraPosition
+import org.maplibre.compose.camera.CameraState
+import org.maplibre.compose.demoapp.Demo
+import org.maplibre.compose.demoapp.DemoAppState
+import org.maplibre.compose.demoapp.DemoShell
+import org.maplibre.compose.demoapp.DemoStyle
+import org.maplibre.compose.demoapp.allDemoStyles
+import org.maplibre.compose.demoapp.allDemos
+import org.maplibre.compose.demoapp.flyTo
+import org.maplibre.compose.style.BaseStyle
+import org.maplibre.spatialk.geojson.FeatureCollection
+import org.maplibre.spatialk.geojson.Position
+import org.maplibre.spatialk.geojson.toJson
+
+/**
+ * Starts the local HTTP agent driver for this app, bound to `127.0.0.1` (default port 8765,
+ * override with the `MAPLIBRE_DEMO_AGENT_PORT` environment variable). It exposes the live
+ * [DemoAppState] over a JSON API so AI agents can drive the demo app. A no-op on platforms that
+ * cannot host a server (iOS, web). For local development only; there is no authentication.
+ */
+@Composable internal expect fun StartAgentDriver(state: DemoAppState)
+
+/** An error the driver reports to the HTTP client with [statusCode]. */
+internal class AgentException(val statusCode: Int, message: String) : Exception(message)
+
+/** The default for request bodies that wait on the map, in milliseconds. */
+private const val DEFAULT_TIMEOUT_MS = 30_000L
+
+/** The default camera animation duration for `POST /camera/animate`, in milliseconds. */
+private const val DEFAULT_ANIMATION_MS = 300L
+
+@Serializable internal data class ErrorDto(val error: String)
+
+@Serializable
+internal data class RouteDto(
+  val method: String,
+  val path: String,
+  val description: String,
+  val body: String? = null,
+  val query: String? = null,
+)
+
+@Serializable internal data class RouteIndexDto(val routes: List<RouteDto>, val notes: List<String>)
+
+@Serializable
+internal data class HealthDto(
+  val status: String,
+  val platform: String,
+  val demos: Int,
+  val styles: Int,
+)
+
+@Serializable
+internal data class DemoDto(
+  val name: String,
+  val description: String,
+  val preferredStyle: String? = null,
+)
+
+@Serializable
+internal data class SelectDemoRequest(val name: String, val timeoutMs: Long = DEFAULT_TIMEOUT_MS)
+
+@Serializable
+internal data class CameraPositionDto(
+  val latitude: Double,
+  val longitude: Double,
+  val zoom: Double,
+  val bearing: Double,
+  val tilt: Double,
+)
+
+@Serializable
+internal data class CameraDto(
+  val position: CameraPositionDto,
+  val isCameraMoving: Boolean,
+  val moveReason: String,
+)
+
+@Serializable
+internal data class CameraUpdateRequest(
+  val latitude: Double? = null,
+  val longitude: Double? = null,
+  val zoom: Double? = null,
+  val bearing: Double? = null,
+  val tilt: Double? = null,
+  /** Only `POST /camera/animate` reads this; `PUT /camera` ignores it. */
+  val durationMs: Long? = null,
+)
+
+@Serializable
+internal data class StyleDto(
+  val name: String?,
+  val isDark: Boolean?,
+  val mode: String,
+  val lightStyle: String,
+  val darkStyle: String,
+)
+
+@Serializable
+internal data class SetStyleRequest(val name: String, val timeoutMs: Long = DEFAULT_TIMEOUT_MS)
+
+@Serializable
+internal data class SettingsDto(
+  val mapStyleMode: String,
+  val paletteMode: String,
+  val useMaterial3Controls: Boolean,
+  val showFpsOverlay: Boolean,
+  val showCameraOverlay: Boolean,
+)
+
+@Serializable
+internal data class AgentStateDto(
+  val demo: String?,
+  val shell: String,
+  val camera: CameraDto,
+  val style: StyleDto,
+  val styleLoadsCompleted: Int,
+  val framesPerSecond: Double,
+  val totalFrames: Long,
+  val settings: SettingsDto,
+)
+
+@Serializable internal data class WaitIdleRequest(val timeoutMs: Long = DEFAULT_TIMEOUT_MS)
+
+@Serializable internal data class WaitIdleResponse(val waitedMs: Long)
+
+@Serializable internal data class PanRequest(val dxPx: Float, val dyPx: Float)
+
+@Serializable
+internal data class ZoomRequest(val factor: Double, val x: Float? = null, val y: Float? = null)
+
+/**
+ * The platform-agnostic handler logic behind the agent driver endpoints. The server passes every
+ * call on the main dispatcher, so these read and mutate Compose snapshot state directly.
+ */
+internal class AgentDriver(
+  private val state: DemoAppState,
+  private val density: Density,
+  private val screenshotCapture: (suspend () -> ByteArray)?,
+  private val platform: String,
+) {
+  fun routeIndex() = ROUTE_INDEX
+
+  fun health() =
+    HealthDto(
+      status = "ok",
+      platform = platform,
+      demos = allDemos.size,
+      styles = allDemoStyles.size,
+    )
+
+  fun demos() = allDemos.map { it.toDto() }
+
+  suspend fun selectDemo(request: SelectDemoRequest): DemoDto {
+    requireValidTimeout(request.timeoutMs)
+    val demo =
+      allDemos.find { it.name.equals(request.name, ignoreCase = true) }
+        ?: throw AgentException(
+          400,
+          "unknown demo '${request.name}'. Valid demos: ${allDemos.joinToString { it.name }}",
+        )
+    val preferred = demo.preferredStyle
+    val newBase = preferred?.base?.takeIf { it != state.appliedStyleSnapshot?.base }
+    val styleLoadsSeen = state.lastStyleLoad.count
+    state.shell = DemoShell.Demos
+    state.selectedDemo = demo
+    val styleTimedOut =
+      if (preferred != null && newBase != null) {
+        try {
+          awaitStyleLoad(styleLoadsSeen, newBase, preferred.displayName, request.timeoutMs)
+          false
+        } catch (e: AgentException) {
+          true
+        }
+      } else {
+        false
+      }
+    // Fly even when the style wait failed, so a timeout never leaves the demo half-applied.
+    state.cameraState.flyTo(demo.destination)
+    if (styleTimedOut) {
+      throw AgentException(
+        408,
+        "demo '${demo.name}' selected, but its style did not load within ${request.timeoutMs} ms",
+      )
+    }
+    return demo.toDto()
+  }
+
+  fun camera() = state.cameraState.toDto()
+
+  fun jumpCamera(request: CameraUpdateRequest): CameraDto {
+    request.validateRanges()
+    state.shell = DemoShell.Demos
+    state.cameraState.position = state.cameraState.position.merged(request)
+    return camera()
+  }
+
+  suspend fun animateCamera(request: CameraUpdateRequest): CameraDto {
+    request.validateRanges()
+    val durationMs = request.durationMs ?: DEFAULT_ANIMATION_MS
+    if (durationMs < 0) throw AgentException(400, "'durationMs' must be >= 0, got $durationMs")
+    state.shell = DemoShell.Demos
+    state.cameraState.animateTo(
+      finalPosition = state.cameraState.position.merged(request),
+      duration = durationMs.milliseconds,
+    )
+    return camera()
+  }
+
+  fun style(): StyleDto {
+    val applied = state.appliedStyleSnapshot
+    return StyleDto(
+      name = applied?.displayName,
+      isDark = applied?.isDark,
+      mode = state.settings.mapStyleMode.name,
+      lightStyle = state.chosenLightStyle.displayName,
+      darkStyle = state.chosenDarkStyle.displayName,
+    )
+  }
+
+  suspend fun setStyle(request: SetStyleRequest): StyleDto {
+    requireValidTimeout(request.timeoutMs)
+    val style = findStyle(request.name)
+    state.selectedDemo?.let {
+      if (it.preferredStyle != null) {
+        throw AgentException(
+          409,
+          "the selected demo '${it.name}' pins its own base style; select another demo first",
+        )
+      }
+    }
+    state.shell = DemoShell.Demos
+    val styleLoadsSeen = state.lastStyleLoad.count
+    // Set both so the style applies regardless of how MapStyleMode resolves.
+    state.chosenLightStyle = style
+    state.chosenDarkStyle = style
+    // appliedStyleSnapshot goes stale while the Benchmarks shell is showing, so this can skip the
+    // await when the demo map still has to load the style on recomposition; /wait/idle covers it.
+    if (state.appliedStyleSnapshot != style) {
+      awaitStyleLoad(styleLoadsSeen, style.base, style.displayName, request.timeoutMs)
+    }
+    return style()
+  }
+
+  fun fullState() =
+    AgentStateDto(
+      demo = state.selectedDemo?.name,
+      shell = state.shell.name,
+      camera = camera(),
+      style = style(),
+      styleLoadsCompleted = state.lastStyleLoad.count,
+      framesPerSecond = state.frameRateState.framesPerSecond,
+      totalFrames = state.frameRateState.totalFrames,
+      settings =
+        SettingsDto(
+          mapStyleMode = state.settings.mapStyleMode.name,
+          paletteMode = state.settings.paletteMode.name,
+          useMaterial3Controls = state.settings.useMaterial3Controls,
+          showFpsOverlay = state.settings.showFpsOverlay,
+          showCameraOverlay = state.settings.showCameraOverlay,
+        ),
+    )
+
+  /**
+   * Waits for a completed style load and a still camera. Only observes *completed* style loads; a
+   * style load currently in flight is invisible to it, and no signal exists for one yet.
+   */
+  suspend fun waitIdle(request: WaitIdleRequest): WaitIdleResponse {
+    requireValidTimeout(request.timeoutMs)
+    val start = TimeSource.Monotonic.markNow()
+    try {
+      withTimeout(request.timeoutMs) {
+        snapshotFlow { state.lastStyleLoad.count > 0 && !state.cameraState.isCameraMoving }
+          .first { it }
+      }
+    } catch (e: TimeoutCancellationException) {
+      throw AgentException(408, "the map did not go idle within ${request.timeoutMs} ms")
+    }
+    return WaitIdleResponse(waitedMs = start.elapsedNow().inWholeMilliseconds)
+  }
+
+  suspend fun screenshot(): ByteArray =
+    screenshotCapture?.invoke()
+      ?: throw AgentException(501, "screenshots are not supported on this host")
+
+  suspend fun featuresJson(xPx: Float, yPx: Float, layerIds: Set<String>?): String {
+    val offset = with(density) { DpOffset(xPx.toDp(), yPx.toDp()) }
+    val features = state.cameraState.queryRenderedFeatures(offset = offset, layerIds = layerIds)
+    return FeatureCollection(features).toJson()
+  }
+
+  /** Pans the map as if dragged by ([request]'s dx, dy) pixels, via the camera. */
+  fun pan(request: PanRequest): CameraDto {
+    requireFinite("dxPx", request.dxPx)
+    requireFinite("dyPx", request.dyPx)
+    val size =
+      state.cameraState.viewport?.size ?: throw AgentException(503, "the map has no viewport yet")
+    val center = DpOffset(size.width / 2, size.height / 2)
+    val moved =
+      with(density) { DpOffset(center.x + request.dxPx.toDp(), center.y + request.dyPx.toDp()) }
+    // Best effort: a screen point off the map has no position, so report the camera unchanged.
+    val atCenter = state.cameraState.positionFromScreenLocation(center) ?: return camera()
+    val atMoved = state.cameraState.positionFromScreenLocation(moved) ?: return camera()
+    val current = state.cameraState.position
+    state.cameraState.position =
+      current.copy(
+        target =
+          Position(
+            longitude = current.target.longitude + (atCenter.longitude - atMoved.longitude),
+            latitude = current.target.latitude + (atCenter.latitude - atMoved.latitude),
+          )
+      )
+    return camera()
+  }
+
+  /**
+   * Zooms the map by [ZoomRequest.factor] via the camera. When an anchor point is given, the target
+   * shifts toward it so the anchor approximately stays put.
+   */
+  fun zoom(request: ZoomRequest): CameraDto {
+    if (!request.factor.isFinite() || request.factor <= 0.0) {
+      throw AgentException(400, "'factor' must be a positive finite number, got ${request.factor}")
+    }
+    if ((request.x == null) != (request.y == null)) {
+      throw AgentException(400, "'x' and 'y' must be given together")
+    }
+    request.x?.let { requireFinite("x", it) }
+    request.y?.let { requireFinite("y", it) }
+    val current = state.cameraState.position
+    val anchor =
+      if (request.x != null && request.y != null) {
+        with(density) { DpOffset(request.x.toDp(), request.y.toDp()) }
+          .let(state.cameraState::positionFromScreenLocation)
+      } else {
+        null
+      }
+    val target =
+      anchor?.let {
+        val fraction = 1.0 - 1.0 / request.factor
+        Position(
+          longitude =
+            current.target.longitude + (it.longitude - current.target.longitude) * fraction,
+          latitude = current.target.latitude + (it.latitude - current.target.latitude) * fraction,
+        )
+      } ?: current.target
+    state.cameraState.position =
+      current.copy(
+        target = target,
+        zoom = (current.zoom + log2(request.factor)).coerceIn(0.0, 25.5),
+      )
+    return camera()
+  }
+
+  private fun findStyle(name: String): DemoStyle =
+    allDemoStyles.find { it.displayName.equals(name, ignoreCase = true) }
+      ?: allDemoStyles
+        .filter { it.displayName.substringBefore(" (").equals(name, ignoreCase = true) }
+        .singleOrNull()
+      ?: throw AgentException(
+        400,
+        "unknown style '$name'. Valid styles: ${allDemoStyles.joinToString { it.displayName }}",
+      )
+
+  private suspend fun awaitStyleLoad(seen: Int, base: BaseStyle, name: String, timeoutMs: Long) {
+    try {
+      withTimeout(timeoutMs) { state.awaitStyleLoad(seen = seen, base = base) }
+    } catch (e: TimeoutCancellationException) {
+      throw AgentException(408, "timed out waiting for style '$name' to load")
+    }
+  }
+
+  private fun CameraUpdateRequest.validateRanges() {
+    latitude?.let { requireInRange("latitude", it, -90.0..90.0) }
+    longitude?.let { requireInRange("longitude", it, -180.0..180.0) }
+    zoom?.let { requireInRange("zoom", it, 0.0..25.5) }
+    bearing?.let { requireFinite("bearing", it) }
+    tilt?.let { requireFinite("tilt", it) }
+  }
+
+  private fun requireInRange(name: String, value: Double, range: ClosedFloatingPointRange<Double>) {
+    if (!value.isFinite() || value !in range) {
+      throw AgentException(
+        400,
+        "'$name' must be a finite number in ${range.start}..${range.endInclusive}, got $value",
+      )
+    }
+  }
+
+  private fun requireFinite(name: String, value: Double) {
+    if (!value.isFinite()) throw AgentException(400, "'$name' must be a finite number, got $value")
+  }
+
+  private fun requireFinite(name: String, value: Float) {
+    if (!value.isFinite()) throw AgentException(400, "'$name' must be a finite number, got $value")
+  }
+
+  private fun requireValidTimeout(timeoutMs: Long) {
+    if (timeoutMs <= 0) throw AgentException(400, "'timeoutMs' must be > 0, got $timeoutMs")
+  }
+
+  private fun CameraPosition.merged(request: CameraUpdateRequest) =
+    copy(
+      target =
+        Position(
+          longitude = request.longitude ?: target.longitude,
+          latitude = request.latitude ?: target.latitude,
+        ),
+      zoom = request.zoom ?: zoom,
+      bearing = request.bearing ?: bearing,
+      tilt = request.tilt ?: tilt,
+    )
+
+  private fun CameraState.toDto(): CameraDto {
+    val position = position
+    return CameraDto(
+      position =
+        CameraPositionDto(
+          latitude = position.target.latitude,
+          longitude = position.target.longitude,
+          zoom = position.zoom,
+          bearing = position.bearing,
+          tilt = position.tilt,
+        ),
+      isCameraMoving = isCameraMoving,
+      moveReason = moveReason.name,
+    )
+  }
+
+  private fun Demo.toDto() =
+    DemoDto(name = name, description = description, preferredStyle = preferredStyle?.displayName)
+
+  private companion object {
+    val ROUTE_INDEX =
+      RouteIndexDto(
+        routes =
+          listOf(
+            RouteDto("GET", "/", "this route index"),
+            RouteDto("GET", "/health", "liveness plus app and platform info"),
+            RouteDto("GET", "/demos", "list demos: name, description, preferred style"),
+            RouteDto(
+              "POST",
+              "/demos/select",
+              "select a demo, await its style load, fly to its destination",
+              body = "{name, timeoutMs?}",
+            ),
+            RouteDto("GET", "/camera", "current camera position and movement state"),
+            RouteDto(
+              "PUT",
+              "/camera",
+              "jump the camera (durationMs is ignored)",
+              body = "{latitude?, longitude?, zoom?, bearing?, tilt?}",
+            ),
+            RouteDto(
+              "POST",
+              "/camera/animate",
+              "animate the camera; responds when the animation ends",
+              body = "{latitude?, longitude?, zoom?, bearing?, tilt?, durationMs?}",
+            ),
+            RouteDto("GET", "/style", "current base style"),
+            RouteDto(
+              "PUT",
+              "/style",
+              "switch the base style; awaits the style load",
+              body = "{name, timeoutMs?}",
+            ),
+            RouteDto(
+              "GET",
+              "/state",
+              "aggregate: demo, shell, camera, fps, style status, settings",
+            ),
+            RouteDto(
+              "POST",
+              "/wait/idle",
+              "wait for a completed style load and a still camera",
+              body = "{timeoutMs?}",
+            ),
+            RouteDto("GET", "/screenshot", "PNG bytes of the app window"),
+            RouteDto(
+              "GET",
+              "/features",
+              "rendered features at a screen point, as GeoJSON",
+              query = "x, y (pixels); layerIds? (comma-separated)",
+            ),
+            RouteDto(
+              "POST",
+              "/gestures/pan",
+              "pan by screen pixels (best effort)",
+              body = "{dxPx, dyPx}",
+            ),
+            RouteDto(
+              "POST",
+              "/gestures/zoom",
+              "zoom by a factor around a screen point (best effort)",
+              body = "{factor, x?, y?}",
+            ),
+          ),
+        notes =
+          listOf(
+            "All responses are JSON except /screenshot (PNG). Errors are JSON {error: message}.",
+            "/camera/animate returns when the animation ends or is superseded by another camera " +
+              "command; await the animate response before calling /wait/idle.",
+            "A 408 from /demos/select still applies the demo and flies the camera; only the " +
+              "style wait timed out.",
+          ),
+      )
+  }
+}

--- a/demo-app/common/src/iosMain/kotlin/org/maplibre/compose/demoapp/agent/StartAgentDriver.kt
+++ b/demo-app/common/src/iosMain/kotlin/org/maplibre/compose/demoapp/agent/StartAgentDriver.kt
@@ -1,0 +1,7 @@
+package org.maplibre.compose.demoapp.agent
+
+import androidx.compose.runtime.Composable
+import org.maplibre.compose.demoapp.DemoAppState
+
+// ktor-server has no iOS artifact we want to depend on, so there is no driver here.
+@Composable internal actual fun StartAgentDriver(state: DemoAppState) {}

--- a/demo-app/common/src/jsMain/kotlin/org/maplibre/compose/demoapp/agent/StartAgentDriver.kt
+++ b/demo-app/common/src/jsMain/kotlin/org/maplibre/compose/demoapp/agent/StartAgentDriver.kt
@@ -1,0 +1,7 @@
+package org.maplibre.compose.demoapp.agent
+
+import androidx.compose.runtime.Composable
+import org.maplibre.compose.demoapp.DemoAppState
+
+// A browser tab cannot host an HTTP server, so there is no driver here.
+@Composable internal actual fun StartAgentDriver(state: DemoAppState) {}

--- a/demo-app/common/src/jvmMain/kotlin/org/maplibre/compose/demoapp/agent/AgentDriverDesktop.kt
+++ b/demo-app/common/src/jvmMain/kotlin/org/maplibre/compose/demoapp/agent/AgentDriverDesktop.kt
@@ -1,0 +1,114 @@
+package org.maplibre.compose.demoapp.agent
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.graphics.layer.GraphicsLayer
+import androidx.compose.ui.graphics.layer.drawLayer
+import androidx.compose.ui.graphics.rememberGraphicsLayer
+import androidx.compose.ui.graphics.toAwtImage
+import java.io.ByteArrayOutputStream
+import javax.imageio.ImageIO
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+
+internal actual val agentPlatformName: String = "desktop"
+
+/**
+ * The [AgentScreenshotRecorder] at the root of the app, provided by the desktop entry point so the
+ * agent driver can capture the window. Null on desktop hosts that don't provide one (compose-glfw,
+ * Nucleus Tao), where screenshots are unsupported.
+ */
+val LocalAgentScreenshotRecorder = compositionLocalOf<AgentScreenshotRecorder?> { null }
+
+@Composable
+internal actual fun rememberAgentScreenshotCapture(): (suspend () -> ByteArray)? {
+  val recorder = LocalAgentScreenshotRecorder.current
+  return remember(recorder) { recorder?.let { it::capture } }
+}
+
+/** Creates an [AgentScreenshotRecorder] whose [GraphicsLayer] is released with the composition. */
+@Composable
+fun rememberAgentScreenshotRecorder(runOnGpuThread: (Runnable) -> Unit): AgentScreenshotRecorder {
+  val layer = rememberGraphicsLayer()
+  return remember(layer) { AgentScreenshotRecorder(layer, runOnGpuThread) }
+}
+
+private const val CAPTURE_TIMEOUT_MS = 10_000L
+
+/**
+ * Captures the content under [modifier] as PNGs by recording a frame into a [GraphicsLayer] on
+ * demand. Recording replays the Compose draw commands, including the map's shared-texture image, so
+ * the capture matches what the window shows without screen-capture permissions. It still needs the
+ * frame pipeline to draw: if frames stop being scheduled, [capture] times out and reports a 503
+ * instead of an image. All entry points run on the UI thread; the agent server already dispatches
+ * there.
+ */
+class AgentScreenshotRecorder
+internal constructor(
+  private val layer: GraphicsLayer,
+  private val runOnGpuThread: (Runnable) -> Unit,
+) {
+  /** Bumped to schedule a frame when a capture is pending; read by [modifier]'s draw. */
+  private var frameGeneration by mutableLongStateOf(0L)
+
+  /** Completed by [modifier]'s draw once it records the pending capture. */
+  private var pendingCapture: CompletableDeferred<Unit>? = null
+
+  /**
+   * Attach to the layout wrapping the content to capture. Draws the content normally, except with a
+   * [capture] pending, when it records the frame into the layer and draws that instead.
+   */
+  val modifier: Modifier = Modifier.drawWithContent {
+    frameGeneration // load-bearing read: capture() bumps it to schedule a frame
+    val pending = pendingCapture
+    if (pending == null) {
+      drawContent()
+    } else {
+      // The DrawScope record() extension retargets drawContent() at the recording canvas; the
+      // GraphicsLayer.record() member would draw it to the frame canvas and record nothing.
+      layer.record { this@drawWithContent.drawContent() }
+      pendingCapture = null
+      pending.complete(Unit)
+      drawLayer(layer)
+    }
+  }
+
+  /** Captures the next frame as PNG bytes. */
+  internal suspend fun capture(): ByteArray {
+    if (pendingCapture != null)
+      throw AgentException(409, "a screenshot capture is already in flight")
+    val pending = CompletableDeferred<Unit>()
+    pendingCapture = pending
+    frameGeneration += 1
+    try {
+      withTimeout(CAPTURE_TIMEOUT_MS) { pending.await() }
+    } catch (e: TimeoutCancellationException) {
+      pendingCapture = null
+      throw AgentException(503, "timed out waiting for a frame to capture")
+    } catch (e: CancellationException) {
+      pendingCapture = null
+      throw e
+    }
+    // toImageBitmap() reads the map's GPU texture back through Skia's context, which the host
+    // guards with its render lock.
+    var png: ByteArray? = null
+    runOnGpuThread(Runnable { png = encodePng() })
+    return checkNotNull(png)
+  }
+
+  private fun encodePng(): ByteArray {
+    val bitmap = runBlocking { layer.toImageBitmap() }
+    val out = ByteArrayOutputStream()
+    ImageIO.write(bitmap.toAwtImage(), "png", out)
+    return out.toByteArray()
+  }
+}

--- a/demo-app/desktop/src/main/kotlin/org/maplibre/compose/demoapp/Main.kt
+++ b/demo-app/desktop/src/main/kotlin/org/maplibre/compose/demoapp/Main.kt
@@ -1,13 +1,25 @@
 package org.maplibre.compose.demoapp
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.window.singleWindowApplication
+import org.maplibre.compose.demoapp.agent.LocalAgentScreenshotRecorder
+import org.maplibre.compose.demoapp.agent.rememberAgentScreenshotRecorder
 import org.maplibre.compose.desktop.ProvideMapHost
 import org.maplibre.compose.desktop.rememberAwtComposeMapHost
 
 // #region main
 fun main() {
   singleWindowApplication {
-    ProvideMapHost(host = rememberAwtComposeMapHost(window)) { DemoApp() }
+    val host = rememberAwtComposeMapHost(window)
+    val screenshotRecorder = rememberAgentScreenshotRecorder(host::runOnGpuThread)
+    CompositionLocalProvider(LocalAgentScreenshotRecorder provides screenshotRecorder) {
+      ProvideMapHost(host = host) {
+        Box(Modifier.fillMaxSize().then(screenshotRecorder.modifier)) { DemoApp() }
+      }
+    }
   }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,6 +38,7 @@ kotlin-dsv = "0.4.0"
 kotlin-wrappers = "2026.8.3"
 kotlinx-coroutines = "1.11.0"
 kotlinx-io = "0.9.1"
+kotlinx-serialization = "1.11.0"
 ktor = "3.5.2"
 lifecycleRuntimeCompose = "2.11.0"
 # compose-glfw generates callbacks against this version's internal ABI.
@@ -100,11 +101,14 @@ kotlinx-coroutines-playServices = { module = "org.jetbrains.kotlinx:kotlinx-coro
 kotlinx-coroutines-swing = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-swing", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 kotlinx-io-core = { module = "org.jetbrains.kotlinx:kotlinx-io-core", version.ref = "kotlinx-io" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "ktor" }
 ktor-client-js = { module = "io.ktor:ktor-client-js", version.ref = "ktor" }
 ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
 ktor-client-contentNegotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
+ktor-server-cio = { module = "io.ktor:ktor-server-cio", version.ref = "ktor" }
+ktor-server-statusPages = { module = "io.ktor:ktor-server-status-pages", version.ref = "ktor" }
 ktor-serialization-kotlinxJson = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 lifecycle-runtime = { module = "org.jetbrains.androidx.lifecycle:lifecycle-runtime", version.ref = "lifecycleRuntimeCompose" }
 lifecycle-runtime-compose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose", version.ref = "lifecycleRuntimeCompose" }


### PR DESCRIPTION
## Description

Adds an HTTP JSON API on 127.0.0.1:8765 to the demo app (desktop + Android) so AI agents can select demos, move the camera, switch styles, query rendered features, and capture screenshots; includes a project skill that teaches agents the workflow.

## Validation

Exercised every endpoint with curl against the desktop app including adversarial inputs and viewed the captured screenshots, built the desktop and Android apps, compile-checked JS and iOS, and `mise run check` passes.

## AI assistance

Kimi Code (Kimi K3), with subagent implementation, adversarial review rounds, and zero-context skill test-drives.