### PR TITLE
Centralize the logical map lifecycle

### DIFF
--- a/.agents/scratch/api-redesign/issues/02-centralize-map-lifecycle.md
+++ b/.agents/scratch/api-redesign/issues/02-centralize-map-lifecycle.md
@@ -7,37 +7,37 @@ seam.
 
 **Blocked by:** None (can start immediately)
 
-**Status:** ready-for-agent
+**Status:** resolved
 
-- [ ] The changed test area contains no redundant, impossible,
+- [x] The changed test area contains no redundant, impossible,
       compatibility-only, or implementation-shape scenarios.
-- [ ] One authority decides every engine-map and presentation transition.
-- [ ] The authority implements OpenDetached, Attaching, Attached, Detaching,
+- [x] One authority decides every engine-map and presentation transition.
+- [x] The authority implements OpenDetached, Attaching, Attached, Detaching,
       Closing, and Closed as explicit states.
-- [ ] Platform adapters perform commands without maintaining a second
+- [x] Platform adapters perform commands without maintaining a second
       authoritative attachment state.
-- [ ] Each attachment receives an opaque render lease.
-- [ ] Durable engine events use engine-map and style identities rather than a
+- [x] Each attachment receives an opaque render lease.
+- [x] Durable engine events use engine-map and style identities rather than a
       presentation lease.
-- [ ] Presentation events and detach requests from departed leases have no
+- [x] Presentation events and detach requests from departed leases have no
       effect.
-- [ ] The closure commit point rejects new work immediately.
-- [ ] Rival attachments fail without waiting during Attaching, Attached, and
+- [x] The closure commit point rejects new work immediately.
+- [x] Rival attachments fail without waiting during Attaching, Attached, and
       Detaching.
-- [ ] Attach failure and detach-during-attach invalidate the lease, clean
+- [x] Attach failure and detach-during-attach invalidate the lease, clean
       partial resources, and return to OpenDetached.
-- [ ] Repeated close and child/runtime close races join one cleanup operation.
-- [ ] Cleanup attempts every resource and awaitClosed reports collected cleanup
+- [x] Repeated close and child/runtime close races join one cleanup operation.
+- [x] Cleanup attempts every resource and awaitClosed reports collected cleanup
       failures.
-- [ ] Physical cleanup continues after caller cancellation.
-- [ ] Common tests cover every valid and refused lifecycle transition through a
+- [x] Physical cleanup continues after caller cancellation.
+- [x] Common tests cover every valid and refused lifecycle transition through a
       fake platform adapter.
-- [ ] The fake emits each event family with its required identity, including
+- [x] The fake emits each event family with its required identity, including
       durable engine and style events accepted while a native map is detached.
-- [ ] Tests that assert obsolete locks, queues, callback storage, or duplicated
+- [x] Tests that assert obsolete locks, queues, callback storage, or duplicated
       session state are deleted rather than preserved beside the authority
       tests.
-- [ ] Existing live-map behavior remains green on native and Web.
+- [x] Existing live-map behavior remains green on native and Web.
 
 ## Test ledger
 
@@ -49,3 +49,10 @@ seam.
   common suite.
 - Run `mise run test:android`, `mise run test:desktop`, `mise run test:ios`, and
   `mise run test:js`.
+
+## Answer
+
+Draft PR #1144 implements the centralized lifecycle authority and routes the
+native and Web sessions through it. Common lifecycle tests cover the transition
+table, refusal paths, races, cancellation, event identities, and cleanup
+failures.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,6 +37,7 @@ kermit = "2.1.0"
 kotlin-dsv = "0.4.0"
 kotlin-wrappers = "2026.8.4"
 kotlinx-coroutines = "1.11.0"
+kotlinx-atomicfu = "0.33.0"
 kotlinx-io = "0.9.1"
 kotlinx-serialization = "1.11.0"
 ktor = "3.5.2"
@@ -101,6 +102,7 @@ kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-cor
 kotlinx-coroutines-playServices = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-play-services", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-swing = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-swing", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
+kotlinx-atomicfu = { module = "org.jetbrains.kotlinx:atomicfu", version.ref = "kotlinx-atomicfu" }
 kotlinx-io-core = { module = "org.jetbrains.kotlinx:kotlinx-io-core", version.ref = "kotlinx-io" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }

--- a/lib/maplibre-compose/build.gradle.kts
+++ b/lib/maplibre-compose/build.gradle.kts
@@ -60,6 +60,7 @@ kotlin {
       api(libs.lifecycle.runtime.compose)
       api(libs.kermit)
       implementation(libs.kotlinx.coroutines.core)
+      implementation(libs.kotlinx.atomicfu)
       api(libs.spatialk.geojson)
       api(libs.spatialk.units)
     }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleAuthority.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleAuthority.kt
@@ -152,6 +152,20 @@ internal class MapLifecycleAuthority(
     }
   }
 
+  /** Claims and delivers a loaded style as one serialized operation. */
+  fun claimStyleIdentity(
+    engine: EngineMapIdentity,
+    request: StyleRequestIdentity,
+    event: () -> Unit,
+  ): StyleIdentity? = serialized {
+    if (!acceptEngineIdentity(engine)) return@serialized null
+    if (currentStyleRequest.load() != StyleRequestClaim(engine, request)) return@serialized null
+    val identity = StyleIdentity(nextIdentity.incrementAndFetch())
+    currentStyle.store(StyleClaim(engine, identity))
+    event()
+    identity
+  }
+
   fun invalidateStyleIdentity(engine: EngineMapIdentity): Boolean {
     return serialized {
       if (!acceptEngineIdentity(engine)) return@serialized false

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleAuthority.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleAuthority.kt
@@ -25,6 +25,9 @@ import kotlinx.coroutines.launch
 /** Identifies one loaded base-style generation on one engine map. */
 @JvmInline internal value class StyleIdentity(private val value: Long)
 
+/** Identifies one requested base-style generation before it has loaded. */
+@JvmInline internal value class StyleRequestIdentity(private val value: Long)
+
 /** Whether detaching a presentation also destroys its engine map. */
 internal enum class EngineRetention {
   RETAIN,
@@ -92,6 +95,8 @@ internal class MapLifecycleAuthority(
   private val nextIdentity = AtomicLong(0L)
   private val current = AtomicReference<InternalState>(InternalState.OpenDetached(null))
   private val currentStyle = AtomicReference<StyleClaim?>(null)
+  private val currentStyleRequest = AtomicReference<StyleRequestClaim?>(null)
+  private val lifecycleGate = AtomicBoolean(false)
   private val closure = CompletableDeferred<Result<Unit>>()
 
   val state: MapLifecycleState
@@ -106,6 +111,25 @@ internal class MapLifecycleAuthority(
   val styleIdentity: StyleIdentity?
     get() = currentStyle.load()?.style
 
+  fun claimStyleRequestIdentity(engine: EngineMapIdentity): StyleRequestIdentity? = serialized {
+    if (!acceptEngineIdentity(engine)) return@serialized null
+    val identity = StyleRequestIdentity(nextIdentity.incrementAndFetch())
+    currentStyle.store(null)
+    currentStyleRequest.store(StyleRequestClaim(engine, identity))
+    identity
+  }
+
+  fun acceptStyleRequestEvent(
+    engine: EngineMapIdentity,
+    request: StyleRequestIdentity,
+    event: () -> Unit,
+  ): Boolean = serialized {
+    if (!acceptEngineIdentity(engine)) return@serialized false
+    if (currentStyleRequest.load() != StyleRequestClaim(engine, request)) return@serialized false
+    event()
+    true
+  }
+
   val acceptsWork: Boolean
     get() {
       val observed = current.load()
@@ -113,27 +137,36 @@ internal class MapLifecycleAuthority(
     }
 
   /** Claims the next loaded-style generation for [engine], invalidating the preceding one. */
-  fun claimStyleIdentity(engine: EngineMapIdentity): StyleIdentity? {
-    if (!acceptEngineIdentity(engine)) return null
-    val identity = StyleIdentity(nextIdentity.incrementAndFetch())
-    currentStyle.store(StyleClaim(engine, identity))
-    return identity
+  fun claimStyleIdentity(
+    engine: EngineMapIdentity,
+    request: StyleRequestIdentity,
+  ): StyleIdentity? {
+    return serialized {
+      if (!acceptEngineIdentity(engine)) return@serialized null
+      if (currentStyleRequest.load() != StyleRequestClaim(engine, request)) return@serialized null
+      val identity = StyleIdentity(nextIdentity.incrementAndFetch())
+      currentStyle.store(StyleClaim(engine, identity))
+      identity
+    }
   }
 
   fun invalidateStyleIdentity(engine: EngineMapIdentity): Boolean {
-    if (!acceptEngineIdentity(engine)) return false
-    while (true) {
-      val claimed = currentStyle.load() ?: return true
-      if (claimed.engine != engine) return false
-      if (currentStyle.compareAndSet(claimed, null)) return true
+    return serialized {
+      if (!acceptEngineIdentity(engine)) return@serialized false
+      val claimed = currentStyle.load() ?: return@serialized true
+      if (claimed.engine != engine) return@serialized false
+      currentStyle.store(null)
+      true
     }
   }
 
   /** Accepts an engine-durable event, including while a retained native engine is detached. */
   fun acceptEngineEvent(engine: EngineMapIdentity, event: () -> Unit): Boolean {
-    if (!acceptEngineIdentity(engine)) return false
-    event()
-    return true
+    return serialized {
+      if (!acceptEngineIdentity(engine)) return@serialized false
+      event()
+      true
+    }
   }
 
   /** Accepts an event only from the current loaded style on the current engine map. */
@@ -142,10 +175,12 @@ internal class MapLifecycleAuthority(
     style: StyleIdentity,
     event: () -> Unit,
   ): Boolean {
-    if (!acceptEngineIdentity(engine)) return false
-    if (currentStyle.load() != StyleClaim(engine, style)) return false
-    event()
-    return true
+    return serialized {
+      if (!acceptEngineIdentity(engine)) return@serialized false
+      if (currentStyle.load() != StyleClaim(engine, style)) return@serialized false
+      event()
+      true
+    }
   }
 
   private fun acceptEngineIdentity(engine: EngineMapIdentity): Boolean {
@@ -169,7 +204,7 @@ internal class MapLifecycleAuthority(
     val result = CompletableDeferred<Result<RenderLease>>()
     val engine = EngineMapIdentity(nextIdentity.incrementAndFetch())
     val lease = RenderLease(nextIdentity.incrementAndFetch())
-    while (true) {
+    val selected = serialized {
       val observed = current.load()
       when (observed) {
         is InternalState.OpenDetached -> {
@@ -181,11 +216,8 @@ internal class MapLifecycleAuthority(
               result = result,
               engineCreated = AtomicBoolean(observed.engine != null),
             )
-          if (!current.compareAndSet(observed, selected)) continue
-          physicalScope.launch(start = CoroutineStart.UNDISPATCHED) {
-            performAttach(selected, observed.engine == null)
-          }
-          return PendingAttachment(lease, result)
+          current.store(selected)
+          selected to (observed.engine == null)
         }
         is InternalState.Attaching,
         is InternalState.Attached,
@@ -194,18 +226,53 @@ internal class MapLifecycleAuthority(
         InternalState.Closed -> throw MapClosedException()
       }
     }
+    physicalScope.launch(start = CoroutineStart.UNDISPATCHED) {
+      performAttach(selected.first, selected.second)
+    }
+    return PendingAttachment(lease, result)
+  }
+
+  /** Replaces a destroy-on-detach engine without transferring its current presentation lease. */
+  fun beginEngineReplacement(engine: EngineMapIdentity, lease: RenderLease): Boolean {
+    check(adapter.engineRetention == EngineRetention.DESTROY) {
+      "Retained engines do not need same-presentation replacement"
+    }
+    val result = CompletableDeferred<Result<RenderLease>>()
+    val replacement = EngineMapIdentity(nextIdentity.incrementAndFetch())
+    val replacing =
+      serialized {
+        val observed = current.load()
+        if (observed !is InternalState.Attached) return@serialized null
+        if (observed.engine != engine || observed.lease != lease) return@serialized null
+        InternalState.Attaching(
+            engine = replacement,
+            lease = lease,
+            result = result,
+            engineCreated = AtomicBoolean(false),
+          )
+          .also { current.store(it) }
+      } ?: return false
+    currentStyle.store(null)
+    currentStyleRequest.store(null)
+    physicalScope.launch(start = CoroutineStart.UNDISPATCHED) {
+      performEngineReplacement(engine, replacing)
+    }
+    return true
   }
 
   /** Commits logical closure synchronously and starts one cancellation-independent cleanup. */
   fun close() {
-    while (true) {
-      val observed = current.load()
-      if (observed is InternalState.Closing || observed === InternalState.Closed) return
-      val closing = InternalState.Closing(observed)
-      if (!current.compareAndSet(observed, closing)) continue
-      physicalScope.launch(start = CoroutineStart.UNDISPATCHED) { performClose(closing) }
-      return
-    }
+    val closing =
+      serialized {
+        val observed = current.load()
+        if (observed is InternalState.Closing || observed === InternalState.Closed) {
+          return@serialized null
+        }
+        val closing = InternalState.Closing(observed)
+        current.store(closing)
+        closing
+      } ?: return
+    physicalScope.launch(start = CoroutineStart.UNDISPATCHED) { performClose(closing) }
   }
 
   /** Waits for every cleanup attempt and reports their combined outcome. */
@@ -221,42 +288,43 @@ internal class MapLifecycleAuthority(
   }
 
   private fun beginDetach(lease: RenderLease): CompletableDeferred<Result<Unit>>? {
-    while (true) {
-      val observed = current.load()
-      when (observed) {
-        is InternalState.Attaching -> {
-          if (observed.lease != lease) return null
-          val result = CompletableDeferred<Result<Unit>>()
-          val detaching =
-            InternalState.Detaching(
-              engine = observed.engine,
-              lease = lease,
-              result = result,
-              attachResult = observed.result,
-              engineCreated = observed.engineCreated,
-            )
-          if (!current.compareAndSet(observed, detaching)) continue
-          physicalScope.launch(start = CoroutineStart.UNDISPATCHED) { performDetach(detaching) }
-          return result
+    val detaching =
+      serialized {
+        val observed = current.load()
+        when (observed) {
+          is InternalState.Attaching -> {
+            if (observed.lease != lease) return null
+            val result = CompletableDeferred<Result<Unit>>()
+            val detaching =
+              InternalState.Detaching(
+                engine = observed.engine,
+                lease = lease,
+                result = result,
+                attachResult = observed.result,
+                engineCreated = observed.engineCreated,
+              )
+            current.store(detaching)
+            detaching
+          }
+          is InternalState.Attached -> {
+            if (observed.lease != lease) return null
+            val result = CompletableDeferred<Result<Unit>>()
+            val detaching =
+              InternalState.Detaching(
+                engine = observed.engine,
+                lease = lease,
+                result = result,
+                attachResult = null,
+                engineCreated = null,
+              )
+            current.store(detaching)
+            detaching
+          }
+          else -> null
         }
-        is InternalState.Attached -> {
-          if (observed.lease != lease) return null
-          val result = CompletableDeferred<Result<Unit>>()
-          val detaching =
-            InternalState.Detaching(
-              engine = observed.engine,
-              lease = lease,
-              result = result,
-              attachResult = null,
-              engineCreated = null,
-            )
-          if (!current.compareAndSet(observed, detaching)) continue
-          physicalScope.launch(start = CoroutineStart.UNDISPATCHED) { performDetach(detaching) }
-          return result
-        }
-        else -> return null
-      }
-    }
+      } ?: return null
+    physicalScope.launch(start = CoroutineStart.UNDISPATCHED) { performDetach(detaching) }
+    return detaching.result
   }
 
   /** Accepts a viewport-bound event only for the currently attached engine and lease. */
@@ -265,11 +333,13 @@ internal class MapLifecycleAuthority(
     lease: RenderLease,
     event: () -> Unit,
   ): Boolean {
-    val observed = current.load()
-    if (observed !is InternalState.Attached) return false
-    if (observed.engine != engine || observed.lease != lease) return false
-    event()
-    return true
+    return serialized {
+      val observed = current.load()
+      if (observed !is InternalState.Attached) return@serialized false
+      if (observed.engine != engine || observed.lease != lease) return@serialized false
+      event()
+      true
+    }
   }
 
   private suspend fun performAttach(attaching: InternalState.Attaching, createEngine: Boolean) {
@@ -286,35 +356,86 @@ internal class MapLifecycleAuthority(
       } catch (error: Throwable) {
         Result.failure(error)
       }
-    val observed = current.load()
-    if (outcome.isSuccess && observed === attaching) {
-      current.compareAndSet(
-        attaching,
-        InternalState.Attached(attaching.engine, attaching.lease),
-      )
-      attaching.result.complete(outcome)
-    } else if (outcome.isFailure && observed === attaching) {
+    val stillAttaching = serialized { current.load() === attaching }
+    if (outcome.isSuccess && stillAttaching) {
+      val committed = serialized {
+        if (current.load() === attaching) {
+          current.store(InternalState.Attached(attaching.engine, attaching.lease))
+          true
+        } else {
+          false
+        }
+      }
+      if (committed) {
+        attaching.result.complete(outcome)
+      } else {
+        attaching.result.complete(Result.failure(MapLeaseInvalidatedException()))
+      }
+    } else if (outcome.isFailure && stillAttaching) {
       val error = checkNotNull(outcome.exceptionOrNull())
       if (attachAttempted) {
         runCatching { adapter.detach(attaching.engine, attaching.lease) }
           .exceptionOrNull()
           ?.let(error::addSuppressed)
       }
-      if (!attaching.engineCreated.load()) {
+      val destroyEngine =
+        !attaching.engineCreated.load() || adapter.engineRetention == EngineRetention.DESTROY
+      if (destroyEngine) {
         runCatching { adapter.destroyEngine(attaching.engine) }
           .exceptionOrNull()
           ?.let(error::addSuppressed)
+        currentStyle.store(null)
+        currentStyleRequest.store(null)
       }
-      current.compareAndSet(
-        attaching,
-        InternalState.OpenDetached(attaching.engine.takeIf { attaching.engineCreated.load() }),
-      )
+      serialized {
+        if (current.load() === attaching) {
+          current.store(InternalState.OpenDetached(attaching.engine.takeIf { !destroyEngine }))
+        }
+      }
       attaching.result.complete(Result.failure(error))
     } else {
       val invalidated = MapLeaseInvalidatedException()
       outcome.exceptionOrNull()?.let(invalidated::addSuppressed)
       attaching.result.complete(Result.failure(invalidated))
     }
+  }
+
+  private suspend fun performEngineReplacement(
+    previousEngine: EngineMapIdentity,
+    attaching: InternalState.Attaching,
+  ) {
+    val failure = runCatching {
+      adapter.destroyEngine(previousEngine)
+      adapter.createEngine(attaching.engine)
+      attaching.engineCreated.store(true)
+      adapter.attach(attaching.engine, attaching.lease)
+    }
+      .exceptionOrNull()
+    if (failure == null) {
+      val committed = serialized {
+        if (current.load() !== attaching) return@serialized false
+        current.store(InternalState.Attached(attaching.engine, attaching.lease))
+        true
+      }
+      attaching.result.complete(
+        if (committed) Result.success(attaching.lease)
+        else Result.failure(MapLeaseInvalidatedException())
+      )
+      return
+    }
+
+    if (attaching.engineCreated.load()) {
+      runCatching { adapter.detach(attaching.engine, attaching.lease) }
+        .exceptionOrNull()
+        ?.let(failure::addSuppressed)
+      runCatching { adapter.destroyEngine(attaching.engine) }
+        .exceptionOrNull()
+        ?.let(failure::addSuppressed)
+    }
+    serialized {
+      if (current.load() === attaching) current.store(InternalState.OpenDetached(null))
+    }
+    attaching.result.complete(Result.failure(failure))
   }
 
   private suspend fun performDetach(detaching: InternalState.Detaching) {
@@ -326,13 +447,16 @@ internal class MapLifecycleAuthority(
     if (destroyEngine) {
       collectFailure(failures) { adapter.destroyEngine(detaching.engine) }
       currentStyle.store(null)
+      currentStyleRequest.store(null)
     }
     val outcome =
       if (failures.isEmpty()) Result.success(Unit)
       else Result.failure(MapLifecycleCleanupException(failures))
     val nextEngine =
       detaching.engine.takeIf { adapter.engineRetention == EngineRetention.RETAIN && engineCreated }
-    current.compareAndSet(detaching, InternalState.OpenDetached(nextEngine))
+    serialized {
+      if (current.load() === detaching) current.store(InternalState.OpenDetached(nextEngine))
+    }
     detaching.result.complete(outcome)
   }
 
@@ -361,9 +485,10 @@ internal class MapLifecycleAuthority(
       collectFailure(failures) { adapter.destroyEngine(engine) }
     }
     currentStyle.store(null)
+    currentStyleRequest.store(null)
     collectFailure(failures) { adapter.closeResources() }
 
-    current.compareAndSet(closing, InternalState.Closed)
+    serialized { if (current.load() === closing) current.store(InternalState.Closed) }
     closure.complete(
       if (failures.isEmpty()) Result.success(Unit)
       else Result.failure(MapLifecycleCleanupException(failures))
@@ -382,7 +507,24 @@ internal class MapLifecycleAuthority(
     else failures += failure
   }
 
+  /** Serializes non-suspending lifecycle commits with callback validation and delivery. */
+  private inline fun <T> serialized(action: () -> T): T {
+    while (!lifecycleGate.compareAndSet(expectedValue = false, newValue = true)) {
+      // Platform callbacks are non-suspending, so the owner releases this gate promptly.
+    }
+    return try {
+      action()
+    } finally {
+      lifecycleGate.store(false)
+    }
+  }
+
   private data class StyleClaim(val engine: EngineMapIdentity, val style: StyleIdentity)
+
+  private data class StyleRequestClaim(
+    val engine: EngineMapIdentity,
+    val request: StyleRequestIdentity,
+  )
 
   private sealed interface InternalState {
     val engine: EngineMapIdentity?

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleAuthority.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleAuthority.kt
@@ -8,6 +8,8 @@ import kotlin.concurrent.atomics.AtomicReference
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.concurrent.atomics.incrementAndFetch
 import kotlin.jvm.JvmInline
+import kotlinx.atomicfu.locks.reentrantLock
+import kotlinx.atomicfu.locks.withLock
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
@@ -96,7 +98,7 @@ internal class MapLifecycleAuthority(
   private val current = AtomicReference<InternalState>(InternalState.OpenDetached(null))
   private val currentStyle = AtomicReference<StyleClaim?>(null)
   private val currentStyleRequest = AtomicReference<StyleRequestClaim?>(null)
-  private val lifecycleGate = AtomicBoolean(false)
+  private val lifecycleLock = reentrantLock()
   private val closure = CompletableDeferred<Result<Unit>>()
 
   val state: MapLifecycleState
@@ -508,16 +510,7 @@ internal class MapLifecycleAuthority(
   }
 
   /** Serializes non-suspending lifecycle commits with callback validation and delivery. */
-  private inline fun <T> serialized(action: () -> T): T {
-    while (!lifecycleGate.compareAndSet(expectedValue = false, newValue = true)) {
-      // Platform callbacks are non-suspending, so the owner releases this gate promptly.
-    }
-    return try {
-      action()
-    } finally {
-      lifecycleGate.store(false)
-    }
-  }
+  private inline fun <T> serialized(action: () -> T): T = lifecycleLock.withLock(action)
 
   private data class StyleClaim(val engine: EngineMapIdentity, val style: StyleIdentity)
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleAuthority.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleAuthority.kt
@@ -1,0 +1,431 @@
+@file:OptIn(ExperimentalAtomicApi::class)
+
+package org.maplibre.compose.map
+
+import kotlin.concurrent.atomics.AtomicBoolean
+import kotlin.concurrent.atomics.AtomicLong
+import kotlin.concurrent.atomics.AtomicReference
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+import kotlin.concurrent.atomics.incrementAndFetch
+import kotlin.jvm.JvmInline
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+
+/** Identifies one platform engine-map instance for exactly as long as that instance is alive. */
+@JvmInline internal value class EngineMapIdentity(private val value: Long)
+
+/** Identifies one temporary attachment of a logical map to a presentation. */
+@JvmInline internal value class RenderLease(private val value: Long)
+
+/** Identifies one loaded base-style generation on one engine map. */
+@JvmInline internal value class StyleIdentity(private val value: Long)
+
+/** Whether detaching a presentation also destroys its engine map. */
+internal enum class EngineRetention {
+  RETAIN,
+  DESTROY,
+}
+
+/** Commands performed for the one authority that owns the logical-map lifecycle. */
+internal interface MapLifecyclePlatformAdapter {
+  val engineRetention: EngineRetention
+
+  suspend fun createEngine(identity: EngineMapIdentity)
+
+  suspend fun attach(identity: EngineMapIdentity, lease: RenderLease)
+
+  suspend fun detach(identity: EngineMapIdentity, lease: RenderLease)
+
+  suspend fun destroyEngine(identity: EngineMapIdentity)
+
+  suspend fun closeResources()
+}
+
+/** The externally observable logical states of one map lifecycle. */
+internal sealed interface MapLifecycleState {
+  data class OpenDetached(val engine: EngineMapIdentity?) : MapLifecycleState
+
+  data class Attaching(val engine: EngineMapIdentity, val lease: RenderLease) : MapLifecycleState
+
+  data class Attached(val engine: EngineMapIdentity, val lease: RenderLease) : MapLifecycleState
+
+  data class Detaching(val engine: EngineMapIdentity, val lease: RenderLease) : MapLifecycleState
+
+  data object Closing : MapLifecycleState
+
+  data object Closed : MapLifecycleState
+}
+
+internal class MapAlreadyAttachedException :
+  IllegalStateException("The map already has a presentation")
+
+internal class MapLeaseInvalidatedException :
+  IllegalStateException("The presentation lease ended before attachment completed")
+
+internal class MapClosedException : IllegalStateException("The map is closed")
+
+internal class MapLifecycleCleanupException internal constructor(val failures: List<Throwable>) :
+  RuntimeException("Map cleanup failed in ${failures.size} resource(s)", failures.first()) {
+  init {
+    failures.drop(1).forEach(::addSuppressed)
+  }
+}
+
+internal data class PendingAttachment(
+  val lease: RenderLease,
+  val completion: CompletableDeferred<Result<RenderLease>>,
+)
+
+/**
+ * The serialized authority for engine creation, leased presentation attachment, and closure.
+ * Platform adapters execute commands but do not decide or mirror the logical state.
+ */
+internal class MapLifecycleAuthority(
+  private val adapter: MapLifecyclePlatformAdapter,
+  private val physicalScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
+) {
+  private val nextIdentity = AtomicLong(0L)
+  private val current = AtomicReference<InternalState>(InternalState.OpenDetached(null))
+  private val currentStyle = AtomicReference<StyleClaim?>(null)
+  private val closure = CompletableDeferred<Result<Unit>>()
+
+  val state: MapLifecycleState
+    get() = current.load().publicState
+
+  val engineIdentity: EngineMapIdentity?
+    get() = current.load().engine
+
+  val renderLease: RenderLease?
+    get() = (current.load() as? InternalState.Attached)?.lease
+
+  val styleIdentity: StyleIdentity?
+    get() = currentStyle.load()?.style
+
+  val acceptsWork: Boolean
+    get() {
+      val observed = current.load()
+      return observed !is InternalState.Closing && observed !== InternalState.Closed
+    }
+
+  /** Claims the next loaded-style generation for [engine], invalidating the preceding one. */
+  fun claimStyleIdentity(engine: EngineMapIdentity): StyleIdentity? {
+    if (!acceptEngineIdentity(engine)) return null
+    val identity = StyleIdentity(nextIdentity.incrementAndFetch())
+    currentStyle.store(StyleClaim(engine, identity))
+    return identity
+  }
+
+  fun invalidateStyleIdentity(engine: EngineMapIdentity): Boolean {
+    if (!acceptEngineIdentity(engine)) return false
+    while (true) {
+      val claimed = currentStyle.load() ?: return true
+      if (claimed.engine != engine) return false
+      if (currentStyle.compareAndSet(claimed, null)) return true
+    }
+  }
+
+  /** Accepts an engine-durable event, including while a retained native engine is detached. */
+  fun acceptEngineEvent(engine: EngineMapIdentity, event: () -> Unit): Boolean {
+    if (!acceptEngineIdentity(engine)) return false
+    event()
+    return true
+  }
+
+  /** Accepts an event only from the current loaded style on the current engine map. */
+  fun acceptStyleEvent(
+    engine: EngineMapIdentity,
+    style: StyleIdentity,
+    event: () -> Unit,
+  ): Boolean {
+    if (!acceptEngineIdentity(engine)) return false
+    if (currentStyle.load() != StyleClaim(engine, style)) return false
+    event()
+    return true
+  }
+
+  private fun acceptEngineIdentity(engine: EngineMapIdentity): Boolean {
+    val observed = current.load()
+    if (observed is InternalState.Closing || observed === InternalState.Closed) return false
+    return observed.engine == engine
+  }
+
+  suspend fun attach(): RenderLease {
+    val request = beginAttach()
+    try {
+      return request.completion.await().getOrThrow()
+    } catch (cancelled: CancellationException) {
+      beginDetach(request.lease)
+      throw cancelled
+    }
+  }
+
+  /** Commits attachment before starting its physical commands. */
+  fun beginAttach(): PendingAttachment {
+    val result = CompletableDeferred<Result<RenderLease>>()
+    val engine = EngineMapIdentity(nextIdentity.incrementAndFetch())
+    val lease = RenderLease(nextIdentity.incrementAndFetch())
+    while (true) {
+      val observed = current.load()
+      when (observed) {
+        is InternalState.OpenDetached -> {
+          val selectedEngine = observed.engine ?: engine
+          val selected =
+            InternalState.Attaching(
+              engine = selectedEngine,
+              lease = lease,
+              result = result,
+              engineCreated = AtomicBoolean(observed.engine != null),
+            )
+          if (!current.compareAndSet(observed, selected)) continue
+          physicalScope.launch(start = CoroutineStart.UNDISPATCHED) {
+            performAttach(selected, observed.engine == null)
+          }
+          return PendingAttachment(lease, result)
+        }
+        is InternalState.Attaching,
+        is InternalState.Attached,
+        is InternalState.Detaching -> throw MapAlreadyAttachedException()
+        is InternalState.Closing,
+        InternalState.Closed -> throw MapClosedException()
+      }
+    }
+  }
+
+  /** Commits logical closure synchronously and starts one cancellation-independent cleanup. */
+  fun close() {
+    while (true) {
+      val observed = current.load()
+      if (observed is InternalState.Closing || observed === InternalState.Closed) return
+      val closing = InternalState.Closing(observed)
+      if (!current.compareAndSet(observed, closing)) continue
+      physicalScope.launch(start = CoroutineStart.UNDISPATCHED) { performClose(closing) }
+      return
+    }
+  }
+
+  /** Waits for every cleanup attempt and reports their combined outcome. */
+  suspend fun awaitClosed() {
+    closure.await().getOrThrow()
+  }
+
+  /** Invalidates [lease] before awaiting physical detachment. Stale leases have no effect. */
+  suspend fun detach(lease: RenderLease): Boolean {
+    val result = beginDetach(lease) ?: return false
+    result.await().getOrThrow()
+    return true
+  }
+
+  private fun beginDetach(lease: RenderLease): CompletableDeferred<Result<Unit>>? {
+    while (true) {
+      val observed = current.load()
+      when (observed) {
+        is InternalState.Attaching -> {
+          if (observed.lease != lease) return null
+          val result = CompletableDeferred<Result<Unit>>()
+          val detaching =
+            InternalState.Detaching(
+              engine = observed.engine,
+              lease = lease,
+              result = result,
+              attachResult = observed.result,
+              engineCreated = observed.engineCreated,
+            )
+          if (!current.compareAndSet(observed, detaching)) continue
+          physicalScope.launch(start = CoroutineStart.UNDISPATCHED) { performDetach(detaching) }
+          return result
+        }
+        is InternalState.Attached -> {
+          if (observed.lease != lease) return null
+          val result = CompletableDeferred<Result<Unit>>()
+          val detaching =
+            InternalState.Detaching(
+              engine = observed.engine,
+              lease = lease,
+              result = result,
+              attachResult = null,
+              engineCreated = null,
+            )
+          if (!current.compareAndSet(observed, detaching)) continue
+          physicalScope.launch(start = CoroutineStart.UNDISPATCHED) { performDetach(detaching) }
+          return result
+        }
+        else -> return null
+      }
+    }
+  }
+
+  /** Accepts a viewport-bound event only for the currently attached engine and lease. */
+  fun acceptPresentationEvent(
+    engine: EngineMapIdentity,
+    lease: RenderLease,
+    event: () -> Unit,
+  ): Boolean {
+    val observed = current.load()
+    if (observed !is InternalState.Attached) return false
+    if (observed.engine != engine || observed.lease != lease) return false
+    event()
+    return true
+  }
+
+  private suspend fun performAttach(attaching: InternalState.Attaching, createEngine: Boolean) {
+    var attachAttempted = false
+    val outcome =
+      try {
+        if (createEngine) {
+          adapter.createEngine(attaching.engine)
+          attaching.engineCreated.store(true)
+        }
+        attachAttempted = true
+        adapter.attach(attaching.engine, attaching.lease)
+        Result.success(attaching.lease)
+      } catch (error: Throwable) {
+        Result.failure(error)
+      }
+    val observed = current.load()
+    if (outcome.isSuccess && observed === attaching) {
+      current.compareAndSet(
+        attaching,
+        InternalState.Attached(attaching.engine, attaching.lease),
+      )
+      attaching.result.complete(outcome)
+    } else if (outcome.isFailure && observed === attaching) {
+      val error = checkNotNull(outcome.exceptionOrNull())
+      if (attachAttempted) {
+        runCatching { adapter.detach(attaching.engine, attaching.lease) }
+          .exceptionOrNull()
+          ?.let(error::addSuppressed)
+      }
+      if (!attaching.engineCreated.load()) {
+        runCatching { adapter.destroyEngine(attaching.engine) }
+          .exceptionOrNull()
+          ?.let(error::addSuppressed)
+      }
+      current.compareAndSet(
+        attaching,
+        InternalState.OpenDetached(attaching.engine.takeIf { attaching.engineCreated.load() }),
+      )
+      attaching.result.complete(Result.failure(error))
+    } else {
+      val invalidated = MapLeaseInvalidatedException()
+      outcome.exceptionOrNull()?.let(invalidated::addSuppressed)
+      attaching.result.complete(Result.failure(invalidated))
+    }
+  }
+
+  private suspend fun performDetach(detaching: InternalState.Detaching) {
+    detaching.attachResult?.await()
+    val failures = mutableListOf<Throwable>()
+    collectFailure(failures) { adapter.detach(detaching.engine, detaching.lease) }
+    val engineCreated = detaching.engineCreated?.load() ?: true
+    val destroyEngine = adapter.engineRetention == EngineRetention.DESTROY || !engineCreated
+    if (destroyEngine) {
+      collectFailure(failures) { adapter.destroyEngine(detaching.engine) }
+      currentStyle.store(null)
+    }
+    val outcome =
+      if (failures.isEmpty()) Result.success(Unit)
+      else Result.failure(MapLifecycleCleanupException(failures))
+    val nextEngine =
+      detaching.engine.takeIf { adapter.engineRetention == EngineRetention.RETAIN && engineCreated }
+    current.compareAndSet(detaching, InternalState.OpenDetached(nextEngine))
+    detaching.result.complete(outcome)
+  }
+
+  private suspend fun performClose(closing: InternalState.Closing) {
+    val previous = closing.previous
+    val failures = mutableListOf<Throwable>()
+
+    when (previous) {
+      is InternalState.Attaching -> {
+        previous.result.await()
+        collectFailure(failures) { adapter.detach(previous.engine, previous.lease) }
+      }
+      is InternalState.Attached ->
+        collectFailure(failures) { adapter.detach(previous.engine, previous.lease) }
+      is InternalState.Detaching ->
+        previous.result.await().exceptionOrNull()?.let { addCleanupFailure(failures, it) }
+      is InternalState.OpenDetached -> Unit
+      is InternalState.Closing,
+      InternalState.Closed -> error("Closure cannot start from ${previous.publicState}")
+    }
+
+    val engine = previous.engine
+    val detachAlreadyDestroyedEngine =
+      previous is InternalState.Detaching && adapter.engineRetention == EngineRetention.DESTROY
+    if (engine != null && !detachAlreadyDestroyedEngine) {
+      collectFailure(failures) { adapter.destroyEngine(engine) }
+    }
+    currentStyle.store(null)
+    collectFailure(failures) { adapter.closeResources() }
+
+    current.compareAndSet(closing, InternalState.Closed)
+    closure.complete(
+      if (failures.isEmpty()) Result.success(Unit)
+      else Result.failure(MapLifecycleCleanupException(failures))
+    )
+  }
+
+  private suspend fun collectFailure(
+    failures: MutableList<Throwable>,
+    cleanup: suspend () -> Unit,
+  ) {
+    runCatching { cleanup() }.exceptionOrNull()?.let(failures::add)
+  }
+
+  private fun addCleanupFailure(failures: MutableList<Throwable>, failure: Throwable) {
+    if (failure is MapLifecycleCleanupException) failures += failure.failures
+    else failures += failure
+  }
+
+  private data class StyleClaim(val engine: EngineMapIdentity, val style: StyleIdentity)
+
+  private sealed interface InternalState {
+    val engine: EngineMapIdentity?
+    val publicState: MapLifecycleState
+
+    data class OpenDetached(override val engine: EngineMapIdentity?) : InternalState {
+      override val publicState = MapLifecycleState.OpenDetached(engine)
+    }
+
+    data class Attaching(
+      override val engine: EngineMapIdentity,
+      val lease: RenderLease,
+      val result: CompletableDeferred<Result<RenderLease>>,
+      val engineCreated: AtomicBoolean,
+    ) : InternalState {
+      override val publicState = MapLifecycleState.Attaching(engine, lease)
+    }
+
+    data class Attached(
+      override val engine: EngineMapIdentity,
+      val lease: RenderLease,
+    ) : InternalState {
+      override val publicState = MapLifecycleState.Attached(engine, lease)
+    }
+
+    data class Detaching(
+      override val engine: EngineMapIdentity,
+      val lease: RenderLease,
+      val result: CompletableDeferred<Result<Unit>>,
+      val attachResult: CompletableDeferred<Result<RenderLease>>?,
+      val engineCreated: AtomicBoolean?,
+    ) : InternalState {
+      override val publicState = MapLifecycleState.Detaching(engine, lease)
+    }
+
+    data class Closing(val previous: InternalState) : InternalState {
+      override val engine: EngineMapIdentity? = previous.engine
+      override val publicState = MapLifecycleState.Closing
+    }
+
+    data object Closed : InternalState {
+      override val engine: EngineMapIdentity? = null
+      override val publicState = MapLifecycleState.Closed
+    }
+  }
+}

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleCallbacks.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleCallbacks.kt
@@ -110,6 +110,9 @@ internal class MapLifecycleCallbacks(
   fun onFrame(engine: EngineMapIdentity, lease: RenderLease, fps: Double) =
     withPresentation(engine, lease) { delegate().onFrame(fps) }
 
+  fun onPresentationEvent(engine: EngineMapIdentity, lease: RenderLease, event: () -> Unit) =
+    withPresentation(engine, lease, event)
+
   private fun withStyle(
     engine: EngineMapIdentity,
     style: StyleIdentity,

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleCallbacks.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleCallbacks.kt
@@ -5,72 +5,103 @@ import org.maplibre.compose.camera.CameraMoveReason
 import org.maplibre.compose.style.StyleBinding
 import org.maplibre.spatialk.geojson.Position
 
-/** Filters platform callbacks through the identities owned by [lifecycle]. */
+/** Filters platform callbacks through identities captured by their platform producer. */
 internal class MapLifecycleCallbacks(
   private val lifecycle: MapLifecycleAuthority,
   private val delegate: () -> MapAdapter.Callbacks,
-) : MapAdapter.Callbacks {
+) {
 
-  override fun onStyleChanged(map: MapAdapter, style: StyleBinding?) {
-    val engine = lifecycle.engineIdentity ?: return
-    if (style == null) {
-      if (lifecycle.invalidateStyleIdentity(engine)) {
-        lifecycle.acceptEngineEvent(engine) { delegate().onStyleChanged(map, null) }
-      }
-      return
-    }
-    val identity = lifecycle.claimStyleIdentity(engine) ?: return
+  fun beginStyleRequest(engine: EngineMapIdentity, map: MapAdapter): StyleRequestIdentity? {
+    val request = lifecycle.claimStyleRequestIdentity(engine) ?: return null
+    lifecycle.acceptStyleRequestEvent(engine, request) { delegate().onStyleChanged(map, null) }
+    return request
+  }
+
+  fun onStyleChanged(
+    engine: EngineMapIdentity,
+    request: StyleRequestIdentity,
+    map: MapAdapter,
+    style: StyleBinding,
+  ): StyleIdentity? {
+    val identity = lifecycle.claimStyleIdentity(engine, request) ?: return null
     lifecycle.acceptStyleEvent(engine, identity) { delegate().onStyleChanged(map, style) }
+    return identity
   }
 
-  override fun onMapFinishedLoading(map: MapAdapter) = withStyle {
-    delegate().onMapFinishedLoading(map)
-  }
+  fun onMapFinishedLoading(engine: EngineMapIdentity, style: StyleIdentity, map: MapAdapter) =
+    withStyle(engine, style) {
+      delegate().onMapFinishedLoading(map)
+    }
 
-  override fun onSourceChanged(map: MapAdapter, sourceId: String?) = withStyle {
-    delegate().onSourceChanged(map, sourceId)
-  }
+  fun onSourceChanged(
+    engine: EngineMapIdentity,
+    style: StyleIdentity,
+    map: MapAdapter,
+    sourceId: String?,
+  ) =
+    withStyle(engine, style) {
+      delegate().onSourceChanged(map, sourceId)
+    }
 
-  override fun onMapFailLoading(reason: String?) = withEngine {
-    delegate().onMapFailLoading(reason)
-  }
+  fun onMapFailLoading(
+    engine: EngineMapIdentity,
+    request: StyleRequestIdentity,
+    reason: String?,
+  ) =
+    lifecycle.acceptStyleRequestEvent(engine, request) {
+      delegate().onMapFailLoading(reason)
+    }
 
-  override fun onCameraMoveStarted(map: MapAdapter, reason: CameraMoveReason) = withPresentation {
-    delegate().onCameraMoveStarted(map, reason)
-  }
+  fun onCameraMoveStarted(
+    engine: EngineMapIdentity,
+    lease: RenderLease,
+    map: MapAdapter,
+    reason: CameraMoveReason,
+  ) =
+    withPresentation(engine, lease) {
+      delegate().onCameraMoveStarted(map, reason)
+    }
 
-  override fun onCameraMoved(map: MapAdapter) = withPresentation {
-    delegate().onCameraMoved(map)
-  }
+  fun onCameraMoved(engine: EngineMapIdentity, lease: RenderLease, map: MapAdapter) =
+    withPresentation(engine, lease) {
+      delegate().onCameraMoved(map)
+    }
 
-  override fun onCameraMoveEnded(map: MapAdapter) = withPresentation {
-    delegate().onCameraMoveEnded(map)
-  }
+  fun onCameraMoveEnded(engine: EngineMapIdentity, lease: RenderLease, map: MapAdapter) =
+    withPresentation(engine, lease) {
+      delegate().onCameraMoveEnded(map)
+    }
 
-  override fun onClick(map: MapAdapter, latLng: Position, offset: DpOffset) = withPresentation {
-    delegate().onClick(map, latLng, offset)
-  }
+  fun onClick(
+    engine: EngineMapIdentity,
+    lease: RenderLease,
+    map: MapAdapter,
+    latLng: Position,
+    offset: DpOffset,
+  ) =
+    withPresentation(engine, lease) {
+      delegate().onClick(map, latLng, offset)
+    }
 
-  override fun onLongClick(map: MapAdapter, latLng: Position, offset: DpOffset) = withPresentation {
-    delegate().onLongClick(map, latLng, offset)
-  }
+  fun onLongClick(
+    engine: EngineMapIdentity,
+    lease: RenderLease,
+    map: MapAdapter,
+    latLng: Position,
+    offset: DpOffset,
+  ) =
+    withPresentation(engine, lease) {
+      delegate().onLongClick(map, latLng, offset)
+    }
 
-  override fun onFrame(fps: Double) = withPresentation { delegate().onFrame(fps) }
+  fun onFrame(engine: EngineMapIdentity, lease: RenderLease, fps: Double) =
+    withPresentation(engine, lease) { delegate().onFrame(fps) }
 
-  private fun withEngine(event: () -> Unit) {
-    val engine = lifecycle.engineIdentity ?: return
-    lifecycle.acceptEngineEvent(engine, event)
-  }
-
-  private fun withStyle(event: () -> Unit) {
-    val engine = lifecycle.engineIdentity ?: return
-    val style = lifecycle.styleIdentity ?: return
+  private fun withStyle(engine: EngineMapIdentity, style: StyleIdentity, event: () -> Unit) {
     lifecycle.acceptStyleEvent(engine, style, event)
   }
 
-  private fun withPresentation(event: () -> Unit) {
-    val engine = lifecycle.engineIdentity ?: return
-    val lease = lifecycle.renderLease ?: return
+  private fun withPresentation(engine: EngineMapIdentity, lease: RenderLease, event: () -> Unit) {
     lifecycle.acceptPresentationEvent(engine, lease, event)
   }
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleCallbacks.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleCallbacks.kt
@@ -23,9 +23,7 @@ internal class MapLifecycleCallbacks(
     map: MapAdapter,
     style: StyleBinding,
   ): StyleIdentity? {
-    val identity = lifecycle.claimStyleIdentity(engine, request) ?: return null
-    lifecycle.acceptStyleEvent(engine, identity) { delegate().onStyleChanged(map, style) }
-    return identity
+    return lifecycle.claimStyleIdentity(engine, request) { delegate().onStyleChanged(map, style) }
   }
 
   fun onMapFinishedLoading(engine: EngineMapIdentity, style: StyleIdentity, map: MapAdapter) =
@@ -62,14 +60,29 @@ internal class MapLifecycleCallbacks(
       delegate().onCameraMoveStarted(map, reason)
     }
 
-  fun onCameraMoved(engine: EngineMapIdentity, lease: RenderLease, map: MapAdapter) =
+  fun onCameraMoved(
+    engine: EngineMapIdentity,
+    lease: RenderLease,
+    map: MapAdapter,
+    beforeDelegate: () -> Unit = {},
+  ) =
     withPresentation(engine, lease) {
+      beforeDelegate()
       delegate().onCameraMoved(map)
     }
 
-  fun onCameraMoveEnded(engine: EngineMapIdentity, lease: RenderLease, map: MapAdapter) =
+  fun onCameraMoveEnded(
+    engine: EngineMapIdentity,
+    lease: RenderLease,
+    map: MapAdapter,
+    afterDelegate: () -> Unit = {},
+  ) =
     withPresentation(engine, lease) {
-      delegate().onCameraMoveEnded(map)
+      try {
+        delegate().onCameraMoveEnded(map)
+      } finally {
+        afterDelegate()
+      }
     }
 
   fun onClick(

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleCallbacks.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleCallbacks.kt
@@ -1,0 +1,76 @@
+package org.maplibre.compose.map
+
+import androidx.compose.ui.unit.DpOffset
+import org.maplibre.compose.camera.CameraMoveReason
+import org.maplibre.compose.style.StyleBinding
+import org.maplibre.spatialk.geojson.Position
+
+/** Filters platform callbacks through the identities owned by [lifecycle]. */
+internal class MapLifecycleCallbacks(
+  private val lifecycle: MapLifecycleAuthority,
+  private val delegate: () -> MapAdapter.Callbacks,
+) : MapAdapter.Callbacks {
+
+  override fun onStyleChanged(map: MapAdapter, style: StyleBinding?) {
+    val engine = lifecycle.engineIdentity ?: return
+    if (style == null) {
+      if (lifecycle.invalidateStyleIdentity(engine)) {
+        lifecycle.acceptEngineEvent(engine) { delegate().onStyleChanged(map, null) }
+      }
+      return
+    }
+    val identity = lifecycle.claimStyleIdentity(engine) ?: return
+    lifecycle.acceptStyleEvent(engine, identity) { delegate().onStyleChanged(map, style) }
+  }
+
+  override fun onMapFinishedLoading(map: MapAdapter) = withStyle {
+    delegate().onMapFinishedLoading(map)
+  }
+
+  override fun onSourceChanged(map: MapAdapter, sourceId: String?) = withStyle {
+    delegate().onSourceChanged(map, sourceId)
+  }
+
+  override fun onMapFailLoading(reason: String?) = withEngine {
+    delegate().onMapFailLoading(reason)
+  }
+
+  override fun onCameraMoveStarted(map: MapAdapter, reason: CameraMoveReason) = withPresentation {
+    delegate().onCameraMoveStarted(map, reason)
+  }
+
+  override fun onCameraMoved(map: MapAdapter) = withPresentation {
+    delegate().onCameraMoved(map)
+  }
+
+  override fun onCameraMoveEnded(map: MapAdapter) = withPresentation {
+    delegate().onCameraMoveEnded(map)
+  }
+
+  override fun onClick(map: MapAdapter, latLng: Position, offset: DpOffset) = withPresentation {
+    delegate().onClick(map, latLng, offset)
+  }
+
+  override fun onLongClick(map: MapAdapter, latLng: Position, offset: DpOffset) = withPresentation {
+    delegate().onLongClick(map, latLng, offset)
+  }
+
+  override fun onFrame(fps: Double) = withPresentation { delegate().onFrame(fps) }
+
+  private fun withEngine(event: () -> Unit) {
+    val engine = lifecycle.engineIdentity ?: return
+    lifecycle.acceptEngineEvent(engine, event)
+  }
+
+  private fun withStyle(event: () -> Unit) {
+    val engine = lifecycle.engineIdentity ?: return
+    val style = lifecycle.styleIdentity ?: return
+    lifecycle.acceptStyleEvent(engine, style, event)
+  }
+
+  private fun withPresentation(event: () -> Unit) {
+    val engine = lifecycle.engineIdentity ?: return
+    val lease = lifecycle.renderLease ?: return
+    lifecycle.acceptPresentationEvent(engine, lease, event)
+  }
+}

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleCallbacks.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleCallbacks.kt
@@ -97,11 +97,15 @@ internal class MapLifecycleCallbacks(
   fun onFrame(engine: EngineMapIdentity, lease: RenderLease, fps: Double) =
     withPresentation(engine, lease) { delegate().onFrame(fps) }
 
-  private fun withStyle(engine: EngineMapIdentity, style: StyleIdentity, event: () -> Unit) {
-    lifecycle.acceptStyleEvent(engine, style, event)
-  }
+  private fun withStyle(
+    engine: EngineMapIdentity,
+    style: StyleIdentity,
+    event: () -> Unit,
+  ): Boolean = lifecycle.acceptStyleEvent(engine, style, event)
 
-  private fun withPresentation(engine: EngineMapIdentity, lease: RenderLease, event: () -> Unit) {
-    lifecycle.acceptPresentationEvent(engine, lease, event)
-  }
+  private fun withPresentation(
+    engine: EngineMapIdentity,
+    lease: RenderLease,
+    event: () -> Unit,
+  ): Boolean = lifecycle.acceptPresentationEvent(engine, lease, event)
 }

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapLifecycleAuthorityTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapLifecycleAuthorityTest.kt
@@ -1,0 +1,350 @@
+package org.maplibre.compose.map
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MapLifecycleAuthorityTest {
+
+  @Test
+  fun a_map_attaches_with_an_engine_identity_and_render_lease() = runTest {
+    val adapter = FakeMapLifecycleAdapter()
+    val lifecycle = MapLifecycleAuthority(adapter, backgroundScope)
+
+    assertEquals(MapLifecycleState.OpenDetached(null), lifecycle.state)
+
+    val lease = lifecycle.attach()
+
+    val engine = lifecycle.engineIdentity
+    assertEquals(MapLifecycleState.Attached(checkNotNull(engine), lease), lifecycle.state)
+    assertEquals(listOf("create $engine", "attach $engine $lease"), adapter.commands)
+  }
+
+  @Test
+  fun a_rival_attachment_fails_without_waiting_or_changing_platform_state() = runTest {
+    val adapter = FakeMapLifecycleAdapter().apply { allowAttach = CompletableDeferred() }
+    val lifecycle = MapLifecycleAuthority(adapter, backgroundScope)
+    val first = async { lifecycle.attach() }
+    adapter.attachStarted.await()
+
+    assertFailsWith<MapAlreadyAttachedException> { lifecycle.attach() }
+    assertTrue(lifecycle.state is MapLifecycleState.Attaching)
+    assertEquals(2, adapter.commands.size)
+
+    adapter.allowAttach.complete(Unit)
+    first.await()
+  }
+
+  @Test
+  fun detaching_invalidates_the_lease_before_retained_engine_cleanup_finishes() = runTest {
+    val adapter = FakeMapLifecycleAdapter()
+    val lifecycle = MapLifecycleAuthority(adapter, backgroundScope)
+    val lease = lifecycle.attach()
+    val engine = checkNotNull(lifecycle.engineIdentity)
+    adapter.allowDetach = CompletableDeferred()
+
+    val detach = async { lifecycle.detach(lease) }
+    adapter.detachStarted.await()
+
+    assertEquals(MapLifecycleState.Detaching(engine, lease), lifecycle.state)
+    assertTrue(!lifecycle.acceptPresentationEvent(engine, lease) { error("stale event ran") })
+    assertFailsWith<MapAlreadyAttachedException> { lifecycle.attach() }
+
+    adapter.allowDetach.complete(Unit)
+    assertTrue(detach.await())
+    assertEquals(MapLifecycleState.OpenDetached(engine), lifecycle.state)
+  }
+
+  @Test
+  fun attach_failure_cleans_partial_resources_and_returns_to_open_detached() = runTest {
+    val adapter = FakeMapLifecycleAdapter().apply { attachFailure = TestFailure("attach") }
+    val lifecycle = MapLifecycleAuthority(adapter, backgroundScope)
+
+    assertFailsWith<TestFailure> { lifecycle.attach() }
+
+    val engine = checkNotNull(lifecycle.engineIdentity)
+    assertEquals(MapLifecycleState.OpenDetached(engine), lifecycle.state)
+    assertEquals(
+      listOf(
+        "create $engine",
+        "attach $engine ${adapter.lastLease}",
+        "detach $engine ${adapter.lastLease}",
+      ),
+      adapter.commands,
+    )
+  }
+
+  @Test
+  fun detach_during_attach_invalidates_the_lease_and_cleans_the_partial_attachment() = runTest {
+    val adapter = FakeMapLifecycleAdapter().apply { allowAttach = CompletableDeferred() }
+    val lifecycle = MapLifecycleAuthority(adapter, backgroundScope)
+    val attaching = async { runCatching { lifecycle.attach() } }
+    adapter.attachStarted.await()
+    val state = lifecycle.state as MapLifecycleState.Attaching
+
+    val detaching = async { lifecycle.detach(state.lease) }
+    runCurrent()
+
+    assertEquals(MapLifecycleState.Detaching(state.engine, state.lease), lifecycle.state)
+    adapter.allowAttach.complete(Unit)
+    assertTrue(detaching.await())
+    assertTrue(attaching.await().exceptionOrNull() is MapLeaseInvalidatedException)
+    assertEquals(MapLifecycleState.OpenDetached(state.engine), lifecycle.state)
+    assertEquals(1, adapter.commands.count { it.startsWith("detach ") })
+  }
+
+  @Test
+  fun close_commits_immediately_and_repeated_callers_join_one_cleanup() = runTest {
+    val adapter = FakeMapLifecycleAdapter().apply { allowDetach = CompletableDeferred() }
+    val lifecycle = MapLifecycleAuthority(adapter, backgroundScope)
+    val lease = lifecycle.attach()
+    val engine = checkNotNull(lifecycle.engineIdentity)
+    val style = checkNotNull(lifecycle.claimStyleIdentity(engine))
+
+    lifecycle.close()
+    lifecycle.close()
+
+    assertEquals(MapLifecycleState.Closing, lifecycle.state)
+    assertFailsWith<MapClosedException> { lifecycle.attach() }
+    assertTrue(!lifecycle.acceptEngineEvent(engine) { error("closed engine event ran") })
+    assertTrue(!lifecycle.acceptStyleEvent(engine, style) { error("closed style event ran") })
+    assertTrue(!lifecycle.acceptPresentationEvent(engine, lease) { error("closed event ran") })
+    adapter.detachStarted.await()
+    adapter.allowDetach.complete(Unit)
+    lifecycle.awaitClosed()
+
+    assertEquals(MapLifecycleState.Closed, lifecycle.state)
+    assertEquals(1, adapter.commands.count { it.startsWith("detach ") })
+    assertEquals(1, adapter.commands.count { it.startsWith("destroy ") })
+    assertEquals(1, adapter.commands.count { it == "close resources" })
+  }
+
+  @Test
+  fun cleanup_attempts_every_resource_and_await_closed_reports_every_failure() = runTest {
+    val adapter =
+      FakeMapLifecycleAdapter().apply {
+        detachFailure = TestFailure("detach")
+        destroyFailure = TestFailure("engine")
+        resourcesFailure = TestFailure("resources")
+      }
+    val lifecycle = MapLifecycleAuthority(adapter, backgroundScope)
+    lifecycle.attach()
+
+    lifecycle.close()
+    val failure = assertFailsWith<MapLifecycleCleanupException> { lifecycle.awaitClosed() }
+
+    assertEquals(listOf("detach", "engine", "resources"), failure.failures.map { it.message })
+    assertIs<MapLifecycleState.Closed>(lifecycle.state)
+  }
+
+  @Test
+  fun cancelling_an_attach_caller_invalidates_the_lease_but_physical_cleanup_continues() = runTest {
+    val adapter = FakeMapLifecycleAdapter().apply { allowAttach = CompletableDeferred() }
+    val lifecycle = MapLifecycleAuthority(adapter, backgroundScope)
+    val caller = async { lifecycle.attach() }
+    adapter.attachStarted.await()
+    val attaching = lifecycle.state as MapLifecycleState.Attaching
+
+    caller.cancelAndJoin()
+    adapter.allowAttach.complete(Unit)
+    runCurrent()
+
+    assertEquals(MapLifecycleState.OpenDetached(attaching.engine), lifecycle.state)
+    assertEquals(1, adapter.commands.count { it.startsWith("detach ") })
+  }
+
+  @Test
+  fun durable_engine_and_current_style_events_are_accepted_while_native_is_detached() = runTest {
+    val lifecycle = MapLifecycleAuthority(FakeMapLifecycleAdapter(), backgroundScope)
+    val lease = lifecycle.attach()
+    val engine = checkNotNull(lifecycle.engineIdentity)
+    val firstStyle = checkNotNull(lifecycle.claimStyleIdentity(engine))
+    val currentStyle = checkNotNull(lifecycle.claimStyleIdentity(engine))
+    lifecycle.detach(lease)
+    val accepted = mutableListOf<String>()
+
+    assertTrue(lifecycle.acceptEngineEvent(engine) { accepted += "engine" })
+    assertTrue(!lifecycle.acceptStyleEvent(engine, firstStyle) { accepted += "stale style" })
+    assertTrue(lifecycle.acceptStyleEvent(engine, currentStyle) { accepted += "style" })
+    assertTrue(!lifecycle.acceptPresentationEvent(engine, lease) { accepted += "presentation" })
+
+    assertEquals(listOf("engine", "style"), accepted)
+  }
+
+  @Test
+  fun close_joins_a_failing_detach_and_still_attempts_engine_and_resource_cleanup() = runTest {
+    val adapter =
+      FakeMapLifecycleAdapter().apply {
+        allowDetach = CompletableDeferred()
+        detachFailure = TestFailure("detach")
+      }
+    val lifecycle = MapLifecycleAuthority(adapter, backgroundScope)
+    val lease = lifecycle.attach()
+    val detaching = async { runCatching { lifecycle.detach(lease) } }
+    adapter.detachStarted.await()
+
+    lifecycle.close()
+    adapter.allowDetach.complete(Unit)
+    val failure = assertFailsWith<MapLifecycleCleanupException> { lifecycle.awaitClosed() }
+
+    assertEquals(listOf("detach"), failure.failures.map { it.message })
+    assertTrue(detaching.await().isFailure)
+    assertEquals(1, adapter.commands.count { it.startsWith("destroy ") })
+    assertTrue("close resources" in adapter.commands)
+  }
+
+  @Test
+  fun destroying_detach_invalidates_engine_and_style_identities_before_reattachment() = runTest {
+    val adapter = FakeMapLifecycleAdapter().apply { retention = EngineRetention.DESTROY }
+    val lifecycle = MapLifecycleAuthority(adapter, backgroundScope)
+    val firstLease = lifecycle.attach()
+    val firstEngine = checkNotNull(lifecycle.engineIdentity)
+    val firstStyle = checkNotNull(lifecycle.claimStyleIdentity(firstEngine))
+
+    lifecycle.detach(firstLease)
+
+    assertEquals(MapLifecycleState.OpenDetached(null), lifecycle.state)
+    assertTrue(!lifecycle.acceptEngineEvent(firstEngine) { error("destroyed engine event ran") })
+    assertTrue(
+      !lifecycle.acceptStyleEvent(firstEngine, firstStyle) { error("destroyed style event ran") }
+    )
+
+    lifecycle.attach()
+    assertTrue(lifecycle.engineIdentity != firstEngine)
+  }
+
+  @Test
+  fun a_departed_lease_cannot_detach_a_later_presentation() = runTest {
+    val adapter = FakeMapLifecycleAdapter()
+    val lifecycle = MapLifecycleAuthority(adapter, backgroundScope)
+    val departed = lifecycle.attach()
+    lifecycle.detach(departed)
+    val current = lifecycle.attach()
+    val commandsBeforeStaleDetach = adapter.commands.toList()
+
+    assertTrue(!lifecycle.detach(departed))
+
+    val state = assertIs<MapLifecycleState.Attached>(lifecycle.state)
+    assertEquals(current, state.lease)
+    assertEquals(commandsBeforeStaleDetach, adapter.commands)
+  }
+
+  @Test
+  fun close_during_attach_invalidates_the_lease_and_joins_its_cleanup() = runTest {
+    val adapter = FakeMapLifecycleAdapter().apply { allowAttach = CompletableDeferred() }
+    val lifecycle = MapLifecycleAuthority(adapter, backgroundScope)
+    val attaching = async { runCatching { lifecycle.attach() } }
+    adapter.attachStarted.await()
+
+    lifecycle.close()
+    adapter.allowAttach.complete(Unit)
+    lifecycle.awaitClosed()
+
+    assertTrue(attaching.await().exceptionOrNull() is MapLeaseInvalidatedException)
+    assertEquals(MapLifecycleState.Closed, lifecycle.state)
+    assertEquals(1, adapter.commands.count { it.startsWith("detach ") })
+    assertEquals(1, adapter.commands.count { it.startsWith("destroy ") })
+  }
+
+  @Test
+  fun closing_a_never_attached_map_still_exposes_closing_until_shared_cleanup_finishes() = runTest {
+    val adapter = FakeMapLifecycleAdapter().apply { allowResources = CompletableDeferred() }
+    val lifecycle = MapLifecycleAuthority(adapter, backgroundScope)
+
+    lifecycle.close()
+
+    assertEquals(MapLifecycleState.Closing, lifecycle.state)
+    adapter.allowResources.complete(Unit)
+    lifecycle.awaitClosed()
+    assertEquals(MapLifecycleState.Closed, lifecycle.state)
+    assertEquals(listOf("close resources"), adapter.commands)
+  }
+
+  @Test
+  fun detach_during_failed_engine_creation_cleans_partial_engine_resources() = runTest {
+    val adapter =
+      FakeMapLifecycleAdapter().apply {
+        allowCreate = CompletableDeferred()
+        createFailure = TestFailure("create")
+      }
+    val lifecycle = MapLifecycleAuthority(adapter, backgroundScope)
+    val attaching = async { runCatching { lifecycle.attach() } }
+    adapter.createStarted.await()
+    val lease = (lifecycle.state as MapLifecycleState.Attaching).lease
+    val detaching = async { lifecycle.detach(lease) }
+    runCurrent()
+
+    adapter.allowCreate.complete(Unit)
+
+    assertTrue(detaching.await())
+    assertTrue(attaching.await().exceptionOrNull() is MapLeaseInvalidatedException)
+    assertEquals(MapLifecycleState.OpenDetached(null), lifecycle.state)
+    assertEquals(1, adapter.commands.count { it.startsWith("destroy ") })
+  }
+}
+
+private class FakeMapLifecycleAdapter : MapLifecyclePlatformAdapter {
+  val commands = mutableListOf<String>()
+  val createStarted = CompletableDeferred<Unit>()
+  val attachStarted = CompletableDeferred<Unit>()
+  val detachStarted = CompletableDeferred<Unit>()
+  var allowCreate = CompletableDeferred(Unit)
+  var allowAttach = CompletableDeferred(Unit)
+  var allowDetach = CompletableDeferred(Unit)
+  var allowResources = CompletableDeferred(Unit)
+  var createFailure: Throwable? = null
+  var attachFailure: Throwable? = null
+  var detachFailure: Throwable? = null
+  var destroyFailure: Throwable? = null
+  var resourcesFailure: Throwable? = null
+  var lastLease: RenderLease? = null
+
+  var retention = EngineRetention.RETAIN
+
+  override val engineRetention: EngineRetention
+    get() = retention
+
+  override suspend fun createEngine(identity: EngineMapIdentity) {
+    commands += "create $identity"
+    createStarted.complete(Unit)
+    allowCreate.await()
+    createFailure?.let { throw it }
+  }
+
+  override suspend fun attach(identity: EngineMapIdentity, lease: RenderLease) {
+    commands += "attach $identity $lease"
+    lastLease = lease
+    attachStarted.complete(Unit)
+    allowAttach.await()
+    attachFailure?.let { throw it }
+  }
+
+  override suspend fun detach(identity: EngineMapIdentity, lease: RenderLease) {
+    commands += "detach $identity $lease"
+    detachStarted.complete(Unit)
+    allowDetach.await()
+    detachFailure?.let { throw it }
+  }
+
+  override suspend fun destroyEngine(identity: EngineMapIdentity) {
+    commands += "destroy $identity"
+    destroyFailure?.let { throw it }
+  }
+
+  override suspend fun closeResources() {
+    commands += "close resources"
+    allowResources.await()
+    resourcesFailure?.let { throw it }
+  }
+}
+
+private class TestFailure(message: String) : RuntimeException(message)

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapLifecycleAuthorityTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapLifecycleAuthorityTest.kt
@@ -179,7 +179,8 @@ class MapLifecycleAuthorityTest {
 
   @Test
   fun durable_engine_and_current_style_events_are_accepted_while_native_is_detached() = runTest {
-    val lifecycle = MapLifecycleAuthority(FakeMapLifecycleAdapter(), backgroundScope)
+    val adapter = FakeMapLifecycleAdapter()
+    val lifecycle = MapLifecycleAuthority(adapter, backgroundScope)
     val lease = lifecycle.attach()
     val engine = checkNotNull(lifecycle.engineIdentity)
     val firstStyle = lifecycle.claimStyle(engine)
@@ -187,12 +188,31 @@ class MapLifecycleAuthorityTest {
     lifecycle.detach(lease)
     val accepted = mutableListOf<String>()
 
-    assertTrue(lifecycle.acceptEngineEvent(engine) { accepted += "engine" })
-    assertTrue(!lifecycle.acceptStyleEvent(engine, firstStyle) { accepted += "stale style" })
-    assertTrue(lifecycle.acceptStyleEvent(engine, currentStyle) { accepted += "style" })
-    assertTrue(!lifecycle.acceptPresentationEvent(engine, lease) { accepted += "presentation" })
+    assertTrue(adapter.emitEngineEvent(lifecycle, engine) { accepted += "engine" })
+    assertTrue(!adapter.emitStyleEvent(lifecycle, engine, firstStyle) { accepted += "stale style" })
+    assertTrue(adapter.emitStyleEvent(lifecycle, engine, currentStyle) { accepted += "style" })
+    assertTrue(
+      !adapter.emitPresentationEvent(lifecycle, engine, lease) { accepted += "presentation" }
+    )
 
     assertEquals(listOf("engine", "style"), accepted)
+  }
+
+  @Test
+  fun the_fake_rejects_a_superseded_style_request_identity() = runTest {
+    val adapter = FakeMapLifecycleAdapter()
+    val lifecycle = MapLifecycleAuthority(adapter, backgroundScope)
+    lifecycle.attach()
+    val engine = checkNotNull(lifecycle.engineIdentity)
+    val superseded = checkNotNull(lifecycle.claimStyleRequestIdentity(engine))
+    val current = checkNotNull(lifecycle.claimStyleRequestIdentity(engine))
+    val accepted = mutableListOf<String>()
+
+    assertTrue(
+      !adapter.emitStyleRequestEvent(lifecycle, engine, superseded) { accepted += "superseded" }
+    )
+    assertTrue(adapter.emitStyleRequestEvent(lifecycle, engine, current) { accepted += "current" })
+    assertEquals(listOf("current"), accepted)
   }
 
   @Test
@@ -381,6 +401,33 @@ private class FakeMapLifecycleAdapter : MapLifecyclePlatformAdapter {
     allowResources.await()
     resourcesFailure?.let { throw it }
   }
+
+  fun emitEngineEvent(
+    lifecycle: MapLifecycleAuthority,
+    engine: EngineMapIdentity,
+    event: () -> Unit,
+  ): Boolean = lifecycle.acceptEngineEvent(engine, event)
+
+  fun emitStyleEvent(
+    lifecycle: MapLifecycleAuthority,
+    engine: EngineMapIdentity,
+    style: StyleIdentity,
+    event: () -> Unit,
+  ): Boolean = lifecycle.acceptStyleEvent(engine, style, event)
+
+  fun emitStyleRequestEvent(
+    lifecycle: MapLifecycleAuthority,
+    engine: EngineMapIdentity,
+    request: StyleRequestIdentity,
+    event: () -> Unit,
+  ): Boolean = lifecycle.acceptStyleRequestEvent(engine, request, event)
+
+  fun emitPresentationEvent(
+    lifecycle: MapLifecycleAuthority,
+    engine: EngineMapIdentity,
+    lease: RenderLease,
+    event: () -> Unit,
+  ): Boolean = lifecycle.acceptPresentationEvent(engine, lease, event)
 }
 
 private class TestFailure(message: String) : RuntimeException(message)

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapLifecycleAuthorityTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapLifecycleAuthorityTest.kt
@@ -84,6 +84,21 @@ class MapLifecycleAuthorityTest {
   }
 
   @Test
+  fun destroy_on_detach_policy_destroys_an_engine_after_attach_failure() = runTest {
+    val adapter =
+      FakeMapLifecycleAdapter().apply {
+        retention = EngineRetention.DESTROY
+        attachFailure = TestFailure("attach")
+      }
+    val lifecycle = MapLifecycleAuthority(adapter, backgroundScope)
+
+    assertFailsWith<TestFailure> { lifecycle.attach() }
+
+    assertEquals(MapLifecycleState.OpenDetached(null), lifecycle.state)
+    assertEquals(1, adapter.commands.count { it.startsWith("destroy ") })
+  }
+
+  @Test
   fun detach_during_attach_invalidates_the_lease_and_cleans_the_partial_attachment() = runTest {
     val adapter = FakeMapLifecycleAdapter().apply { allowAttach = CompletableDeferred() }
     val lifecycle = MapLifecycleAuthority(adapter, backgroundScope)
@@ -108,7 +123,7 @@ class MapLifecycleAuthorityTest {
     val lifecycle = MapLifecycleAuthority(adapter, backgroundScope)
     val lease = lifecycle.attach()
     val engine = checkNotNull(lifecycle.engineIdentity)
-    val style = checkNotNull(lifecycle.claimStyleIdentity(engine))
+    val style = lifecycle.claimStyle(engine)
 
     lifecycle.close()
     lifecycle.close()
@@ -167,8 +182,8 @@ class MapLifecycleAuthorityTest {
     val lifecycle = MapLifecycleAuthority(FakeMapLifecycleAdapter(), backgroundScope)
     val lease = lifecycle.attach()
     val engine = checkNotNull(lifecycle.engineIdentity)
-    val firstStyle = checkNotNull(lifecycle.claimStyleIdentity(engine))
-    val currentStyle = checkNotNull(lifecycle.claimStyleIdentity(engine))
+    val firstStyle = lifecycle.claimStyle(engine)
+    val currentStyle = lifecycle.claimStyle(engine)
     lifecycle.detach(lease)
     val accepted = mutableListOf<String>()
 
@@ -208,7 +223,7 @@ class MapLifecycleAuthorityTest {
     val lifecycle = MapLifecycleAuthority(adapter, backgroundScope)
     val firstLease = lifecycle.attach()
     val firstEngine = checkNotNull(lifecycle.engineIdentity)
-    val firstStyle = checkNotNull(lifecycle.claimStyleIdentity(firstEngine))
+    val firstStyle = lifecycle.claimStyle(firstEngine)
 
     lifecycle.detach(firstLease)
 
@@ -220,6 +235,27 @@ class MapLifecycleAuthorityTest {
 
     lifecycle.attach()
     assertTrue(lifecycle.engineIdentity != firstEngine)
+  }
+
+  @Test
+  fun destroy_on_detach_engine_replacement_keeps_the_lease_but_changes_engine_identity() = runTest {
+    val adapter = FakeMapLifecycleAdapter().apply { retention = EngineRetention.DESTROY }
+    val lifecycle = MapLifecycleAuthority(adapter, backgroundScope)
+    val lease = lifecycle.attach()
+    val departedEngine = checkNotNull(lifecycle.engineIdentity)
+    val departedStyle = lifecycle.claimStyle(departedEngine)
+
+    assertTrue(lifecycle.beginEngineReplacement(departedEngine, lease))
+
+    val replacement = assertIs<MapLifecycleState.Attached>(lifecycle.state)
+    assertEquals(lease, replacement.lease)
+    assertTrue(replacement.engine != departedEngine)
+    assertTrue(!lifecycle.acceptEngineEvent(departedEngine) { error("departed engine event ran") })
+    assertTrue(
+      !lifecycle.acceptStyleEvent(departedEngine, departedStyle) {
+        error("departed style event ran")
+      }
+    )
   }
 
   @Test
@@ -348,3 +384,8 @@ private class FakeMapLifecycleAdapter : MapLifecyclePlatformAdapter {
 }
 
 private class TestFailure(message: String) : RuntimeException(message)
+
+private fun MapLifecycleAuthority.claimStyle(engine: EngineMapIdentity): StyleIdentity {
+  val request = checkNotNull(claimStyleRequestIdentity(engine))
+  return checkNotNull(claimStyleIdentity(engine, request))
+}

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsModule.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsModule.kt
@@ -28,6 +28,8 @@ internal external class MaplibreMap(options: MapOptions) {
 
   fun on(type: String, listener: (event: MapEvent) -> Unit): Subscription
 
+  fun fire(type: String, properties: Any)
+
   fun getCanvas(): HTMLCanvasElement
 
   fun setPixelRatio(pixelRatio: Double)

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
@@ -33,6 +33,7 @@ import org.maplibre.compose.gljs.GlJsFrameTarget
 import org.maplibre.compose.gljs.GlJsMapRenderer
 import org.maplibre.compose.gljs.GlJsRenderTarget
 import org.maplibre.compose.gljs.GlJsRuntime
+import org.maplibre.compose.gljs.GlJsSubscription
 import org.maplibre.compose.gljs.GlJsSurfaceSession
 import org.maplibre.compose.gljs.JumpToOptions
 import org.maplibre.compose.gljs.MapEvent
@@ -568,6 +569,7 @@ internal class GlJsMapSession(
         errorSubscription.cancel()
         if (styleLoadSubscription === loadSubscription) styleLoadSubscription = null
         if (styleErrorSubscription === errorSubscription) styleErrorSubscription = null
+        styleLoadPending = false
         val binding = GlJsStyleBinding(map, logger) { appliedExtent.scaleFactor.toFloat() }
         if (styleLoadTracker?.loaded(trackerRequest, binding.identity) != true) {
           binding.invalidate()
@@ -615,16 +617,20 @@ internal class GlJsMapSession(
         if (styleLoadSubscription === loadSubscription) styleLoadSubscription = null
         if (styleErrorSubscription === errorSubscription) styleErrorSubscription = null
         val reason = event.error?.message ?: "MapLibre failed to load the map"
-        if (
+        styleLoadPending = false
+        val accepted =
           styleLoadTracker?.failed(
             trackerRequest,
             TrackedStyleLoadState.Failed.Stage.BASE_STYLE,
             reason,
-          ) == true && lifecycleCallbacks.onMapFailLoading(engine, lifecycleRequest, reason)
-        ) {
-          styleLoadPending = false
-          logger?.e { "Map loading failed: $reason" }
-          if (!hasLoadedInitialStyle) abandonPending(pendingInitialStyleActions)
+          ) == true
+        if (accepted) {
+          if (lifecycleCallbacks.onMapFailLoading(engine, lifecycleRequest, reason)) {
+            logger?.e { "Map loading failed: $reason" }
+            if (!hasLoadedInitialStyle) abandonPending(pendingInitialStyleActions)
+          }
+        } else {
+          applyRequestedStyle(map)
         }
       }
     styleLoadSubscription = loadSubscription

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
@@ -90,6 +90,10 @@ internal class GlJsMapSession(
   internal var callbacks: MapAdapter.Callbacks = callbacks
   private val lifecycle = MapLifecycleAuthority(this)
   private val lifecycleCallbacks = MapLifecycleCallbacks(lifecycle) { this.callbacks }
+  private var lifecycleEngineIdentity: EngineMapIdentity? = null
+  private var lifecycleRenderLease: RenderLease? = null
+  private var lifecycleStyleRequestIdentity: StyleRequestIdentity? = null
+  private var lifecycleStyleIdentity: StyleIdentity? = null
 
   override val engineRetention: EngineRetention = EngineRetention.DESTROY
 
@@ -156,7 +160,9 @@ internal class GlJsMapSession(
 
   override fun onSurfaceLost() {
     // The map's context belongs to the surface, so it cannot outlive it.
-    destroyMap()
+    val engine = lifecycleEngineIdentity
+    val lease = lifecycleRenderLease
+    if (engine != null && lease != null) lifecycle.beginEngineReplacement(engine, lease)
     surface = null
   }
 
@@ -227,13 +233,25 @@ internal class GlJsMapSession(
     }
   }
 
-  override suspend fun createEngine(identity: EngineMapIdentity) = Unit
+  override suspend fun createEngine(identity: EngineMapIdentity) {
+    lifecycleEngineIdentity = identity
+    lifecycleStyleRequestIdentity = lifecycle.claimStyleRequestIdentity(identity)
+  }
 
-  override suspend fun attach(identity: EngineMapIdentity, lease: RenderLease) = Unit
+  override suspend fun attach(identity: EngineMapIdentity, lease: RenderLease) {
+    lifecycleRenderLease = lease
+  }
 
-  override suspend fun detach(identity: EngineMapIdentity, lease: RenderLease) = Unit
+  override suspend fun detach(identity: EngineMapIdentity, lease: RenderLease) {
+    if (lifecycleRenderLease == lease) lifecycleRenderLease = null
+  }
 
   override suspend fun destroyEngine(identity: EngineMapIdentity) {
+    if (lifecycleEngineIdentity == identity) {
+      lifecycleEngineIdentity = null
+      lifecycleStyleRequestIdentity = null
+      lifecycleStyleIdentity = null
+    }
     destroyMap()
   }
 
@@ -293,7 +311,9 @@ internal class GlJsMapSession(
       GlJsRuntime.redirectDefaultFramebuffer(created.painter.context) { framebuffer }
     }
     GlJsRuntime.interceptRepaintRequests(created) { surface?.requestFrame() }
-    wireEvents(created)
+    val engine = lifecycleEngineIdentity ?: return null
+    val lease = lifecycleRenderLease ?: return null
+    wireEvents(created, engine, lease)
 
     map = created
     hasLoadedInitialStyle = false
@@ -308,7 +328,7 @@ internal class GlJsMapSession(
     hasLoadedInitialStyle = false
     val current = map ?: return
     map = null
-    lifecycleCallbacks.onStyleChanged(this, null)
+    callbacks.onStyleChanged(this, null)
     styleBinding?.invalidate()
     styleBinding = null
     appliedStyle = null
@@ -340,7 +360,9 @@ internal class GlJsMapSession(
     map.resize()
     // resize() may also fire `move`; a second onCameraMoved is how overlays learn the viewport
     // changed when the camera position did not.
-    lifecycleCallbacks.onCameraMoved(this)
+    withLifecyclePresentation { engine, lease ->
+      lifecycleCallbacks.onCameraMoved(engine, lease, this)
+    }
   }
 
   private fun maxTextureSize(gl: dynamic): Array<Double> {
@@ -363,44 +385,60 @@ internal class GlJsMapSession(
     val now = TimeSource.Monotonic.markNow()
     val elapsed = (now - lastFrameTime).toDouble(DurationUnit.SECONDS)
     lastFrameTime = now
-    if (elapsed > 0.0) lifecycleCallbacks.onFrame(1.0 / elapsed)
+    if (elapsed > 0.0) {
+      withLifecyclePresentation { engine, lease ->
+        lifecycleCallbacks.onFrame(engine, lease, 1.0 / elapsed)
+      }
+    }
   }
 
   // endregion
 
   // region events
 
-  private fun wireEvents(map: MaplibreMap) {
+  private fun wireEvents(map: MaplibreMap, engine: EngineMapIdentity, lease: RenderLease) {
+    var styleIdentity: StyleIdentity? = null
     map.subscribe("style.load") {
+      val lifecycleRequest = lifecycleStyleRequestIdentity ?: return@subscribe
       styleLoadPending = false
       styleBinding?.invalidate()
       val binding =
         GlJsStyleBinding(map, logger) { appliedExtent.scaleFactor.toFloat() }
           .also { styleBinding = it }
-      val request = appliedStyleRequest ?: return@subscribe binding.invalidate()
-      if (styleLoadTracker?.loaded(request, binding.identity) != true) {
+      val trackerRequest = appliedStyleRequest ?: return@subscribe binding.invalidate()
+      if (styleLoadTracker?.loaded(trackerRequest, binding.identity) != true) {
         binding.invalidate()
         applyRequestedStyle(map)
         return@subscribe
       }
       hasLoadedFirstStyle = true
-      lifecycleCallbacks.onStyleChanged(this, binding)
+      styleIdentity =
+        lifecycleCallbacks.onStyleChanged(
+          engine,
+          lifecycleRequest,
+          this,
+          binding,
+        )
+      lifecycleStyleIdentity = styleIdentity
       applyTileLod(map)
       if (!hasLoadedInitialStyle) {
         hasLoadedInitialStyle = true
         runPending(pendingInitialStyleActions, map)
       }
       reportStyleLoaded = true
-      reportLoadedOnceStyleIsReady(map)
+      reportLoadedOnceStyleIsReady(map, engine, styleIdentity)
     }
     // A source naming a TileJSON fetches it after `style.load`, so its attribution is not readable
     // there.
-    map.subscribe("styledata") { reportLoadedOnceStyleIsReady(map) }
+    map.subscribe("styledata") { reportLoadedOnceStyleIsReady(map, engine, styleIdentity) }
     map.subscribe("sourcedata") { event ->
-      reportLoadedOnceStyleIsReady(map)
+      reportLoadedOnceStyleIsReady(map, engine, styleIdentity)
       if (event.sourceDataType == "metadata") {
         applyTileLod(map)
-        event.sourceId?.let { lifecycleCallbacks.onSourceChanged(this, it) }
+        val style = styleIdentity
+        if (style != null) {
+          event.sourceId?.let { lifecycleCallbacks.onSourceChanged(engine, style, this, it) }
+        }
       }
     }
     map.subscribe("error") { event ->
@@ -408,16 +446,18 @@ internal class GlJsMapSession(
       if (styleLoadPending) {
         styleLoadPending = false
         logger?.e { "Map loading failed: $reason" }
-        val request = appliedStyleRequest
+        val trackerRequest = appliedStyleRequest
         val accepted =
-          request != null &&
+          trackerRequest != null &&
             styleLoadTracker?.failed(
-              request,
+              trackerRequest,
               TrackedStyleLoadState.Failed.Stage.BASE_STYLE,
               reason,
             ) == true
         if (accepted) {
-          lifecycleCallbacks.onMapFailLoading(reason)
+          lifecycleStyleRequestIdentity?.let {
+            lifecycleCallbacks.onMapFailLoading(engine, it, reason)
+          }
         } else {
           applyRequestedStyle(map)
         }
@@ -429,22 +469,27 @@ internal class GlJsMapSession(
     }
 
     map.subscribe("movestart") { beginCameraMove() }
-    map.subscribe("move") { lifecycleCallbacks.onCameraMoved(this) }
+    map.subscribe("move") { lifecycleCallbacks.onCameraMoved(engine, lease, this) }
     map.subscribe("moveend") {
-      lifecycleCallbacks.onCameraMoved(this)
+      lifecycleCallbacks.onCameraMoved(engine, lease, this)
       // A drag is a stream of jumps, each with its own moveend.
       if (!isGestureInProgress) endCameraMove()
       resumeTransitions()
     }
   }
 
-  private fun reportLoadedOnceStyleIsReady(map: MaplibreMap) {
+  private fun reportLoadedOnceStyleIsReady(
+    map: MaplibreMap,
+    engine: EngineMapIdentity,
+    style: StyleIdentity?,
+  ) {
     if (!reportStyleLoaded || !map.isStyleLoaded()) return
+    style ?: return
     reportStyleLoaded = false
-    val request = appliedStyleRequest ?: return
+    val trackerRequest = appliedStyleRequest ?: return
     val identity = styleBinding?.identity ?: return
-    if (styleLoadTracker?.reconciled(request, identity) == true) {
-      lifecycleCallbacks.onMapFinishedLoading(this)
+    if (styleLoadTracker?.reconciled(trackerRequest, identity) == true) {
+      lifecycleCallbacks.onMapFinishedLoading(engine, style, this)
     }
   }
 
@@ -454,14 +499,19 @@ internal class GlJsMapSession(
       if (isGestureInProgress) CameraMoveReason.GESTURE else CameraMoveReason.PROGRAMMATIC
     if (reportedMoveReason == reason) return
     reportedMoveReason = reason
-    lifecycleCallbacks.onCameraMoveStarted(this, reason)
+    withLifecyclePresentation { engine, lease ->
+      lifecycleCallbacks.onCameraMoveStarted(engine, lease, this, reason)
+    }
   }
 
   private fun endCameraMove(duringCleanup: Boolean = false) {
     if (reportedMoveReason == null) return
     reportedMoveReason = null
     if (duringCleanup) callbacks.onCameraMoveEnded(this)
-    else lifecycleCallbacks.onCameraMoveEnded(this)
+    else
+      withLifecyclePresentation { engine, lease ->
+        lifecycleCallbacks.onCameraMoveEnded(engine, lease, this)
+      }
   }
 
   private var reportedMoveReason: CameraMoveReason? = null
@@ -523,7 +573,10 @@ internal class GlJsMapSession(
     } else {
       tracker.request(style, engineAvailable = map != null)
     }
-    lifecycleCallbacks.onStyleChanged(this, null)
+    lifecycleEngineIdentity?.let {
+      lifecycleStyleRequestIdentity = lifecycleCallbacks.beginStyleRequest(it, this)
+    }
+    lifecycleStyleIdentity = null
     onMap(::applyRequestedStyle)
   }
 
@@ -555,7 +608,11 @@ internal class GlJsMapSession(
           reason,
         ) == true
       ) {
-        lifecycleCallbacks.onMapFailLoading(reason)
+        val engine = lifecycleEngineIdentity
+        val lifecycleRequest = lifecycleStyleRequestIdentity
+        if (engine != null && lifecycleRequest != null) {
+          lifecycleCallbacks.onMapFailLoading(engine, lifecycleRequest, reason)
+        }
       }
       if (!hasLoadedInitialStyle) abandonPending(pendingInitialStyleActions)
     }
@@ -986,13 +1043,23 @@ internal class GlJsMapSession(
 
   override fun onPrimaryClick(offset: DpOffset) {
     val position = map?.unprojectAt(offset.x.value.toDouble(), offset.y.value.toDouble()) ?: return
-    lifecycleCallbacks.onClick(this, position, offset)
+    withLifecyclePresentation { engine, lease ->
+      lifecycleCallbacks.onClick(engine, lease, this, position, offset)
+    }
   }
 
   /** A mouse has no press-and-hold convention, so the secondary button is the long press. */
   override fun onSecondaryClick(offset: DpOffset) {
     val position = map?.unprojectAt(offset.x.value.toDouble(), offset.y.value.toDouble()) ?: return
-    lifecycleCallbacks.onLongClick(this, position, offset)
+    withLifecyclePresentation { engine, lease ->
+      lifecycleCallbacks.onLongClick(engine, lease, this, position, offset)
+    }
+  }
+
+  private inline fun withLifecyclePresentation(action: (EngineMapIdentity, RenderLease) -> Unit) {
+    val engine = lifecycleEngineIdentity ?: return
+    val lease = lifecycleRenderLease ?: return
+    action(engine, lease)
   }
 
   // endregion

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
@@ -82,10 +82,16 @@ private const val FRAME_INTERVAL_SLACK = 0.1
  * calls before then are queued and reads answer from what was last asked for.
  */
 internal class GlJsMapSession(
-  internal var callbacks: MapAdapter.Callbacks,
+  callbacks: MapAdapter.Callbacks,
   internal var logger: Logger?,
   internal var layoutDirection: LayoutDirection,
-) : MapAdapter, GlJsMapRenderer, GestureTarget {
+) : MapAdapter, GlJsMapRenderer, GestureTarget, MapLifecyclePlatformAdapter {
+
+  internal var callbacks: MapAdapter.Callbacks = callbacks
+  private val lifecycle = MapLifecycleAuthority(this)
+  private val lifecycleCallbacks = MapLifecycleCallbacks(lifecycle) { this.callbacks }
+
+  override val engineRetention: EngineRetention = EngineRetention.DESTROY
 
   private var map: MaplibreMap? = null
 
@@ -93,7 +99,6 @@ internal class GlJsMapSession(
   private var container: HTMLElement? = null
 
   private var surface: GlJsSurfaceSession? = null
-  private var closed = false
 
   private class PendingMapAction(
     val run: (MaplibreMap) -> Unit,
@@ -144,7 +149,7 @@ internal class GlJsMapSession(
   // region surface lifecycle
 
   override fun onSurfaceAvailable(surface: GlJsSurfaceSession) {
-    if (closed) return
+    if (!lifecycle.acceptsWork) return
     this.surface = surface
     surface.requestFrame()
   }
@@ -156,7 +161,7 @@ internal class GlJsMapSession(
   }
 
   override fun render(target: GlJsFrameTarget, extent: MapExtent): Boolean {
-    if (closed || extent.isEmpty) return false
+    if (!lifecycle.acceptsWork || extent.isEmpty) return false
     // A detached map cannot later adopt a context: everything it uploaded belongs to the one it
     // has.
     val composited = target as? GlJsFrameTarget.Composited
@@ -211,13 +216,32 @@ internal class GlJsMapSession(
     if (lentContext != null) null else map?.getCanvas()
 
   override fun close() {
-    if (closed) return
-    closed = true
+    lifecycle.close()
+  }
+
+  fun start() {
+    when (lifecycle.state) {
+      is MapLifecycleState.Attaching,
+      is MapLifecycleState.Attached -> return
+      else -> lifecycle.beginAttach()
+    }
+  }
+
+  override suspend fun createEngine(identity: EngineMapIdentity) = Unit
+
+  override suspend fun attach(identity: EngineMapIdentity, lease: RenderLease) = Unit
+
+  override suspend fun detach(identity: EngineMapIdentity, lease: RenderLease) = Unit
+
+  override suspend fun destroyEngine(identity: EngineMapIdentity) {
+    destroyMap()
+  }
+
+  override suspend fun closeResources() {
     isGestureInProgress = false
-    endCameraMove()
+    endCameraMove(duringCleanup = true)
     abandonPending(pendingMapActions)
     abandonPending(pendingInitialStyleActions)
-    destroyMap()
     surface = null
   }
 
@@ -230,7 +254,7 @@ internal class GlJsMapSession(
     map?.let {
       return it
     }
-    if (closed) return null
+    if (!lifecycle.acceptsWork) return null
 
     val host = document.createElement("div").unsafeCast<HTMLElement>()
     host.style.cssText = OFFSCREEN_CONTAINER_STYLE
@@ -284,7 +308,7 @@ internal class GlJsMapSession(
     hasLoadedInitialStyle = false
     val current = map ?: return
     map = null
-    callbacks.onStyleChanged(this, null)
+    lifecycleCallbacks.onStyleChanged(this, null)
     styleBinding?.invalidate()
     styleBinding = null
     appliedStyle = null
@@ -316,7 +340,7 @@ internal class GlJsMapSession(
     map.resize()
     // resize() may also fire `move`; a second onCameraMoved is how overlays learn the viewport
     // changed when the camera position did not.
-    callbacks.onCameraMoved(this)
+    lifecycleCallbacks.onCameraMoved(this)
   }
 
   private fun maxTextureSize(gl: dynamic): Array<Double> {
@@ -339,7 +363,7 @@ internal class GlJsMapSession(
     val now = TimeSource.Monotonic.markNow()
     val elapsed = (now - lastFrameTime).toDouble(DurationUnit.SECONDS)
     lastFrameTime = now
-    if (elapsed > 0.0) callbacks.onFrame(1.0 / elapsed)
+    if (elapsed > 0.0) lifecycleCallbacks.onFrame(1.0 / elapsed)
   }
 
   // endregion
@@ -360,7 +384,7 @@ internal class GlJsMapSession(
         return@subscribe
       }
       hasLoadedFirstStyle = true
-      callbacks.onStyleChanged(this, binding)
+      lifecycleCallbacks.onStyleChanged(this, binding)
       applyTileLod(map)
       if (!hasLoadedInitialStyle) {
         hasLoadedInitialStyle = true
@@ -376,7 +400,7 @@ internal class GlJsMapSession(
       reportLoadedOnceStyleIsReady(map)
       if (event.sourceDataType == "metadata") {
         applyTileLod(map)
-        event.sourceId?.let { callbacks.onSourceChanged(this, it) }
+        event.sourceId?.let { lifecycleCallbacks.onSourceChanged(this, it) }
       }
     }
     map.subscribe("error") { event ->
@@ -393,7 +417,7 @@ internal class GlJsMapSession(
               reason,
             ) == true
         if (accepted) {
-          callbacks.onMapFailLoading(reason)
+          lifecycleCallbacks.onMapFailLoading(reason)
         } else {
           applyRequestedStyle(map)
         }
@@ -405,9 +429,9 @@ internal class GlJsMapSession(
     }
 
     map.subscribe("movestart") { beginCameraMove() }
-    map.subscribe("move") { callbacks.onCameraMoved(this) }
+    map.subscribe("move") { lifecycleCallbacks.onCameraMoved(this) }
     map.subscribe("moveend") {
-      callbacks.onCameraMoved(this)
+      lifecycleCallbacks.onCameraMoved(this)
       // A drag is a stream of jumps, each with its own moveend.
       if (!isGestureInProgress) endCameraMove()
       resumeTransitions()
@@ -420,7 +444,7 @@ internal class GlJsMapSession(
     val request = appliedStyleRequest ?: return
     val identity = styleBinding?.identity ?: return
     if (styleLoadTracker?.reconciled(request, identity) == true) {
-      callbacks.onMapFinishedLoading(this)
+      lifecycleCallbacks.onMapFinishedLoading(this)
     }
   }
 
@@ -430,13 +454,14 @@ internal class GlJsMapSession(
       if (isGestureInProgress) CameraMoveReason.GESTURE else CameraMoveReason.PROGRAMMATIC
     if (reportedMoveReason == reason) return
     reportedMoveReason = reason
-    callbacks.onCameraMoveStarted(this, reason)
+    lifecycleCallbacks.onCameraMoveStarted(this, reason)
   }
 
-  private fun endCameraMove() {
+  private fun endCameraMove(duringCleanup: Boolean = false) {
     if (reportedMoveReason == null) return
     reportedMoveReason = null
-    callbacks.onCameraMoveEnded(this)
+    if (duringCleanup) callbacks.onCameraMoveEnded(this)
+    else lifecycleCallbacks.onCameraMoveEnded(this)
   }
 
   private var reportedMoveReason: CameraMoveReason? = null
@@ -450,7 +475,7 @@ internal class GlJsMapSession(
   }
 
   private fun postWhenMapExists(action: PendingMapAction) {
-    if (closed) {
+    if (!lifecycle.acceptsWork) {
       action.abandon()
       return
     }
@@ -459,7 +484,7 @@ internal class GlJsMapSession(
   }
 
   private fun postWhenInitialStyleLoaded(action: PendingMapAction) {
-    if (closed) {
+    if (!lifecycle.acceptsWork) {
       action.abandon()
       return
     }
@@ -498,7 +523,7 @@ internal class GlJsMapSession(
     } else {
       tracker.request(style, engineAvailable = map != null)
     }
-    callbacks.onStyleChanged(this, null)
+    lifecycleCallbacks.onStyleChanged(this, null)
     onMap(::applyRequestedStyle)
   }
 
@@ -530,7 +555,7 @@ internal class GlJsMapSession(
           reason,
         ) == true
       ) {
-        callbacks.onMapFailLoading(reason)
+        lifecycleCallbacks.onMapFailLoading(reason)
       }
       if (!hasLoadedInitialStyle) abandonPending(pendingInitialStyleActions)
     }
@@ -961,13 +986,13 @@ internal class GlJsMapSession(
 
   override fun onPrimaryClick(offset: DpOffset) {
     val position = map?.unprojectAt(offset.x.value.toDouble(), offset.y.value.toDouble()) ?: return
-    callbacks.onClick(this, position, offset)
+    lifecycleCallbacks.onClick(this, position, offset)
   }
 
   /** A mouse has no press-and-hold convention, so the secondary button is the long press. */
   override fun onSecondaryClick(offset: DpOffset) {
     val position = map?.unprojectAt(offset.x.value.toDouble(), offset.y.value.toDouble()) ?: return
-    callbacks.onLongClick(this, position, offset)
+    lifecycleCallbacks.onLongClick(this, position, offset)
   }
 
   // endregion

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
@@ -170,10 +170,12 @@ internal class GlJsMapSession(
       try {
         endCameraMove(engine, lease)
       } finally {
+        surface = null
         lifecycle.beginEngineReplacement(engine, lease)
       }
+    } else {
+      surface = null
     }
-    surface = null
   }
 
   override fun render(target: GlJsFrameTarget, extent: MapExtent): Boolean {
@@ -429,10 +431,11 @@ internal class GlJsMapSession(
     map.subscribe("movestart") { beginCameraMove(engine, lease) }
     map.subscribe("move") { lifecycleCallbacks.onCameraMoved(engine, lease, this) }
     map.subscribe("moveend") {
-      lifecycleCallbacks.onCameraMoved(engine, lease, this)
-      // A drag is a stream of jumps, each with its own moveend.
-      if (!isGestureInProgress) endCameraMove(engine, lease)
-      resumeTransitions()
+      if (lifecycleCallbacks.onCameraMoved(engine, lease, this)) {
+        // A drag is a stream of jumps, each with its own moveend.
+        if (!isGestureInProgress) endCameraMove(engine, lease)
+        resumeTransitions()
+      }
     }
   }
 
@@ -472,7 +475,7 @@ internal class GlJsMapSession(
   ) {
     if (reportedMoveReason == null) return
     if (engine != null && lease != null) {
-      if (lifecycleCallbacks.onCameraMoveEnded(engine, lease, this)) reportedMoveReason = null
+      lifecycleCallbacks.onCameraMoveEnded(engine, lease, this) { reportedMoveReason = null }
     }
   }
 

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
@@ -93,6 +93,7 @@ internal class GlJsMapSession(
   private var lifecycleEngineIdentity: EngineMapIdentity? = null
   private var lifecycleRenderLease: RenderLease? = null
   private var lifecycleStyleRequestIdentity: StyleRequestIdentity? = null
+  private var appliedStyleRequestIdentity: StyleRequestIdentity? = null
   private var lifecycleStyleIdentity: StyleIdentity? = null
 
   override val engineRetention: EngineRetention = EngineRetention.DESTROY
@@ -162,7 +163,10 @@ internal class GlJsMapSession(
     // The map's context belongs to the surface, so it cannot outlive it.
     val engine = lifecycleEngineIdentity
     val lease = lifecycleRenderLease
-    if (engine != null && lease != null) lifecycle.beginEngineReplacement(engine, lease)
+    if (engine != null && lease != null) {
+      endCameraMove(engine, lease)
+      lifecycle.beginEngineReplacement(engine, lease)
+    }
     surface = null
   }
 
@@ -222,6 +226,7 @@ internal class GlJsMapSession(
     if (lentContext != null) null else map?.getCanvas()
 
   override fun close() {
+    endCameraMove()
     lifecycle.close()
   }
 
@@ -250,6 +255,7 @@ internal class GlJsMapSession(
     if (lifecycleEngineIdentity == identity) {
       lifecycleEngineIdentity = null
       lifecycleStyleRequestIdentity = null
+      appliedStyleRequestIdentity = null
       lifecycleStyleIdentity = null
     }
     destroyMap()
@@ -257,7 +263,6 @@ internal class GlJsMapSession(
 
   override suspend fun closeResources() {
     isGestureInProgress = false
-    endCameraMove(duringCleanup = true)
     abandonPending(pendingMapActions)
     abandonPending(pendingInitialStyleActions)
     surface = null
@@ -399,7 +404,7 @@ internal class GlJsMapSession(
   private fun wireEvents(map: MaplibreMap, engine: EngineMapIdentity, lease: RenderLease) {
     var styleIdentity: StyleIdentity? = null
     map.subscribe("style.load") {
-      val lifecycleRequest = lifecycleStyleRequestIdentity ?: return@subscribe
+      val lifecycleRequest = appliedStyleRequestIdentity ?: return@subscribe
       styleLoadPending = false
       styleBinding?.invalidate()
       val binding =
@@ -455,7 +460,7 @@ internal class GlJsMapSession(
               reason,
             ) == true
         if (accepted) {
-          lifecycleStyleRequestIdentity?.let {
+          appliedStyleRequestIdentity?.let {
             lifecycleCallbacks.onMapFailLoading(engine, it, reason)
           }
         } else {
@@ -468,12 +473,12 @@ internal class GlJsMapSession(
       }
     }
 
-    map.subscribe("movestart") { beginCameraMove() }
+    map.subscribe("movestart") { beginCameraMove(engine, lease) }
     map.subscribe("move") { lifecycleCallbacks.onCameraMoved(engine, lease, this) }
     map.subscribe("moveend") {
       lifecycleCallbacks.onCameraMoved(engine, lease, this)
       // A drag is a stream of jumps, each with its own moveend.
-      if (!isGestureInProgress) endCameraMove()
+      if (!isGestureInProgress) endCameraMove(engine, lease)
       resumeTransitions()
     }
   }
@@ -494,24 +499,26 @@ internal class GlJsMapSession(
   }
 
   /** A move spans the gesture rather than the jump, as every other platform reports it. */
-  private fun beginCameraMove() {
+  private fun beginCameraMove(
+    engine: EngineMapIdentity? = lifecycleEngineIdentity,
+    lease: RenderLease? = lifecycleRenderLease,
+  ) {
     val reason =
       if (isGestureInProgress) CameraMoveReason.GESTURE else CameraMoveReason.PROGRAMMATIC
     if (reportedMoveReason == reason) return
     reportedMoveReason = reason
-    withLifecyclePresentation { engine, lease ->
+    if (engine != null && lease != null) {
       lifecycleCallbacks.onCameraMoveStarted(engine, lease, this, reason)
     }
   }
 
-  private fun endCameraMove(duringCleanup: Boolean = false) {
+  private fun endCameraMove(
+    engine: EngineMapIdentity? = lifecycleEngineIdentity,
+    lease: RenderLease? = lifecycleRenderLease,
+  ) {
     if (reportedMoveReason == null) return
     reportedMoveReason = null
-    if (duringCleanup) callbacks.onCameraMoveEnded(this)
-    else
-      withLifecyclePresentation { engine, lease ->
-        lifecycleCallbacks.onCameraMoveEnded(engine, lease, this)
-      }
+    if (engine != null && lease != null) lifecycleCallbacks.onCameraMoveEnded(engine, lease, this)
   }
 
   private var reportedMoveReason: CameraMoveReason? = null
@@ -588,6 +595,7 @@ internal class GlJsMapSession(
     val request = styleLoadTracker?.beginLoading() ?: return
     appliedStyleRequest = request
     styleLoadPending = true
+    appliedStyleRequestIdentity = lifecycleStyleRequestIdentity
     // MapLibre diffs by default, keeping the same Style object, so no `style.load` would fire.
     val options = unsafeJso<SetStyleOptions> { diff = false }
     try {
@@ -609,7 +617,7 @@ internal class GlJsMapSession(
         ) == true
       ) {
         val engine = lifecycleEngineIdentity
-        val lifecycleRequest = lifecycleStyleRequestIdentity
+        val lifecycleRequest = appliedStyleRequestIdentity
         if (engine != null && lifecycleRequest != null) {
           lifecycleCallbacks.onMapFailLoading(engine, lifecycleRequest, reason)
         }

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
@@ -35,6 +35,7 @@ import org.maplibre.compose.gljs.GlJsRenderTarget
 import org.maplibre.compose.gljs.GlJsRuntime
 import org.maplibre.compose.gljs.GlJsSurfaceSession
 import org.maplibre.compose.gljs.JumpToOptions
+import org.maplibre.compose.gljs.MapEvent
 import org.maplibre.compose.gljs.MapOptions
 import org.maplibre.compose.gljs.MaplibreMap
 import org.maplibre.compose.gljs.PaddingOptions
@@ -134,7 +135,7 @@ internal class GlJsMapSession(
   private var styleLoadTracker: StyleLoadTracker? = null
   private var appliedStyleRequest: StyleRequestId? = null
 
-  /** Set while a style load is outstanding, so an `error` can be told from a tile failure. */
+  /** Set while a style load is outstanding and its listener classifies `error` events. */
   private var styleLoadPending = false
 
   private var styleBinding: GlJsStyleBinding? = null
@@ -608,6 +609,7 @@ internal class GlJsMapSession(
       }
     errorSubscription =
       map.subscribe("error") { event ->
+        if (!event.isTerminalStyleLoadFailure()) return@subscribe
         loadSubscription.cancel()
         errorSubscription.cancel()
         if (styleLoadSubscription === loadSubscription) styleLoadSubscription = null
@@ -655,6 +657,26 @@ internal class GlJsMapSession(
       }
       if (!hasLoadedInitialStyle) abandonPending(pendingInitialStyleActions)
     }
+  }
+
+  /**
+   * MapLibre sends style-request, source, sprite, tile, and API errors through one event. A
+   * terminal style-request error has no active request and occurs before MapLibre marks the style
+   * as loaded. The pinned MapLibre version exposes these fields on its internal `Style` object.
+   */
+  private fun MapEvent.isTerminalStyleLoadFailure(): Boolean {
+    val style = asDynamic().style ?: return false
+    return style._loaded != true && style._loadStyleRequest == null && style._frameRequest == null
+  }
+
+  internal fun fireStyleErrorForTest(message: String) {
+    val currentMap = map ?: return
+    val properties = js("({})")
+    properties.error = js("new Error()")
+    properties.error.message = message
+    properties.style = currentMap.asDynamic().style
+    properties.sourceId = "unrelated-source"
+    currentMap.fire("error", properties)
   }
 
   /** Answers camera reads made before the map exists. */

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
@@ -93,8 +93,11 @@ internal class GlJsMapSession(
   private var lifecycleEngineIdentity: EngineMapIdentity? = null
   private var lifecycleRenderLease: RenderLease? = null
   private var lifecycleStyleRequestIdentity: StyleRequestIdentity? = null
-  private var appliedStyleRequestIdentity: StyleRequestIdentity? = null
   private var lifecycleStyleIdentity: StyleIdentity? = null
+  private var styleLoadSubscription: GlJsSubscription? = null
+  private var styleErrorSubscription: GlJsSubscription? = null
+  private var styleDataSubscription: GlJsSubscription? = null
+  private var sourceDataSubscription: GlJsSubscription? = null
 
   override val engineRetention: EngineRetention = EngineRetention.DESTROY
 
@@ -164,8 +167,11 @@ internal class GlJsMapSession(
     val engine = lifecycleEngineIdentity
     val lease = lifecycleRenderLease
     if (engine != null && lease != null) {
-      endCameraMove(engine, lease)
-      lifecycle.beginEngineReplacement(engine, lease)
+      try {
+        endCameraMove(engine, lease)
+      } finally {
+        lifecycle.beginEngineReplacement(engine, lease)
+      }
     }
     surface = null
   }
@@ -226,8 +232,11 @@ internal class GlJsMapSession(
     if (lentContext != null) null else map?.getCanvas()
 
   override fun close() {
-    endCameraMove()
-    lifecycle.close()
+    try {
+      endCameraMove()
+    } finally {
+      lifecycle.close()
+    }
   }
 
   fun start() {
@@ -255,7 +264,6 @@ internal class GlJsMapSession(
     if (lifecycleEngineIdentity == identity) {
       lifecycleEngineIdentity = null
       lifecycleStyleRequestIdentity = null
-      appliedStyleRequestIdentity = null
       lifecycleStyleIdentity = null
     }
     destroyMap()
@@ -336,6 +344,14 @@ internal class GlJsMapSession(
     callbacks.onStyleChanged(this, null)
     styleBinding?.invalidate()
     styleBinding = null
+    styleLoadSubscription?.cancel()
+    styleLoadSubscription = null
+    styleErrorSubscription?.cancel()
+    styleErrorSubscription = null
+    styleDataSubscription?.cancel()
+    styleDataSubscription = null
+    sourceDataSubscription?.cancel()
+    sourceDataSubscription = null
     appliedStyle = null
     appliedStyleRequest = null
     styleLoadPending = false
@@ -402,72 +418,9 @@ internal class GlJsMapSession(
   // region events
 
   private fun wireEvents(map: MaplibreMap, engine: EngineMapIdentity, lease: RenderLease) {
-    var styleIdentity: StyleIdentity? = null
-    map.subscribe("style.load") {
-      val lifecycleRequest = appliedStyleRequestIdentity ?: return@subscribe
-      styleLoadPending = false
-      styleBinding?.invalidate()
-      val binding =
-        GlJsStyleBinding(map, logger) { appliedExtent.scaleFactor.toFloat() }
-          .also { styleBinding = it }
-      val trackerRequest = appliedStyleRequest ?: return@subscribe binding.invalidate()
-      if (styleLoadTracker?.loaded(trackerRequest, binding.identity) != true) {
-        binding.invalidate()
-        applyRequestedStyle(map)
-        return@subscribe
-      }
-      hasLoadedFirstStyle = true
-      styleIdentity =
-        lifecycleCallbacks.onStyleChanged(
-          engine,
-          lifecycleRequest,
-          this,
-          binding,
-        )
-      lifecycleStyleIdentity = styleIdentity
-      applyTileLod(map)
-      if (!hasLoadedInitialStyle) {
-        hasLoadedInitialStyle = true
-        runPending(pendingInitialStyleActions, map)
-      }
-      reportStyleLoaded = true
-      reportLoadedOnceStyleIsReady(map, engine, styleIdentity)
-    }
-    // A source naming a TileJSON fetches it after `style.load`, so its attribution is not readable
-    // there.
-    map.subscribe("styledata") { reportLoadedOnceStyleIsReady(map, engine, styleIdentity) }
-    map.subscribe("sourcedata") { event ->
-      reportLoadedOnceStyleIsReady(map, engine, styleIdentity)
-      if (event.sourceDataType == "metadata") {
-        applyTileLod(map)
-        val style = styleIdentity
-        if (style != null) {
-          event.sourceId?.let { lifecycleCallbacks.onSourceChanged(engine, style, this, it) }
-        }
-      }
-    }
     map.subscribe("error") { event ->
       val reason = event.error?.message ?: "MapLibre failed to load the map"
-      if (styleLoadPending) {
-        styleLoadPending = false
-        logger?.e { "Map loading failed: $reason" }
-        val trackerRequest = appliedStyleRequest
-        val accepted =
-          trackerRequest != null &&
-            styleLoadTracker?.failed(
-              trackerRequest,
-              TrackedStyleLoadState.Failed.Stage.BASE_STYLE,
-              reason,
-            ) == true
-        if (accepted) {
-          appliedStyleRequestIdentity?.let {
-            lifecycleCallbacks.onMapFailLoading(engine, it, reason)
-          }
-        } else {
-          applyRequestedStyle(map)
-        }
-        if (!hasLoadedInitialStyle) abandonPending(pendingInitialStyleActions)
-      } else {
+      if (!styleLoadPending) {
         // Tile and sprite failures land here too, and are not the map failing to load.
         logger?.w { "MapLibre reported an error: $reason" }
       }
@@ -506,9 +459,10 @@ internal class GlJsMapSession(
     val reason =
       if (isGestureInProgress) CameraMoveReason.GESTURE else CameraMoveReason.PROGRAMMATIC
     if (reportedMoveReason == reason) return
-    reportedMoveReason = reason
     if (engine != null && lease != null) {
-      lifecycleCallbacks.onCameraMoveStarted(engine, lease, this, reason)
+      if (lifecycleCallbacks.onCameraMoveStarted(engine, lease, this, reason)) {
+        reportedMoveReason = reason
+      }
     }
   }
 
@@ -517,8 +471,9 @@ internal class GlJsMapSession(
     lease: RenderLease? = lifecycleRenderLease,
   ) {
     if (reportedMoveReason == null) return
-    reportedMoveReason = null
-    if (engine != null && lease != null) lifecycleCallbacks.onCameraMoveEnded(engine, lease, this)
+    if (engine != null && lease != null) {
+      if (lifecycleCallbacks.onCameraMoveEnded(engine, lease, this)) reportedMoveReason = null
+    }
   }
 
   private var reportedMoveReason: CameraMoveReason? = null
@@ -592,10 +547,83 @@ internal class GlJsMapSession(
     if (style == appliedStyle) return
     if (styleLoadPending) return
     appliedStyle = style
-    val request = styleLoadTracker?.beginLoading() ?: return
-    appliedStyleRequest = request
+    val trackerRequest = styleLoadTracker?.beginLoading() ?: return
+    appliedStyleRequest = trackerRequest
     styleLoadPending = true
-    appliedStyleRequestIdentity = lifecycleStyleRequestIdentity
+    val engine = lifecycleEngineIdentity ?: return
+    val lifecycleRequest = lifecycleStyleRequestIdentity ?: return
+    styleLoadSubscription?.cancel()
+    styleErrorSubscription?.cancel()
+    styleDataSubscription?.cancel()
+    sourceDataSubscription?.cancel()
+    lateinit var loadSubscription: GlJsSubscription
+    lateinit var errorSubscription: GlJsSubscription
+    loadSubscription =
+      map.subscribe("style.load") {
+        loadSubscription.cancel()
+        errorSubscription.cancel()
+        if (styleLoadSubscription === loadSubscription) styleLoadSubscription = null
+        if (styleErrorSubscription === errorSubscription) styleErrorSubscription = null
+        val binding = GlJsStyleBinding(map, logger) { appliedExtent.scaleFactor.toFloat() }
+        if (styleLoadTracker?.loaded(trackerRequest, binding.identity) != true) {
+          binding.invalidate()
+          applyRequestedStyle(map)
+          return@subscribe
+        }
+        val acceptedStyle =
+          lifecycleCallbacks.onStyleChanged(engine, lifecycleRequest, this, binding)
+        if (acceptedStyle != null) {
+          styleLoadPending = false
+          hasLoadedFirstStyle = true
+          styleBinding?.invalidate()
+          styleBinding = binding
+          lifecycleStyleIdentity = acceptedStyle
+          styleDataSubscription =
+            map.subscribe("styledata") {
+              reportLoadedOnceStyleIsReady(map, engine, acceptedStyle)
+            }
+          sourceDataSubscription =
+            map.subscribe("sourcedata") { event ->
+              reportLoadedOnceStyleIsReady(map, engine, acceptedStyle)
+              if (event.sourceDataType == "metadata") {
+                applyTileLod(map)
+                event.sourceId?.let {
+                  lifecycleCallbacks.onSourceChanged(engine, acceptedStyle, this, it)
+                }
+              }
+            }
+          applyTileLod(map)
+          if (!hasLoadedInitialStyle) {
+            hasLoadedInitialStyle = true
+            runPending(pendingInitialStyleActions, map)
+          }
+          reportStyleLoaded = true
+          reportLoadedOnceStyleIsReady(map, engine, acceptedStyle)
+        } else {
+          binding.invalidate()
+        }
+      }
+    errorSubscription =
+      map.subscribe("error") { event ->
+        loadSubscription.cancel()
+        errorSubscription.cancel()
+        if (styleLoadSubscription === loadSubscription) styleLoadSubscription = null
+        if (styleErrorSubscription === errorSubscription) styleErrorSubscription = null
+        val reason = event.error?.message ?: "MapLibre failed to load the map"
+        if (
+          styleLoadTracker?.failed(
+            trackerRequest,
+            TrackedStyleLoadState.Failed.Stage.BASE_STYLE,
+            reason,
+          ) == true && lifecycleCallbacks.onMapFailLoading(engine, lifecycleRequest, reason)
+        ) {
+          styleLoadPending = false
+          logger?.e { "Map loading failed: $reason" }
+          if (!hasLoadedInitialStyle) abandonPending(pendingInitialStyleActions)
+        }
+      }
+    styleLoadSubscription = loadSubscription
+    styleErrorSubscription = errorSubscription
     // MapLibre diffs by default, keeping the same Style object, so no `style.load` would fire.
     val options = unsafeJso<SetStyleOptions> { diff = false }
     try {
@@ -606,21 +634,21 @@ internal class GlJsMapSession(
     } catch (error: Throwable) {
       // An inline style is parsed here rather than fetched, so a malformed one throws where every
       // other load failure arrives as an `error` event.
+      styleLoadSubscription?.cancel()
+      styleLoadSubscription = null
+      styleErrorSubscription?.cancel()
+      styleErrorSubscription = null
       styleLoadPending = false
       val reason = error.message ?: "MapLibre failed to load the map"
       logger?.e(error) { "Map loading failed: $reason" }
       if (
         styleLoadTracker?.failed(
-          request,
+          trackerRequest,
           TrackedStyleLoadState.Failed.Stage.BASE_STYLE,
           reason,
         ) == true
       ) {
-        val engine = lifecycleEngineIdentity
-        val lifecycleRequest = appliedStyleRequestIdentity
-        if (engine != null && lifecycleRequest != null) {
-          lifecycleCallbacks.onMapFailLoading(engine, lifecycleRequest, reason)
-        }
+        lifecycleCallbacks.onMapFailLoading(engine, lifecycleRequest, reason)
       }
       if (!hasLoadedInitialStyle) abandonPending(pendingInitialStyleActions)
     }

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/JsMapView.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/JsMapView.kt
@@ -46,7 +46,10 @@ internal actual fun ComposableMapView(
   // subcomposition inserting layers, or a style switch crashes on anchor validation (see #269).
   SideEffect { session.setBaseStyle(style) }
 
-  LaunchedEffect(session, options, update) { update(session) }
+  LaunchedEffect(session, options, update) {
+    update(session)
+    session.start()
+  }
 
   DisposableEffect(session) {
     onDispose {

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/CompositedMap.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/CompositedMap.kt
@@ -27,6 +27,7 @@ internal class CompositedMap(style: BaseStyle, private val scaleFactor: Double =
   private val session = GlJsMapSession(Callbacks(), logger = null, LayoutDirection.Ltr)
 
   init {
+    session.start()
     session.onSurfaceAvailable(
       object : GlJsSurfaceSession {
         override fun requestFrame() {

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserStyleFailureTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserStyleFailureTest.kt
@@ -1,0 +1,62 @@
+package org.maplibre.compose.map
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+import org.maplibre.compose.style.BaseStyle
+import org.maplibre.compose.testing.GlJsMapFixture
+import org.maplibre.compose.testing.MapFixture
+import org.maplibre.compose.testing.MapTestResult
+import org.maplibre.compose.testing.createMapFixture
+import org.maplibre.compose.testing.runMapTest
+
+class BrowserStyleFailureTest {
+  @Test
+  fun a_source_error_does_not_cancel_a_pending_style(): MapTestResult = runMapTest {
+    createMapFixture().use { fixture ->
+      fixture.loadStyle(BaseStyle.Json(STYLE_A))
+      fixture.events.clear()
+      fixture.errors.clear()
+
+      fixture.session.setBaseStyle(BaseStyle.Json(STYLE_B))
+      (fixture as GlJsMapFixture).fireStyleError("unrelated source failure")
+      fixture.session.setBaseStyle(BaseStyle.Json(STYLE_B))
+      fixture.pumpUntil("the replacement style to load", timeout = 5.seconds) {
+        fixture.events.contains(MapFixture.STYLE_LOADED)
+      }
+
+      assertTrue(fixture.errors.isEmpty(), "The source error failed the style: ${fixture.errors}")
+    }
+  }
+
+  @Test
+  fun a_missing_style_url_is_reported_once(): MapTestResult = runMapTest {
+    createMapFixture().use { fixture ->
+      fixture.session.setBaseStyle(BaseStyle.Uri("/missing-maplibre-compose-style.json"))
+      fixture.pumpUntil("the missing style URL to fail") { fixture.errors.isNotEmpty() }
+
+      val reported = fixture.errors.single()
+      fixture.pump(frames = 20)
+      assertEquals(listOf(reported), fixture.errors)
+    }
+  }
+
+  @Test
+  fun an_invalid_inline_style_is_reported_once(): MapTestResult = runMapTest {
+    createMapFixture().use { fixture ->
+      fixture.session.setBaseStyle(BaseStyle.Json(INVALID_STYLE))
+      fixture.pumpUntil("the invalid style to fail") { fixture.errors.isNotEmpty() }
+
+      val reported = fixture.errors.single()
+      fixture.pump(frames = 20)
+      assertEquals(listOf(reported), fixture.errors)
+    }
+  }
+
+  private companion object {
+    const val STYLE_A = """{"version":8,"sources":{},"layers":[]}"""
+    const val STYLE_B = """{"version":8,"name":"replacement","sources":{},"layers":[]}"""
+    const val INVALID_STYLE = """{"version":7,"sources":{},"layers":[]}"""
+  }
+}

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/testing/GlJsMapFixture.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/testing/GlJsMapFixture.kt
@@ -73,6 +73,10 @@ internal class GlJsMapFixture(private val extent: MapExtent) : MapFixture {
     pumpUntil("style $style to load", timeout) { events.contains(MapFixture.STYLE_LOADED) }
   }
 
+  internal fun fireStyleError(message: String) {
+    glJsSession.fireStyleErrorForTest(message)
+  }
+
   override suspend fun awaitMapReady(timeout: Duration) {
     pumpUntil("the map to render its first frame", timeout) { hasRendered }
   }

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/testing/GlJsMapFixture.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/testing/GlJsMapFixture.kt
@@ -53,6 +53,7 @@ internal class GlJsMapFixture(private val extent: MapExtent) : MapFixture {
   private var frameRequested = true
 
   init {
+    glJsSession.start()
     glJsSession.onSurfaceAvailable(
       object : GlJsSurfaceSession {
         override fun requestFrame() {

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapRuntimeLoop.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapRuntimeLoop.kt
@@ -162,9 +162,9 @@ internal class MlnFfiMapRuntimeLoop(
   fun post(action: (MapHandle) -> Unit, abandon: () -> Unit = {}): Boolean =
     submit(run = action, abandon = abandon)
 
-  /** Queues a test callback that runs after the next native pump and event drain. */
-  fun postEventDrainBarrierForTest(action: () -> Unit): Boolean =
-    post(action = { eventDrainBarriers += action })
+  /** Queues a callback that runs after the next native pump and event drain. */
+  fun postEventDrainBarrier(action: () -> Unit, abandon: () -> Unit = {}): Boolean =
+    post(action = { eventDrainBarriers += action }, abandon = abandon)
 
   private fun submit(run: (MapHandle) -> Unit, abandon: () -> Unit): Boolean = acceptLock.withLock {
     if (!accepting) return false

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -432,12 +432,15 @@ internal class MlnFfiMapSession(
   }
 
   override suspend fun attach(identity: EngineMapIdentity, lease: RenderLease) {
-    updateOwnerThreadPresentation { ownerThreadRenderLease = lease }
+    updateOwnerThreadPresentationAfterDrain { ownerThreadRenderLease = lease }
     lifecycleRenderLease = lease
   }
 
   override suspend fun detach(identity: EngineMapIdentity, lease: RenderLease) {
     if (lifecycleRenderLease == lease) lifecycleRenderLease = null
+    // This must happen before the first suspension. A host may tear down its renderer thread as
+    // soon as close() returns, but the native handle can only be closed through that thread.
+    closeRenderSession()
     updateOwnerThreadPresentation {
       if (ownerThreadRenderLease == lease) ownerThreadRenderLease = null
     }
@@ -488,7 +491,7 @@ internal class MlnFfiMapSession(
           resourceProviderFactory = resourceProviderFactory,
           onMapCreated = ::onMapCreated,
           onEvent = { handleEvent(identity, it) },
-          onEventsDrained = ::onEventsDrained,
+          onEventsDrained = { onEventsDrained(identity, it) },
           requestFrame = ::requestRender,
           mapEventMask = HANDLED_MAP_EVENTS,
         )
@@ -962,12 +965,30 @@ internal class MlnFfiMapSession(
   private suspend fun updateOwnerThreadPresentation(action: () -> Unit) {
     val completion = CompletableDeferred<Result<Unit>>()
     val accepted =
-      postWhenMapExists(
+      loop?.post(
         action = { completion.complete(runCatching(action)) },
         abandon = {
           completion.complete(Result.failure(IllegalStateException("Map owner loop stopped")))
         },
-      )
+      ) ?: false
+    if (!accepted) {
+      completion.complete(Result.failure(IllegalStateException("Map owner loop is unavailable")))
+    }
+    completion.await().getOrThrow()
+  }
+
+  /**
+   * Installs a new producer only after events raised without a presentation have been discarded.
+   */
+  private suspend fun updateOwnerThreadPresentationAfterDrain(action: () -> Unit) {
+    val completion = CompletableDeferred<Result<Unit>>()
+    val accepted =
+      loop?.postEventDrainBarrier(
+        action = { completion.complete(runCatching(action)) },
+        abandon = {
+          completion.complete(Result.failure(IllegalStateException("Map owner loop stopped")))
+        },
+      ) ?: false
     if (!accepted) {
       completion.complete(Result.failure(IllegalStateException("Map owner loop is unavailable")))
     }
@@ -1602,10 +1623,13 @@ internal class MlnFfiMapSession(
     endCameraMove()
   }
 
-  private fun onEventsDrained(map: MapHandle) {
-    snapshotViewport(map)
-    finishPendingGesture(map)
-    flushTransitionResumes()
+  private fun onEventsDrained(engine: EngineMapIdentity, map: MapHandle) {
+    val lease = ownerThreadRenderLease ?: return
+    lifecycleCallbacks.onPresentationEvent(engine, lease) {
+      snapshotViewport(map)
+      finishPendingGesture(map)
+      flushTransitionResumes()
+    }
   }
 
   private fun onMap(gestureToken: GestureToken?, action: (MapHandle) -> Unit) {

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -156,7 +156,7 @@ internal class MlnFfiMapSession(
   @Volatile private var lifecycleEngineIdentity: EngineMapIdentity? = null
   @Volatile private var lifecycleRenderLease: RenderLease? = null
   @Volatile private var lifecycleStyleRequestIdentity: StyleRequestIdentity? = null
-  @Volatile private var appliedStyleRequestIdentity: StyleRequestIdentity? = null
+  @Volatile private var styleEventProducer: StyleEventProducer? = null
   @Volatile private var lifecycleStyleIdentity: StyleIdentity? = null
 
   override val engineRetention: EngineRetention = EngineRetention.RETAIN
@@ -415,8 +415,11 @@ internal class MlnFfiMapSession(
   }
 
   override fun close() {
-    endCameraMove()
-    lifecycle.close()
+    try {
+      endCameraMove()
+    } finally {
+      lifecycle.close()
+    }
   }
 
   override suspend fun createEngine(identity: EngineMapIdentity) {
@@ -437,7 +440,7 @@ internal class MlnFfiMapSession(
     if (lifecycleEngineIdentity == identity) {
       lifecycleEngineIdentity = null
       lifecycleStyleRequestIdentity = null
-      appliedStyleRequestIdentity = null
+      styleEventProducer = null
       lifecycleStyleIdentity = null
     }
     closePlatform()
@@ -720,11 +723,14 @@ internal class MlnFfiMapSession(
 
   private fun reportLoadedStyle(engine: EngineMapIdentity) {
     if (!styleLoadUnreported) return
-    styleLoadUnreported = false
     val request = appliedStyleRequest ?: return
     val identity = styleBinding?.identity ?: return
     if (styleLoadTracker?.reconciled(request, identity) == true) {
-      lifecycleStyleIdentity?.let { lifecycleCallbacks.onMapFinishedLoading(engine, it, this) }
+      lifecycleStyleIdentity?.let {
+        if (lifecycleCallbacks.onMapFinishedLoading(engine, it, this)) {
+          styleLoadUnreported = false
+        }
+      }
     }
   }
 
@@ -736,20 +742,26 @@ internal class MlnFfiMapSession(
 
       RuntimeEventType.MAP_STYLE_LOADED -> {
         styleLoadPending = false
-        // Descriptors holding the previous binding must not write into a style that is gone.
-        styleBinding?.invalidate()
-        val binding = createStyleBinding().also { styleBinding = it }
-        val request = appliedStyleRequest ?: return binding.invalidate()
-        if (styleLoadTracker?.loaded(request, binding.identity) != true) {
+        val producer = styleEventProducer?.takeIf { it.engine == engine } ?: return
+        val binding = createStyleBinding()
+        val trackerRequest = appliedStyleRequest ?: return binding.invalidate()
+        if (styleLoadTracker?.loaded(trackerRequest, binding.identity) != true) {
           binding.invalidate()
           loop?.map?.let(::applyRequestedStyle)
           return
         }
+        val acceptedStyle =
+          lifecycleCallbacks.onStyleChanged(engine, producer.request, this, binding)
+        if (acceptedStyle == null) {
+          binding.invalidate()
+          return
+        }
+        // Descriptors holding the previous binding must not write into a style that is gone.
+        styleBinding?.invalidate()
+        styleBinding = binding
         featureStateReplayPending.store(true)
         hasLoadedFirstStyle = true
-        val lifecycleRequest = appliedStyleRequestIdentity ?: return binding.invalidate()
-        lifecycleStyleIdentity =
-          lifecycleCallbacks.onStyleChanged(engine, lifecycleRequest, this, binding)
+        lifecycleStyleIdentity = acceptedStyle
         styleLoadUnreported = true
         reportedUrlAttribution.clear()
         // A producer frame that started before this callback can still hold the previous style.
@@ -779,7 +791,6 @@ internal class MlnFfiMapSession(
         // The only channel for a URL style's failure; a malformed inline style also throws from the
         // setter.
         val reason = event.message.ifBlank { "MapLibre failed to load the map" }
-        logger?.e { "Map loading failed (code ${event.code}): $reason" }
         val request = appliedStyleRequest
         val accepted =
           request != null &&
@@ -789,9 +800,13 @@ internal class MlnFfiMapSession(
               reason,
             ) == true
         if (accepted) {
-          appliedStyleRequestIdentity?.let {
-            lifecycleCallbacks.onMapFailLoading(engine, it, reason)
-          }
+          styleEventProducer
+            ?.takeIf { it.engine == engine }
+            ?.let {
+              if (lifecycleCallbacks.onMapFailLoading(engine, it.request, reason)) {
+                logger?.e { "Map loading failed (code ${event.code}): $reason" }
+              }
+            }
         } else {
           loop?.map?.let(::applyRequestedStyle)
         }
@@ -854,9 +869,10 @@ internal class MlnFfiMapSession(
     val reason =
       if (isGestureInProgress) CameraMoveReason.GESTURE else CameraMoveReason.PROGRAMMATIC
     if (reportedMoveReason == reason) return
-    reportedMoveReason = reason
     if (engine != null && lease != null) {
-      lifecycleCallbacks.onCameraMoveStarted(engine, lease, this, reason)
+      if (lifecycleCallbacks.onCameraMoveStarted(engine, lease, this, reason)) {
+        reportedMoveReason = reason
+      }
     }
   }
 
@@ -865,8 +881,9 @@ internal class MlnFfiMapSession(
     lease: RenderLease? = lifecycleRenderLease,
   ) {
     if (reportedMoveReason == null) return
-    reportedMoveReason = null
-    if (engine != null && lease != null) lifecycleCallbacks.onCameraMoveEnded(engine, lease, this)
+    if (engine != null && lease != null) {
+      if (lifecycleCallbacks.onCameraMoveEnded(engine, lease, this)) reportedMoveReason = null
+    }
   }
 
   /** Exists for tests. */
@@ -1020,7 +1037,11 @@ internal class MlnFfiMapSession(
     val request = styleLoadTracker?.beginLoading() ?: return
     appliedStyleRequest = request
     styleLoadPending = true
-    appliedStyleRequestIdentity = lifecycleStyleRequestIdentity
+    val engine = lifecycleEngineIdentity ?: return
+    val lifecycleRequest = lifecycleStyleRequestIdentity ?: return
+    // Replacing the native style disconnects the preceding style event producer. The runtime loop
+    // serializes this command with its event callback, so later events belong to this producer.
+    styleEventProducer = StyleEventProducer(engine, lifecycleRequest)
     // setStyleJson parses inline, so a malformed style throws as well as queueing
     // MAP_LOADING_FAILED; the queued event is what reports it.
     try {
@@ -1034,6 +1055,11 @@ internal class MlnFfiMapSession(
       logger?.e(error) { "Failed to apply style $style" }
     }
   }
+
+  private data class StyleEventProducer(
+    val engine: EngineMapIdentity,
+    val request: StyleRequestIdentity,
+  )
 
   /** Applied when a map is created. Getters read [mirroredViewport] after native applies it. */
   @Volatile private var requestedCamera: CameraPosition? = null

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -141,14 +141,20 @@ private const val FRAME_INTERVAL_SLACK = 0.1
  * advances it from `onDidFinishRenderingFrame`.
  */
 internal class MlnFfiMapSession(
-  @Volatile internal var callbacks: MapAdapter.Callbacks,
+  callbacks: MapAdapter.Callbacks,
   @Volatile internal var logger: Logger?,
   renderBackend: MapRenderBackend,
   scaleFactor: Double = 1.0,
   @Volatile internal var layoutDirection: LayoutDirection,
   private val cacheFile: Path,
   private val resourceProviderFactory: MlnFfiResourceProviderFactory = ::MlnFfiResourceProvider,
-) : MapAdapter, MlnFfiMapRenderer, GestureTarget {
+) : MapAdapter, MlnFfiMapRenderer, GestureTarget, MapLifecyclePlatformAdapter {
+
+  @Volatile internal var callbacks: MapAdapter.Callbacks = callbacks
+  private val lifecycle = MapLifecycleAuthority(this)
+  private val lifecycleCallbacks = MapLifecycleCallbacks(lifecycle) { this.callbacks }
+
+  override val engineRetention: EngineRetention = EngineRetention.RETAIN
 
   override val backend: MapRenderBackend = renderBackend
   private val initialExtent = MapExtent.fromLogical(1, 1, scaleFactor)
@@ -208,7 +214,6 @@ internal class MlnFfiMapSession(
 
   private var hasRenderedAFrame = false
 
-  @Volatile private var closed = false
   private var failureReported = false
 
   @Volatile private var requestedStyle: BaseStyle? = null
@@ -253,7 +258,7 @@ internal class MlnFfiMapSession(
           !info.attribution.isNullOrEmpty() &&
           reportedUrlAttribution.add(id)
       ) {
-        callbacks.onSourceChanged(this, id)
+        lifecycleCallbacks.onSourceChanged(this, id)
       }
     }
   }
@@ -261,12 +266,12 @@ internal class MlnFfiMapSession(
   private fun createStyleBinding(): MlnFfiStyleBinding =
     MlnFfiStyleBinding(
       loggerProvider = { logger },
-      sessionOpen = { !closed },
+      sessionOpen = { lifecycle.acceptsWork },
       accessMap = { action ->
-        if (closed) false else runOnMap(action).let { true }
+        if (!lifecycle.acceptsWork) false else runOnMap(action).let { true }
       },
       accessRenderSession = { action ->
-        if (closed || !renderSessionReady) {
+        if (!lifecycle.acceptsWork || !renderSessionReady) {
           false
         } else {
           withRendererAccess {
@@ -284,7 +289,7 @@ internal class MlnFfiMapSession(
       sourceChanged = { sourceId ->
         featureStateReplayPending.store(true)
         reportedUrlAttribution.remove(sourceId)
-        callbacks.onSourceChanged(this, sourceId)
+        lifecycleCallbacks.onSourceChanged(this, sourceId)
       },
       getScale = ::imageScale,
     )
@@ -300,7 +305,7 @@ internal class MlnFfiMapSession(
   // region host surface lifecycle
 
   override fun onSurfaceAvailable(session: MlnFfiMapHostSession) {
-    if (closed) {
+    if (!lifecycle.acceptsWork) {
       logger?.w { "Ignoring a host surface offered to a closed map session" }
       return
     }
@@ -324,7 +329,7 @@ internal class MlnFfiMapSession(
   }
 
   override fun render(frame: MlnFfiMapFrame): MlnFfiFrameResult {
-    if (closed || frame.extent.isEmpty) return MlnFfiFrameResult.SKIPPED
+    if (!lifecycle.acceptsWork || frame.extent.isEmpty) return MlnFfiFrameResult.SKIPPED
 
     val loop = loop ?: return MlnFfiFrameResult.SKIPPED
     loop.failure?.let { error ->
@@ -401,8 +406,24 @@ internal class MlnFfiMapSession(
   }
 
   override fun close() {
-    if (closed) return
-    closed = true
+    lifecycle.close()
+  }
+
+  override suspend fun createEngine(identity: EngineMapIdentity) {
+    startEngine()
+  }
+
+  override suspend fun attach(identity: EngineMapIdentity, lease: RenderLease) = Unit
+
+  override suspend fun detach(identity: EngineMapIdentity, lease: RenderLease) = Unit
+
+  override suspend fun destroyEngine(identity: EngineMapIdentity) {
+    closePlatform()
+  }
+
+  override suspend fun closeResources() = Unit
+
+  private fun closePlatform() {
     try {
       stopLoop(endOutstandingMove = true)
     } finally {
@@ -413,8 +434,16 @@ internal class MlnFfiMapSession(
   }
 
   fun start() {
+    when (lifecycle.state) {
+      is MapLifecycleState.Attaching,
+      is MapLifecycleState.Attached -> return
+      else -> lifecycle.beginAttach()
+    }
+  }
+
+  private fun startEngine() {
     val started = stateLock.withLock {
-      check(!closed) { "Cannot start a closed map session" }
+      check(lifecycle.acceptsWork) { "Cannot start a closed map session" }
       loop?.let {
         return
       }
@@ -453,7 +482,7 @@ internal class MlnFfiMapSession(
       current
     }
     abandoned.forEach { it.abandon() }
-    if (styleBinding != null) callbacks.onStyleChanged(this, null)
+    if (styleBinding != null) lifecycleCallbacks.onStyleChanged(this, null)
     styleBinding?.invalidate()
     styleBinding = null
     appliedStyle = null
@@ -470,7 +499,7 @@ internal class MlnFfiMapSession(
         isGestureInProgress = false
         activeGestureToken = null
         pendingGestureEndToken = null
-        endCameraMove()
+        endCameraMove(duringCleanup = true)
       }
       resumeStrandedTransitions()
     }
@@ -676,7 +705,7 @@ internal class MlnFfiMapSession(
     val request = appliedStyleRequest ?: return
     val identity = styleBinding?.identity ?: return
     if (styleLoadTracker?.reconciled(request, identity) == true) {
-      callbacks.onMapFinishedLoading(this)
+      lifecycleCallbacks.onMapFinishedLoading(this)
     }
   }
 
@@ -698,7 +727,7 @@ internal class MlnFfiMapSession(
         }
         featureStateReplayPending.store(true)
         hasLoadedFirstStyle = true
-        callbacks.onStyleChanged(this, binding)
+        lifecycleCallbacks.onStyleChanged(this, binding)
         styleLoadUnreported = true
         reportedUrlAttribution.clear()
         // A producer frame that started before this callback can still hold the previous style.
@@ -738,7 +767,7 @@ internal class MlnFfiMapSession(
               reason,
             ) == true
         if (accepted) {
-          callbacks.onMapFailLoading(reason)
+          lifecycleCallbacks.onMapFailLoading(reason)
         } else {
           loop?.map?.let(::applyRequestedStyle)
         }
@@ -748,12 +777,12 @@ internal class MlnFfiMapSession(
 
       RuntimeEventType.MAP_CAMERA_IS_CHANGING -> {
         loop?.map?.let(::snapshotViewport)
-        callbacks.onCameraMoved(this)
+        lifecycleCallbacks.onCameraMoved(this)
       }
 
       RuntimeEventType.MAP_CAMERA_DID_CHANGE -> {
         loop?.map?.let(::snapshotViewport)
-        callbacks.onCameraMoved(this)
+        lifecycleCallbacks.onCameraMoved(this)
         // A drag is a stream of jumps, each with its own did-change.
         if (!isGestureInProgress) endCameraMove()
       }
@@ -799,13 +828,14 @@ internal class MlnFfiMapSession(
       if (isGestureInProgress) CameraMoveReason.GESTURE else CameraMoveReason.PROGRAMMATIC
     if (reportedMoveReason == reason) return
     reportedMoveReason = reason
-    callbacks.onCameraMoveStarted(this, reason)
+    lifecycleCallbacks.onCameraMoveStarted(this, reason)
   }
 
-  private fun endCameraMove() {
+  private fun endCameraMove(duringCleanup: Boolean = false) {
     if (reportedMoveReason == null) return
     reportedMoveReason = null
-    callbacks.onCameraMoveEnded(this)
+    if (duringCleanup) callbacks.onCameraMoveEnded(this)
+    else lifecycleCallbacks.onCameraMoveEnded(this)
   }
 
   /** Exists for tests. */
@@ -840,7 +870,7 @@ internal class MlnFfiMapSession(
     val now = frameTimer.markNow()
     val elapsed = (now - lastFrameTime).toDouble(DurationUnit.SECONDS)
     lastFrameTime = now
-    if (elapsed > 0.0) callbacks.onFrame(1.0 / elapsed)
+    if (elapsed > 0.0) lifecycleCallbacks.onFrame(1.0 / elapsed)
   }
 
   // endregion
@@ -863,7 +893,7 @@ internal class MlnFfiMapSession(
   /** Queues [action] until a map exists, including before the session starts. */
   private fun postWhenMapExists(action: (MapHandle) -> Unit, abandon: () -> Unit): Boolean {
     val current = stateLock.withLock {
-      if (closed) return false
+      if (!lifecycle.acceptsWork) return false
       loop.also { if (it == null) pendingMapActions += PendingMapAction(action, abandon) }
     }
     return current?.post(action, abandon) ?: true
@@ -876,7 +906,7 @@ internal class MlnFfiMapSession(
   /** Queues [action] until the first render target has supplied the map's real dimensions. */
   private fun postWhenViewportExists(action: (MapHandle) -> Unit, abandon: () -> Unit): Boolean {
     val current = stateLock.withLock {
-      if (closed) return false
+      if (!lifecycle.acceptsWork) return false
       if (!hasAttachedViewport) {
         pendingViewportActions += PendingMapAction(action, abandon)
         return true
@@ -889,7 +919,7 @@ internal class MlnFfiMapSession(
   private fun publishAttachedViewport() {
     val (current, pending) =
       stateLock.withLock {
-        if (closed || hasAttachedViewport) return
+        if (!lifecycle.acceptsWork || hasAttachedViewport) return
         hasAttachedViewport = true
         loop to pendingViewportActions.toList().also { pendingViewportActions.clear() }
       }
@@ -940,7 +970,7 @@ internal class MlnFfiMapSession(
     }
     // Disposes the composition holding the old style's sources and layers, which would otherwise
     // fail anchor validation against the base layers being replaced.
-    callbacks.onStyleChanged(this, null)
+    lifecycleCallbacks.onStyleChanged(this, null)
     onMap(::applyRequestedStyle)
   }
 
@@ -999,7 +1029,7 @@ internal class MlnFfiMapSession(
    */
   private fun snapshotViewportAndNotify(map: MapHandle) {
     snapshotViewport(map)
-    callbacks.onCameraMoved(this)
+    lifecycleCallbacks.onCameraMoved(this)
   }
 
   /** Owner thread only. Publishes the applied camera and viewport for any-thread getters. */
@@ -1095,7 +1125,9 @@ internal class MlnFfiMapSession(
     // After one exists it runs as one round-trip instead, so a camera or viewport read made right
     // after this call observes the fitted camera rather than the previous mirrored snapshot —
     // the ordering the blocking getters on main provided.
-    val hasViewport = stateLock.withLock { hasAttachedViewport && !closed && loop != null }
+    val hasViewport = stateLock.withLock {
+      hasAttachedViewport && lifecycle.acceptsWork && loop != null
+    }
     if (hasViewport && runOnMap(fit) != null) return
     postWhenViewportExists(fit, abandon = {})
   }
@@ -1388,7 +1420,7 @@ internal class MlnFfiMapSession(
     layerIds: Set<String>?,
     predicate: CompiledExpression<BooleanValue>?,
   ): List<Feature<Geometry, JsonObject?>> = suspendCancellableCoroutine { continuation ->
-    if (closed) {
+    if (!lifecycle.acceptsWork) {
       continuation.resume(emptyList())
       return@suspendCancellableCoroutine
     }
@@ -1568,24 +1600,24 @@ internal class MlnFfiMapSession(
   }
 
   override fun onPrimaryClick(offset: DpOffset) {
-    if (closed) return
+    if (!lifecycle.acceptsWork) return
     val position = withSnapshotProjection { it.latLngForPixel(offset.toScreenPoint()).toPosition() }
     if (position == null) {
       logger?.w { "Dropped a map click at $offset: the map has no viewport" }
       return
     }
-    callbacks.onClick(this, position, offset)
+    lifecycleCallbacks.onClick(this, position, offset)
   }
 
   /** A mouse has no press-and-hold convention, so the secondary button is the long press. */
   override fun onSecondaryClick(offset: DpOffset) {
-    if (closed) return
+    if (!lifecycle.acceptsWork) return
     val position = withSnapshotProjection { it.latLngForPixel(offset.toScreenPoint()).toPosition() }
     if (position == null) {
       logger?.w { "Dropped a map long click at $offset: the map has no viewport" }
       return
     }
-    callbacks.onLongClick(this, position, offset)
+    lifecycleCallbacks.onLongClick(this, position, offset)
   }
 
   override fun cancelTransitions() {

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -25,6 +25,7 @@ import kotlin.time.Duration
 import kotlin.time.DurationUnit
 import kotlin.time.TimeSource
 import kotlinx.coroutines.CancellableContinuation
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.io.files.Path
 import kotlinx.serialization.json.JsonObject
@@ -155,6 +156,8 @@ internal class MlnFfiMapSession(
   private val lifecycleCallbacks = MapLifecycleCallbacks(lifecycle) { this.callbacks }
   @Volatile private var lifecycleEngineIdentity: EngineMapIdentity? = null
   @Volatile private var lifecycleRenderLease: RenderLease? = null
+  /** Presentation producer installed and sampled only on the native map's owner thread. */
+  private var ownerThreadRenderLease: RenderLease? = null
   @Volatile private var lifecycleStyleRequestIdentity: StyleRequestIdentity? = null
   @Volatile private var styleEventProducer: StyleEventProducer? = null
   @Volatile private var lifecycleStyleIdentity: StyleIdentity? = null
@@ -429,11 +432,16 @@ internal class MlnFfiMapSession(
   }
 
   override suspend fun attach(identity: EngineMapIdentity, lease: RenderLease) {
+    updateOwnerThreadPresentation { ownerThreadRenderLease = lease }
     lifecycleRenderLease = lease
   }
 
   override suspend fun detach(identity: EngineMapIdentity, lease: RenderLease) {
     if (lifecycleRenderLease == lease) lifecycleRenderLease = null
+    updateOwnerThreadPresentation {
+      if (ownerThreadRenderLease == lease) ownerThreadRenderLease = null
+    }
+    awaitEventDrain()
   }
 
   override suspend fun destroyEngine(identity: EngineMapIdentity) {
@@ -736,7 +744,7 @@ internal class MlnFfiMapSession(
 
   /** Runs on the map's owner thread, as do the callbacks it makes. */
   private fun handleEvent(engine: EngineMapIdentity, event: RuntimeEvent) {
-    val lease = lifecycleRenderLease
+    val lease = ownerThreadRenderLease
     when (event.type) {
       RuntimeEventType.MAP_RENDER_UPDATE_AVAILABLE -> requestRender()
 
@@ -815,15 +823,24 @@ internal class MlnFfiMapSession(
       RuntimeEventType.MAP_CAMERA_WILL_CHANGE -> beginCameraMove(engine, lease)
 
       RuntimeEventType.MAP_CAMERA_IS_CHANGING -> {
-        loop?.map?.let(::snapshotViewport)
-        lease?.let { lifecycleCallbacks.onCameraMoved(engine, it, this) }
+        lease?.let {
+          lifecycleCallbacks.onCameraMoved(engine, it, this) {
+            loop?.map?.let(::snapshotViewport)
+          }
+        }
       }
 
       RuntimeEventType.MAP_CAMERA_DID_CHANGE -> {
-        loop?.map?.let(::snapshotViewport)
-        lease?.let { lifecycleCallbacks.onCameraMoved(engine, it, this) }
-        // A drag is a stream of jumps, each with its own did-change.
-        if (!isGestureInProgress) endCameraMove(engine, lease)
+        lease?.let {
+          if (
+            lifecycleCallbacks.onCameraMoved(engine, it, this) {
+              loop?.map?.let(::snapshotViewport)
+            }
+          ) {
+            // A drag is a stream of jumps, each with its own did-change.
+            if (!isGestureInProgress) endCameraMove(engine, lease)
+          }
+        }
       }
 
       RuntimeEventType.MAP_CAMERA_TRANSITION_FINISHED -> {
@@ -882,7 +899,7 @@ internal class MlnFfiMapSession(
   ) {
     if (reportedMoveReason == null) return
     if (engine != null && lease != null) {
-      if (lifecycleCallbacks.onCameraMoveEnded(engine, lease, this)) reportedMoveReason = null
+      lifecycleCallbacks.onCameraMoveEnded(engine, lease, this) { reportedMoveReason = null }
     }
   }
 
@@ -940,7 +957,38 @@ internal class MlnFfiMapSession(
 
   /** Test seam that runs [action] after the next native pump and event drain. */
   internal fun postEventDrainBarrierForTest(action: () -> Unit): Boolean =
-    loop?.postEventDrainBarrierForTest(action) ?: false
+    loop?.postEventDrainBarrier(action) ?: false
+
+  private suspend fun updateOwnerThreadPresentation(action: () -> Unit) {
+    val completion = CompletableDeferred<Result<Unit>>()
+    val accepted =
+      postWhenMapExists(
+        action = { completion.complete(runCatching(action)) },
+        abandon = {
+          completion.complete(Result.failure(IllegalStateException("Map owner loop stopped")))
+        },
+      )
+    if (!accepted) {
+      completion.complete(Result.failure(IllegalStateException("Map owner loop is unavailable")))
+    }
+    completion.await().getOrThrow()
+  }
+
+  /** Prevents a later attachment from adopting native events queued by the departed lease. */
+  private suspend fun awaitEventDrain() {
+    val completion = CompletableDeferred<Result<Unit>>()
+    val accepted =
+      loop?.postEventDrainBarrier(
+        action = { completion.complete(Result.success(Unit)) },
+        abandon = {
+          completion.complete(Result.failure(IllegalStateException("Map owner loop stopped")))
+        },
+      ) ?: false
+    if (!accepted) {
+      completion.complete(Result.failure(IllegalStateException("Map owner loop is unavailable")))
+    }
+    completion.await().getOrThrow()
+  }
 
   /** Queues [action] until a map exists, including before the session starts. */
   private fun postWhenMapExists(action: (MapHandle) -> Unit, abandon: () -> Unit): Boolean {

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -156,6 +156,7 @@ internal class MlnFfiMapSession(
   @Volatile private var lifecycleEngineIdentity: EngineMapIdentity? = null
   @Volatile private var lifecycleRenderLease: RenderLease? = null
   @Volatile private var lifecycleStyleRequestIdentity: StyleRequestIdentity? = null
+  @Volatile private var appliedStyleRequestIdentity: StyleRequestIdentity? = null
   @Volatile private var lifecycleStyleIdentity: StyleIdentity? = null
 
   override val engineRetention: EngineRetention = EngineRetention.RETAIN
@@ -414,6 +415,7 @@ internal class MlnFfiMapSession(
   }
 
   override fun close() {
+    endCameraMove()
     lifecycle.close()
   }
 
@@ -435,6 +437,7 @@ internal class MlnFfiMapSession(
     if (lifecycleEngineIdentity == identity) {
       lifecycleEngineIdentity = null
       lifecycleStyleRequestIdentity = null
+      appliedStyleRequestIdentity = null
       lifecycleStyleIdentity = null
     }
     closePlatform()
@@ -444,7 +447,7 @@ internal class MlnFfiMapSession(
 
   private fun closePlatform() {
     try {
-      stopLoop(endOutstandingMove = true)
+      stopLoop()
     } finally {
       hostSession = null
       // The owner thread is gone, so this is the last published handle. Destruction is any-thread.
@@ -489,7 +492,7 @@ internal class MlnFfiMapSession(
   }
 
   /** MapLibre refuses to destroy a map that still has a render session attached. */
-  private fun stopLoop(endOutstandingMove: Boolean = false) {
+  private fun stopLoop() {
     val abandoned = mutableListOf<PendingMapAction>()
     val stopping = stateLock.withLock {
       val current = loop
@@ -514,12 +517,9 @@ internal class MlnFfiMapSession(
       stopping?.close()
     } finally {
       // After the join, so the owner thread is gone and this is the only reader of that state.
-      if (endOutstandingMove) {
-        isGestureInProgress = false
-        activeGestureToken = null
-        pendingGestureEndToken = null
-        endCameraMove(duringCleanup = true)
-      }
+      isGestureInProgress = false
+      activeGestureToken = null
+      pendingGestureEndToken = null
       resumeStrandedTransitions()
     }
   }
@@ -730,6 +730,7 @@ internal class MlnFfiMapSession(
 
   /** Runs on the map's owner thread, as do the callbacks it makes. */
   private fun handleEvent(engine: EngineMapIdentity, event: RuntimeEvent) {
+    val lease = lifecycleRenderLease
     when (event.type) {
       RuntimeEventType.MAP_RENDER_UPDATE_AVAILABLE -> requestRender()
 
@@ -746,7 +747,7 @@ internal class MlnFfiMapSession(
         }
         featureStateReplayPending.store(true)
         hasLoadedFirstStyle = true
-        val lifecycleRequest = lifecycleStyleRequestIdentity ?: return binding.invalidate()
+        val lifecycleRequest = appliedStyleRequestIdentity ?: return binding.invalidate()
         lifecycleStyleIdentity =
           lifecycleCallbacks.onStyleChanged(engine, lifecycleRequest, this, binding)
         styleLoadUnreported = true
@@ -788,7 +789,7 @@ internal class MlnFfiMapSession(
               reason,
             ) == true
         if (accepted) {
-          lifecycleStyleRequestIdentity?.let {
+          appliedStyleRequestIdentity?.let {
             lifecycleCallbacks.onMapFailLoading(engine, it, reason)
           }
         } else {
@@ -796,18 +797,18 @@ internal class MlnFfiMapSession(
         }
       }
 
-      RuntimeEventType.MAP_CAMERA_WILL_CHANGE -> beginCameraMove()
+      RuntimeEventType.MAP_CAMERA_WILL_CHANGE -> beginCameraMove(engine, lease)
 
       RuntimeEventType.MAP_CAMERA_IS_CHANGING -> {
         loop?.map?.let(::snapshotViewport)
-        lifecycleRenderLease?.let { lifecycleCallbacks.onCameraMoved(engine, it, this) }
+        lease?.let { lifecycleCallbacks.onCameraMoved(engine, it, this) }
       }
 
       RuntimeEventType.MAP_CAMERA_DID_CHANGE -> {
         loop?.map?.let(::snapshotViewport)
-        lifecycleRenderLease?.let { lifecycleCallbacks.onCameraMoved(engine, it, this) }
+        lease?.let { lifecycleCallbacks.onCameraMoved(engine, it, this) }
         // A drag is a stream of jumps, each with its own did-change.
-        if (!isGestureInProgress) endCameraMove()
+        if (!isGestureInProgress) endCameraMove(engine, lease)
       }
 
       RuntimeEventType.MAP_CAMERA_TRANSITION_FINISHED -> {
@@ -846,24 +847,26 @@ internal class MlnFfiMapSession(
    * The reason is re-reported when it changes: the gesture flag is set from the UI thread and can
    * arrive after a drag's first camera change.
    */
-  private fun beginCameraMove() {
+  private fun beginCameraMove(
+    engine: EngineMapIdentity? = lifecycleEngineIdentity,
+    lease: RenderLease? = lifecycleRenderLease,
+  ) {
     val reason =
       if (isGestureInProgress) CameraMoveReason.GESTURE else CameraMoveReason.PROGRAMMATIC
     if (reportedMoveReason == reason) return
     reportedMoveReason = reason
-    withLifecyclePresentation { engine, lease ->
+    if (engine != null && lease != null) {
       lifecycleCallbacks.onCameraMoveStarted(engine, lease, this, reason)
     }
   }
 
-  private fun endCameraMove(duringCleanup: Boolean = false) {
+  private fun endCameraMove(
+    engine: EngineMapIdentity? = lifecycleEngineIdentity,
+    lease: RenderLease? = lifecycleRenderLease,
+  ) {
     if (reportedMoveReason == null) return
     reportedMoveReason = null
-    if (duringCleanup) callbacks.onCameraMoveEnded(this)
-    else
-      withLifecyclePresentation { engine, lease ->
-        lifecycleCallbacks.onCameraMoveEnded(engine, lease, this)
-      }
+    if (engine != null && lease != null) lifecycleCallbacks.onCameraMoveEnded(engine, lease, this)
   }
 
   /** Exists for tests. */
@@ -1017,6 +1020,7 @@ internal class MlnFfiMapSession(
     val request = styleLoadTracker?.beginLoading() ?: return
     appliedStyleRequest = request
     styleLoadPending = true
+    appliedStyleRequestIdentity = lifecycleStyleRequestIdentity
     // setStyleJson parses inline, so a malformed style throws as well as queueing
     // MAP_LOADING_FAILED; the queued event is what reports it.
     try {

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -440,7 +440,7 @@ internal class MlnFfiMapSession(
     if (lifecycleRenderLease == lease) lifecycleRenderLease = null
     // This must happen before the first suspension. A host may tear down its renderer thread as
     // soon as close() returns, but the native handle can only be closed through that thread.
-    closeRenderSession()
+    closeRenderSessionForLifecycle()
     updateOwnerThreadPresentation {
       if (ownerThreadRenderLease == lease) ownerThreadRenderLease = null
     }
@@ -538,26 +538,33 @@ internal class MlnFfiMapSession(
     }
   }
 
-  /**
-   * Never throws. The bookkeeping is cleared first and unconditionally: a stale [attachedTarget]
-   * would leave the next frame attaching a second session to a map that permits only one.
-   */
+  /** Best-effort cleanup for render and surface transitions that cannot report a failure. */
   private fun closeRenderSession() {
+    releaseRenderSession()?.let { logger?.e(it) { "Failed to close the MapLibre render session" } }
+  }
+
+  /** Lifecycle cleanup reports this resource failure so [MapLifecycleAuthority.awaitClosed] can. */
+  private fun closeRenderSessionForLifecycle() {
+    releaseRenderSession()?.let { throw it }
+  }
+
+  /** Clears bookkeeping before attempting the owner-thread close and returns its failure. */
+  private fun releaseRenderSession(): Throwable? {
     val handle = renderSession
     renderSession = null
     renderSessionReady = false
     attachedTarget = null
-    if (handle == null) return
+    if (handle == null) return null
 
     val host = hostSession
     if (host == null) {
       // Only the thread that attached the handle may close it, and that is reached through the
       // host.
-      logger?.w { "Leaking a MapLibre render session: its host surface is already gone" }
-      return
+      return IllegalStateException(
+        "Cannot close the MapLibre render session because its host surface is already gone"
+      )
     }
-    runCatching { host.withRendererAccess { handle.close() } }
-      .onFailure { logger?.e(it) { "Failed to close the MapLibre render session" } }
+    return runCatching { host.withRendererAccess { handle.close() } }.exceptionOrNull()
   }
 
   // endregion

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -153,6 +153,10 @@ internal class MlnFfiMapSession(
   @Volatile internal var callbacks: MapAdapter.Callbacks = callbacks
   private val lifecycle = MapLifecycleAuthority(this)
   private val lifecycleCallbacks = MapLifecycleCallbacks(lifecycle) { this.callbacks }
+  @Volatile private var lifecycleEngineIdentity: EngineMapIdentity? = null
+  @Volatile private var lifecycleRenderLease: RenderLease? = null
+  @Volatile private var lifecycleStyleRequestIdentity: StyleRequestIdentity? = null
+  @Volatile private var lifecycleStyleIdentity: StyleIdentity? = null
 
   override val engineRetention: EngineRetention = EngineRetention.RETAIN
 
@@ -258,7 +262,9 @@ internal class MlnFfiMapSession(
           !info.attribution.isNullOrEmpty() &&
           reportedUrlAttribution.add(id)
       ) {
-        lifecycleCallbacks.onSourceChanged(this, id)
+        withLifecycleStyle { engine, style ->
+          lifecycleCallbacks.onSourceChanged(engine, style, this, id)
+        }
       }
     }
   }
@@ -289,7 +295,9 @@ internal class MlnFfiMapSession(
       sourceChanged = { sourceId ->
         featureStateReplayPending.store(true)
         reportedUrlAttribution.remove(sourceId)
-        lifecycleCallbacks.onSourceChanged(this, sourceId)
+        withLifecycleStyle { engine, style ->
+          lifecycleCallbacks.onSourceChanged(engine, style, this, sourceId)
+        }
       },
       getScale = ::imageScale,
     )
@@ -410,14 +418,25 @@ internal class MlnFfiMapSession(
   }
 
   override suspend fun createEngine(identity: EngineMapIdentity) {
-    startEngine()
+    lifecycleEngineIdentity = identity
+    lifecycleStyleRequestIdentity = lifecycle.claimStyleRequestIdentity(identity)
+    startEngine(identity)
   }
 
-  override suspend fun attach(identity: EngineMapIdentity, lease: RenderLease) = Unit
+  override suspend fun attach(identity: EngineMapIdentity, lease: RenderLease) {
+    lifecycleRenderLease = lease
+  }
 
-  override suspend fun detach(identity: EngineMapIdentity, lease: RenderLease) = Unit
+  override suspend fun detach(identity: EngineMapIdentity, lease: RenderLease) {
+    if (lifecycleRenderLease == lease) lifecycleRenderLease = null
+  }
 
   override suspend fun destroyEngine(identity: EngineMapIdentity) {
+    if (lifecycleEngineIdentity == identity) {
+      lifecycleEngineIdentity = null
+      lifecycleStyleRequestIdentity = null
+      lifecycleStyleIdentity = null
+    }
     closePlatform()
   }
 
@@ -441,7 +460,7 @@ internal class MlnFfiMapSession(
     }
   }
 
-  private fun startEngine() {
+  private fun startEngine(identity: EngineMapIdentity) {
     val started = stateLock.withLock {
       check(lifecycle.acceptsWork) { "Cannot start a closed map session" }
       loop?.let {
@@ -454,7 +473,7 @@ internal class MlnFfiMapSession(
           getLogger = { logger },
           resourceProviderFactory = resourceProviderFactory,
           onMapCreated = ::onMapCreated,
-          onEvent = ::handleEvent,
+          onEvent = { handleEvent(identity, it) },
           onEventsDrained = ::onEventsDrained,
           requestFrame = ::requestRender,
           mapEventMask = HANDLED_MAP_EVENTS,
@@ -482,7 +501,7 @@ internal class MlnFfiMapSession(
       current
     }
     abandoned.forEach { it.abandon() }
-    if (styleBinding != null) lifecycleCallbacks.onStyleChanged(this, null)
+    if (styleBinding != null) callbacks.onStyleChanged(this, null)
     styleBinding?.invalidate()
     styleBinding = null
     appliedStyle = null
@@ -699,18 +718,18 @@ internal class MlnFfiMapSession(
 
   // region events, on the map's owner thread
 
-  private fun reportLoadedStyle() {
+  private fun reportLoadedStyle(engine: EngineMapIdentity) {
     if (!styleLoadUnreported) return
     styleLoadUnreported = false
     val request = appliedStyleRequest ?: return
     val identity = styleBinding?.identity ?: return
     if (styleLoadTracker?.reconciled(request, identity) == true) {
-      lifecycleCallbacks.onMapFinishedLoading(this)
+      lifecycleStyleIdentity?.let { lifecycleCallbacks.onMapFinishedLoading(engine, it, this) }
     }
   }
 
   /** Runs on the map's owner thread, as do the callbacks it makes. */
-  private fun handleEvent(event: RuntimeEvent) {
+  private fun handleEvent(engine: EngineMapIdentity, event: RuntimeEvent) {
     when (event.type) {
       RuntimeEventType.MAP_RENDER_UPDATE_AVAILABLE -> requestRender()
 
@@ -727,7 +746,9 @@ internal class MlnFfiMapSession(
         }
         featureStateReplayPending.store(true)
         hasLoadedFirstStyle = true
-        lifecycleCallbacks.onStyleChanged(this, binding)
+        val lifecycleRequest = lifecycleStyleRequestIdentity ?: return binding.invalidate()
+        lifecycleStyleIdentity =
+          lifecycleCallbacks.onStyleChanged(engine, lifecycleRequest, this, binding)
         styleLoadUnreported = true
         reportedUrlAttribution.clear()
         // A producer frame that started before this callback can still hold the previous style.
@@ -741,12 +762,12 @@ internal class MlnFfiMapSession(
       // loaded, so a style that parses between two frames is never reported. Idle carries the same
       // guarantee and does arrive, so whichever comes first reports the load.
       RuntimeEventType.MAP_LOADING_FINISHED -> {
-        reportLoadedStyle()
+        reportLoadedStyle(engine)
       }
 
       RuntimeEventType.MAP_IDLE -> {
         if (styleLoadUnreported) {
-          reportLoadedStyle()
+          reportLoadedStyle(engine)
         } else {
           reportNewlyArrivedAttribution()
         }
@@ -767,7 +788,9 @@ internal class MlnFfiMapSession(
               reason,
             ) == true
         if (accepted) {
-          lifecycleCallbacks.onMapFailLoading(reason)
+          lifecycleStyleRequestIdentity?.let {
+            lifecycleCallbacks.onMapFailLoading(engine, it, reason)
+          }
         } else {
           loop?.map?.let(::applyRequestedStyle)
         }
@@ -777,12 +800,12 @@ internal class MlnFfiMapSession(
 
       RuntimeEventType.MAP_CAMERA_IS_CHANGING -> {
         loop?.map?.let(::snapshotViewport)
-        lifecycleCallbacks.onCameraMoved(this)
+        lifecycleRenderLease?.let { lifecycleCallbacks.onCameraMoved(engine, it, this) }
       }
 
       RuntimeEventType.MAP_CAMERA_DID_CHANGE -> {
         loop?.map?.let(::snapshotViewport)
-        lifecycleCallbacks.onCameraMoved(this)
+        lifecycleRenderLease?.let { lifecycleCallbacks.onCameraMoved(engine, it, this) }
         // A drag is a stream of jumps, each with its own did-change.
         if (!isGestureInProgress) endCameraMove()
       }
@@ -828,14 +851,19 @@ internal class MlnFfiMapSession(
       if (isGestureInProgress) CameraMoveReason.GESTURE else CameraMoveReason.PROGRAMMATIC
     if (reportedMoveReason == reason) return
     reportedMoveReason = reason
-    lifecycleCallbacks.onCameraMoveStarted(this, reason)
+    withLifecyclePresentation { engine, lease ->
+      lifecycleCallbacks.onCameraMoveStarted(engine, lease, this, reason)
+    }
   }
 
   private fun endCameraMove(duringCleanup: Boolean = false) {
     if (reportedMoveReason == null) return
     reportedMoveReason = null
     if (duringCleanup) callbacks.onCameraMoveEnded(this)
-    else lifecycleCallbacks.onCameraMoveEnded(this)
+    else
+      withLifecyclePresentation { engine, lease ->
+        lifecycleCallbacks.onCameraMoveEnded(engine, lease, this)
+      }
   }
 
   /** Exists for tests. */
@@ -870,7 +898,11 @@ internal class MlnFfiMapSession(
     val now = frameTimer.markNow()
     val elapsed = (now - lastFrameTime).toDouble(DurationUnit.SECONDS)
     lastFrameTime = now
-    if (elapsed > 0.0) lifecycleCallbacks.onFrame(1.0 / elapsed)
+    if (elapsed > 0.0) {
+      withLifecyclePresentation { engine, lease ->
+        lifecycleCallbacks.onFrame(engine, lease, 1.0 / elapsed)
+      }
+    }
   }
 
   // endregion
@@ -970,7 +1002,10 @@ internal class MlnFfiMapSession(
     }
     // Disposes the composition holding the old style's sources and layers, which would otherwise
     // fail anchor validation against the base layers being replaced.
-    lifecycleCallbacks.onStyleChanged(this, null)
+    lifecycleEngineIdentity?.let {
+      lifecycleStyleRequestIdentity = lifecycleCallbacks.beginStyleRequest(it, this)
+    }
+    lifecycleStyleIdentity = null
     onMap(::applyRequestedStyle)
   }
 
@@ -1029,7 +1064,9 @@ internal class MlnFfiMapSession(
    */
   private fun snapshotViewportAndNotify(map: MapHandle) {
     snapshotViewport(map)
-    lifecycleCallbacks.onCameraMoved(this)
+    withLifecyclePresentation { engine, lease ->
+      lifecycleCallbacks.onCameraMoved(engine, lease, this)
+    }
   }
 
   /** Owner thread only. Publishes the applied camera and viewport for any-thread getters. */
@@ -1606,7 +1643,9 @@ internal class MlnFfiMapSession(
       logger?.w { "Dropped a map click at $offset: the map has no viewport" }
       return
     }
-    lifecycleCallbacks.onClick(this, position, offset)
+    withLifecyclePresentation { engine, lease ->
+      lifecycleCallbacks.onClick(engine, lease, this, position, offset)
+    }
   }
 
   /** A mouse has no press-and-hold convention, so the secondary button is the long press. */
@@ -1617,7 +1656,21 @@ internal class MlnFfiMapSession(
       logger?.w { "Dropped a map long click at $offset: the map has no viewport" }
       return
     }
-    lifecycleCallbacks.onLongClick(this, position, offset)
+    withLifecyclePresentation { engine, lease ->
+      lifecycleCallbacks.onLongClick(engine, lease, this, position, offset)
+    }
+  }
+
+  private inline fun withLifecycleStyle(action: (EngineMapIdentity, StyleIdentity) -> Unit) {
+    val engine = lifecycleEngineIdentity ?: return
+    val style = lifecycleStyleIdentity ?: return
+    action(engine, style)
+  }
+
+  private inline fun withLifecyclePresentation(action: (EngineMapIdentity, RenderLease) -> Unit) {
+    val engine = lifecycleEngineIdentity ?: return
+    val lease = lifecycleRenderLease ?: return
+    action(engine, lease)
   }
 
   override fun cancelTransitions() {


### PR DESCRIPTION
## Description

Centralizes logical map creation, leased presentation lifecycle, closure, and platform-event acceptance in one serialized authority shared by native and Web sessions.

## Validation

Passed mise run check, test:android, test:ios, and test:js; the desktop suite passed 468 of 469 tests before one StyleOwnershipTest style-load timeout, and the complete failing class passed on immediate rerun.

## AI assistance

OpenAI Codex with a GPT-5 model implemented and reviewed the change in the Codex desktop harness.