### PR TITLE
give the nucleus demo a draggable title bar.

### DIFF
--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoApp.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoApp.kt
@@ -10,6 +10,7 @@ import androidx.compose.animation.core.updateTransition
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
@@ -50,9 +51,12 @@ import org.maplibre.compose.demoapp.generated.chevron_left_24px
 import org.maplibre.compose.demoapp.generated.chevron_right_24px
 
 @Composable
-fun DemoApp(state: DemoAppState = rememberDemoAppState()) {
+fun DemoApp(
+  state: DemoAppState = rememberDemoAppState(),
+  contentPadding: PaddingValues = PaddingValues(0.dp),
+) {
   StartAgentDriver(state)
-  DemoAppTheme(state) { DemoShell(state) }
+  DemoAppTheme(state) { DemoShell(state, contentPadding) }
 }
 
 @Composable
@@ -83,11 +87,14 @@ private enum class DemoShellLayout {
 }
 
 @Composable
-private fun DemoShell(state: DemoAppState) {
+private fun DemoShell(state: DemoAppState, contentPadding: PaddingValues) {
   BoxWithConstraints(Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background)) {
     val density = LocalDensity.current
     val layoutDirection = LocalLayoutDirection.current
-    val safeInsets = WindowInsets.safeDrawing.toMapViewportInsets(density, layoutDirection)
+    val safeInsets =
+      WindowInsets.safeDrawing
+        .toMapViewportInsets(density, layoutDirection)
+        .union(contentPadding.toMapViewportInsets(layoutDirection))
     val windowAdaptiveInfo = currentWindowAdaptiveInfoV2()
     val windowSizeClass = windowAdaptiveInfo.windowSizeClass
     val layout = windowSizeClass.toDemoShellLayout()

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoApp.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoApp.kt
@@ -50,16 +50,18 @@ import org.maplibre.compose.demoapp.generated.chevron_left_24px
 import org.maplibre.compose.demoapp.generated.chevron_right_24px
 
 @Composable
-fun DemoApp() {
-  val state = rememberDemoAppState()
+fun DemoApp(state: DemoAppState = rememberDemoAppState()) {
   StartAgentDriver(state)
+  DemoAppTheme(state) { DemoShell(state) }
+}
+
+@Composable
+fun DemoAppTheme(state: DemoAppState, content: @Composable () -> Unit) {
   val dark =
     if (state.shell == DemoShell.Benchmarks) state.selectedScenario.style.isDark
     else state.appliedStyle.isDark
   val colorScheme = rememberDemoColorScheme(dark, state.settings.paletteMode)
-  MaterialTheme(colorScheme = colorScheme) {
-    DemoShell(state)
-  }
+  MaterialTheme(colorScheme = colorScheme, content = content)
 }
 
 private val MediumPanelWidth = 280.dp

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/MapViewportInsets.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/MapViewportInsets.kt
@@ -43,3 +43,11 @@ fun WindowInsets.toMapViewportInsets(
       bottom = getBottom(density).toDp(),
     )
   }
+
+fun PaddingValues.toMapViewportInsets(layoutDirection: LayoutDirection): MapViewportInsets =
+  MapViewportInsets(
+    left = calculateLeftPadding(layoutDirection),
+    top = calculateTopPadding(),
+    right = calculateRightPadding(layoutDirection),
+    bottom = calculateBottomPadding(),
+  )

--- a/demo-app/desktop-nucleus/build.gradle.kts
+++ b/demo-app/desktop-nucleus/build.gradle.kts
@@ -19,7 +19,9 @@ kotlin {
 dependencies {
   implementation(project(":demo-app:common"))
   implementation(project(":lib:maplibre-compose"))
+  implementation(libs.jetbrains.compose.material3)
   implementation(libs.nucleus.application)
+  implementation(libs.nucleus.decoratedWindowMaterial3)
   implementation(libs.nucleus.decoratedWindowTao)
 
   runtimeOnly(project(":lib:${desktopHostPlatform.runtimeArtifactId(desktopRenderBackend)}"))

--- a/demo-app/desktop-nucleus/src/main/kotlin/org/maplibre/compose/nucleus/Main.kt
+++ b/demo-app/desktop-nucleus/src/main/kotlin/org/maplibre/compose/nucleus/Main.kt
@@ -1,13 +1,22 @@
 package org.maplibre.compose.nucleus
 
-import androidx.compose.material3.Text
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.remember
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.rememberWindowState
 import dev.nucleusframework.application.NucleusBackend
 import dev.nucleusframework.application.nucleusApplication
+import dev.nucleusframework.window.TitleBarPlacement
+import dev.nucleusframework.window.WindowAppearance
+import dev.nucleusframework.window.WindowAppearanceMode
+import dev.nucleusframework.window.WindowBackground
+import dev.nucleusframework.window.WindowScaffold
 import dev.nucleusframework.window.material.MaterialDecoratedWindow
 import dev.nucleusframework.window.material.MaterialTitleBar
+import dev.nucleusframework.window.material.rememberMaterialTitleBarStyle
 import org.maplibre.compose.demoapp.DemoApp
 import org.maplibre.compose.demoapp.DemoAppTheme
 import org.maplibre.compose.demoapp.rememberDemoAppState
@@ -32,9 +41,43 @@ fun main() {
         title = "MapLibre Compose on Nucleus Tao",
         state = rememberWindowState(size = DpSize(960.dp, 640.dp)),
       ) {
-        MaterialTitleBar { Text("MapLibre Compose on Nucleus Tao") }
-        val host = rememberTaoComposeMapHost() ?: return@MaterialDecoratedWindow
-        ProvideMapHost(host = host) { DemoApp(state) }
+        WindowBackground(MaterialTheme.colorScheme.background)
+        WindowAppearance(
+          if (MaterialTheme.colorScheme.background.luminance() < 0.5f) {
+            WindowAppearanceMode.Dark
+          } else {
+            WindowAppearanceMode.Light
+          }
+        )
+
+        val windowScope = this
+        val materialTitleBarStyle = rememberMaterialTitleBarStyle(MaterialTheme.colorScheme)
+        val transparentTitleBarStyle =
+          remember(materialTitleBarStyle) {
+            materialTitleBarStyle.copy(
+              colors =
+                materialTitleBarStyle.colors.copy(
+                  background = Color.Transparent,
+                  inactiveBackground = Color.Transparent,
+                  border = Color.Transparent,
+                  fullscreenControlButtonsBackground = Color.Transparent,
+                ),
+              metrics =
+                materialTitleBarStyle.metrics.copy(
+                  height = 24.dp,
+                  titlePaneButtonSize = DpSize(24.dp, 24.dp),
+                ),
+            )
+          }
+        WindowScaffold(
+          titleBar = {
+            windowScope.MaterialTitleBar(style = transparentTitleBarStyle)
+          },
+          titleBarPlacement = TitleBarPlacement.Overlay(),
+        ) { chromePadding ->
+          val host = rememberTaoComposeMapHost() ?: return@WindowScaffold
+          ProvideMapHost(host = host) { DemoApp(state, contentPadding = chromePadding) }
+        }
       }
     }
   }

--- a/demo-app/desktop-nucleus/src/main/kotlin/org/maplibre/compose/nucleus/Main.kt
+++ b/demo-app/desktop-nucleus/src/main/kotlin/org/maplibre/compose/nucleus/Main.kt
@@ -1,12 +1,16 @@
 package org.maplibre.compose.nucleus
 
+import androidx.compose.material3.Text
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.rememberWindowState
-import dev.nucleusframework.application.DecoratedWindow
 import dev.nucleusframework.application.NucleusBackend
 import dev.nucleusframework.application.nucleusApplication
+import dev.nucleusframework.window.material.MaterialDecoratedWindow
+import dev.nucleusframework.window.material.MaterialTitleBar
 import org.maplibre.compose.demoapp.DemoApp
+import org.maplibre.compose.demoapp.DemoAppTheme
+import org.maplibre.compose.demoapp.rememberDemoAppState
 import org.maplibre.compose.desktop.MapLibre
 import org.maplibre.compose.desktop.ProvideMapHost
 
@@ -21,13 +25,17 @@ fun main() {
     // A fixture, not a shipped app: allow parallel launches next to other demos.
     enableSingleInstance = false,
   ) {
-    DecoratedWindow(
-      onCloseRequest = ::exitApplication,
-      title = "MapLibre Compose on Nucleus Tao",
-      state = rememberWindowState(size = DpSize(960.dp, 640.dp)),
-    ) {
-      val host = rememberTaoComposeMapHost() ?: return@DecoratedWindow
-      ProvideMapHost(host = host) { DemoApp() }
+    val state = rememberDemoAppState()
+    DemoAppTheme(state) {
+      MaterialDecoratedWindow(
+        onCloseRequest = ::exitApplication,
+        title = "MapLibre Compose on Nucleus Tao",
+        state = rememberWindowState(size = DpSize(960.dp, 640.dp)),
+      ) {
+        MaterialTitleBar { Text("MapLibre Compose on Nucleus Tao") }
+        val host = rememberTaoComposeMapHost() ?: return@MaterialDecoratedWindow
+        ProvideMapHost(host = host) { DemoApp(state) }
+      }
     }
   }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -90,6 +90,7 @@ dbus-java-transport-native-unixsocket = { module = "com.github.hypfvieh:dbus-jav
 htmlConverterCompose = { module = "be.digitalia.compose.htmlconverter:htmlconverter", version.ref = "htmlConverterCompose" }
 hms-location = { module = "com.huawei.hms:location", version.ref = "hms-location" }
 nucleus-application = { module = "dev.nucleusframework:nucleus.nucleus-application", version.ref = "nucleus" }
+nucleus-decoratedWindowMaterial3 = { module = "dev.nucleusframework:nucleus.decorated-window-material3", version.ref = "nucleus" }
 nucleus-decoratedWindowTao = { module = "dev.nucleusframework:nucleus.decorated-window-tao", version.ref = "nucleus" }
 kermit = { group = "co.touchlab", name = "kermit", version.ref = "kermit" }
 kotlin-dsv = { module = "dev.sargunv.kotlin-dsv:kotlin-dsv", version.ref = "kotlin-dsv" }


### PR DESCRIPTION
## Description

Use Nucleus Material 3 window chrome and an overlay `WindowScaffold` so the Tao demo map renders edge to edge while panels and camera padding avoid the title-bar inset.

## Validation

`mise run check`; `./gradlew :demo-app:desktop-nucleus:compileKotlin`; launched `mise run demo:desktop-nucleus` on macOS and confirmed that the Metal map extent remained 960×640.

## AI assistance

OpenAI Codex implemented and validated the change with repository tasks and the Nucleus demo driver.