### PR TITLE
Bump MapLibre GL JS from 6.2.0 to 6.6.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,12 +44,12 @@ lifecycleRuntimeCompose = "2.11.0"
 # compose-glfw generates callbacks against this version's internal ABI.
 lwjgl = "3.4.2"
 materialKolor = "5.0.0"
-maplibre-js = "6.2.0"
+maplibre-js = "6.6.0"
 maplibre-nativeFfi = "0.202608.3"
 # The style-spec release the parity catalog reads; ci/style_spec_parity.py
 # fetches v8.json at this tag. Follow the maplibre-gl release's own
 # @maplibre/maplibre-gl-style-spec dependency when bumping maplibre-js.
-maplibre-styleSpec = "26.2.1"
+maplibre-styleSpec = "26.3.0"
 mobilityData = "0.4.0"
 playServices-location = "21.4.0"
 spatialk = "0.7.0"

--- a/kotlin-js-store/yarn.lock
+++ b/kotlin-js-store/yarn.lock
@@ -159,10 +159,10 @@
   dependencies:
     kdbush "^4.1.0"
 
-"@maplibre/maplibre-gl-style-spec@^26.2.1":
-  version "26.2.1"
-  resolved "https://registry.yarnpkg.com/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-26.2.1.tgz#00eb056468c6957bc762088a085ded91000caee8"
-  integrity sha512-QFKCXkOeSzOr8jF75jm6kySOg+dUvOehPhRi68gcOYPHb7U5JloUq0dJW0Y5/fZV8ygfT0Vp2RWodvq+fyxFWA==
+"@maplibre/maplibre-gl-style-spec@^26.3.0":
+  version "26.4.1"
+  resolved "https://registry.yarnpkg.com/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-26.4.1.tgz#e9cf3ed8f33b7f57c730f550375cb7ff115c1a93"
+  integrity sha512-I/qcIKVFHFSg1Meu/eqHrkSTjIez0gCsSaK56TNPutM3TkE61aSq6F1cZ4Kg4KiNs3cpViLtubDjfyRcQCdEJQ==
   dependencies:
     "@mapbox/jsonlint-lines-primitives" "^2.0.3"
     "@mapbox/unitbezier" "^1.0.0"
@@ -171,10 +171,10 @@
     quickselect "^3.0.0"
     tinyqueue "^3.0.0"
 
-"@maplibre/mlt@^1.1.12":
-  version "1.1.12"
-  resolved "https://registry.yarnpkg.com/@maplibre/mlt/-/mlt-1.1.12.tgz#32c5e41eeb765a107125ec92a8533cb27cddf253"
-  integrity sha512-ZeK5w2TTeHOajcLaEQs1KZXw2V9wIKo1PmThlxlsHoXsQsYlBqLJzPOd6tJHRtGTChUY3DPPmjXRArYVvAbmZw==
+"@maplibre/mlt@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@maplibre/mlt/-/mlt-1.2.0.tgz#fe13acd002b926c9eb683394be83c3fe5ef5c135"
+  integrity sha512-g45M8gEI4sMO3X9ib4K7n3ZKFf0qQOL+NMkHCnEK51lOrYFHiEssOuZncx1+miIgi1IEE2NcbRMcq8RBkL+QHA==
   dependencies:
     "@mapbox/point-geometry" "^1.1.0"
 
@@ -2106,18 +2106,18 @@ lru-cache@^10.2.0:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.4.3.tgz#410fc8a17b70e598013df257c2446b7f3383f119"
   integrity sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==
 
-maplibre-gl@6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/maplibre-gl/-/maplibre-gl-6.2.0.tgz#cd7b092d438e3e9887d2f3359fbd3b9557a55fd4"
-  integrity sha512-PaNYtxWmYgIdDHshXsnU3Pho+H9IPme9H6dTjZbFWNazi+Q5QgKgIlu2GiSGVtOZ77/Fz3n5/1/kGM6ETzu0Lg==
+maplibre-gl@6.6.0:
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/maplibre-gl/-/maplibre-gl-6.6.0.tgz#e845757656b3a768d31fc38eceaa1120ba483f19"
+  integrity sha512-EQql6eZYPhbHvJpqY4AwoiuLkUfXFRBHk67S8mDtzNo1F/jAo7xAxunIzO7gJ1vwTcPMgrK9b64dqKHvnkTlDQ==
   dependencies:
     "@mapbox/point-geometry" "^1.1.0"
     "@mapbox/tiny-sdf" "^2.2.0"
     "@mapbox/unitbezier" "^1.0.0"
     "@mapbox/vector-tile" "^3.0.0"
     "@maplibre/geojson-vt" "^6.1.1"
-    "@maplibre/maplibre-gl-style-spec" "^26.2.1"
-    "@maplibre/mlt" "^1.1.12"
+    "@maplibre/maplibre-gl-style-spec" "^26.3.0"
+    "@maplibre/mlt" "^1.2.0"
     "@maplibre/vt-pbf" "^4.3.2"
     "@types/geojson" "^7946.0.16"
     earcut "^3.2.3"

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/value/SymbolHeightAnchor.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/value/SymbolHeightAnchor.kt
@@ -1,0 +1,16 @@
+package org.maplibre.compose.expressions.value
+
+import org.maplibre.compose.expressions.ast.StringLiteral
+
+/** What `symbol-height-offset` is measured from. */
+public enum class SymbolHeightAnchor(override val literal: StringLiteral) :
+  EnumValue<SymbolHeightAnchor> {
+  /**
+   * The offset is measured from the terrain surface below the symbol, or from zero when terrain is
+   * off.
+   */
+  Ground(StringLiteral.of("ground")),
+
+  /** The offset is measured from sea level. Terrain under the symbol is ignored. */
+  Absolute(StringLiteral.of("absolute")),
+}

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/SymbolLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/SymbolLayer.kt
@@ -29,6 +29,7 @@ import org.maplibre.compose.expressions.value.ImageValue
 import org.maplibre.compose.expressions.value.ListValue
 import org.maplibre.compose.expressions.value.StringValue
 import org.maplibre.compose.expressions.value.SymbolAnchor
+import org.maplibre.compose.expressions.value.SymbolHeightAnchor
 import org.maplibre.compose.expressions.value.SymbolOverlap
 import org.maplibre.compose.expressions.value.SymbolPlacement
 import org.maplibre.compose.expressions.value.SymbolZOrder
@@ -96,6 +97,20 @@ private fun rememberEmCompiler(textSize: Expression<TextUnitValue>): LayerProper
  * @param zOrder Determines whether overlapping symbols in the same layer are rendered in the order
  *   that they appear in the data source or by their y-position relative to the viewport. To control
  *   the order and prioritization of symbols otherwise, use [sortKey].
+ * @param heightOffset Height in meters above [heightAnchor] at which the symbol is placed. Only
+ *   applicable when [placement] is [SymbolPlacement.Point]. The expression may use feature
+ *   properties.
+ *
+ *   Not yet supported on native
+ *   ([maplibre-native#1929](https://github.com/maplibre/maplibre-native/issues/1929)).
+ *
+ * @param heightAnchor What [heightOffset] is measured from. [SymbolHeightAnchor.Ground] measures
+ *   from the terrain surface below the symbol, or from zero when terrain is off.
+ *   [SymbolHeightAnchor.Absolute] measures from sea level and ignores terrain.
+ *
+ *   Not yet supported on native
+ *   ([maplibre-native#1929](https://github.com/maplibre/maplibre-native/issues/1929)).
+ *
  * @param iconImage Image to use for drawing an image background. The expression may use feature
  *   properties.
  * @param iconOpacity The opacity at which the icon will be drawn. A value in the range `[0..1]`.
@@ -428,6 +443,8 @@ public fun SymbolLayer(
   spacing: Expression<DpValue> = const(250.dp),
   avoidEdges: Expression<BooleanValue> = const(false),
   zOrder: Expression<SymbolZOrder> = const(SymbolZOrder.Auto),
+  heightOffset: Expression<FloatValue> = nil(),
+  heightAnchor: Expression<SymbolHeightAnchor> = nil(),
 
   // icon image
   iconImage: Expression<ImageValue> = nil(),
@@ -520,6 +537,8 @@ public fun SymbolLayer(
   val compiledSpacing = compile(spacing)
   val compiledAvoidEdges = compile(avoidEdges)
   val compiledZOrder = compile(zOrder)
+  val compiledHeightOffset = compile(heightOffset)
+  val compiledHeightAnchor = compile(heightAnchor)
   val compiledPlacement = compile(placement)
 
   val compiledIconImage = compile(iconImage)
@@ -592,6 +611,8 @@ public fun SymbolLayer(
       set(compiledAvoidEdges) { layer.setSymbolAvoidEdges(it) }
       set(compiledSortKey) { layer.setSymbolSortKey(it) }
       set(compiledZOrder) { layer.setSymbolZOrder(it) }
+      set(compiledHeightOffset) { layer.setSymbolHeightOffset(it) }
+      set(compiledHeightAnchor) { layer.setSymbolHeightAnchor(it) }
 
       set(compiledIconAllowOverlap) { layer.setIconAllowOverlap(it) }
       set(compiledIconOverlap) { layer.setIconOverlap(it) }
@@ -687,6 +708,14 @@ internal class SymbolLayer(id: String, source: Source) : FeatureLayer(id, source
 
   fun setSymbolZOrder(zOrder: CompiledExpression<SymbolZOrder>) {
     setLayoutProperty("symbol-z-order", zOrder)
+  }
+
+  fun setSymbolHeightOffset(offset: CompiledExpression<FloatValue>) {
+    setLayoutProperty("symbol-height-offset", offset)
+  }
+
+  fun setSymbolHeightAnchor(anchor: CompiledExpression<SymbolHeightAnchor>) {
+    setLayoutProperty("symbol-height-anchor", anchor)
   }
 
   fun setIconAllowOverlap(allowOverlap: CompiledExpression<BooleanValue>) {

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/layers/LayerPropertyRoundTripTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/layers/LayerPropertyRoundTripTest.kt
@@ -42,6 +42,7 @@ import org.maplibre.compose.expressions.value.LineJoin
 import org.maplibre.compose.expressions.value.ListValue
 import org.maplibre.compose.expressions.value.RasterResampling
 import org.maplibre.compose.expressions.value.SymbolAnchor
+import org.maplibre.compose.expressions.value.SymbolHeightAnchor
 import org.maplibre.compose.expressions.value.SymbolOverlap
 import org.maplibre.compose.expressions.value.SymbolPlacement
 import org.maplibre.compose.expressions.value.SymbolZOrder
@@ -700,6 +701,10 @@ class LayerPropertyRoundTripTest {
           Case("icon-overlap", "\"cooperative\"") { it.setIconOverlap(const("cooperative").c()) },
           Case("text-overlap", "\"cooperative\"") {
             it.setTextOverlap(const(SymbolOverlap.Cooperative).c())
+          },
+          Case("symbol-height-offset", "15.0") { it.setSymbolHeightOffset(const(15f).c()) },
+          Case("symbol-height-anchor", "\"absolute\"") {
+            it.setSymbolHeightAnchor(const(SymbolHeightAnchor.Absolute).c())
           },
         )
   }

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/style/MlnFfiStyleBinding.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/style/MlnFfiStyleBinding.kt
@@ -530,6 +530,8 @@ internal interface MlnFfiStyleBinding : StyleBinding {
         ("symbol" to "text-overlap") to
           "MapLibre Native does not implement it. Use textAllowOverlap instead; note that it " +
             "cannot express the 'cooperative' value.",
+        ("symbol" to "symbol-height-offset") to "MapLibre Native does not implement it.",
+        ("symbol" to "symbol-height-anchor") to "MapLibre Native does not implement it.",
         ("fill" to "fill-layer-opacity") to "MapLibre Native does not implement it.",
         ("line" to "line-layer-opacity") to "MapLibre Native does not implement it.",
         ("hillshade" to "resampling") to "MapLibre Native does not implement it.",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Bumps the browser MapLibre GL JS pin to 6.6.0, the bundled style spec to 26.3.0, and exposes the new JS-only `symbol-height-offset` and `symbol-height-anchor` layout properties.

## Validation

`mise run test:js` passed (219 maplibre-compose browser tests, 0 failures), `mise run style-spec:parity -- --check` passed, `:demo-app:common:compileKotlinJs` passed, and `mise run check` passed.

## AI assistance

Cursor Grok 4.6 cloud agent, following the bump-maplibre-gl-js and style-spec-parity skills.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-14481e93-fb21-4242-8e57-2821d5709730?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-14481e93-fb21-4242-8e57-2821d5709730&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

