### PR TITLE
Fix camera constraints canceling animations

### DIFF
--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/CameraConstraints.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/CameraConstraints.kt
@@ -1,0 +1,11 @@
+package org.maplibre.compose.map
+
+import org.maplibre.spatialk.geojson.BoundingBox
+
+internal data class CameraConstraints(
+  val minZoom: Double,
+  val maxZoom: Double,
+  val minPitch: Double,
+  val maxPitch: Double,
+  val boundingBox: BoundingBox?,
+)

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapAdapter.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapAdapter.kt
@@ -44,15 +44,7 @@ internal interface MapAdapter {
     padding: PaddingValues,
   )
 
-  fun setCameraBoundingBox(boundingBox: BoundingBox?)
-
-  fun setMaxZoom(maxZoom: Double)
-
-  fun setMinZoom(minZoom: Double)
-
-  fun setMinPitch(minPitch: Double)
-
-  fun setMaxPitch(maxPitch: Double)
+  fun setCameraConstraints(value: CameraConstraints)
 
   fun getVisibleBoundingBox(): BoundingBox
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MaplibreMap.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MaplibreMap.kt
@@ -262,14 +262,18 @@ public fun MaplibreMap(
       update = { map ->
         map.setCameraPadding(cameraPadding)
         cameraState.map = map
-        map.setMinZoom(zoomRange.start.toDouble())
-        map.setMaxZoom(zoomRange.endInclusive.toDouble())
-        map.setMinPitch(pitchRange.start.toDouble())
-        map.setMaxPitch(pitchRange.endInclusive.toDouble())
+        map.setCameraConstraints(
+          CameraConstraints(
+            minZoom = zoomRange.start.toDouble(),
+            maxZoom = zoomRange.endInclusive.toDouble(),
+            minPitch = pitchRange.start.toDouble(),
+            maxPitch = pitchRange.endInclusive.toDouble(),
+            boundingBox = boundingBox,
+          )
+        )
         map.setRenderSettings(options.renderOptions)
         map.setGestureSettings(options.gestureOptions)
         map.setTileLodSettings(options.tileLodOptions)
-        map.setCameraBoundingBox(boundingBox)
       },
       onReset = {
         cameraState.map = null

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsModule.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsModule.kt
@@ -56,6 +56,16 @@ internal external class MaplibreMap(options: MapOptions) {
 
   fun getBounds(): LngLatBounds
 
+  fun getMaxBounds(): LngLatBounds?
+
+  fun getMinZoom(): Double
+
+  fun getMaxZoom(): Double
+
+  fun getMinPitch(): Double
+
+  fun getMaxPitch(): Double
+
   fun jumpTo(options: JumpToOptions)
 
   fun easeTo(options: EaseToOptions)

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
@@ -131,6 +131,7 @@ internal class GlJsMapSession(
   private var lentContext: WebGL2RenderingContext? = null
 
   private var maximumFps: Int? = null
+  private var cameraConstraints: CameraConstraints? = null
   private var tileLodOptions: TileLodOptions = TileLodOptions.Standard
   private var lastRenderTime = TimeSource.Monotonic.markNow()
   private var lastFrameTime = TimeSource.Monotonic.markNow()
@@ -270,6 +271,7 @@ internal class GlJsMapSession(
     hasLoadedInitialStyle = false
     appliedExtent = MapExtent.Empty
     applyRequestedStyle(created)
+    cameraConstraints?.let { applyCameraConstraints(created, it) }
     runPending(pendingMapActions, created)
     return created
   }
@@ -579,24 +581,30 @@ internal class GlJsMapSession(
     this.padding = padding.toPaddingOptions(layoutDirection)
   }
 
-  override fun setCameraBoundingBox(boundingBox: BoundingBox?) {
-    onMap { map -> map.setMaxBounds(boundingBox?.toLngLatBounds()) }
+  override fun setCameraConstraints(value: CameraConstraints) {
+    if (value == cameraConstraints) return
+    cameraConstraints = value
+    map?.let { applyCameraConstraints(it, value) }
   }
 
-  override fun setMaxZoom(maxZoom: Double) {
-    onMap { it.setMaxZoom(maxZoom) }
-  }
+  private fun applyCameraConstraints(map: MaplibreMap, value: CameraConstraints) {
+    if (map.getMaxBounds()?.toBoundingBox() != value.boundingBox) {
+      map.setMaxBounds(value.boundingBox?.toLngLatBounds())
+    }
 
-  override fun setMinZoom(minZoom: Double) {
-    onMap { it.setMinZoom(minZoom) }
-  }
+    val minZoom = map.getMinZoom()
+    val maxZoom = map.getMaxZoom()
+    if (value.minZoom < minZoom) map.setMinZoom(value.minZoom)
+    if (value.maxZoom > maxZoom) map.setMaxZoom(value.maxZoom)
+    if (value.minZoom > minZoom) map.setMinZoom(value.minZoom)
+    if (value.maxZoom < maxZoom) map.setMaxZoom(value.maxZoom)
 
-  override fun setMinPitch(minPitch: Double) {
-    onMap { it.setMinPitch(minPitch) }
-  }
-
-  override fun setMaxPitch(maxPitch: Double) {
-    onMap { it.setMaxPitch(maxPitch) }
+    val minPitch = map.getMinPitch()
+    val maxPitch = map.getMaxPitch()
+    if (value.minPitch < minPitch) map.setMinPitch(value.minPitch)
+    if (value.maxPitch > maxPitch) map.setMaxPitch(value.maxPitch)
+    if (value.minPitch > minPitch) map.setMinPitch(value.minPitch)
+    if (value.maxPitch < maxPitch) map.setMaxPitch(value.maxPitch)
   }
 
   override fun getVisibleBoundingBox(): BoundingBox =

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/MapCameraTransitionTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/MapCameraTransitionTest.kt
@@ -225,6 +225,47 @@ class MapCameraTransitionTest {
     }
   }
 
+  @Test
+  fun reapplying_identical_camera_constraints_does_not_cancel_an_animation(): MapTestResult =
+    runMapTest {
+      createMapFixture().use {
+        it.startAtOrigin()
+        it.session.applyTestConstraints()
+        it.pump(frames = 2)
+
+        val animation =
+          CoroutineScope(Dispatchers.Default).launch {
+            it.session.animateCameraPosition(TARGET, 2.seconds)
+          }
+        it.awaitCameraMoving()
+        it.session.applyTestConstraints()
+        it.pumpUntil("the animation to complete after the constraints repeat") {
+          animation.isCompleted
+        }
+
+        assertNear(
+          TARGET.zoom,
+          it.session.getCameraPosition().zoom,
+          "repeating identical constraints should not stop the animation",
+        )
+      }
+    }
+
+  @Test
+  fun replacing_a_camera_range_with_a_disjoint_range_applies_it_atomically(): MapTestResult =
+    runMapTest {
+      createMapFixture().use {
+        it.startAtOrigin()
+        it.session.setCameraConstraints(TEST_CONSTRAINTS)
+        it.pump(frames = 2)
+
+        it.session.setCameraConstraints(DISJOINT_ZOOM_CONSTRAINTS)
+        it.pumpUntil("the camera to adopt the disjoint zoom range") {
+          abs(it.session.getCameraPosition().zoom - DISJOINT_ZOOM_CONSTRAINTS.minZoom) < 0.01
+        }
+      }
+    }
+
   /** A zero-duration animation emits its event during the call, so it must not deadlock. */
   @Test
   fun a_zero_duration_animation_completes(): MapTestResult = runMapTest {
@@ -365,6 +406,10 @@ class MapCameraTransitionTest {
     }
   }
 
+  private fun MapAdapter.applyTestConstraints() {
+    setCameraConstraints(TEST_CONSTRAINTS)
+  }
+
   private companion object {
     val START = CameraPosition(target = Position(0.0, 0.0), zoom = 2.0)
     val TARGET = CameraPosition(target = Position(11.0, 47.0), zoom = 8.0)
@@ -374,6 +419,15 @@ class MapCameraTransitionTest {
         southwest = Position(longitude = -5.0, latitude = -5.0),
         northeast = Position(longitude = 5.0, latitude = 5.0),
       )
+    val TEST_CONSTRAINTS =
+      CameraConstraints(
+        minZoom = 0.0,
+        maxZoom = 20.0,
+        minPitch = 0.0,
+        maxPitch = 60.0,
+        boundingBox = null,
+      )
+    val DISJOINT_ZOOM_CONSTRAINTS = TEST_CONSTRAINTS.copy(minZoom = 21.0, maxZoom = 22.0)
     val ANTIMERIDIAN_BOUNDS =
       BoundingBox(
         southwest = Position(longitude = 170.0, latitude = -10.0),

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -73,7 +73,6 @@ import org.maplibre.compose.util.toLatLngBounds
 import org.maplibre.compose.util.toPosition
 import org.maplibre.compose.util.toScreenPoint
 import org.maplibre.nativeffi.camera.AnimationOptions
-import org.maplibre.nativeffi.camera.BoundOptions
 import org.maplibre.nativeffi.camera.BoundsConstraint
 import org.maplibre.nativeffi.camera.CameraFitOptions
 import org.maplibre.nativeffi.camera.CameraOptions
@@ -331,6 +330,7 @@ internal class MlnFfiMapSession(
   }
 
   @Volatile private var maximumFps: Int? = null
+  private var cameraConstraints: CameraConstraints? = null
   private var tileLodOptions: TileLodOptions = TileLodOptions.Standard
   private var lastRenderTime = TimeSource.Monotonic.markNow()
 
@@ -1233,25 +1233,23 @@ internal class MlnFfiMapSession(
     waiters.forEach { waiter -> runCatching { waiter.resume(Unit) } }
   }
 
-  override fun setCameraBoundingBox(boundingBox: BoundingBox?) = setBounds {
-    // Unbounded is not world bounds: world bounds clamp longitude to ±180 and stop the map
-    // panning across the antimeridian.
-    it.bounds =
-      boundingBox?.let { box -> BoundsConstraint.Bounded(box.toLatLngBounds()) }
-        ?: BoundsConstraint.Unbounded
-  }
-
-  override fun setMaxZoom(maxZoom: Double) = setBounds { it.maxZoom = maxZoom }
-
-  override fun setMinZoom(minZoom: Double) = setBounds { it.minZoom = minZoom }
-
-  override fun setMinPitch(minPitch: Double) = setBounds { it.minPitch = minPitch }
-
-  override fun setMaxPitch(maxPitch: Double) = setBounds { it.maxPitch = maxPitch }
-
-  /** `BoundOptions` is a field mask, so only the field [update] touches changes. */
-  private fun setBounds(update: (BoundOptions) -> Unit) {
-    configureMap { map -> map.bounds = map.bounds.also(update) }
+  override fun setCameraConstraints(value: CameraConstraints) {
+    if (value == cameraConstraints) return
+    cameraConstraints = value
+    configureMap { map ->
+      map.bounds =
+        map.bounds.copy {
+          // Unbounded is not world bounds: world bounds clamp longitude to ±180 and stop the map
+          // panning across the antimeridian.
+          bounds =
+            value.boundingBox?.let { box -> BoundsConstraint.Bounded(box.toLatLngBounds()) }
+              ?: BoundsConstraint.Unbounded
+          minZoom = value.minZoom
+          maxZoom = value.maxZoom
+          minPitch = value.minPitch
+          maxPitch = value.maxPitch
+        }
+    }
   }
 
   override fun getVisibleBoundingBox(): BoundingBox = mirroredViewport.boundingBox


### PR DESCRIPTION
## Description

Apply camera constraints atomically and only when their declarative value changes so render-option recompositions such as dynamic maximumFps updates do not cancel camera animations reported in #1119 and discussion #1123.

## Validation

Validated with mise run check, mise run test:desktop, mise run test:js, and mise run test:ios, plus three successful Android 14 API 34 runs of the reporter's dynamic maximumFps reproduction.

## AI assistance

Codex (GPT-5) diagnosed, implemented, and validated this change under user direction.