### PR TITLE
Render maps through MapRuntime and MapState

### DIFF
--- a/.agents/scratch/api-redesign/issues/03-render-through-runtime-and-state.md
+++ b/.agents/scratch/api-redesign/issues/03-render-through-runtime-and-state.md
@@ -1,41 +1,64 @@
 # 03: Render through MapRuntime and MapState
 
 **What to build:** Add a complete public path that creates one logical map
-through an explicit or process-owned runtime, attaches it to one MaplibreMap,
+through an explicit or process-default runtime, attaches it to one MaplibreMap,
 and exposes its current presentation. Keep the superseded public path
 temporarily so later migrations remain green.
 
 **Blocked by:** 02
 
-**Status:** ready-for-agent
+**Status:** resolved
 
-- [ ] The changed test area contains no redundant, impossible,
+- [x] The changed test area contains no redundant, impossible,
       compatibility-only, or implementation-shape scenarios.
-- [ ] MapRuntime creates and tracks MapState children.
-- [ ] Independently configured OwnedMapRuntime instances can coexist and close
+- [x] MapRuntime creates and tracks MapState children.
+- [x] Independently configured MapRuntime instances can coexist and close
       independently.
-- [ ] rememberMapRuntime returns one process-owned default runtime without a
-      public closure operation.
-- [ ] rememberMapState accepts an explicit runtime and defaults to the shared
+- [x] rememberMapRuntime returns one process-default runtime. Closing it
+      permanently closes that instance.
+- [x] rememberMapState accepts an explicit runtime and defaults to the shared
       runtime.
-- [ ] rememberMapState closes the state it creates when its call leaves
-      composition; createMapState returns caller-owned state.
-- [ ] Saveable restoration creates a new logical map, restores its camera
+- [x] rememberMapState closes the state it creates when its call leaves
+      composition; the caller closes a state from createMapState.
+- [x] Saveable restoration creates a new logical map, restores its camera
       position, and reapplies the caller's initial base style.
-- [ ] A MapState renders a basic base-style map on native and Web.
-- [ ] MapState exposes at most one current MapPresentation.
-- [ ] A rival attachment fails before logical or platform state changes.
-- [ ] Closing a child does not close its runtime.
-- [ ] Owned-runtime closure closes every child before shared resources.
-- [ ] OwnedMapRuntime.close commits logical closure immediately, and awaitClosed
+- [x] A MapState renders a basic base-style map on native and Web.
+- [x] MapState exposes at most one current MapPresentation.
+- [x] A rival attachment fails before logical or platform state changes.
+- [x] Closing a child does not close its runtime.
+- [x] Runtime closure closes every child before shared resources.
+- [x] MapRuntime.close commits logical closure immediately, and awaitClosed
       observes completed cleanup.
 
 ## Test ledger
 
 - Add public-API tests for runtime child ordering, independently configured
-  runtimes, remembered-state disposal, caller-owned state, and camera restore.
+  runtimes, remembered-state disposal, caller-closed state, and camera restore.
 - Rewrite `AndroidCameraStateRecreationTest.kt`, `MapLibreConfigurationTest.kt`,
   and `MlnFfiOfflineRuntimeTest.kt` where their contracts remain public; remove
   process-singleton assertions.
 - Run `mise run test:android`, `mise run test:android:device`,
   `mise run test:desktop`, and `mise run test:js`.
+
+## Answer
+
+`MapRuntime` now creates and tracks logical `MapState` children. Every runtime
+exposes the same closure API. Closing the process default permanently closes
+that instance. Native runtime options are passed directly to each map session,
+so independently configured runtimes can render and close without changing the
+legacy process configuration.
+
+`rememberMapState` closes the state when its call leaves composition. Its saver
+creates a new state with the saved camera position and the caller's current
+initial base style. `MaplibreMap(state)` reserves one presentation before it
+creates a platform map, publishes that presentation after attachment, and
+releases it during disposal. The previous overload remains available for later
+migration tickets.
+
+The new common, browser, native composition, Android recreation, and desktop
+configuration tests cover runtime closure order, independent runtimes,
+remembered and caller-closed lifetimes, restoration, base-style rendering, and
+single-presentation rejection. The Android host, Android device, Desktop, and
+Web suites pass. A temporary mutation that skipped child closure made the
+closure-order regression test fail, which confirms that test exercises the
+production invariant.

--- a/.agents/scratch/api-redesign/spec.md
+++ b/.agents/scratch/api-redesign/spec.md
@@ -76,7 +76,7 @@ exact result types.
 ```kotlin
 fun createMapRuntime(
   options: MapRuntimeOptions,
-): OwnedMapRuntime
+): MapRuntime
 
 @Composable
 fun rememberMapRuntime(): MapRuntime
@@ -98,6 +98,7 @@ fun MaplibreMap(
 interface MapRuntime {
   val capabilities: MapRuntimeCapabilities
   val offlineManager: OfflineManager
+  val isClosed: Boolean
 
   fun createMapState(
     initialCameraPosition: CameraPosition = CameraPosition(),
@@ -108,17 +109,15 @@ interface MapRuntime {
     baseStyle: BaseStyle,
     styleComposition: StyleComposition = StyleComposition.Empty,
   ): MapSnapshotter
+
+  fun close()
+  suspend fun awaitClosed()
 }
 
 data class MapRuntimeCapabilities(
   val supportsOfflinePacks: Boolean,
   val supportsAmbientCacheManagement: Boolean,
 )
-
-interface OwnedMapRuntime : MapRuntime {
-  fun close()
-  suspend fun awaitClosed()
-}
 
 interface MapState {
   val cameraPosition: CameraPosition
@@ -156,12 +155,15 @@ interface MapSnapshotter {
 }
 ```
 
-`rememberMapRuntime()` returns the process-owned default runtime. It does not
-create one runtime per call and does not expose closure. Applications call
-`createMapRuntime()` when they need custom configuration or deterministic
-closure; the result is an `OwnedMapRuntime`. Independently configured owned
-runtimes can coexist. There is no `LocalMapRuntime`; runtime ownership is
-explicit in `rememberMapState`.
+`rememberMapRuntime()` returns one default runtime for the process. It does not
+create one runtime per call. `createMapRuntime()` creates a runtime with custom
+configuration. Independently configured runtimes can coexist. There is no
+`LocalMapRuntime`; `rememberMapState` receives its runtime explicitly.
+
+Every runtime exposes `close()` and `awaitClosed()`. Closing the process default
+closes its children and permanently closes that instance. Later
+`rememberMapRuntime()` calls return the same closed instance, and new child
+creation fails.
 
 ### Runtime
 
@@ -175,15 +177,13 @@ explicit in `rememberMapState`.
 - Expose platform capabilities when a common operation is not universally
   available.
 
-`OwnedMapRuntime.close()` commits logical closure synchronously. New work fails
-after that call. Physical cleanup runs in a non-cancellable path.
-`awaitClosed()` waits until every child and shared resource has finished
-cleanup. Closing a child does not close its runtime.
+`MapRuntime.close()` commits logical closure synchronously. New work fails after
+that call. Physical cleanup runs in a non-cancellable path. `awaitClosed()`
+waits until every child and shared resource has finished cleanup. Closing a
+child does not close its runtime.
 
-The default runtime is process-owned and is not closeable through the public
-API. An explicit runtime is application-owned. The current process-wide native
-configuration singleton is an implementation constraint to remove, not a public
-invariant to preserve.
+The current process-wide native configuration singleton is an implementation
+constraint to remove, not a public invariant to preserve.
 
 Web implements the same runtime type. `MapRuntimeCapabilities` reports
 `supportsOfflinePacks` and `supportsAmbientCacheManagement`. Native reports the

--- a/lib/maplibre-compose/src/androidDeviceTest/kotlin/org/maplibre/compose/camera/AndroidCameraStateRecreationTest.kt
+++ b/lib/maplibre-compose/src/androidDeviceTest/kotlin/org/maplibre/compose/camera/AndroidCameraStateRecreationTest.kt
@@ -13,7 +13,12 @@ import kotlin.test.Test
 import kotlin.test.assertNotSame
 import kotlin.test.assertTrue
 import org.maplibre.compose.map.MapAdapter
+import org.maplibre.compose.map.MapRuntime
+import org.maplibre.compose.map.MapState
 import org.maplibre.compose.map.MaplibreMap
+import org.maplibre.compose.map.StyleLoadState
+import org.maplibre.compose.map.rememberMapRuntime
+import org.maplibre.compose.map.rememberMapState
 import org.maplibre.compose.mlnffi.FfiTestPlatform
 import org.maplibre.compose.mlnffi.MlnFfiApplication
 import org.maplibre.compose.mlnffi.MlnFfiRuntimeOptions
@@ -32,33 +37,37 @@ class AndroidCameraStateRecreationTest {
 
     try {
       runAndroidComposeUiTest<CameraStateRecreationActivity> {
-        waitUntil(timeoutMillis = TIMEOUT_MILLIS) { activity?.cameraState?.map != null }
+        waitUntil(timeoutMillis = TIMEOUT_MILLIS) { activity?.mapState?.presentation != null }
         val firstActivity = requireNotNull(activity)
+        val firstState = requireNotNull(firstActivity.mapState)
+        assertTrue(firstActivity.defaultRuntimeIsShared)
 
-        runOnIdle { requireNotNull(firstActivity.cameraState).position = EXPECTED_CAMERA }
+        runOnIdle { firstState.cameraState.position = EXPECTED_CAMERA }
         waitUntil(timeoutMillis = TIMEOUT_MILLIS) {
-          firstActivity.cameraState?.map?.hasCamera(EXPECTED_CAMERA) == true
+          firstState.presentation?.adapter?.hasCamera(EXPECTED_CAMERA) == true
         }
 
         runOnIdle { firstActivity.recreate() }
         waitUntil(timeoutMillis = TIMEOUT_MILLIS) {
           activity != null &&
             activity !== firstActivity &&
-            activity?.cameraState?.map?.hasCamera(EXPECTED_CAMERA) == true
+            activity?.mapState?.presentation?.adapter?.hasCamera(EXPECTED_CAMERA) == true
         }
 
         val replacementActivity = requireNotNull(activity)
         assertNotSame(firstActivity, replacementActivity, "the activity should have been recreated")
-        val restoredState = requireNotNull(replacementActivity.cameraState)
-        assertCamera(EXPECTED_CAMERA, restoredState.position, "restored CameraState")
+        val restoredState = requireNotNull(replacementActivity.mapState)
+        assertNotSame(firstState, restoredState, "restoration should create a new logical map")
+        assertCamera(EXPECTED_CAMERA, restoredState.cameraPosition, "restored MapState")
         assertCamera(
           EXPECTED_CAMERA,
-          requireNotNull(restoredState.map).getCameraPosition(),
+          requireNotNull(restoredState.presentation).adapter.getCameraPosition(),
           "replacement native map",
         )
+        assertTrue(restoredState.style.baseStyle == BaseStyle.Empty)
         assertTrue(
-          replacementActivity.mapLoadFailures.isEmpty(),
-          "the replacement map reported load failures: ${replacementActivity.mapLoadFailures}",
+          restoredState.style.loadState !is StyleLoadState.Failed,
+          "the replacement map reported ${restoredState.style.loadState}",
         )
       }
     } finally {
@@ -102,21 +111,25 @@ class AndroidCameraStateRecreationTest {
 }
 
 class CameraStateRecreationActivity : ComponentActivity() {
-  var cameraState: CameraState? = null
+  var mapState: MapState? = null
     private set
 
-  val mapLoadFailures = mutableListOf<String?>()
+  var defaultRuntimeIsShared: Boolean = false
+    private set
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     setContent {
-      val state = rememberCameraState()
-      SideEffect { cameraState = state }
+      val firstRuntime: MapRuntime = rememberMapRuntime()
+      val secondRuntime: MapRuntime = rememberMapRuntime()
+      val state = rememberMapState(firstRuntime, initialBaseStyle = BaseStyle.Empty)
+      SideEffect {
+        mapState = state
+        defaultRuntimeIsShared = firstRuntime === secondRuntime
+      }
       MaplibreMap(
+        state = state,
         modifier = Modifier.fillMaxSize(),
-        baseStyle = BaseStyle.Empty,
-        cameraState = state,
-        onMapLoadFailed = { mapLoadFailures += it },
       )
     }
   }

--- a/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MlnFfiMapCompositionTest.kt
+++ b/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MlnFfiMapCompositionTest.kt
@@ -93,6 +93,28 @@ class MlnFfiMapCompositionTest {
     )
   }
 
+  @Test
+  fun map_state_renders_a_base_style_and_publishes_one_presentation() = runFfiComposeUiTest {
+    val runtime = createNativeMapRuntime(runtimeOptions)
+    val state = runtime.createMapState(initialBaseStyle = BaseStyle.Empty)
+
+    setFfiTestMapContent(runtimeOptions) { MaplibreMap(state) }
+    waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) {
+      state.presentation != null && state.style.loadState == StyleLoadState.Ready
+    }
+
+    assertTrue(state.presentation?.isValid == true)
+    assertTrue(
+      onAllNodesWithTag(MAP_LOAD_PLACEHOLDER_TAG).fetchSemanticsNodes().isEmpty(),
+      "the load placeholder should be absent after the base style is ready",
+    )
+
+    runtime.close()
+    runtime.awaitClosed()
+    assertTrue(state.isClosed)
+    assertNull(state.presentation)
+  }
+
   /** Style loading needs no rendering, so no frame runs — and none is drawn — before a style. */
   @Test
   fun an_unloaded_style_keeps_the_transparent_load_placeholder() = runFfiComposeUiTest {

--- a/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/android/AndroidRuntimeOptions.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/android/AndroidRuntimeOptions.kt
@@ -6,7 +6,7 @@ import java.io.File
 import kotlinx.io.files.Path
 import org.maplibre.compose.mlnffi.MlnFfiRuntimeOptions
 
-/** Process-wide configuration for MapLibre Native on Android. */
+/** Configuration for one MapLibre Native runtime on Android. */
 @Immutable
 public data class AndroidRuntimeOptions(
   /** Where the ambient resource cache and offline-region database live. */

--- a/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/map/AndroidMapView.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/map/AndroidMapView.kt
@@ -4,8 +4,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import co.touchlab.kermit.Logger
 import org.maplibre.compose.mlnffi.AndroidMapSurfaceKind
+import org.maplibre.compose.mlnffi.AndroidMlnFfiPlatform
 import org.maplibre.compose.mlnffi.AndroidMlnFfiSurface
 import org.maplibre.compose.mlnffi.EnsureMlnFfiConfigured
 import org.maplibre.compose.mlnffi.MapRenderBackend
@@ -15,6 +17,7 @@ import org.maplibre.compose.style.StyleBinding
 @Composable
 internal actual fun ComposableMapView(
   modifier: Modifier,
+  runtime: RuntimeImplementation?,
   style: BaseStyle,
   rememberedStyle: StyleBinding?,
   update: (map: MapAdapter) -> Unit,
@@ -23,7 +26,8 @@ internal actual fun ComposableMapView(
   callbacks: MapAdapter.Callbacks,
   options: MapOptions,
 ) {
-  EnsureMlnFfiConfigured()
+  if (runtime == null) EnsureMlnFfiConfigured()
+  else AndroidMlnFfiPlatform.initialize(LocalContext.current)
   val runtimeBackends = remember { loadRuntimeBackends(logger) }
   val renderBackend =
     remember(runtimeBackends) { runtimeBackends.firstOrNull() ?: MapRenderBackend.OPENGL }
@@ -48,6 +52,7 @@ internal actual fun ComposableMapView(
         )
       },
       modifier = modifier,
+      runtimeOptions = runtime?.nativeRuntimeOptions,
       style = style,
       update = update,
       onReset = onReset,

--- a/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/map/MapRuntime.android.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/map/MapRuntime.android.kt
@@ -1,0 +1,18 @@
+package org.maplibre.compose.map
+
+import androidx.compose.runtime.Composable
+import org.maplibre.compose.android.AndroidRuntimeOptions
+import org.maplibre.compose.android.toMlnFfiRuntimeOptions
+import org.maplibre.compose.mlnffi.EnsureMlnFfiConfigured
+import org.maplibre.compose.mlnffi.MlnFfiApplication
+
+public actual typealias MapRuntimeOptions = AndroidRuntimeOptions
+
+public actual fun createMapRuntime(options: MapRuntimeOptions): MapRuntime =
+  createNativeMapRuntime(options.toMlnFfiRuntimeOptions())
+
+@Composable
+public actual fun rememberMapRuntime(): MapRuntime {
+  EnsureMlnFfiConfigured()
+  return ProcessNativeMapRuntime.get(MlnFfiApplication.options)
+}

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/ComposableMapView.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/ComposableMapView.kt
@@ -9,6 +9,7 @@ import org.maplibre.compose.style.StyleBinding
 @Composable
 internal expect fun ComposableMapView(
   modifier: Modifier,
+  runtime: RuntimeImplementation?,
   style: BaseStyle,
   rememberedStyle: StyleBinding?,
   update: (map: MapAdapter) -> Unit,

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapAdapter.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapAdapter.kt
@@ -19,6 +19,10 @@ import org.maplibre.spatialk.geojson.Geometry
 import org.maplibre.spatialk.geojson.Position
 
 internal interface MapAdapter {
+  fun close()
+
+  suspend fun awaitClosed()
+
   suspend fun animateCameraPosition(finalPosition: CameraPosition, duration: Duration)
 
   suspend fun animateCameraPosition(

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
@@ -1,0 +1,405 @@
+@file:OptIn(ExperimentalAtomicApi::class)
+
+package org.maplibre.compose.map
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshots.Snapshot
+import androidx.compose.runtime.structuralEqualityPolicy
+import kotlin.concurrent.atomics.AtomicLong
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+import kotlin.concurrent.atomics.incrementAndFetch
+import kotlin.jvm.JvmInline
+import kotlinx.atomicfu.locks.reentrantLock
+import kotlinx.atomicfu.locks.withLock
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import org.maplibre.compose.camera.CameraPosition
+import org.maplibre.compose.camera.CameraState
+import org.maplibre.compose.style.BaseStyle
+import org.maplibre.compose.style.StyleState
+import org.maplibre.spatialk.geojson.Position
+
+/** Platform configuration for one [MapRuntime]. */
+public expect class MapRuntimeOptions
+
+/** Creates a runtime from [options]. The caller must close the result. */
+public expect fun createMapRuntime(options: MapRuntimeOptions): MapRuntime
+
+/** Returns the default runtime for this process. */
+@Composable public expect fun rememberMapRuntime(): MapRuntime
+
+/** Creates logical maps that share one application-level configuration. */
+public interface MapRuntime {
+  /** Creates a logical map. The caller must close the result. */
+  public fun createMapState(
+    initialCameraPosition: CameraPosition = CameraPosition(),
+    initialBaseStyle: BaseStyle = BaseStyle.Demo,
+  ): MapState
+
+  /** Whether [close] has marked this runtime as closed. */
+  public val isClosed: Boolean
+
+  /** Marks this runtime as closed and starts child and shared-resource cleanup. */
+  public fun close()
+
+  /** Waits until every child and shared resource has finished cleanup. */
+  public suspend fun awaitClosed()
+}
+
+/** Thrown when an operation targets a closed runtime. */
+public class MapRuntimeClosedException : IllegalStateException("The map runtime is closed")
+
+/** Thrown when an operation targets a closed logical map. */
+public class MapStateClosedException : IllegalStateException("The map state is closed")
+
+/** The load state for the desired base style of one logical map. */
+public sealed interface StyleLoadState {
+  /** No presentation can currently load the desired style. */
+  public data object Pending : StyleLoadState
+
+  /** The current presentation is loading the desired style. */
+  public data object Loading : StyleLoadState
+
+  /** The current presentation has loaded the desired style. */
+  public data object Ready : StyleLoadState
+
+  /** The current presentation failed to load the desired style. */
+  public data class Failed(public val reason: String?) : StyleLoadState
+}
+
+/** Desired and applied style state for one [MapState]. */
+public class MapStyleState internal constructor(initialBaseStyle: BaseStyle) {
+  private var owner: MapState? = null
+  private var baseStyleState: BaseStyle by
+    mutableStateOf(initialBaseStyle, structuralEqualityPolicy())
+
+  public var baseStyle: BaseStyle
+    get() = baseStyleState
+    set(value) {
+      owner?.setBaseStyle(value) ?: setBaseStyleState(value)
+    }
+
+  public var loadState: StyleLoadState by mutableStateOf(StyleLoadState.Pending)
+    internal set
+
+  internal fun attach(owner: MapState) {
+    this.owner = owner
+  }
+
+  internal fun setBaseStyleState(value: BaseStyle) {
+    baseStyleState = value
+  }
+}
+
+/** One temporary connection between a [MapState] and a map surface. */
+public class MapPresentation
+internal constructor(
+  private val owner: MapState,
+  internal val token: MapPresentationToken,
+  internal val adapter: MapAdapter,
+) {
+  /** Whether this presentation is still the current connection. */
+  public val isValid: Boolean
+    get() = owner.isCurrent(this)
+}
+
+/** One logical map, independent from its temporary UI presentation. */
+public class MapState
+internal constructor(
+  internal val runtime: RuntimeImplementation,
+  initialCameraPosition: CameraPosition,
+  initialBaseStyle: BaseStyle,
+) {
+  private val lock = reentrantLock()
+  private val closure = CompletableDeferred<Result<Unit>>()
+  private var attachment: Attachment? = null
+  private var closed = false
+
+  internal val cameraState = CameraState(initialCameraPosition)
+  internal val compatibilityStyleState = StyleState()
+
+  public val style: MapStyleState = MapStyleState(initialBaseStyle).also { it.attach(this) }
+
+  public val cameraPosition: CameraPosition
+    get() = cameraState.position
+
+  public var presentation: MapPresentation? by mutableStateOf(null)
+    private set
+
+  public val isClosed: Boolean
+    get() = lock.withLock { closed }
+
+  /** Marks this state as closed and starts cleanup of the current presentation. */
+  public fun close() {
+    val map = lock.withLock {
+      if (closed) return
+      closed = true
+      val map = attachment?.adapter
+      attachment = null
+      Snapshot.withMutableSnapshot { presentation = null }
+      map
+    }
+    cameraState.map = null
+    if (map == null) {
+      completeClosure(Result.success(Unit))
+      return
+    }
+    map.close()
+    runtime.physicalScope.launch(start = CoroutineStart.UNDISPATCHED) {
+      completeClosure(runCatching { map.awaitClosed() })
+    }
+  }
+
+  /** Waits until presentation cleanup has completed. */
+  public suspend fun awaitClosed() {
+    closure.await().getOrThrow()
+  }
+
+  internal fun reservePresentation(): MapPresentationToken = lock.withLock {
+    requireOpenLocked()
+    check(attachment == null) { "The map state already has a presentation" }
+    val token = MapPresentationToken(nextPresentationToken.incrementAndFetch())
+    attachment = Attachment(token)
+    token
+  }
+
+  internal fun publishPresentation(token: MapPresentationToken, adapter: MapAdapter) {
+    lock.withLock {
+      requireOpenLocked()
+      val current = attachment
+      check(current?.token == token && !current.releasing) {
+        "The map presentation reservation is no longer current"
+      }
+      if (current.adapter === adapter) return
+      check(current.adapter == null) { "The map state already has a presentation" }
+      current.adapter = adapter
+      MapPresentation(this, token, adapter).also { presentation = it }
+      cameraState.map = adapter
+      adapter.setBaseStyle(style.baseStyle)
+      style.loadState = StyleLoadState.Loading
+    }
+  }
+
+  internal fun releasePresentation(token: MapPresentationToken, adapter: MapAdapter? = null) {
+    val closingAdapter = lock.withLock {
+      val current = attachment ?: return
+      if (current.token != token) return
+      if (adapter != null && current.adapter !== adapter) return
+      if (current.releasing) return
+      current.releasing = true
+      presentation = null
+      style.loadState = StyleLoadState.Pending
+      current.adapter
+    }
+    if (cameraState.map === closingAdapter) cameraState.map = null
+    if (closingAdapter == null) {
+      lock.withLock { if (attachment?.token == token) attachment = null }
+      return
+    }
+    closingAdapter.close()
+    runtime.physicalScope.launch(start = CoroutineStart.UNDISPATCHED) {
+      runCatching { closingAdapter.awaitClosed() }
+      lock.withLock { if (attachment?.token == token) attachment = null }
+    }
+  }
+
+  internal fun markStyleReady(adapter: MapAdapter) {
+    lock.withLock {
+      if (!closed && attachment?.adapter === adapter) style.loadState = StyleLoadState.Ready
+    }
+  }
+
+  internal fun markStyleFailed(adapter: MapAdapter, reason: String?) {
+    lock.withLock {
+      if (!closed && attachment?.adapter === adapter) {
+        style.loadState = StyleLoadState.Failed(reason)
+      }
+    }
+  }
+
+  internal fun setBaseStyle(value: BaseStyle) {
+    lock.withLock {
+      requireOpenLocked()
+      if (style.baseStyle == value) return
+      style.setBaseStyleState(value)
+      val adapter = attachment?.adapter
+      if (adapter == null) {
+        style.loadState = StyleLoadState.Pending
+      } else {
+        style.loadState = StyleLoadState.Loading
+        adapter.setBaseStyle(value)
+      }
+    }
+  }
+
+  internal fun isCurrent(candidate: MapPresentation): Boolean = lock.withLock {
+    !closed && presentation === candidate && attachment?.token == candidate.token
+  }
+
+  private fun requireOpenLocked() {
+    if (closed) throw MapStateClosedException()
+  }
+
+  private fun completeClosure(result: Result<Unit>) {
+    if (closure.complete(result)) runtime.childClosed(this)
+  }
+
+  private class Attachment(
+    val token: MapPresentationToken,
+    var adapter: MapAdapter? = null,
+    var releasing: Boolean = false,
+  )
+
+  private companion object {
+    val nextPresentationToken = AtomicLong(0L)
+  }
+}
+
+@JvmInline internal value class MapPresentationToken(val value: Long)
+
+/**
+ * Remembers a logical map and closes it when this call leaves composition. Restoration creates a
+ * new map with the saved camera position and the caller's current [initialBaseStyle].
+ */
+@Composable
+public fun rememberMapState(
+  runtime: MapRuntime = rememberMapRuntime(),
+  initialCameraPosition: CameraPosition = CameraPosition(),
+  initialBaseStyle: BaseStyle = BaseStyle.Demo,
+): MapState {
+  val state =
+    rememberSaveable(
+      runtime,
+      saver = mapStateSaver(runtime, initialBaseStyle),
+    ) {
+      runtime.createMapState(initialCameraPosition, initialBaseStyle)
+    }
+  DisposableEffect(state) { onDispose { state.close() } }
+  return state
+}
+
+private data class SavedCameraPosition(
+  val bearing: Double,
+  val longitude: Double,
+  val latitude: Double,
+  val tilt: Double,
+  val zoom: Double,
+)
+
+private fun mapStateSaver(
+  runtime: MapRuntime,
+  initialBaseStyle: BaseStyle,
+): Saver<MapState, List<Double>> =
+  Saver(
+    save = { state ->
+      state.cameraPosition.toSavedCameraPosition().toList()
+    },
+    restore = { values ->
+      val saved = values.toSavedCameraPosition()
+      runtime.createMapState(
+        initialCameraPosition =
+          CameraPosition(
+            bearing = saved.bearing,
+            target = Position(longitude = saved.longitude, latitude = saved.latitude),
+            tilt = saved.tilt,
+            zoom = saved.zoom,
+          ),
+        initialBaseStyle = initialBaseStyle,
+      )
+    },
+  )
+
+private fun CameraPosition.toSavedCameraPosition(): SavedCameraPosition =
+  SavedCameraPosition(bearing, target.longitude, target.latitude, tilt, zoom)
+
+private fun SavedCameraPosition.toList(): List<Double> =
+  listOf(bearing, longitude, latitude, tilt, zoom)
+
+private fun List<Double>.toSavedCameraPosition(): SavedCameraPosition {
+  require(size == 5) { "A saved camera position must contain five values" }
+  return SavedCameraPosition(
+    bearing = this[0],
+    longitude = this[1],
+    latitude = this[2],
+    tilt = this[3],
+    zoom = this[4],
+  )
+}
+
+internal fun interface MapRuntimeResources {
+  suspend fun close()
+}
+
+internal class RuntimeImplementation(
+  internal val platformOptions: Any?,
+  private val resources: MapRuntimeResources,
+  internal val physicalScope: CoroutineScope =
+    CoroutineScope(SupervisorJob() + Dispatchers.Default),
+) : MapRuntime {
+  private val lock = reentrantLock()
+  private val children = linkedSetOf<MapState>()
+  private val closure = CompletableDeferred<Result<Unit>>()
+  private var closed = false
+
+  final override fun createMapState(
+    initialCameraPosition: CameraPosition,
+    initialBaseStyle: BaseStyle,
+  ): MapState = lock.withLock {
+    if (closed) throw MapRuntimeClosedException()
+    MapState(this, initialCameraPosition, initialBaseStyle).also(children::add)
+  }
+
+  override fun close() {
+    val closingChildren = lock.withLock {
+      if (closed) return
+      closed = true
+      children.toList()
+    }
+    closingChildren.forEach(MapState::close)
+    physicalScope.launch(start = CoroutineStart.UNDISPATCHED) {
+      val failures = mutableListOf<Throwable>()
+      closingChildren.forEach { child ->
+        runCatching { child.awaitClosed() }.exceptionOrNull()?.let(failures::add)
+      }
+      runCatching { resources.close() }.exceptionOrNull()?.let(failures::add)
+      closure.complete(
+        if (failures.isEmpty()) Result.success(Unit)
+        else Result.failure(MapRuntimeCleanupException(failures))
+      )
+    }
+  }
+
+  override val isClosed: Boolean
+    get() = lock.withLock { closed }
+
+  override suspend fun awaitClosed() {
+    closure.await().getOrThrow()
+  }
+
+  internal fun childClosed(child: MapState) {
+    lock.withLock { children.remove(child) }
+  }
+}
+
+internal class MapRuntimeCleanupException(failures: List<Throwable>) :
+  RuntimeException("Map runtime cleanup failed in ${failures.size} resource(s)", failures.first()) {
+  init {
+    failures.drop(1).forEach(::addSuppressed)
+  }
+}
+
+internal fun mapRuntimeForTest(closeResources: suspend () -> Unit = {}): MapRuntime =
+  RuntimeImplementation(
+    platformOptions = null,
+    resources = MapRuntimeResources(closeResources),
+  )

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MaplibreMap.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MaplibreMap.kt
@@ -7,12 +7,15 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
@@ -37,6 +40,64 @@ import org.maplibre.compose.util.MapClickHandler
 import org.maplibre.compose.util.MaplibreComposable
 import org.maplibre.spatialk.geojson.BoundingBox
 import org.maplibre.spatialk.geojson.Position
+
+private class MapStateAttachment(
+  private val state: MapState,
+  private val token: MapPresentationToken,
+) {
+  val runtime: RuntimeImplementation
+    get() = state.runtime
+
+  fun publish(map: MapAdapter) {
+    state.publishPresentation(token, map)
+  }
+
+  fun release(map: MapAdapter? = null) {
+    state.releasePresentation(token, map)
+  }
+
+  fun markStyleReady(map: MapAdapter) {
+    state.markStyleReady(map)
+  }
+
+  fun markStyleFailed(map: MapAdapter, reason: String?) {
+    state.markStyleFailed(map, reason)
+  }
+}
+
+private val LocalMapStateAttachment = staticCompositionLocalOf<MapStateAttachment?> { null }
+
+/**
+ * Displays [state] through one temporary presentation.
+ *
+ * The caller keeps [state] alive. This composable creates only the current presentation and
+ * releases it when the call leaves composition.
+ */
+@Composable
+public fun MaplibreMap(
+  state: MapState,
+  modifier: Modifier = Modifier,
+  options: MapOptions = MapOptions(),
+  contentWindowInsets: WindowInsets = WindowInsets.safeDrawing,
+  overlay: MapOverlay = MapOverlay.Default,
+  content: @Composable @MaplibreComposable () -> Unit = {},
+) {
+  val token = remember(state) { state.reservePresentation() }
+  val attachment = remember(state, token) { MapStateAttachment(state, token) }
+  DisposableEffect(attachment) { onDispose { attachment.release() } }
+  CompositionLocalProvider(LocalMapStateAttachment provides attachment) {
+    MaplibreMap(
+      modifier = modifier,
+      baseStyle = state.style.baseStyle,
+      cameraState = state.cameraState,
+      styleState = state.compatibilityStyleState,
+      options = options,
+      contentWindowInsets = contentWindowInsets,
+      overlay = overlay,
+      content = content,
+    )
+  }
+}
 
 /**
  * Displays a MapLibre based map.
@@ -144,6 +205,7 @@ public fun MaplibreMap(
     return
   }
 
+  val stateAttachment = LocalMapStateAttachment.current
   var rememberedStyle by remember { mutableStateOf<StyleBinding?>(null) }
   val styleComposition by rememberStyleComposition(styleState, rememberedStyle, logger, content)
   val mapClickScope = rememberCoroutineScope()
@@ -152,7 +214,7 @@ public fun MaplibreMap(
   SideEffect { cameraState.density = density }
 
   val callbacks =
-    remember(cameraState, styleState, styleComposition, mapClickScope) {
+    remember(cameraState, styleState, styleComposition, mapClickScope, stateAttachment) {
       object : MapAdapter.Callbacks {
         override fun onStyleChanged(map: MapAdapter, style: StyleBinding?) {
           rememberedStyle = style
@@ -160,10 +222,12 @@ public fun MaplibreMap(
         }
 
         override fun onMapFailLoading(reason: String?) {
+          cameraState.map?.let { map -> stateAttachment?.markStyleFailed(map, reason) }
           onMapLoadFailed(reason)
         }
 
         override fun onMapFinishedLoading(map: MapAdapter) {
+          stateAttachment?.markStyleReady(map)
           styleState.refreshSources()
           onMapLoadFinished()
         }
@@ -252,10 +316,12 @@ public fun MaplibreMap(
   Box(modifier.fillMaxSize()) {
     ComposableMapView(
       modifier = Modifier.fillMaxSize(),
+      runtime = stateAttachment?.runtime,
       style = baseStyle,
       update = { map ->
         map.setCameraPadding(cameraPadding)
         cameraState.map = map
+        stateAttachment?.publish(map)
         map.setCameraConstraints(
           CameraConstraints(
             minZoom = zoomRange.start.toDouble(),
@@ -270,6 +336,7 @@ public fun MaplibreMap(
         map.setTileLodSettings(options.tileLodOptions)
       },
       onReset = {
+        stateAttachment?.release(cameraState.map)
         cameraState.map = null
         rememberedStyle = null
       },

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapRuntimeTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapRuntimeTest.kt
@@ -1,0 +1,112 @@
+package org.maplibre.compose.map
+
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotSame
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import org.maplibre.compose.camera.CameraPosition
+import org.maplibre.compose.style.BaseStyle
+import org.maplibre.spatialk.geojson.Position
+
+class MapRuntimeTest {
+
+  @Test
+  fun runtime_closes_every_child_before_shared_resources() = runTest {
+    lateinit var first: MapState
+    lateinit var second: MapState
+    var resourcesClosed = false
+    val runtime = mapRuntimeForTest {
+      assertTrue(first.isClosed)
+      assertTrue(second.isClosed)
+      resourcesClosed = true
+    }
+    first = runtime.createMapState()
+    second = runtime.createMapState()
+
+    runtime.close()
+
+    assertTrue(first.isClosed)
+    assertTrue(second.isClosed)
+    assertFailsWith<MapRuntimeClosedException> { runtime.createMapState() }
+    runtime.awaitClosed()
+    assertTrue(resourcesClosed)
+  }
+
+  @Test
+  fun child_closure_does_not_close_its_runtime() = runTest {
+    val runtime = mapRuntimeForTest()
+    val first = runtime.createMapState()
+
+    first.close()
+    first.awaitClosed()
+
+    assertTrue(first.isClosed)
+    assertFalse(runtime.isClosed)
+    val second = runtime.createMapState()
+    assertNotSame(first, second)
+    runtime.close()
+    runtime.awaitClosed()
+  }
+
+  @Test
+  fun independently_configured_runtimes_close_independently() = runTest {
+    var firstResourcesClosed = false
+    var secondResourcesClosed = false
+    val first = mapRuntimeForTest { firstResourcesClosed = true }
+    val second = mapRuntimeForTest { secondResourcesClosed = true }
+    val secondState = second.createMapState()
+
+    first.close()
+    first.awaitClosed()
+
+    assertTrue(firstResourcesClosed)
+    assertFalse(secondResourcesClosed)
+    assertFalse(secondState.isClosed)
+    second.createMapState().close()
+    second.close()
+    second.awaitClosed()
+    assertTrue(secondResourcesClosed)
+  }
+
+  @Test
+  fun state_starts_with_the_requested_durable_values() {
+    val runtime = mapRuntimeForTest()
+    val camera =
+      CameraPosition(
+        bearing = 12.0,
+        target = Position(longitude = 7.0, latitude = 8.0),
+        tilt = 30.0,
+        zoom = 9.0,
+      )
+
+    val state = runtime.createMapState(camera, BaseStyle.Empty)
+
+    assertTrue(state.cameraPosition == camera)
+    assertTrue(state.style.baseStyle == BaseStyle.Empty)
+    assertTrue(state.presentation == null)
+    state.close()
+    runtime.close()
+  }
+
+  @Test
+  fun await_closed_waits_for_shared_resource_cleanup() = runTest {
+    val releaseResources = CompletableDeferred<Unit>()
+    val runtime = mapRuntimeForTest { releaseResources.await() }
+
+    runtime.close()
+    val waiting = CompletableDeferred<Unit>()
+    backgroundScope.launch {
+      runtime.awaitClosed()
+      waiting.complete(Unit)
+    }
+
+    testScheduler.runCurrent()
+    assertFalse(waiting.isCompleted)
+    releaseResources.complete(Unit)
+    waiting.await()
+  }
+}

--- a/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/ios/IosRuntimeOptions.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/ios/IosRuntimeOptions.kt
@@ -7,7 +7,7 @@ import platform.Foundation.NSCachesDirectory
 import platform.Foundation.NSSearchPathForDirectoriesInDomains
 import platform.Foundation.NSUserDomainMask
 
-/** Process-wide configuration for MapLibre Native on iOS. */
+/** Configuration for one MapLibre Native runtime on iOS. */
 @Immutable
 public data class IosRuntimeOptions(
   /** Where the ambient resource cache and offline-region database live. */

--- a/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/map/IosMapView.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/map/IosMapView.kt
@@ -12,6 +12,7 @@ import org.maplibre.compose.style.StyleBinding
 @Composable
 internal actual fun ComposableMapView(
   modifier: Modifier,
+  runtime: RuntimeImplementation?,
   style: BaseStyle,
   rememberedStyle: StyleBinding?,
   update: (map: MapAdapter) -> Unit,
@@ -34,6 +35,7 @@ internal actual fun ComposableMapView(
       )
     },
     modifier = modifier,
+    runtimeOptions = runtime?.nativeRuntimeOptions,
     style = style,
     update = update,
     onReset = onReset,

--- a/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/map/MapRuntime.ios.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/map/MapRuntime.ios.kt
@@ -1,0 +1,18 @@
+package org.maplibre.compose.map
+
+import androidx.compose.runtime.Composable
+import org.maplibre.compose.ios.IosRuntimeOptions
+import org.maplibre.compose.ios.toMlnFfiRuntimeOptions
+import org.maplibre.compose.mlnffi.EnsureMlnFfiConfigured
+import org.maplibre.compose.mlnffi.MlnFfiApplication
+
+public actual typealias MapRuntimeOptions = IosRuntimeOptions
+
+public actual fun createMapRuntime(options: MapRuntimeOptions): MapRuntime =
+  createNativeMapRuntime(options.toMlnFfiRuntimeOptions())
+
+@Composable
+public actual fun rememberMapRuntime(): MapRuntime {
+  EnsureMlnFfiConfigured()
+  return ProcessNativeMapRuntime.get(MlnFfiApplication.options)
+}

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
@@ -89,6 +89,10 @@ internal class GlJsMapSession(
   internal var layoutDirection: LayoutDirection,
 ) : MapAdapter, GlJsMapRenderer, GestureTarget, MapLifecyclePlatformAdapter {
 
+  init {
+    createdCount += 1
+  }
+
   internal var callbacks: MapAdapter.Callbacks = callbacks
   private val lifecycle = MapLifecycleAuthority(this)
   private val lifecycleCallbacks = MapLifecycleCallbacks(lifecycle) { this.callbacks }
@@ -241,6 +245,10 @@ internal class GlJsMapSession(
     } finally {
       lifecycle.close()
     }
+  }
+
+  override suspend fun awaitClosed() {
+    lifecycle.awaitClosed()
   }
 
   fun start() {
@@ -1160,8 +1168,11 @@ internal class GlJsMapSession(
       )
       .toPosition()
 
-  private companion object {
+  internal companion object {
     const val OFFSCREEN_CONTAINER_STYLE =
       "position:absolute;left:-10000px;top:0;visibility:hidden;pointer-events:none;"
+
+    var createdCount: Int = 0
+      private set
   }
 }

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/JsMapView.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/JsMapView.kt
@@ -20,6 +20,7 @@ import org.maplibre.compose.style.StyleBinding
 @Composable
 internal actual fun ComposableMapView(
   modifier: Modifier,
+  runtime: RuntimeImplementation?,
   style: BaseStyle,
   rememberedStyle: StyleBinding?,
   update: (map: MapAdapter) -> Unit,
@@ -45,11 +46,9 @@ internal actual fun ComposableMapView(
   // Must run in the apply phase, not from a coroutine: the unload has to precede the content
   // subcomposition inserting layers, or a style switch crashes on anchor validation (see #269).
   SideEffect { session.setBaseStyle(style) }
+  SideEffect { update(session) }
 
-  LaunchedEffect(session, options, update) {
-    update(session)
-    session.start()
-  }
+  LaunchedEffect(session) { session.start() }
 
   DisposableEffect(session) {
     onDispose {

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/MapRuntime.js.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/MapRuntime.js.kt
@@ -1,0 +1,14 @@
+package org.maplibre.compose.map
+
+import androidx.compose.runtime.Composable
+
+/** Browser runtime configuration. */
+public actual class MapRuntimeOptions
+
+public actual fun createMapRuntime(options: MapRuntimeOptions): MapRuntime =
+  RuntimeImplementation(platformOptions = options, resources = MapRuntimeResources {})
+
+private val processMapRuntime: MapRuntime =
+  RuntimeImplementation(platformOptions = null, resources = MapRuntimeResources {})
+
+@Composable public actual fun rememberMapRuntime(): MapRuntime = processMapRuntime

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserMapStateTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserMapStateTest.kt
@@ -1,0 +1,92 @@
+package org.maplibre.compose.map
+
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.test.ExperimentalTestApi
+import kotlin.js.Promise
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+import org.maplibre.compose.gljs.runBrowserMapTest
+import org.maplibre.compose.gljs.setBrowserMapContent
+import org.maplibre.compose.gljs.waitUntilMap
+import org.maplibre.compose.style.BaseStyle
+
+@OptIn(ExperimentalTestApi::class)
+class BrowserMapStateTest {
+
+  @Test
+  fun remembered_runtime_is_shared_and_remains_closed_after_state_disposal(): Promise<*> =
+    runBrowserMapTest {
+      val includeState = mutableStateOf(true)
+      lateinit var firstRuntime: MapRuntime
+      lateinit var secondRuntime: MapRuntime
+      lateinit var state: MapState
+      setBrowserMapContent {
+        firstRuntime = rememberMapRuntime()
+        secondRuntime = rememberMapRuntime()
+        if (includeState.value) {
+          val remembered = rememberMapState(firstRuntime, initialBaseStyle = BaseStyle.Empty)
+          SideEffect { state = remembered }
+        }
+      }
+      waitForIdle()
+
+      assertSame(firstRuntime, secondRuntime)
+      assertTrue(!state.isClosed)
+
+      runOnIdle { includeState.value = false }
+      waitUntilMap("the remembered state to close") { state.isClosed }
+      assertTrue(state.isClosed)
+
+      firstRuntime.close()
+      firstRuntime.awaitClosed()
+      lateinit var runtimeAfterClosure: MapRuntime
+      setBrowserMapContent { runtimeAfterClosure = rememberMapRuntime() }
+      waitForIdle()
+
+      assertSame(firstRuntime, runtimeAfterClosure)
+      assertTrue(runtimeAfterClosure.isClosed)
+      assertFailsWith<MapRuntimeClosedException> { runtimeAfterClosure.createMapState() }
+    }
+
+  @Test
+  fun map_state_renders_a_base_style_and_publishes_one_presentation(): Promise<*> =
+    runBrowserMapTest {
+      val runtime = createMapRuntime(MapRuntimeOptions())
+      val state = runtime.createMapState(initialBaseStyle = BaseStyle.Empty)
+      val includeRival = mutableStateOf(false)
+
+      setBrowserMapContent {
+        MaplibreMap(state)
+        if (includeRival.value) MaplibreMap(state)
+      }
+      waitUntilMap("the logical map presentation to load") {
+        state.presentation != null && state.style.loadState == StyleLoadState.Ready
+      }
+
+      assertNotNull(state.presentation)
+      val presentation = state.presentation!!
+      assertTrue(presentation.isValid)
+      val createdSessions = GlJsMapSession.createdCount
+
+      runOnIdle { includeRival.value = true }
+      assertFailsWith<IllegalStateException> { waitForIdle() }
+      assertEquals(createdSessions, GlJsMapSession.createdCount)
+      assertSame(presentation, state.presentation)
+      assertTrue(presentation.isValid)
+
+      setContent {}
+      waitUntilMap("the presentation to detach") { state.presentation == null }
+      assertNull(state.presentation)
+      assertFalse(state.isClosed)
+
+      runtime.close()
+      runtime.awaitClosed()
+    }
+}

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/MapLibre.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/MapLibre.kt
@@ -5,6 +5,17 @@ import java.nio.file.Paths
 import org.maplibre.compose.mlnffi.MlnFfiApplication
 import org.maplibre.compose.mlnffi.MlnFfiRuntimeOptions
 
+/** Configuration for one desktop map runtime that the caller closes. */
+public data class DesktopRuntimeOptions(
+  /** Reverse-domain name for the runtime's cache directory. */
+  public val applicationId: String = inferredApplicationId(),
+  /** Ambient cache size in bytes, or null for MapLibre's default. */
+  public val maximumCacheSizeBytes: Long? = null,
+)
+
+internal fun DesktopRuntimeOptions.toMlnFfiRuntimeOptions(): MlnFfiRuntimeOptions =
+  desktopRuntimeOptions(applicationId, maximumCacheSizeBytes)
+
 /** Desktop configuration for MapLibre Compose. */
 public object MapLibre {
   /**

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/map/DesktopMapView.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/map/DesktopMapView.kt
@@ -12,6 +12,7 @@ import org.maplibre.compose.style.StyleBinding
 @Composable
 internal actual fun ComposableMapView(
   modifier: Modifier,
+  runtime: RuntimeImplementation?,
   style: BaseStyle,
   rememberedStyle: StyleBinding?,
   update: (map: MapAdapter) -> Unit,
@@ -28,6 +29,7 @@ internal actual fun ComposableMapView(
   MlnFfiMapView(
     hostFactory = hostFactory,
     modifier = modifier,
+    runtimeOptions = runtime?.nativeRuntimeOptions,
     style = style,
     update = update,
     onReset = onReset,

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/map/MapRuntime.desktop.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/map/MapRuntime.desktop.kt
@@ -1,0 +1,18 @@
+package org.maplibre.compose.map
+
+import androidx.compose.runtime.Composable
+import org.maplibre.compose.desktop.DesktopRuntimeOptions
+import org.maplibre.compose.desktop.toMlnFfiRuntimeOptions
+import org.maplibre.compose.mlnffi.EnsureMlnFfiConfigured
+import org.maplibre.compose.mlnffi.MlnFfiApplication
+
+public actual typealias MapRuntimeOptions = DesktopRuntimeOptions
+
+public actual fun createMapRuntime(options: MapRuntimeOptions): MapRuntime =
+  createNativeMapRuntime(options.toMlnFfiRuntimeOptions())
+
+@Composable
+public actual fun rememberMapRuntime(): MapRuntime {
+  EnsureMlnFfiConfigured()
+  return ProcessNativeMapRuntime.get(MlnFfiApplication.options)
+}

--- a/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/desktop/MapLibreConfigurationTest.kt
+++ b/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/desktop/MapLibreConfigurationTest.kt
@@ -7,7 +7,8 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
-import org.maplibre.compose.mlnffi.MlnFfiApplication
+import kotlinx.coroutines.test.runTest
+import org.maplibre.compose.map.createMapRuntime
 
 class MapLibreConfigurationTest {
 
@@ -23,8 +24,12 @@ class MapLibreConfigurationTest {
 
   @Test
   fun application_ids_cannot_escape_the_cache_directory() {
-    assertFailsWith<IllegalArgumentException> { MapLibre.configure("../another-app") }
-    assertFailsWith<IllegalArgumentException> { MapLibre.configure("com/example/app") }
+    assertFailsWith<IllegalArgumentException> {
+      createMapRuntime(DesktopRuntimeOptions("../another-app"))
+    }
+    assertFailsWith<IllegalArgumentException> {
+      createMapRuntime(DesktopRuntimeOptions("com/example/app"))
+    }
   }
 
   @Test
@@ -38,49 +43,21 @@ class MapLibreConfigurationTest {
   }
 
   @Test
-  fun repeating_the_same_configuration_is_harmless() {
-    try {
-      MapLibre.configure("com.example.same")
-      MapLibre.configure("com.example.same")
-    } finally {
-      MlnFfiApplication.resetForTest()
-    }
-  }
+  fun independently_configured_runtimes_coexist_and_close_independently() = runTest {
+    val first = createMapRuntime(DesktopRuntimeOptions("com.example.first"))
+    val second =
+      createMapRuntime(DesktopRuntimeOptions("com.example.second", maximumCacheSizeBytes = 2_000))
+    val firstState = first.createMapState()
+    val secondState = second.createMapState()
 
-  @Test
-  fun replacing_the_application_configuration_fails() {
-    try {
-      MapLibre.configure("com.example.first")
+    first.close()
+    first.awaitClosed()
 
-      assertFailsWith<IllegalStateException> { MapLibre.configure("com.example.second") }
-    } finally {
-      MlnFfiApplication.resetForTest()
-    }
-  }
-
-  @Test
-  fun replacing_the_cache_limit_fails() {
-    try {
-      MapLibre.configure("com.example.same", maximumCacheSizeBytes = 1_000)
-
-      assertFailsWith<IllegalStateException> {
-        MapLibre.configure("com.example.same", maximumCacheSizeBytes = 2_000)
-      }
-    } finally {
-      MlnFfiApplication.resetForTest()
-    }
-  }
-
-  @Test
-  fun default_configuration_does_not_replace_an_existing_one() {
-    try {
-      MapLibre.configure("com.example.first")
-      MlnFfiApplication.ensureConfigured { desktopRuntimeOptions("com.example.second") }
-      val installed = MlnFfiApplication.options.cacheFile.toString()
-      assertTrue(installed.contains("com.example.first"))
-    } finally {
-      MlnFfiApplication.resetForTest()
-    }
+    assertTrue(firstState.isClosed)
+    assertTrue(!secondState.isClosed)
+    second.createMapState().close()
+    second.close()
+    second.awaitClosed()
   }
 
   @Test

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -425,6 +425,10 @@ internal class MlnFfiMapSession(
     }
   }
 
+  override suspend fun awaitClosed() {
+    lifecycle.awaitClosed()
+  }
+
   override suspend fun createEngine(identity: EngineMapIdentity) {
     lifecycleEngineIdentity = identity
     lifecycleStyleRequestIdentity = lifecycle.claimStyleRequestIdentity(identity)

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapView.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapView.kt
@@ -38,6 +38,7 @@ internal const val MAP_LOAD_PLACEHOLDER_TAG = "maplibre-map-load-placeholder"
 internal fun MlnFfiMapView(
   hostFactory: MlnFfiMapHostFactory,
   modifier: Modifier,
+  runtimeOptions: org.maplibre.compose.mlnffi.MlnFfiRuntimeOptions? = null,
   style: BaseStyle,
   update: (map: MapAdapter) -> Unit,
   onReset: () -> Unit,
@@ -65,6 +66,7 @@ internal fun MlnFfiMapView(
       )
     },
     modifier = modifier,
+    runtimeOptions = runtimeOptions,
     style = style,
     update = update,
     onReset = onReset,
@@ -80,6 +82,7 @@ internal fun MlnFfiMapView(
   renderBackend: MapRenderBackend,
   surface: @Composable (MlnFfiMapRenderer, Modifier, Logger?, Boolean) -> Unit,
   modifier: Modifier,
+  runtimeOptions: org.maplibre.compose.mlnffi.MlnFfiRuntimeOptions? = null,
   style: BaseStyle,
   update: (map: MapAdapter) -> Unit,
   onReset: () -> Unit,
@@ -87,8 +90,8 @@ internal fun MlnFfiMapView(
   callbacks: MapAdapter.Callbacks,
   options: MapOptions,
 ) {
-  EnsureMlnFfiConfigured()
-  val applicationOptions = MlnFfiApplication.options
+  if (runtimeOptions == null) EnsureMlnFfiConfigured()
+  val applicationOptions = runtimeOptions ?: MlnFfiApplication.options
   val layoutDirection = LocalLayoutDirection.current
   val density = LocalDensity.current
   val scaleFactor = density.density.toDouble()
@@ -114,12 +117,10 @@ internal fun MlnFfiMapView(
   // Must run in the apply phase, not from a coroutine: the unload has to precede the content
   // subcomposition inserting layers, or a style switch fails anchor validation (see #269).
   SideEffect { session.setBaseStyle(style) }
+  // Publish the adapter before another thread can close a runtime whose composition has applied.
+  SideEffect { update(session) }
 
-  LaunchedEffect(session, options, update) {
-    // Attach deferred state before native events can report the map's default state to Compose.
-    update(session)
-    session.start()
-  }
+  LaunchedEffect(session) { session.start() }
 
   DisposableEffect(session) {
     onDispose {

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/NativeMapRuntime.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/NativeMapRuntime.kt
@@ -1,0 +1,29 @@
+package org.maplibre.compose.map
+
+import org.maplibre.compose.mlnffi.MlnFfiLock
+import org.maplibre.compose.mlnffi.MlnFfiRuntimeOptions
+import org.maplibre.compose.mlnffi.withLock
+
+internal object ProcessNativeMapRuntime {
+  private val lock = MlnFfiLock()
+  private var current: RuntimeImplementation? = null
+  private var currentOptions: MlnFfiRuntimeOptions? = null
+
+  fun get(options: MlnFfiRuntimeOptions): MapRuntime = lock.withLock {
+    current?.takeIf { currentOptions == options }
+      ?: RuntimeImplementation(
+          platformOptions = options,
+          resources = MapRuntimeResources {},
+        )
+        .also {
+          currentOptions = options
+          current = it
+        }
+  }
+}
+
+internal fun createNativeMapRuntime(options: MlnFfiRuntimeOptions): MapRuntime =
+  RuntimeImplementation(platformOptions = options, resources = MapRuntimeResources {})
+
+internal val RuntimeImplementation.nativeRuntimeOptions: MlnFfiRuntimeOptions
+  get() = platformOptions as MlnFfiRuntimeOptions


### PR DESCRIPTION
## Description

Adds a closeable MapRuntime and MapState rendering path with saveable camera restoration, presentation tracking, independently configured runtimes, and temporary legacy API coexistence.

## Validation

Validated with mise run check, mise run test:android, mise run test:desktop, caffeinate -dimsu mise run test:js, iOS simulator compilation, and Android device tests; the rebased device rerun hit one timeout in MlnFfiStyleSwitchTest whose isolated rerun passed immediately, while the same full tree had passed earlier.

## AI assistance

OpenAI Codex desktop with GPT-5 implemented the change and ran parallel standards and specification reviews.