### PR TITLE
Align preserved resize frames with camera padding

### DIFF
--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoApp.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoApp.kt
@@ -7,6 +7,7 @@ import androidx.compose.animation.core.animateDp
 import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.core.updateTransition
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.WindowInsets
@@ -81,7 +82,7 @@ private enum class DemoShellLayout {
 
 @Composable
 private fun DemoShell(state: DemoAppState) {
-  BoxWithConstraints(Modifier.fillMaxSize()) {
+  BoxWithConstraints(Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background)) {
     val density = LocalDensity.current
     val layoutDirection = LocalLayoutDirection.current
     val safeInsets = WindowInsets.safeDrawing.toMapViewportInsets(density, layoutDirection)

--- a/lib/maplibre-compose/src/androidDeviceTest/kotlin/org/maplibre/compose/mlnffi/AndroidEglTestRenderDriver.kt
+++ b/lib/maplibre-compose/src/androidDeviceTest/kotlin/org/maplibre/compose/mlnffi/AndroidEglTestRenderDriver.kt
@@ -61,7 +61,11 @@ private constructor(private val display: EGLDisplay, private val config: EGLConf
     )
   }
 
-  override fun draw(scope: DrawScope, target: MlnFfiRenderTarget): Boolean = false
+  override fun draw(
+    scope: DrawScope,
+    target: MlnFfiRenderTarget,
+    destination: MlnFfiMapDestination,
+  ): Boolean = false
 
   /** The producer renders directly into this EGL pbuffer, so there is no consumer-side bridge. */
   override fun present(target: MlnFfiRenderTarget): Boolean = true

--- a/lib/maplibre-compose/src/iosTest/kotlin/org/maplibre/compose/mlnffi/IosMetalTestRenderDriver.kt
+++ b/lib/maplibre-compose/src/iosTest/kotlin/org/maplibre/compose/mlnffi/IosMetalTestRenderDriver.kt
@@ -74,7 +74,11 @@ internal class IosMetalTestRenderDriver private constructor(private val device: 
     action()
   }
 
-  override fun draw(scope: DrawScope, target: MlnFfiRenderTarget): Boolean = false
+  override fun draw(
+    scope: DrawScope,
+    target: MlnFfiRenderTarget,
+    destination: MlnFfiMapDestination,
+  ): Boolean = false
 
   /** The producer renders directly into the test texture, so there is nothing to present. */
   override fun present(target: MlnFfiRenderTarget): Boolean = true

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/bridge/Direct3D12Presenter.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/bridge/Direct3D12Presenter.kt
@@ -16,7 +16,6 @@ import org.maplibre.compose.mlnffi.MlnFfiHostException
 import org.maplibre.compose.mlnffi.MlnFfiMapDestination
 import org.maplibre.compose.mlnffi.NativeHandle
 import org.maplibre.compose.mlnffi.TextureOrigin
-import org.maplibre.compose.mlnffi.centeredDestination
 
 internal const val DXGI_FORMAT_B8G8R8A8_UNORM: Int = 87
 
@@ -46,11 +45,11 @@ internal class Direct3D12Presenter(private val gpuHost: ComposeMapHost) : AutoCl
     scope: DrawScope,
     skiaContext: DirectContext,
     target: Direct3DTextureTarget,
+    destination: MlnFfiMapDestination,
     completion: ComposeFrameCompletion,
   ): Boolean {
     var drew = false
     scope.drawIntoCanvas { composeCanvas ->
-      val destination = scope.centeredDestination(target.extent)
       val presenter =
         presenters.getOrPut(target.texture.address) { TexturePresenter(target.texture) }
       presenter.draw(

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/bridge/MetalMapHost.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/bridge/MetalMapHost.kt
@@ -9,6 +9,7 @@ import org.maplibre.compose.mlnffi.ComposeRenderBackend
 import org.maplibre.compose.mlnffi.MapRenderBackend
 import org.maplibre.compose.mlnffi.MetalTextureTarget
 import org.maplibre.compose.mlnffi.MlnFfiHostException
+import org.maplibre.compose.mlnffi.MlnFfiMapDestination
 import org.maplibre.compose.mlnffi.MlnFfiMapFrame
 import org.maplibre.compose.mlnffi.MlnFfiMapFrameAcquisition
 import org.maplibre.compose.mlnffi.MlnFfiMapHost
@@ -75,10 +76,14 @@ internal class MetalMapHost(private val gpuHost: ComposeMapHost) : MlnFfiMapHost
 
   override fun enqueueRenderer(action: () -> Unit): Boolean = rendererThread.post(action)
 
-  override fun draw(scope: DrawScope, target: MlnFfiRenderTarget): Boolean {
+  override fun draw(
+    scope: DrawScope,
+    target: MlnFfiRenderTarget,
+    destination: MlnFfiMapDestination,
+  ): Boolean {
     if (target !is MetalTextureTarget || target.texture.isNull) return false
     return withPreparedContext { context ->
-      presenter.draw(scope, context.skiaContext, target, frameCompletion)
+      presenter.draw(scope, context.skiaContext, target, destination, frameCompletion)
     } ?: false
   }
 

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/bridge/MetalPresenter.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/bridge/MetalPresenter.kt
@@ -18,7 +18,6 @@ import org.maplibre.compose.mlnffi.MlnFfiHostException
 import org.maplibre.compose.mlnffi.MlnFfiMapDestination
 import org.maplibre.compose.mlnffi.NativeHandle
 import org.maplibre.compose.mlnffi.TextureOrigin
-import org.maplibre.compose.mlnffi.centeredDestination
 
 /**
  * Draws MapLibre's Metal texture into the Compose scene by wrapping it as a Skia surface. Every
@@ -34,12 +33,12 @@ internal class MetalPresenter(private val gpuHost: ComposeMapHost) : AutoCloseab
     scope: DrawScope,
     skiaContext: DirectContext,
     target: MetalTextureTarget,
+    destination: MlnFfiMapDestination,
     completion: ComposeFrameCompletion,
   ): Boolean {
     releaseRetired(keepAlive = target.texture.address)
     var drew = false
     scope.drawIntoCanvas { composeCanvas ->
-      val destination = scope.centeredDestination(target.extent)
       val presenter =
         presenters.getOrPut(target.texture.address) { TexturePresenter(target.texture) }
       presenter.draw(

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/bridge/OpenGlPresenter.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/bridge/OpenGlPresenter.kt
@@ -29,7 +29,6 @@ import org.maplibre.compose.mlnffi.MlnFfiHostException
 import org.maplibre.compose.mlnffi.MlnFfiMapDestination
 import org.maplibre.compose.mlnffi.OpenGlTextureTarget
 import org.maplibre.compose.mlnffi.TextureOrigin
-import org.maplibre.compose.mlnffi.centeredDestination
 
 /**
  * Draws MapLibre's OpenGL texture into a Compose Skia canvas.
@@ -45,12 +44,12 @@ internal class OpenGlPresenter private constructor(private val backend: OpenGlPr
     scope: DrawScope,
     skiaContext: DirectContext,
     target: OpenGlTextureTarget,
+    destination: MlnFfiMapDestination,
     completion: ComposeFrameCompletion,
   ): Boolean {
     var drew = false
     scope.drawIntoCanvas { composeCanvas ->
       backend.ensureUsable()
-      val destination = scope.centeredDestination(target.extent)
       val presenter =
         presenters.getOrPut(target.textureName) {
           TexturePresenter(target.textureName, backend)

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/bridge/VulkanDirect3D12MapHost.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/bridge/VulkanDirect3D12MapHost.kt
@@ -80,6 +80,7 @@ import org.maplibre.compose.map.MapExtent
 import org.maplibre.compose.mlnffi.ComposeRenderBackend
 import org.maplibre.compose.mlnffi.MapRenderBackend
 import org.maplibre.compose.mlnffi.MlnFfiHostException
+import org.maplibre.compose.mlnffi.MlnFfiMapDestination
 import org.maplibre.compose.mlnffi.MlnFfiMapFrame
 import org.maplibre.compose.mlnffi.MlnFfiMapFrameAcquisition
 import org.maplibre.compose.mlnffi.MlnFfiMapHost
@@ -183,7 +184,11 @@ internal class VulkanDirect3D12MapHost(private val gpuHost: ComposeMapHost) : Ml
 
   override fun enqueueRenderer(action: () -> Unit): Boolean = rendererThread.post(action)
 
-  override fun draw(scope: DrawScope, target: MlnFfiRenderTarget): Boolean {
+  override fun draw(
+    scope: DrawScope,
+    target: MlnFfiRenderTarget,
+    destination: MlnFfiMapDestination,
+  ): Boolean {
     if (target !is VulkanImageTarget) return false
     val direct3DTarget =
       if (target.generation == generation) presentationTarget()
@@ -191,7 +196,7 @@ internal class VulkanDirect3D12MapHost(private val gpuHost: ComposeMapHost) : Ml
     if (direct3DTarget == null) return false
     val drew =
       withPreparedContext { context ->
-        presenter.draw(scope, context.skiaContext, direct3DTarget, frameCompletion)
+        presenter.draw(scope, context.skiaContext, direct3DTarget, destination, frameCompletion)
       } ?: false
     if (drew) disposeRetiredTextures(exceptGeneration = target.generation)
     return drew

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/bridge/VulkanOpenGlMapHost.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/bridge/VulkanOpenGlMapHost.kt
@@ -105,6 +105,7 @@ import org.maplibre.compose.mlnffi.ComposeRenderBackend
 import org.maplibre.compose.mlnffi.EglContextHandles
 import org.maplibre.compose.mlnffi.MapRenderBackend
 import org.maplibre.compose.mlnffi.MlnFfiHostException
+import org.maplibre.compose.mlnffi.MlnFfiMapDestination
 import org.maplibre.compose.mlnffi.MlnFfiMapFrame
 import org.maplibre.compose.mlnffi.MlnFfiMapFrameAcquisition
 import org.maplibre.compose.mlnffi.MlnFfiMapHost
@@ -171,7 +172,11 @@ internal class VulkanOpenGlMapHost(private val gpuHost: ComposeMapHost) : MlnFfi
 
   override fun enqueueRenderer(action: () -> Unit): Boolean = rendererThread.post(action)
 
-  override fun draw(scope: DrawScope, target: MlnFfiRenderTarget): Boolean {
+  override fun draw(
+    scope: DrawScope,
+    target: MlnFfiRenderTarget,
+    destination: MlnFfiMapDestination,
+  ): Boolean {
     if (target !is VulkanImageTarget) return false
     return gpuHost.withOpenGlContextOrNull { context ->
       frameCompletion.prepare(context.skiaContext, ::abandonContext)
@@ -189,6 +194,7 @@ internal class VulkanOpenGlMapHost(private val gpuHost: ComposeMapHost) : MlnFfi
           scope,
           context.skiaContext,
           imported.target(target.generation),
+          destination,
           frameCompletion,
         )
       if (drew) disposeRetiredTextures(exceptGeneration = target.generation)

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/bridge/VulkanOpenGlWin32MapHost.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/bridge/VulkanOpenGlWin32MapHost.kt
@@ -5,6 +5,7 @@ import org.maplibre.compose.desktop.ComposeMapHost
 import org.maplibre.compose.map.MapExtent
 import org.maplibre.compose.mlnffi.ComposeRenderBackend
 import org.maplibre.compose.mlnffi.MapRenderBackend
+import org.maplibre.compose.mlnffi.MlnFfiMapDestination
 import org.maplibre.compose.mlnffi.MlnFfiMapFrame
 import org.maplibre.compose.mlnffi.MlnFfiMapFrameAcquisition
 import org.maplibre.compose.mlnffi.MlnFfiMapHost
@@ -66,7 +67,11 @@ internal class VulkanOpenGlWin32MapHost(private val gpuHost: ComposeMapHost) : M
 
   override fun enqueueRenderer(action: () -> Unit): Boolean = rendererThread.post(action)
 
-  override fun draw(scope: DrawScope, target: MlnFfiRenderTarget): Boolean {
+  override fun draw(
+    scope: DrawScope,
+    target: MlnFfiRenderTarget,
+    destination: MlnFfiMapDestination,
+  ): Boolean {
     if (target !is VulkanImageTarget) return false
     return gpuHost.withOpenGlContextOrNull { context ->
       frameCompletion.prepare(context.skiaContext, ::abandonContext)
@@ -81,6 +86,7 @@ internal class VulkanOpenGlWin32MapHost(private val gpuHost: ComposeMapHost) : M
           scope,
           context.skiaContext,
           imported.target(target.generation),
+          destination,
           frameCompletion,
         )
       if (drew) disposeRetiredTextures(exceptGeneration = target.generation)

--- a/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/desktop/bridge/LinuxVulkanOpenGlInteropTest.kt
+++ b/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/desktop/bridge/LinuxVulkanOpenGlInteropTest.kt
@@ -72,6 +72,7 @@ import org.maplibre.compose.map.MapExtent
 import org.maplibre.compose.map.MlnFfiMapSession
 import org.maplibre.compose.mlnffi.ComposeRenderBackend
 import org.maplibre.compose.mlnffi.MlnFfiFrameResult
+import org.maplibre.compose.mlnffi.MlnFfiMapDestination
 import org.maplibre.compose.mlnffi.MlnFfiMapFrameAcquisition
 import org.maplibre.compose.mlnffi.MlnFfiMapHostSession
 import org.maplibre.compose.mlnffi.MlnFfiRenderTarget
@@ -420,7 +421,12 @@ class LinuxVulkanOpenGlInteropTest {
         destination.canvas.asComposeCanvas(),
         Size(DRAW_WIDTH.toFloat(), DRAW_HEIGHT.toFloat()),
       ) {
-        drew = host.draw(this, target)
+        drew =
+          host.draw(
+            this,
+            target,
+            MlnFfiMapDestination(0, 0, target.extent.physicalWidth, target.extent.physicalHeight),
+          )
       }
       assertTrue(drew, "The OpenGL host did not draw generation ${target.generation}")
       return readDestination()

--- a/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/mlnffi/ProductionBridgeTestRenderDriver.kt
+++ b/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/mlnffi/ProductionBridgeTestRenderDriver.kt
@@ -99,7 +99,11 @@ private constructor(
 
   override fun present(target: MlnFfiRenderTarget): Boolean = environment.present(bridge, target)
 
-  override fun draw(scope: DrawScope, target: MlnFfiRenderTarget): Boolean = present(target)
+  override fun draw(
+    scope: DrawScope,
+    target: MlnFfiRenderTarget,
+    destination: MlnFfiMapDestination,
+  ): Boolean = present(target)
 
   override fun readPixel(x: Int, y: Int): RgbaPixel = environment.readPixel(x, y)
 
@@ -169,7 +173,7 @@ private abstract class DesktopTestGpuEnvironment : AutoCloseable {
         recording.asComposeCanvas(),
         Size(width.toFloat(), height.toFloat()),
       ) {
-        drew = bridge.draw(this, target)
+        drew = bridge.draw(this, target, MlnFfiMapDestination(0, 0, width, height))
       }
       recorder.finishRecordingAsPicture().use(surface.canvas::drawPicture)
     }

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -41,6 +41,7 @@ import org.maplibre.compose.mlnffi.MlnFfiFrameResult
 import org.maplibre.compose.mlnffi.MlnFfiLock
 import org.maplibre.compose.mlnffi.MlnFfiMapFrame
 import org.maplibre.compose.mlnffi.MlnFfiMapHostSession
+import org.maplibre.compose.mlnffi.MlnFfiMapPresentationAnchor
 import org.maplibre.compose.mlnffi.MlnFfiMapRenderer
 import org.maplibre.compose.mlnffi.MlnFfiRecoverableFrameException
 import org.maplibre.compose.mlnffi.MlnFfiRenderTarget
@@ -158,6 +159,8 @@ internal class MlnFfiMapSession(
   @Volatile private var loop: MlnFfiMapRuntimeLoop? = null
 
   @Volatile private var cameraPadding: EdgeInsets = EdgeInsets.ZERO
+  @Volatile private var appliedCameraPadding: EdgeInsets = EdgeInsets.ZERO
+  @Volatile private var renderedCameraPadding: EdgeInsets = EdgeInsets.ZERO
 
   /** One-shot map actions accepted before this session starts. Guarded by [stateLock]. */
   private class PendingMapAction(val run: (MapHandle) -> Unit, val abandon: () -> Unit)
@@ -378,6 +381,7 @@ internal class MlnFfiMapSession(
     }
 
     val map = loop.map ?: return MlnFfiFrameResult.SKIPPED
+    renderedCameraPadding = appliedCameraPadding
 
     if (!ensureAttached(map, frame)) return MlnFfiFrameResult.SKIPPED
     // Consumed before rendering, so an update published during the render below is not discarded.
@@ -425,6 +429,18 @@ internal class MlnFfiMapSession(
     lastRenderTime = renderStart
     reportFrameRate()
     return MlnFfiFrameResult.RENDERED
+  }
+
+  override fun presentationAnchor(extent: MapExtent): MlnFfiMapPresentationAnchor {
+    val padding = renderedCameraPadding
+    return MlnFfiMapPresentationAnchor(
+      x =
+        ((extent.physicalWidth + (padding.left - padding.right) * extent.scaleFactor) / 2.0)
+          .toInt(),
+      y =
+        ((extent.physicalHeight + (padding.top - padding.bottom) * extent.scaleFactor) / 2.0)
+          .toInt(),
+    )
   }
 
   override fun close() {
@@ -1059,6 +1075,7 @@ internal class MlnFfiMapSession(
     cameraPadding = insets
     configureMap { map ->
       map.jumpTo(CameraOptions().also { it.padding = insets })
+      appliedCameraPadding = insets
       snapshotViewport(map)
     }
   }

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/mlnffi/MlnFfiMapHost.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/mlnffi/MlnFfiMapHost.kt
@@ -1,7 +1,6 @@
 package org.maplibre.compose.mlnffi
 
 import androidx.compose.ui.graphics.drawscope.DrawScope
-import kotlin.math.roundToInt
 import org.maplibre.compose.map.MapExtent
 
 /** Pixel-aligned destination for a completed render target in a Compose draw scope. */
@@ -18,15 +17,17 @@ internal data class MlnFfiMapDestination(
     get() = top + height
 }
 
-/** Centers [extent] at its physical size, with at most one extra pixel on the bottom or right. */
-internal fun DrawScope.centeredDestination(extent: MapExtent): MlnFfiMapDestination {
-  val width = extent.physicalWidth
-  val height = extent.physicalHeight
+/** Aligns [sourceAnchor] with [destinationAnchor] without scaling [extent]. */
+internal fun presentationDestination(
+  extent: MapExtent,
+  sourceAnchor: MlnFfiMapPresentationAnchor,
+  destinationAnchor: MlnFfiMapPresentationAnchor,
+): MlnFfiMapDestination {
   return MlnFfiMapDestination(
-    left = (size.width.roundToInt() - width) / 2,
-    top = (size.height.roundToInt() - height) / 2,
-    width = width,
-    height = height,
+    left = destinationAnchor.x - sourceAnchor.x,
+    top = destinationAnchor.y - sourceAnchor.y,
+    width = extent.physicalWidth,
+    height = extent.physicalHeight,
   )
 }
 
@@ -135,13 +136,17 @@ internal interface MlnFfiMapHost : AutoCloseable {
   }
 
   /**
-   * Draws [target] at its physical size, centered and clipped in the Compose scene, and returns
-   * whether anything was drawn.
+   * Draws [target] at [destination], clipped in the Compose scene, and returns whether anything was
+   * drawn.
    *
    * [target] is the most recently completed target, which may be from an earlier frame if the
    * renderer skipped this one.
    */
-  fun draw(scope: DrawScope, target: MlnFfiRenderTarget): Boolean
+  fun draw(
+    scope: DrawScope,
+    target: MlnFfiRenderTarget,
+    destination: MlnFfiMapDestination,
+  ): Boolean
 }
 
 /** Creates the [MlnFfiMapHost] that backs a map. */

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/mlnffi/MlnFfiMapRenderer.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/mlnffi/MlnFfiMapRenderer.kt
@@ -10,6 +10,13 @@ internal enum class MlnFfiFrameResult {
   SKIPPED,
 }
 
+/** The physical pixel in a render target that contains the padded camera center. */
+internal data class MlnFfiMapPresentationAnchor(val x: Int, val y: Int)
+
+/** Returns the unpadded center of this extent in physical pixels. */
+internal fun MapExtent.centerPresentationAnchor(): MlnFfiMapPresentationAnchor =
+  MlnFfiMapPresentationAnchor(x = physicalWidth / 2, y = physicalHeight / 2)
+
 /**
  * Receives surface lifecycle and frames from a [MlnFfiMapHost]. Every method is called with
  * renderer access held, on the host's renderer thread.
@@ -30,6 +37,13 @@ internal interface MlnFfiMapRenderer : AutoCloseable {
 
   /** Renders one frame into [frame]'s target. */
   fun render(frame: MlnFfiMapFrame): MlnFfiFrameResult
+
+  /**
+   * Returns the camera anchor for the most recent [render] attempt at [extent]. The surface stores
+   * this value with a completed target so that a later resize can preserve its screen position.
+   */
+  fun presentationAnchor(extent: MapExtent): MlnFfiMapPresentationAnchor =
+    extent.centerPresentationAnchor()
 
   /**
    * Called when the surface went away and any target handles previously seen are now dangling.

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/mlnffi/MlnFfiMapSurface.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/mlnffi/MlnFfiMapSurface.kt
@@ -92,7 +92,15 @@ internal fun MlnFfiMapSurface(
         }
 
         fun presentLastCompletedTarget() {
-          drawState.lastCompletedTarget?.let { drew = host.draw(this, it) }
+          val completed = drawState.lastCompletedPresentation ?: return
+          val destinationAnchor = drawState.presentationAnchor(frameExtent)
+          val destination =
+            presentationDestination(
+              extent = completed.target.extent,
+              sourceAnchor = completed.anchor,
+              destinationAnchor = destinationAnchor,
+            )
+          drew = host.draw(this, completed.target, destination)
         }
 
         when (val acquisition = host.acquireFrame(frameId, frameExtent, nowNanos)) {
@@ -104,10 +112,16 @@ internal fun MlnFfiMapSurface(
             val frame = acquisition.frame
             var rendered = false
             try {
-              when (host.withProducerAccess(frame) { renderer.render(frame) }) {
+              val (result, anchor) =
+                host.withProducerAccess(frame) {
+                  renderer.render(frame) to renderer.presentationAnchor(frame.extent)
+                }
+              drawState.recordPresentationAnchor(frame.extent, anchor)
+              when (result) {
                 MlnFfiFrameResult.RENDERED -> {
                   host.completeProducerAccess(frame)
-                  drawState.lastCompletedTarget = frame.target
+                  drawState.lastCompletedPresentation =
+                    MlnFfiMapCompletedPresentation(frame.target, anchor)
                   rendered = true
                 }
                 MlnFfiFrameResult.SKIPPED -> Unit
@@ -161,7 +175,7 @@ private fun recoverFromFrameFailure(
     "Map frame $frameId failed; rebuilding the render session " +
       "(attempt $attempt of $MAX_FRAME_RECOVERY_ATTEMPTS)"
   }
-  drawState.lastCompletedTarget = null
+  drawState.lastCompletedPresentation = null
   try {
     renderer.onSurfaceLost()
   } catch (releaseError: Throwable) {
@@ -185,8 +199,10 @@ private class MlnFfiMapDrawState {
   private var nextFrameId = 1L
   private var rendererClosed = false
 
-  var lastCompletedTarget: MlnFfiRenderTarget? = null
+  var lastCompletedPresentation: MlnFfiMapCompletedPresentation? = null
   var configuredExtent: MapExtent = MapExtent.Empty
+  private var presentationExtent: MapExtent = MapExtent.Empty
+  private var currentPresentationAnchor: MlnFfiMapPresentationAnchor? = null
 
   var frameFailures: Int = 0
     private set
@@ -206,12 +222,28 @@ private class MlnFfiMapDrawState {
   }
 
   fun reset() {
-    lastCompletedTarget = null
+    lastCompletedPresentation = null
     configuredExtent = MapExtent.Empty
+    presentationExtent = MapExtent.Empty
+    currentPresentationAnchor = null
     frameFailures = 0
     rendererClosed = false
   }
+
+  fun recordPresentationAnchor(extent: MapExtent, anchor: MlnFfiMapPresentationAnchor) {
+    presentationExtent = extent
+    currentPresentationAnchor = anchor
+  }
+
+  fun presentationAnchor(extent: MapExtent): MlnFfiMapPresentationAnchor =
+    currentPresentationAnchor?.takeIf { presentationExtent == extent }
+      ?: extent.centerPresentationAnchor()
 }
+
+private data class MlnFfiMapCompletedPresentation(
+  val target: MlnFfiRenderTarget,
+  val anchor: MlnFfiMapPresentationAnchor,
+)
 
 private class MlnFfiMapHostSessionImpl(
   private val host: MlnFfiMapHost,

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/MlnFfiMapResizeTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/MlnFfiMapResizeTest.kt
@@ -1,9 +1,12 @@
 package org.maplibre.compose.map
 
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.ui.unit.dp
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import org.maplibre.compose.mlnffi.BridgeMapFixture
+import org.maplibre.compose.mlnffi.MlnFfiMapPresentationAnchor
 import org.maplibre.compose.style.BaseStyle
 
 /**
@@ -53,6 +56,27 @@ class MlnFfiMapResizeTest {
         fixture.session.retargetCount >= 3,
         "each of the three sizes should have retargeted, got ${fixture.session.retargetCount}",
       )
+    }
+  }
+
+  @Test
+  fun camera_padding_defines_the_physical_presentation_anchor() {
+    BridgeMapFixture.create(BridgeMapFixture.RETINA_EXTENT).use { fixture ->
+      fixture.loadStyle(BaseStyle.Json(EMPTY_STYLE), extent = BridgeMapFixture.RETINA_EXTENT)
+      fixture.pumpUntilRendered(BridgeMapFixture.RETINA_EXTENT)
+
+      fixture.session.setCameraPadding(
+        PaddingValues(start = 120.dp, top = 40.dp, end = 20.dp, bottom = 8.dp)
+      )
+
+      val expected = MlnFfiMapPresentationAnchor(x = 612, y = 544)
+      fixture.pumpUntil(
+        "the padded camera anchor to reach the renderer",
+        extent = BridgeMapFixture.RETINA_EXTENT,
+      ) {
+        fixture.session.presentationAnchor(BridgeMapFixture.RETINA_EXTENT) == expected
+      }
+      assertEquals(expected, fixture.session.presentationAnchor(BridgeMapFixture.RETINA_EXTENT))
     }
   }
 

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/mlnffi/FakeMlnFfiMapHost.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/mlnffi/FakeMlnFfiMapHost.kt
@@ -179,10 +179,13 @@ internal class FakeMlnFfiMapHost(
     return action()
   }
 
-  override fun draw(scope: DrawScope, target: MlnFfiRenderTarget): Boolean {
+  override fun draw(
+    scope: DrawScope,
+    target: MlnFfiRenderTarget,
+    destination: MlnFfiMapDestination,
+  ): Boolean {
     calls += "draw(gen=${target.generation})"
     drawnTargets += target
-    val destination = scope.centeredDestination(target.extent)
     drawRecords +=
       DrawRecord(
         target = target,

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/mlnffi/MlnFfiMapSurfaceRecoveryTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/mlnffi/MlnFfiMapSurfaceRecoveryTest.kt
@@ -133,6 +133,38 @@ class MlnFfiMapSurfaceRecoveryTest {
   }
 
   @Test
+  fun resize_aligns_the_completed_frames_camera_anchor_with_the_current_anchor() =
+    runFfiComposeUiTest {
+      val renderer = RecordingRenderer()
+      val factory = FakeMlnFfiMapHostFactory()
+      val size = mutableStateOf(64.dp)
+      val hostResult = factory.create(factory.bridges.single())
+      renderer.presentationAnchorOffsetX = 12
+      renderer.presentationAnchorOffsetY = -4
+
+      setContent { MlnFfiMapSurface(renderer, hostResult, Modifier.size(size.value)) }
+      val host = factory.created.single()
+      waitUntil(timeoutMillis = TIMEOUT_MILLIS) { host.drawRecords.isNotEmpty() }
+      val completedTarget = host.drawRecords.last().target
+      val drawsBeforeResize = host.drawRecords.size
+
+      renderer.presentationAnchorOffsetX = 24
+      renderer.presentationAnchorOffsetY = 8
+      renderer.skipAllRenders = true
+      size.value = 96.dp
+      waitUntil(timeoutMillis = TIMEOUT_MILLIS) { renderer.skippedFrames > 0 }
+      waitForIdle()
+
+      val resizeDraws = host.drawRecords.drop(drawsBeforeResize)
+      assertTrue(resizeDraws.isNotEmpty())
+      assertTrue(resizeDraws.all { it.target == completedTarget })
+      for (draw in resizeDraws) {
+        assertEquals(28, draw.destinationLeft)
+        assertEquals(28, draw.destinationTop)
+      }
+    }
+
+  @Test
   fun render_uses_the_extent_configured_for_the_same_frame() = runFfiComposeUiTest {
     val renderer = RecordingRenderer()
     val factory = FakeMlnFfiMapHostFactory()
@@ -325,6 +357,8 @@ class MlnFfiMapSurfaceRecoveryTest {
     var failingSurfaceChanges = 0
     var skipNextRender = false
     var skipAllRenders = false
+    var presentationAnchorOffsetX = 0
+    var presentationAnchorOffsetY = 0
     var skippedFrames = 0
       private set
 
@@ -372,6 +406,14 @@ class MlnFfiMapSurfaceRecoveryTest {
         return MlnFfiFrameResult.SKIPPED
       }
       return renderResults.removeFirstOrNull() ?: MlnFfiFrameResult.RENDERED
+    }
+
+    override fun presentationAnchor(extent: MapExtent): MlnFfiMapPresentationAnchor {
+      val center = extent.centerPresentationAnchor()
+      return MlnFfiMapPresentationAnchor(
+        x = center.x + presentationAnchorOffsetX,
+        y = center.y + presentationAnchorOffsetY,
+      )
     }
 
     override fun close() {


### PR DESCRIPTION
## Description

Preserve the rendered camera anchor across resize fallback frames and paint the demo background with the active Material color.

## Validation

Validated with mise run check, mise run test:desktop, mise run test:android, and mise run test:ios.

## AI assistance

Implemented and validated with OpenAI Codex.