### PR TITLE
Fix Dokka and Astro warnings from main CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,13 @@ jobs:
         if: env.DEPENDABOT_PR != 'true'
         with:
           persist-credentials: false
+          # The docs versions file is generated from the release tags.
+          fetch-tags: true
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: env.DEPENDABOT_PR == 'true'
         with:
           ref: ${{ github.head_ref }}
+          fetch-tags: true
       - uses: ./.github/actions/setup-ci-deps
         with:
           dprint-cache: "true"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,9 +178,9 @@ build tree removes the device.
 
 The site is a pnpm workspace and its own mise config root, so its tasks run as
 `//docs:<task>`. `//docs:api` generates the Dokka reference into
-`docs/public/api/`, and `//docs:versions` writes the versions the pages quote
-into `docs/src/generated/versions.json`. Both are generated rather than checked
-in, and the `dev`, `build`, and `preview` tasks depend on them.
+`docs/public/api/`. A mise dependency of the docs config root writes the quoted
+versions into `docs/src/generated/versions.json`. Both are generated rather than
+checked in, and the `dev`, `build`, and `preview` tasks depend on them.
 
 Use the tasks rather than Astro or Gradle directly. They pass the versions
 derived from the Git tags, which the site prints as the coordinates to depend

--- a/buildSrc/src/main/kotlin/module-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/module-conventions.gradle.kts
@@ -1,4 +1,5 @@
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+import org.jetbrains.dokka.gradle.DokkaExtension
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 group = "org.maplibre.compose"
@@ -9,6 +10,13 @@ version = providers.gradleProperty("maplibreVersion").get()
 // task rather than by extension so that it does not matter which Kotlin plugin a module applies.
 tasks.withType<KotlinCompilationTask<*>>().configureEach {
   compilerOptions { allWarningsAsErrors = true }
+}
+
+// Unresolved KDoc links otherwise only print `w:` in the docs and publishing jobs.
+pluginManager.withPlugin("org.jetbrains.dokka") {
+  extensions.configure<DokkaExtension> {
+    dokkaPublications.configureEach { failOnWarning.set(true) }
+  }
 }
 
 // Compose's iOS metadata contains duplicate KLIB names. Keep the upstream warning visible without

--- a/docs/astro.config.mts
+++ b/docs/astro.config.mts
@@ -2,6 +2,7 @@
 
 import { publicDirectoryIndex } from "./src/integrations/public-directory-index";
 import { remarkVersions } from "./src/plugins/remark-versions.mjs";
+import { unified } from "@astrojs/markdown-remark";
 import starlight from "@astrojs/starlight";
 import { defineConfig } from "astro/config";
 import starlightCopyButton from "starlight-copy-button";
@@ -13,7 +14,11 @@ const base = "/maplibre-compose";
 export default defineConfig({
   site: "https://maplibre.org",
   base,
-  markdown: { remarkPlugins: [remarkVersions] },
+  markdown: {
+    processor: unified({
+      remarkPlugins: [remarkVersions],
+    }),
+  },
   integrations: [
     publicDirectoryIndex(base),
     starlight({

--- a/docs/mise.toml
+++ b/docs/mise.toml
@@ -18,7 +18,16 @@ printf '%s\n' "$flags" | node docs/scripts/generate-versions.mjs
 '''
 
 [tasks.install]
-run = "pnpm exec astro sync"
+# Hygiene runs this for Astro's generated types and does not fetch Git tags, so
+# `versions` cannot run there. A stub is enough for `astro sync`; `build` and
+# `dev` overwrite it with the real file.
+run = '''
+if [ ! -f src/generated/versions.json ]; then
+  mkdir -p src/generated
+  printf '%s\n' '{"release":"0.0.0","snapshot":"0.0.0-SNAPSHOT","maplibreJs":"0.0.0"}' > src/generated/versions.json
+fi
+pnpm exec astro sync
+'''
 
 [tasks.demo]
 description = "Copy the browser demo into the site's public directory."

--- a/docs/mise.toml
+++ b/docs/mise.toml
@@ -9,6 +9,20 @@ cp -a build/dokka/html/. docs/public/api/
 node docs/scripts/generate-api-index.mjs
 '''
 
+[deps.versions]
+auto = true
+description = "Write the versions the pages quote into src/generated."
+sources = [
+  "../gradle/libs.versions.toml",
+  "../.mise/bin/version-args",
+  "scripts/generate-versions.mjs",
+]
+outputs = ["src/generated/versions.json"]
+run = '''
+flags="$(../.mise/bin/version-args build)"
+printf '%s\n' "$flags" | node scripts/generate-versions.mjs
+'''
+
 [tasks.versions]
 description = "Write the versions the pages quote into src/generated."
 dir = ".."
@@ -18,16 +32,7 @@ printf '%s\n' "$flags" | node docs/scripts/generate-versions.mjs
 '''
 
 [tasks.install]
-# Hygiene runs this for Astro's generated types and does not fetch Git tags, so
-# `versions` cannot run there. A stub is enough for `astro sync`; `build` and
-# `dev` overwrite it with the real file.
-run = '''
-if [ ! -f src/generated/versions.json ]; then
-  mkdir -p src/generated
-  printf '%s\n' '{"release":"0.0.0","snapshot":"0.0.0-SNAPSHOT","maplibreJs":"0.0.0"}' > src/generated/versions.json
-fi
-pnpm exec astro sync
-'''
+run = "pnpm exec astro sync"
 
 [tasks.demo]
 description = "Copy the browser demo into the site's public directory."

--- a/docs/package.json
+++ b/docs/package.json
@@ -8,6 +8,7 @@
     "preview": "astro preview"
   },
   "dependencies": {
+    "@astrojs/markdown-remark": "^7.2.2",
     "@astrojs/starlight": "^0.41.6",
     "@fontsource/alata": "^5.3.0",
     "astro": "^7.1.6",

--- a/lib/location-runtime-linux/src/main/kotlin/org/maplibre/compose/location/desktop/linux/LinuxPortalLocationBackend.kt
+++ b/lib/location-runtime-linux/src/main/kotlin/org/maplibre/compose/location/desktop/linux/LinuxPortalLocationBackend.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
 import org.maplibre.compose.location.DesktopLocationBackend
 import org.maplibre.compose.location.DesktopLocationProvider
+import org.maplibre.compose.location.LocationAccuracy
 import org.maplibre.compose.location.LocationAccuracyAuthorization
 import org.maplibre.compose.location.LocationBackendAvailability
 import org.maplibre.compose.location.LocationEvent

--- a/lib/location/src/jsMain/kotlin/org/maplibre/compose/location/BrowserLocationProvider.kt
+++ b/lib/location/src/jsMain/kotlin/org/maplibre/compose/location/BrowserLocationProvider.kt
@@ -142,8 +142,13 @@ internal constructor(
  *
  * [BrowserLocationProvider] delegates [LocationProvider.permission] and
  * [LocationProvider.requestPermission] to an instance of this class. Construct one with a
- * [CoroutineScope] to back a custom [LocationProvider], or use
- * [rememberBrowserLocationPermissionRequester] to bind permission observation to the composition.
+ * [CoroutineScope] to back a custom [LocationProvider].
+ *
+ * [`PermissionStatus.state`](https://developer.mozilla.org/en-US/docs/Web/API/PermissionStatus/state)
+ * maps `granted` to [LocationPermission.Granted], `prompt` to [LocationPermission.NotGranted] with
+ * `canRequest = true`, and `denied` to `canRequest = false`. A browser without the Permissions API
+ * reports `canRequest = null` until an explicit request determines the result. A missing
+ * Geolocation API maps [backendAvailability] to [LocationBackendAvailability.Unsupported].
  */
 public class BrowserLocationPermissionRequester
 internal constructor(
@@ -231,14 +236,8 @@ internal constructor(
 }
 
 /**
- * Creates and remembers the browser geolocation permission requester.
- *
- * [`PermissionStatus.state`](https://developer.mozilla.org/en-US/docs/Web/API/PermissionStatus/state)
- * maps `granted` to [LocationPermission.Granted], `prompt` to [LocationPermission.NotGranted] with
- * `canRequest = true`, and `denied` to `canRequest = false`. A browser without the Permissions API
- * reports `canRequest = null` until an explicit request determines the result. A missing
- * Geolocation API maps [BrowserLocationPermissionRequester.backendAvailability] to
- * [LocationBackendAvailability.Unsupported].
+ * Browser Permissions API states that [BrowserLocationPermissionRequester] maps to
+ * [LocationPermission].
  */
 internal enum class BrowserPermission {
   Unknown,

--- a/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/android/MapLibre.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/android/MapLibre.kt
@@ -11,7 +11,7 @@ public object MapLibre {
    * process.
    *
    * Defaults to [androidCacheFile] and MapLibre's cache budget. A conflicting call throws
-   * [IllegalStateException].
+   * `IllegalStateException`.
    */
   public fun configure(
     context: Context,

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/value/GeometryType.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/value/GeometryType.kt
@@ -2,7 +2,10 @@ package org.maplibre.compose.expressions.value
 
 import org.maplibre.compose.expressions.ast.StringLiteral
 
-/** Type of a GeoJson feature, as returned by [Feature.type]. */
+/**
+ * Type of a GeoJson feature, as returned by
+ * [Feature.geometryType][org.maplibre.compose.expressions.dsl.Feature.geometryType].
+ */
 public enum class GeometryType(override val literal: StringLiteral) : EnumValue<GeometryType> {
   Point(StringLiteral.of("Point")),
   LineString(StringLiteral.of("LineString")),

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/value/unions.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/value/unions.kt
@@ -1,6 +1,7 @@
 package org.maplibre.compose.expressions.value
 
 import org.maplibre.compose.expressions.ast.Expression
+import org.maplibre.compose.expressions.dsl.const
 import org.maplibre.compose.expressions.dsl.eq
 import org.maplibre.compose.expressions.dsl.format
 import org.maplibre.compose.expressions.dsl.gt
@@ -11,7 +12,7 @@ import org.maplibre.compose.expressions.dsl.lte
 import org.maplibre.compose.expressions.dsl.neq
 import org.maplibre.compose.expressions.dsl.switch
 
-/** Represents and [Expression] that resolves to a value that can be an input to [format]. */
+/** Represents an [Expression] that resolves to a value that can be an input to [format]. */
 public sealed interface FormattableValue : ExpressionValue
 
 /**

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/value/values.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/value/values.kt
@@ -10,18 +10,23 @@ import org.maplibre.compose.expressions.ast.StringLiteral
 import org.maplibre.compose.util.DpPadding
 
 /**
- * Represents a value that an [Expression] can resolve to. Many of these types are never actually
- * instantiated at runtime; they're only used as type parameters to hint at the type of an
- * [Expression].
+ * Represents a value that an [Expression][org.maplibre.compose.expressions.ast.Expression] can
+ * resolve to. Many of these types are never actually instantiated at runtime; they're only used as
+ * type parameters to hint at the type of an
+ * [Expression][org.maplibre.compose.expressions.ast.Expression].
  */
 public sealed interface ExpressionValue
 
-/** Represents an [ExpressionValue] that resolves to a true or false value. See [const]. */
+/**
+ * Represents an [ExpressionValue] that resolves to a true or false value. See
+ * [const][org.maplibre.compose.expressions.dsl.const].
+ */
 public sealed interface BooleanValue : ExpressionValue, EquatableValue
 
 /**
  * Represents an [ExpressionValue] that resolves to a numeric quantity. Corresponds to numbers in
- * the JSON style spec. Use [const] to create a literal [NumberValue].
+ * the JSON style spec. Use [const][org.maplibre.compose.expressions.dsl.const] to create a literal
+ * [NumberValue].
  *
  * @param U the unit type of the number. For dimensionless quantities, use [Number].
  */
@@ -33,21 +38,27 @@ public sealed interface NumberValue<U> :
   EquatableValue,
   FloatOrVectorValue<U>
 
-/** Represents an [ExpressionValue] that resolves to a dimensionless quantity. See [const]. */
+/**
+ * Represents an [ExpressionValue] that resolves to a dimensionless quantity. See
+ * [const][org.maplibre.compose.expressions.dsl.const].
+ */
 public typealias FloatValue = NumberValue<Number>
 
 /**
- * Represents an [ExpressionValue] that resolves to an integer dimensionless quantity. See [const].
+ * Represents an [ExpressionValue] that resolves to an integer dimensionless quantity. See
+ * [const][org.maplibre.compose.expressions.dsl.const].
  */
 public sealed interface IntValue : NumberValue<Number>
 
 /**
- * Represents an [ExpressionValue] that resolves to device-independent pixels ([Dp]). See [const].
+ * Represents an [ExpressionValue] that resolves to device-independent pixels ([Dp]). See
+ * [const][org.maplibre.compose.expressions.dsl.const].
  */
 public typealias DpValue = NumberValue<Dp>
 
 /**
- * Represents an [ExpressionValue] that resolves to scalable pixels or em ([TextUnit]). See [const].
+ * Represents an [ExpressionValue] that resolves to scalable pixels or em ([TextUnit]). See
+ * [const][org.maplibre.compose.expressions.dsl.const].
  *
  * Which unit it resolves to is determined by the style property it's used in.
  */
@@ -55,11 +66,14 @@ public typealias TextUnitValue = NumberValue<TextUnit>
 
 /**
  * Represents an [ExpressionValue] that resolves to an amount of time with millisecond precision
- * ([Duration]). See [const].
+ * ([Duration]). See [const][org.maplibre.compose.expressions.dsl.const].
  */
 public typealias MillisecondsValue = NumberValue<Duration>
 
-/** Represents an [ExpressionValue] that resolves to a string value. See [const]. */
+/**
+ * Represents an [ExpressionValue] that resolves to a string value. See
+ * [const][org.maplibre.compose.expressions.dsl.const].
+ */
 public sealed interface StringValue :
   ExpressionValue,
   MatchableValue,
@@ -69,7 +83,8 @@ public sealed interface StringValue :
   FormattedValue
 
 /**
- * Represents an [ExpressionValue] that resolves to an enum string. See [const].
+ * Represents an [ExpressionValue] that resolves to an enum string. See
+ * [const][org.maplibre.compose.expressions.dsl.const].
  *
  * @param T The [EnumValue] descendent type that this value represents.
  */
@@ -78,18 +93,21 @@ public sealed interface EnumValue<out T> : StringValue {
   public val literal: StringLiteral
 }
 
-/** Represents an [ExpressionValue] that resolves to a [Color] value. See [const]. */
+/**
+ * Represents an [ExpressionValue] that resolves to a [Color] value. See
+ * [const][org.maplibre.compose.expressions.dsl.const].
+ */
 public sealed interface ColorValue : ExpressionValue, InterpolatableValue<ColorValue>
 
 /**
  * Represents an [ExpressionValue] that resolves to a map value (corresponds to a JSON object). See
- * [const].
+ * [const][org.maplibre.compose.expressions.dsl.const].
  */
 public sealed interface MapValue<@Suppress("unused") out T : ExpressionValue> : ExpressionValue
 
 /**
  * Represents an [ExpressionValue] that resolves to a list value (corresponds to a JSON array). See
- * [const].
+ * [const][org.maplibre.compose.expressions.dsl.const].
  */
 public sealed interface ListValue<out T : ExpressionValue> : ExpressionValue
 
@@ -122,7 +140,7 @@ public sealed interface VectorValue<U> :
   ListValue<NumberValue<U>>, InterpolatableValue<VectorValue<U>>, FloatOrVectorValue<U>
 
 /**
- * Represents an [ExpressionValue] that reoslves to a 2D vector in some unit.
+ * Represents an [ExpressionValue] that resolves to a 2D vector in some unit.
  *
  * @param U the unit type of the offset. For dimensionless quantities, use [Number].
  */
@@ -130,45 +148,54 @@ public sealed interface OffsetValue<U> : VectorValue<U>
 
 /**
  * Represents an [ExpressionValue] that resolves to a 2D floating point offset without a particular
- * unit. ([Offset]). See [offset].
+ * unit. ([Offset]). See [offset][org.maplibre.compose.expressions.dsl.offset].
  */
 public typealias FloatOffsetValue = OffsetValue<Number>
 
 /**
  * Represents an [ExpressionValue] that resolves to a 2D floating point offset in device-independent
- * pixels ([DpOffset]). See [offset].
+ * pixels ([DpOffset]). See [offset][org.maplibre.compose.expressions.dsl.offset].
  */
 public typealias DpOffsetValue = OffsetValue<Dp>
 
 /**
  * Represents an [ExpressionValue] that resolves to a 2D floating point offset in scalable pixels or
- * em ([TextUnit]). See [offset].
+ * em ([TextUnit]). See [offset][org.maplibre.compose.expressions.dsl.offset].
  */
 public typealias TextUnitOffsetValue = OffsetValue<TextUnit>
 
 /**
  * Represents an [ExpressionValue] that resolves to four-sided padding in device-independent pixels
- * ([DpPadding]). See [const] and [padding].
+ * ([DpPadding]). See [const][org.maplibre.compose.expressions.dsl.const] and
+ * [padding][org.maplibre.compose.expressions.dsl.padding].
  */
 public sealed interface DpPaddingValue : VectorValue<Dp>
 
 /**
  * Represents an [ExpressionValue] that resolves to a collator object for use in locale-dependent
- * comparison operations. See [collator].
+ * comparison operations. See [collator][org.maplibre.compose.expressions.dsl.collator].
  */
 public sealed interface CollatorValue : ExpressionValue
 
-/** Represents an [ExpressionValue] that resolves to a formatted string. See [format]. */
+/**
+ * Represents an [ExpressionValue] that resolves to a formatted string. See
+ * [format][org.maplibre.compose.expressions.dsl.format].
+ */
 public sealed interface FormattedValue : ExpressionValue
 
 /** Represents an [ExpressionValue] that resolves to a geometry object. */
 public sealed interface GeoJsonValue : ExpressionValue
 
-/** Represents an [ExpressionValue] that resolves to an image. See [image] */
+/**
+ * Represents an [ExpressionValue] that resolves to an image. See
+ * [image][org.maplibre.compose.expressions.dsl.image].
+ */
 public sealed interface ImageValue : ExpressionValue, FormattableValue
 
 /**
- * Represents an [ExpressionValue] that resolves to an interpolation type. See [linear],
- * [exponential], and [cubicBezier].
+ * Represents an [ExpressionValue] that resolves to an interpolation type. See
+ * [linear][org.maplibre.compose.expressions.dsl.linear],
+ * [exponential][org.maplibre.compose.expressions.dsl.exponential], and
+ * [cubicBezier][org.maplibre.compose.expressions.dsl.cubicBezier].
  */
 public sealed interface InterpolationValue : ExpressionValue

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/HeatmapLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/HeatmapLayer.kt
@@ -32,7 +32,8 @@ import org.maplibre.compose.util.MaplibreComposable
  *   supported.
  * @param visible Whether the layer should be displayed.
  * @param color Defines the color of each pixel based on its density value in a heatmap. Should be
- *   an expression that uses [heatmapDensity] as input.
+ *   an expression that uses [heatmapDensity][org.maplibre.compose.expressions.dsl.heatmapDensity]
+ *   as input.
  * @param opacity The global opacity at which the heatmap layer will be drawn.
  * @param radius Radius of influence of one heatmap point. Increasing the value makes the heatmap
  *   smoother, but less detailed. The expression may use feature properties and feature state.

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/GestureMath.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/GestureMath.kt
@@ -99,7 +99,7 @@ internal object GestureMath {
 
   /**
    * Screen-space travel for a flick of this speed. Equal speeds produce equal offsets, whether or
-   * not the camera is pitched. [MapInput] applies the offset in small `moveBy` steps.
+   * not the camera is pitched. [mapInput] applies the offset in small `moveBy` steps.
    */
   fun fling(velocityXDpPerSecond: Double, velocityYDpPerSecond: Double): Fling? {
     val velocity = hypot(velocityXDpPerSecond, velocityYDpPerSecond)

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/Attribution.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/Attribution.kt
@@ -73,8 +73,8 @@ import org.maplibre.compose.util.vertical
  * Info button from which an attribution popup text is expanded. This version retracts when the user
  * interacts with the map.
  *
- * This component draws with Compose Foundation alone. The
- * [Material 3 module][org.maplibre.compose.material3] provides a themed version of it.
+ * This component draws with Compose Foundation alone. The Material 3 module provides a themed
+ * version of it.
  *
  * @param cameraState Used to dismiss the attribution when the user interacts with the map.
  * @param styleState Used to get the attribution links to display.
@@ -132,8 +132,8 @@ public fun ExpandingAttributionButton(
  * Info button from which an attribution popup text is expanded. This version allows the caller to
  * manage the state.
  *
- * This component draws with Compose Foundation alone. The
- * [Material 3 module][org.maplibre.compose.material3] provides a themed version of it.
+ * This component draws with Compose Foundation alone. The Material 3 module provides a themed
+ * version of it.
  *
  * @param expanded Whether the attribution text is expanded.
  * @param onClick Called when the button is pressed. Should toggle the expanded state.

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/CompassButton.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/CompassButton.kt
@@ -56,8 +56,8 @@ import org.maplibre.compose.util.AngleMath
 /**
  * A compass that points north and returns the camera to [getHomePosition] when it is clicked.
  *
- * This component draws with Compose Foundation alone. The
- * [Material 3 module][org.maplibre.compose.material3] provides a themed version of it.
+ * This component draws with Compose Foundation alone. The Material 3 module provides a themed
+ * version of it.
  *
  * @param cameraState The camera that the needle follows and that a click resets.
  * @param onClick Called after the camera animation starts.
@@ -121,8 +121,8 @@ public fun CompassButton(
  * A [CompassButton] that appears when the camera turns away from [getHomePosition] and fades out
  * once the camera returns to it.
  *
- * This component draws with Compose Foundation alone. The
- * [Material 3 module][org.maplibre.compose.material3] provides a themed version of it.
+ * This component draws with Compose Foundation alone. The Material 3 module provides a themed
+ * version of it.
  *
  * @param visibilityDuration How long the button stays visible after the camera returns home.
  * @param slop How far the camera may turn from [getHomePosition] before the button appears, in

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/DisappearingScaleBar.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/DisappearingScaleBar.kt
@@ -22,8 +22,8 @@ import kotlinx.coroutines.delay
  * An animated scale bar that appears when the [zoom] level of the map changes, and then disappears
  * after [visibilityDuration]. This composable wraps [ScaleBar] with visibility animations.
  *
- * This component draws with Compose Foundation alone. The
- * [Material 3 module][org.maplibre.compose.material3] provides a themed version of it.
+ * This component draws with Compose Foundation alone. The Material 3 module provides a themed
+ * version of it.
  *
  * @param metersPerDp how many meters are displayed in one device independent pixel (dp), i.e. the
  *   scale. See

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/ScaleBar.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/ScaleBar.kt
@@ -33,8 +33,8 @@ import org.maplibre.spatialk.units.extensions.meters
  * A scale bar composable that shows the current scale of the map in feet, meters or feet and meters
  * when zoomed in to the map, changing to miles and kilometers, respectively, when zooming out.
  *
- * This component draws with Compose Foundation alone. The
- * [Material 3 module][org.maplibre.compose.material3] provides a themed version of it.
+ * This component draws with Compose Foundation alone. The Material 3 module provides a themed
+ * version of it.
  *
  * @param metersPerDp how many meters are displayed in one device independent pixel (dp), i.e. the
  *   scale. See

--- a/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/ios/MapLibre.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/ios/MapLibre.kt
@@ -9,7 +9,7 @@ public object MapLibre {
    * process.
    *
    * Defaults to [iosCacheFile] and MapLibre's cache budget. A conflicting call throws
-   * [IllegalStateException].
+   * `IllegalStateException`.
    */
   public fun configure(options: IosRuntimeOptions = IosRuntimeOptions(iosCacheFile())) {
     MlnFfiApplication.configure(options.toMlnFfiRuntimeOptions())

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/MapLibre.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/MapLibre.kt
@@ -12,7 +12,7 @@ public object MapLibre {
    * process.
    *
    * [applicationId] defaults to the package of the process `main` class. [maximumCacheSizeBytes]
-   * defaults to MapLibre's cache budget. A conflicting call throws [IllegalStateException].
+   * defaults to MapLibre's cache budget. A conflicting call throws `IllegalStateException`.
    *
    * @param applicationId Reverse-domain name for the cache directory, such as `com.example.myapp`.
    * @param maximumCacheSizeBytes Ambient cache size in bytes, or null for MapLibre's default.

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/bridge/Direct3D12Presenter.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/bridge/Direct3D12Presenter.kt
@@ -32,7 +32,7 @@ internal data class Direct3DTextureTarget(
   /** The size [texture] was allocated at. */
   val extent: MapExtent,
   /**
-   * The [org.maplibre.compose.desktop.MlnFfiRenderTarget.generation] this texture corresponds to.
+   * The [org.maplibre.compose.mlnffi.MlnFfiRenderTarget.generation] this texture corresponds to.
    */
   val generation: Long,
 )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
 
   docs:
     dependencies:
+      '@astrojs/markdown-remark':
+        specifier: ^7.2.2
+        version: 7.2.2
       '@astrojs/starlight':
         specifier: ^0.41.6
         version: 0.41.7(@astrojs/markdown-remark@7.2.2)(astro@7.2.0(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.13.3)(yaml@2.9.0))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Clears the unresolved KDoc links and the deprecated Astro markdown config that show up as warnings on recent `main` CI.

## Validation

`dokkaGenerate` with `failOnWarning` succeeded with zero unresolved links, `mise run //docs:install` now generates real versions via a mise dep then syncs, and `mise run check` plus the previous CI run on this branch were green.

## AI assistance

Cursor Grok 4.6 cloud agent.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b77281ad-66c1-4242-a78c-bc57f33c7acc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b77281ad-66c1-4242-a78c-bc57f33c7acc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

