### PR TITLE
Retain native maps between presentations

### DIFF
--- a/.agents/scratch/api-redesign/issues/04-retain-native-map.md
+++ b/.agents/scratch/api-redesign/issues/04-retain-native-map.md
@@ -7,23 +7,23 @@ presentation has an incompatible render backend or scale factor.
 
 **Blocked by:** 03
 
-**Status:** ready-for-agent
+**Status:** resolved
 
-- [ ] The changed test area contains no redundant, impossible,
+- [x] The changed test area contains no redundant, impossible,
       compatibility-only, or implementation-shape scenarios.
-- [ ] Android, iOS, and Desktop create the engine map lazily.
-- [ ] Detachment makes MapState.presentation null and invalidates the departed
+- [x] Android, iOS, and Desktop create the engine map lazily.
+- [x] Detachment makes MapState.presentation null and invalidates the departed
       presentation.
-- [ ] Reattachment to a compatible host uses the same native engine-map
+- [x] Reattachment to a compatible host uses the same native engine-map
       identity.
-- [ ] An incompatible host replaces the engine identity, replays durable state,
+- [x] An incompatible host replaces the engine identity, replays durable state,
       and leaves the logical MapState unchanged.
-- [ ] The camera position and applied base style survive detachment.
-- [ ] Current engine and style events remain observable while the native map is
+- [x] The camera position and applied base style survive detachment.
+- [x] Current engine and style events remain observable while the native map is
       detached.
-- [ ] A cached presentation fails after its lease ends.
-- [ ] Closing a detached MapState releases the retained engine map.
-- [ ] Native live-map tests prove compatible identity retention, incompatible
+- [x] A cached presentation fails after its lease ends.
+- [x] Closing a detached MapState releases the retained engine map.
+- [x] Native live-map tests prove compatible identity retention, incompatible
       replacement, replay, and stale-event rejection.
 
 ## Test ledger
@@ -35,3 +35,27 @@ presentation has an incompatible render backend or scale factor.
 - Delete tests that preserve a session or surface ownership shape superseded by
   MapState and presentation leases.
 - Run `mise run test:android`, `mise run test:desktop`, and `mise run test:ios`.
+
+## Answer
+
+`MapState` retains a native map adapter after presentation detachment. A later
+presentation reuses that adapter when the render backend and scale factor match.
+An incompatible presentation closes the retained adapter, creates a new one, and
+applies the durable camera and base style to it.
+
+The retained adapter remains part of `MapState` cleanup while it is detached or
+being replaced. Style-load events from the retained adapter remain observable
+without a presentation. Events from a replaced adapter cannot update the logical
+map. Style requests made while detached reach the retained engine, failures stay
+observable through the logical state, and the desired base style reconciles on
+reattachment.
+
+The native Compose test covers compatible retention, incompatible scale-factor
+replacement, replay, stale presentation invalidation, and detached closure.
+Lifecycle-authority tests cover stale engine, style, presentation, and detach
+events. Surface-loss, recovery, resize, and backend tests remain focused on
+their distinct platform boundaries.
+
+Validation passed with `mise run check`, `mise run test:android`,
+`mise run test:desktop`, `mise run test:ios`, and
+`caffeinate -dimsu mise run test:js`.

--- a/lib/maplibre-compose/src/androidDeviceTest/kotlin/org/maplibre/compose/mlnffi/FfiComposeTestPlatform.android.kt
+++ b/lib/maplibre-compose/src/androidDeviceTest/kotlin/org/maplibre/compose/mlnffi/FfiComposeTestPlatform.android.kt
@@ -19,8 +19,10 @@ internal actual fun runFfiComposeUiTest(block: suspend ComposeUiTest.() -> Unit)
 @OptIn(ExperimentalTestApi::class)
 internal actual fun ComposeUiTest.setFfiTestMapContent(
   runtimeOptions: MlnFfiRuntimeOptions,
+  presentationCount: Int,
   content: @Composable () -> Unit,
 ) {
+  require(presentationCount > 0) { "A map test must prepare at least one presentation" }
   MlnFfiApplication.configure(runtimeOptions)
   setContent(content)
 }

--- a/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MlnFfiMapCompositionTest.kt
+++ b/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MlnFfiMapCompositionTest.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.ComposeUiTest
@@ -22,6 +23,7 @@ import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.getUnclippedBoundsInRoot
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import co.touchlab.kermit.Logger
@@ -32,6 +34,8 @@ import kotlin.math.abs
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotSame
 import kotlin.test.assertNull
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
@@ -113,6 +117,105 @@ class MlnFfiMapCompositionTest {
     runtime.awaitClosed()
     assertTrue(state.isClosed)
     assertNull(state.presentation)
+  }
+
+  @Test
+  fun a_map_state_retains_its_native_map_between_presentations() = runFfiComposeUiTest {
+    val runtime = createNativeMapRuntime(runtimeOptions)
+    val camera = CameraPosition(target = Position(longitude = 11.0, latitude = 47.0), zoom = 6.0)
+    val state =
+      runtime.createMapState(initialCameraPosition = camera, initialBaseStyle = BaseStyle.Empty)
+    var presented by mutableStateOf(true)
+
+    setFfiTestMapContent(runtimeOptions, presentationCount = 2) {
+      if (presented) MaplibreMap(state)
+    }
+    waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) {
+      state.presentation != null && state.style.loadState == StyleLoadState.Ready
+    }
+    val firstPresentation = requireNotNull(state.presentation)
+    val firstMap = firstPresentation.adapter
+
+    presented = false
+    waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) { state.presentation == null }
+
+    assertTrue(!firstPresentation.isValid)
+    assertFailsWith<IllegalStateException> { firstPresentation.setCameraPosition(CameraPosition()) }
+    assertEquals(StyleLoadState.Ready, state.style.loadState)
+    state.style.baseStyle = BaseStyle.Json("{")
+    waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) {
+      state.presentation == null && state.style.loadState is StyleLoadState.Failed
+    }
+    state.style.baseStyle = RETAINED_STYLE
+    assertEquals(StyleLoadState.Loading, state.style.loadState)
+
+    presented = true
+    waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) {
+      state.presentation != null && state.style.loadState == StyleLoadState.Ready
+    }
+
+    assertSame(firstMap, requireNotNull(state.presentation).adapter)
+    assertCameraEquals(camera, state.cameraPosition)
+    assertTrue("retained-style" in (firstMap as MlnFfiMapSession).currentStyleLayerIds())
+
+    presented = false
+    waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) { state.presentation == null }
+    runtime.close()
+    runtime.awaitClosed()
+  }
+
+  @Test
+  fun an_incompatible_scale_factor_replaces_the_native_map_and_replays_state() =
+    runFfiComposeUiTest {
+      val runtime = createNativeMapRuntime(runtimeOptions)
+      val camera =
+        CameraPosition(target = Position(longitude = -122.4, latitude = 37.8), zoom = 10.0)
+      val state =
+        runtime.createMapState(
+          initialCameraPosition = camera,
+          initialBaseStyle = REPLACEMENT_STYLE,
+        )
+      var presented by mutableStateOf(true)
+      var scaleFactor by mutableStateOf(1f)
+
+      setFfiTestMapContent(runtimeOptions, presentationCount = 2) {
+        CompositionLocalProvider(LocalDensity provides Density(scaleFactor)) {
+          if (presented) MaplibreMap(state)
+        }
+      }
+      waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) {
+        state.presentation != null && state.style.loadState == StyleLoadState.Ready
+      }
+      val firstMap = requireNotNull(state.presentation).adapter
+
+      presented = false
+      waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) { state.presentation == null }
+      scaleFactor = 2f
+      presented = true
+      waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) {
+        state.presentation != null && state.style.loadState == StyleLoadState.Ready
+      }
+
+      val replacementMap = requireNotNull(state.presentation).adapter
+      assertNotSame(firstMap, replacementMap)
+      assertCameraEquals(camera, state.cameraPosition)
+      assertTrue("replacement-style" in (replacementMap as MlnFfiMapSession).currentStyleLayerIds())
+
+      runtime.close()
+      runtime.awaitClosed()
+    }
+
+  private fun assertCameraEquals(expected: CameraPosition, actual: CameraPosition) {
+    assertEquals(expected.bearing, actual.bearing, POSITION_TOLERANCE, "bearing")
+    assertEquals(
+      expected.target.longitude,
+      actual.target.longitude,
+      POSITION_TOLERANCE,
+      "longitude",
+    )
+    assertEquals(expected.target.latitude, actual.target.latitude, POSITION_TOLERANCE, "latitude")
+    assertEquals(expected.tilt, actual.tilt, POSITION_TOLERANCE, "tilt")
+    assertEquals(expected.zoom, actual.zoom, POSITION_TOLERANCE, "zoom")
   }
 
   /** Style loading needs no rendering, so no frame runs — and none is drawn — before a style. */
@@ -467,6 +570,16 @@ class MlnFfiMapCompositionTest {
   }
 
   private companion object {
+    val RETAINED_STYLE =
+      BaseStyle.Json(
+        """{"version":8,"sources":{},"layers":[{"id":"retained-style","type":"background"}]}"""
+      )
+
+    val REPLACEMENT_STYLE =
+      BaseStyle.Json(
+        """{"version":8,"sources":{},"layers":[{"id":"replacement-style","type":"background"}]}"""
+      )
+
     const val RENDER_TIMEOUT_MILLIS = 30_000L
 
     const val PLACED_AT_TAG = "map-placed-at"

--- a/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/map/AndroidMapView.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/map/AndroidMapView.kt
@@ -18,6 +18,7 @@ import org.maplibre.compose.style.StyleBinding
 internal actual fun ComposableMapView(
   modifier: Modifier,
   runtime: RuntimeImplementation?,
+  state: MapState?,
   style: BaseStyle,
   rememberedStyle: StyleBinding?,
   update: (map: MapAdapter) -> Unit,
@@ -52,6 +53,7 @@ internal actual fun ComposableMapView(
         )
       },
       modifier = modifier,
+      state = state,
       runtimeOptions = runtime?.nativeRuntimeOptions,
       style = style,
       update = update,

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/ComposableMapView.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/ComposableMapView.kt
@@ -10,6 +10,7 @@ import org.maplibre.compose.style.StyleBinding
 internal expect fun ComposableMapView(
   modifier: Modifier,
   runtime: RuntimeImplementation?,
+  state: MapState?,
   style: BaseStyle,
   rememberedStyle: StyleBinding?,
   update: (map: MapAdapter) -> Unit,

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapAdapter.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapAdapter.kt
@@ -19,6 +19,23 @@ import org.maplibre.spatialk.geojson.Geometry
 import org.maplibre.spatialk.geojson.Position
 
 internal interface MapAdapter {
+  /** Whether the engine remains alive after its current presentation detaches. */
+  val retainsEngineBetweenPresentations: Boolean
+    get() = false
+
+  /** Identifies the presentation properties that constrain engine reuse. */
+  val presentationCompatibilityKey: Any?
+    get() = null
+
+  /** Attaches this engine to its current presentation host. */
+  suspend fun attachPresentation() = Unit
+
+  /** Detaches this engine from its current presentation host. */
+  suspend fun detachPresentation() {
+    close()
+    awaitClosed()
+  }
+
   fun close()
 
   suspend fun awaitClosed()
@@ -95,7 +112,7 @@ internal interface MapAdapter {
     /** A null [sourceId] means that the adapter cannot identify the changed source. */
     fun onSourceChanged(map: MapAdapter, sourceId: String?)
 
-    fun onMapFailLoading(reason: String?)
+    fun onMapFailLoading(map: MapAdapter, reason: String?)
 
     fun onCameraMoveStarted(map: MapAdapter, reason: CameraMoveReason)
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleAuthority.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleAuthority.kt
@@ -215,6 +215,20 @@ internal class MapLifecycleAuthority(
     }
   }
 
+  /** Attaches after a preceding presentation has completed its physical detachment. */
+  suspend fun attachRetainedEngine(): RenderLease {
+    while (true) {
+      when (val observed = current.load()) {
+        is InternalState.OpenDetached -> return attach()
+        is InternalState.Attaching -> return observed.result.await().getOrThrow()
+        is InternalState.Attached -> return observed.lease
+        is InternalState.Detaching -> observed.result.await().getOrThrow()
+        is InternalState.Closing,
+        InternalState.Closed -> throw MapClosedException()
+      }
+    }
+  }
+
   /** Commits attachment before starting its physical commands. */
   fun beginAttach(): PendingAttachment {
     val result = CompletableDeferred<Result<RenderLease>>()
@@ -301,6 +315,22 @@ internal class MapLifecycleAuthority(
     val result = beginDetach(lease) ?: return false
     result.await().getOrThrow()
     return true
+  }
+
+  /** Detaches the current presentation, or joins a detachment that already started. */
+  suspend fun detachCurrentPresentation(): Boolean {
+    val observed = current.load()
+    return when (observed) {
+      is InternalState.Attaching -> detach(observed.lease)
+      is InternalState.Attached -> detach(observed.lease)
+      is InternalState.Detaching -> {
+        observed.result.await().getOrThrow()
+        true
+      }
+      is InternalState.OpenDetached,
+      is InternalState.Closing,
+      InternalState.Closed -> false
+    }
   }
 
   private fun beginDetach(lease: RenderLease): CompletableDeferred<Result<Unit>>? {

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleCallbacks.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleCallbacks.kt
@@ -44,10 +44,11 @@ internal class MapLifecycleCallbacks(
   fun onMapFailLoading(
     engine: EngineMapIdentity,
     request: StyleRequestIdentity,
+    map: MapAdapter,
     reason: String?,
   ) =
     lifecycle.acceptStyleRequestEvent(engine, request) {
-      delegate().onMapFailLoading(reason)
+      delegate().onMapFailLoading(map, reason)
     }
 
   fun onCameraMoveStarted(

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
@@ -111,6 +111,11 @@ internal constructor(
   /** Whether this presentation is still the current connection. */
   public val isValid: Boolean
     get() = owner.isCurrent(this)
+
+  /** Sets the camera for this presentation, or fails if its render lease has ended. */
+  public fun setCameraPosition(position: CameraPosition) {
+    owner.setCameraPosition(this, position)
+  }
 }
 
 /** One logical map, independent from its temporary UI presentation. */
@@ -123,6 +128,8 @@ internal constructor(
   private val lock = reentrantLock()
   private val closure = CompletableDeferred<Result<Unit>>()
   private var attachment: Attachment? = null
+  private var retainedAdapter: MapAdapter? = null
+  private val retiringAdapters = linkedSetOf<MapAdapter>()
   private var closed = false
 
   internal val cameraState = CameraState(initialCameraPosition)
@@ -141,22 +148,35 @@ internal constructor(
 
   /** Marks this state as closed and starts cleanup of the current presentation. */
   public fun close() {
-    val map = lock.withLock {
+    val maps = lock.withLock {
       if (closed) return
       closed = true
-      val map = attachment?.adapter
+      val maps = buildSet {
+        retainedAdapter?.let(::add)
+        attachment?.adapter?.let(::add)
+        addAll(retiringAdapters)
+      }
       attachment = null
+      retainedAdapter = null
+      retiringAdapters.clear()
       Snapshot.withMutableSnapshot { presentation = null }
-      map
+      maps
     }
     cameraState.map = null
-    if (map == null) {
+    if (maps.isEmpty()) {
       completeClosure(Result.success(Unit))
       return
     }
-    map.close()
+    maps.forEach(MapAdapter::close)
     runtime.physicalScope.launch(start = CoroutineStart.UNDISPATCHED) {
-      completeClosure(runCatching { map.awaitClosed() })
+      val failures = mutableListOf<Throwable>()
+      maps.forEach { map ->
+        runCatching { map.awaitClosed() }.exceptionOrNull()?.let(failures::add)
+      }
+      completeClosure(
+        if (failures.isEmpty()) Result.success(Unit)
+        else Result.failure(MapStateCleanupException(failures))
+      )
     }
   }
 
@@ -174,7 +194,7 @@ internal constructor(
   }
 
   internal fun publishPresentation(token: MapPresentationToken, adapter: MapAdapter) {
-    lock.withLock {
+    val replaced = lock.withLock {
       requireOpenLocked()
       val current = attachment
       check(current?.token == token && !current.releasing) {
@@ -183,10 +203,24 @@ internal constructor(
       if (current.adapter === adapter) return
       check(current.adapter == null) { "The map state already has a presentation" }
       current.adapter = adapter
+      val reusesRetainedAdapter = retainedAdapter === adapter
+      val replaced = retainedAdapter?.takeUnless { retained ->
+        retained === adapter || !adapter.retainsEngineBetweenPresentations
+      }
+      if (adapter.retainsEngineBetweenPresentations) retainedAdapter = adapter
+      if (replaced != null) retiringAdapters += replaced
       MapPresentation(this, token, adapter).also { presentation = it }
       cameraState.map = adapter
       adapter.setBaseStyle(style.baseStyle)
-      style.loadState = StyleLoadState.Loading
+      if (!reusesRetainedAdapter) style.loadState = StyleLoadState.Loading
+      replaced
+    }
+    if (replaced != null) {
+      replaced.close()
+      runtime.physicalScope.launch {
+        runCatching { replaced.awaitClosed() }
+        lock.withLock { retiringAdapters.remove(replaced) }
+      }
     }
   }
 
@@ -198,7 +232,9 @@ internal constructor(
       if (current.releasing) return
       current.releasing = true
       presentation = null
-      style.loadState = StyleLoadState.Pending
+      if (current.adapter?.retainsEngineBetweenPresentations != true) {
+        style.loadState = StyleLoadState.Pending
+      }
       current.adapter
     }
     if (cameraState.map === closingAdapter) cameraState.map = null
@@ -206,22 +242,30 @@ internal constructor(
       lock.withLock { if (attachment?.token == token) attachment = null }
       return
     }
-    closingAdapter.close()
     runtime.physicalScope.launch(start = CoroutineStart.UNDISPATCHED) {
-      runCatching { closingAdapter.awaitClosed() }
+      runCatching { closingAdapter.detachPresentation() }
       lock.withLock { if (attachment?.token == token) attachment = null }
+    }
+  }
+
+  internal fun retainedAdapter(compatibilityKey: Any): MapAdapter? = lock.withLock {
+    retainedAdapter?.takeIf { adapter ->
+      adapter.retainsEngineBetweenPresentations &&
+        adapter.presentationCompatibilityKey == compatibilityKey
     }
   }
 
   internal fun markStyleReady(adapter: MapAdapter) {
     lock.withLock {
-      if (!closed && attachment?.adapter === adapter) style.loadState = StyleLoadState.Ready
+      if (!closed && (attachment?.adapter === adapter || retainedAdapter === adapter)) {
+        style.loadState = StyleLoadState.Ready
+      }
     }
   }
 
   internal fun markStyleFailed(adapter: MapAdapter, reason: String?) {
     lock.withLock {
-      if (!closed && attachment?.adapter === adapter) {
+      if (!closed && (attachment?.adapter === adapter || retainedAdapter === adapter)) {
         style.loadState = StyleLoadState.Failed(reason)
       }
     }
@@ -232,7 +276,7 @@ internal constructor(
       requireOpenLocked()
       if (style.baseStyle == value) return
       style.setBaseStyleState(value)
-      val adapter = attachment?.adapter
+      val adapter = attachment?.adapter ?: retainedAdapter
       if (adapter == null) {
         style.loadState = StyleLoadState.Pending
       } else {
@@ -244,6 +288,15 @@ internal constructor(
 
   internal fun isCurrent(candidate: MapPresentation): Boolean = lock.withLock {
     !closed && presentation === candidate && attachment?.token == candidate.token
+  }
+
+  internal fun setCameraPosition(candidate: MapPresentation, position: CameraPosition) {
+    lock.withLock {
+      check(!closed && presentation === candidate && attachment?.token == candidate.token) {
+        "The map presentation lease has ended"
+      }
+      candidate.adapter.setCameraPosition(position)
+    }
   }
 
   private fun requireOpenLocked() {
@@ -262,6 +315,13 @@ internal constructor(
 
   private companion object {
     val nextPresentationToken = AtomicLong(0L)
+  }
+}
+
+internal class MapStateCleanupException(failures: List<Throwable>) :
+  RuntimeException("Map state cleanup failed in ${failures.size} resource(s)", failures.first()) {
+  init {
+    failures.drop(1).forEach(::addSuppressed)
   }
 }
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MaplibreMap.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MaplibreMap.kt
@@ -42,7 +42,7 @@ import org.maplibre.spatialk.geojson.BoundingBox
 import org.maplibre.spatialk.geojson.Position
 
 private class MapStateAttachment(
-  private val state: MapState,
+  val state: MapState,
   private val token: MapPresentationToken,
 ) {
   val runtime: RuntimeImplementation
@@ -221,8 +221,8 @@ public fun MaplibreMap(
           if (cameraState.map === map) cameraState.viewportState.value = map.getViewport()
         }
 
-        override fun onMapFailLoading(reason: String?) {
-          cameraState.map?.let { map -> stateAttachment?.markStyleFailed(map, reason) }
+        override fun onMapFailLoading(map: MapAdapter, reason: String?) {
+          stateAttachment?.markStyleFailed(map, reason)
           onMapLoadFailed(reason)
         }
 
@@ -317,6 +317,7 @@ public fun MaplibreMap(
     ComposableMapView(
       modifier = Modifier.fillMaxSize(),
       runtime = stateAttachment?.runtime,
+      state = stateAttachment?.state,
       style = baseStyle,
       update = { map ->
         map.setCameraPadding(cameraPadding)

--- a/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/map/IosMapView.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/map/IosMapView.kt
@@ -13,6 +13,7 @@ import org.maplibre.compose.style.StyleBinding
 internal actual fun ComposableMapView(
   modifier: Modifier,
   runtime: RuntimeImplementation?,
+  state: MapState?,
   style: BaseStyle,
   rememberedStyle: StyleBinding?,
   update: (map: MapAdapter) -> Unit,
@@ -35,6 +36,7 @@ internal actual fun ComposableMapView(
       )
     },
     modifier = modifier,
+    state = state,
     runtimeOptions = runtime?.nativeRuntimeOptions,
     style = style,
     update = update,

--- a/lib/maplibre-compose/src/iosTest/kotlin/org/maplibre/compose/mlnffi/FfiComposeTestPlatform.ios.kt
+++ b/lib/maplibre-compose/src/iosTest/kotlin/org/maplibre/compose/mlnffi/FfiComposeTestPlatform.ios.kt
@@ -18,10 +18,12 @@ internal actual fun runFfiComposeUiTest(block: suspend ComposeUiTest.() -> Unit)
 @OptIn(ExperimentalTestApi::class)
 internal actual fun ComposeUiTest.setFfiTestMapContent(
   runtimeOptions: MlnFfiRuntimeOptions,
+  presentationCount: Int,
   content: @Composable () -> Unit,
 ) {
   // The iOS map view builds its own surface controller, like Android's, so no host factory needs
   // to be prepared off the test thread.
+  require(presentationCount > 0) { "A map test must prepare at least one presentation" }
   MlnFfiApplication.configure(runtimeOptions)
   setContent(content)
 }

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
@@ -633,7 +633,7 @@ internal class GlJsMapSession(
             reason,
           ) == true
         if (accepted) {
-          if (lifecycleCallbacks.onMapFailLoading(engine, lifecycleRequest, reason)) {
+          if (lifecycleCallbacks.onMapFailLoading(engine, lifecycleRequest, this, reason)) {
             logger?.e { "Map loading failed: $reason" }
             if (!hasLoadedInitialStyle) abandonPending(pendingInitialStyleActions)
           }
@@ -667,7 +667,7 @@ internal class GlJsMapSession(
           reason,
         ) == true
       ) {
-        lifecycleCallbacks.onMapFailLoading(engine, lifecycleRequest, reason)
+        lifecycleCallbacks.onMapFailLoading(engine, lifecycleRequest, this, reason)
       }
       if (!hasLoadedInitialStyle) abandonPending(pendingInitialStyleActions)
     }

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/JsMapView.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/JsMapView.kt
@@ -21,6 +21,7 @@ import org.maplibre.compose.style.StyleBinding
 internal actual fun ComposableMapView(
   modifier: Modifier,
   runtime: RuntimeImplementation?,
+  state: MapState?,
   style: BaseStyle,
   rememberedStyle: StyleBinding?,
   update: (map: MapAdapter) -> Unit,

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/CompositedMap.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/CompositedMap.kt
@@ -78,7 +78,7 @@ internal class CompositedMap(style: BaseStyle, private val scaleFactor: Double =
 
     override fun onSourceChanged(map: MapAdapter, sourceId: String?) = Unit
 
-    override fun onMapFailLoading(reason: String?) {
+    override fun onMapFailLoading(map: MapAdapter, reason: String?) {
       loadFailure = reason ?: "unknown"
     }
 

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/map/DesktopMapView.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/map/DesktopMapView.kt
@@ -13,6 +13,7 @@ import org.maplibre.compose.style.StyleBinding
 internal actual fun ComposableMapView(
   modifier: Modifier,
   runtime: RuntimeImplementation?,
+  state: MapState?,
   style: BaseStyle,
   rememberedStyle: StyleBinding?,
   update: (map: MapAdapter) -> Unit,
@@ -29,6 +30,7 @@ internal actual fun ComposableMapView(
   MlnFfiMapView(
     hostFactory = hostFactory,
     modifier = modifier,
+    state = state,
     runtimeOptions = runtime?.nativeRuntimeOptions,
     style = style,
     update = update,

--- a/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/desktop/bridge/LinuxVulkanOpenGlInteropTest.kt
+++ b/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/desktop/bridge/LinuxVulkanOpenGlInteropTest.kt
@@ -250,7 +250,7 @@ class LinuxVulkanOpenGlInteropTest {
           if (style != null) styleLoads++
         }
 
-        override fun onMapFailLoading(reason: String?) {
+        override fun onMapFailLoading(map: MapAdapter, reason: String?) {
           failure = reason ?: "unknown map load failure"
         }
 

--- a/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/mlnffi/FfiComposeTestPlatform.desktop.kt
+++ b/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/mlnffi/FfiComposeTestPlatform.desktop.kt
@@ -55,10 +55,11 @@ private fun startHangWatchdog(): Thread {
 @OptIn(ExperimentalTestApi::class)
 internal actual fun ComposeUiTest.setFfiTestMapContent(
   runtimeOptions: MlnFfiRuntimeOptions,
+  presentationCount: Int,
   content: @Composable () -> Unit,
 ) {
   MlnFfiApplication.configure(runtimeOptions)
-  val preparedFactory = CurrentRuntimeTestMapHostFactory.prepare()
+  val preparedFactory = CurrentRuntimeTestMapHostFactory.prepare(presentationCount)
   try {
     setContent {
       CompositionLocalProvider(
@@ -75,7 +76,9 @@ internal actual fun ComposeUiTest.setFfiTestMapContent(
 
 /** Creates a production bridge for whichever runtime this Desktop test process packages. */
 private class CurrentRuntimeTestMapHostFactory
-private constructor(private var preparedDriver: FfiTestRenderDriver?) : MlnFfiMapHostFactory {
+private constructor(private val preparedDrivers: ArrayDeque<FfiTestRenderDriver>) :
+  MlnFfiMapHostFactory {
+  private val initialDriverCount = preparedDrivers.size
   override val bridges: List<RenderBackendPair> =
     listOf(
       when (val packaged = Maplibre.supportedRenderBackends().singleOrNull()) {
@@ -89,21 +92,20 @@ private constructor(private var preparedDriver: FfiTestRenderDriver?) : MlnFfiMa
 
   override fun create(backends: RenderBackendPair): MlnFfiMapHostResult {
     val driver =
-      preparedDriver
+      preparedDrivers.removeFirstOrNull()
         ?: return MlnFfiMapHostResult.Failed(
-          "The prepared Desktop test bridge was already consumed; each test map may create one host"
+          "The Desktop test used more presentation hosts than it prepared"
         )
-    preparedDriver = null
     return MlnFfiMapHostResult.Created(driver)
   }
 
   fun closePendingDriver() {
-    preparedDriver?.close()
-    preparedDriver = null
+    preparedDrivers.forEach(FfiTestRenderDriver::close)
+    preparedDrivers.clear()
   }
 
   fun requireConsumed() {
-    if (preparedDriver == null) return
+    if (preparedDrivers.size < initialDriverCount) return
     closePendingDriver()
     error("The test content did not create a Desktop map host during initial composition")
   }
@@ -116,11 +118,14 @@ private constructor(private var preparedDriver: FfiTestRenderDriver?) : MlnFfiMa
     }
 
   companion object {
-    fun prepare(): CurrentRuntimeTestMapHostFactory {
+    fun prepare(presentationCount: Int): CurrentRuntimeTestMapHostFactory {
       check(!EventQueue.isDispatchThread()) {
         "The Desktop test bridge must be prepared off the EDT"
       }
-      return CurrentRuntimeTestMapHostFactory(FfiTestPlatform.createRenderDriver())
+      require(presentationCount > 0) { "A map test must prepare at least one presentation host" }
+      return CurrentRuntimeTestMapHostFactory(
+        ArrayDeque(List(presentationCount) { FfiTestPlatform.createRenderDriver() })
+      )
     }
   }
 }

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/testing/MapFixture.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/testing/MapFixture.kt
@@ -147,7 +147,7 @@ internal class RecordingMapCallbacks : MapAdapter.Callbacks {
     sourceChanges += sourceId
   }
 
-  override fun onMapFailLoading(reason: String?) {
+  override fun onMapFailLoading(map: MapAdapter, reason: String?) {
     errors += "mapFailLoading: $reason"
   }
 

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -136,6 +136,11 @@ private val HANDLED_MAP_EVENTS: RuntimeEventMask =
 /** The fraction of a capped frame interval a frame may arrive early and still be drawn. */
 private const val FRAME_INTERVAL_SLACK = 0.1
 
+internal data class NativeEngineCompatibility(
+  val renderBackend: MapRenderBackend,
+  val scaleFactor: Double,
+)
+
 /**
  * The runtime and the map belong to [MlnFfiMapRuntimeLoop]'s thread; the render session belongs to
  * the host's renderer thread. A camera transition only steps while frames are being drawn: mbgl
@@ -163,6 +168,11 @@ internal class MlnFfiMapSession(
   @Volatile private var lifecycleStyleIdentity: StyleIdentity? = null
 
   override val engineRetention: EngineRetention = EngineRetention.RETAIN
+
+  override val retainsEngineBetweenPresentations: Boolean = true
+
+  override val presentationCompatibilityKey: Any =
+    NativeEngineCompatibility(renderBackend = renderBackend, scaleFactor = scaleFactor)
 
   override val backend: MapRenderBackend = renderBackend
   private val initialExtent = MapExtent.fromLogical(1, 1, scaleFactor)
@@ -427,6 +437,14 @@ internal class MlnFfiMapSession(
 
   override suspend fun awaitClosed() {
     lifecycle.awaitClosed()
+  }
+
+  override suspend fun attachPresentation() {
+    lifecycle.attachRetainedEngine()
+  }
+
+  override suspend fun detachPresentation() {
+    lifecycle.detachCurrentPresentation()
   }
 
   override suspend fun createEngine(identity: EngineMapIdentity) {
@@ -825,7 +843,7 @@ internal class MlnFfiMapSession(
           styleEventProducer
             ?.takeIf { it.engine == engine }
             ?.let {
-              if (lifecycleCallbacks.onMapFailLoading(engine, it.request, reason)) {
+              if (lifecycleCallbacks.onMapFailLoading(engine, it.request, this, reason)) {
                 logger?.e { "Map loading failed (code ${event.code}): $reason" }
               }
             }

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapView.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapView.kt
@@ -38,6 +38,7 @@ internal const val MAP_LOAD_PLACEHOLDER_TAG = "maplibre-map-load-placeholder"
 internal fun MlnFfiMapView(
   hostFactory: MlnFfiMapHostFactory,
   modifier: Modifier,
+  state: MapState?,
   runtimeOptions: org.maplibre.compose.mlnffi.MlnFfiRuntimeOptions? = null,
   style: BaseStyle,
   update: (map: MapAdapter) -> Unit,
@@ -66,6 +67,7 @@ internal fun MlnFfiMapView(
       )
     },
     modifier = modifier,
+    state = state,
     runtimeOptions = runtimeOptions,
     style = style,
     update = update,
@@ -82,6 +84,7 @@ internal fun MlnFfiMapView(
   renderBackend: MapRenderBackend,
   surface: @Composable (MlnFfiMapRenderer, Modifier, Logger?, Boolean) -> Unit,
   modifier: Modifier,
+  state: MapState?,
   runtimeOptions: org.maplibre.compose.mlnffi.MlnFfiRuntimeOptions? = null,
   style: BaseStyle,
   update: (map: MapAdapter) -> Unit,
@@ -95,19 +98,25 @@ internal fun MlnFfiMapView(
   val layoutDirection = LocalLayoutDirection.current
   val density = LocalDensity.current
   val scaleFactor = density.density.toDouble()
+  val compatibility =
+    remember(renderBackend, scaleFactor) {
+      NativeEngineCompatibility(renderBackend = renderBackend, scaleFactor = scaleFactor)
+    }
+  val retainedSession = state?.retainedAdapter(compatibility) as? MlnFfiMapSession
 
   val session =
-    remember(renderBackend, scaleFactor, applicationOptions) {
-      MlnFfiMapSession(
-        callbacks = callbacks,
-        logger = logger,
-        renderBackend = renderBackend,
-        scaleFactor = scaleFactor,
-        layoutDirection = layoutDirection,
-        cacheFile = applicationOptions.cacheFile,
-        resourceProviderFactory = applicationOptions.resourceProviderFactory,
-      )
-    }
+    retainedSession
+      ?: remember(renderBackend, scaleFactor, applicationOptions, state) {
+        MlnFfiMapSession(
+          callbacks = callbacks,
+          logger = logger,
+          renderBackend = renderBackend,
+          scaleFactor = scaleFactor,
+          layoutDirection = layoutDirection,
+          cacheFile = applicationOptions.cacheFile,
+          resourceProviderFactory = applicationOptions.resourceProviderFactory,
+        )
+      }
 
   session.callbacks = callbacks
   session.logger = logger
@@ -120,11 +129,11 @@ internal fun MlnFfiMapView(
   // Publish the adapter before another thread can close a runtime whose composition has applied.
   SideEffect { update(session) }
 
-  LaunchedEffect(session) { session.start() }
+  LaunchedEffect(session) { session.attachPresentation() }
 
   DisposableEffect(session) {
     onDispose {
-      session.close()
+      if (state == null) session.close()
       currentOnReset.value()
     }
   }

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/mlnffi/FfiComposeTestPlatform.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/mlnffi/FfiComposeTestPlatform.kt
@@ -15,5 +15,6 @@ internal expect fun runFfiComposeUiTest(block: suspend ComposeUiTest.() -> Unit)
 @ExperimentalTestApi
 internal expect fun ComposeUiTest.setFfiTestMapContent(
   runtimeOptions: MlnFfiRuntimeOptions,
+  presentationCount: Int = 1,
   content: @Composable () -> Unit,
 )


### PR DESCRIPTION
## Description

Retain each `MapState` native engine between compatible UI presentations, replace incompatible engines with durable camera and style replay, and reject expired presentation operations.

## Validation

Validated with `mise run check`, `mise run test:android`, `mise run test:desktop`, `mise run test:ios`, and `caffeinate -dimsu mise run test:js`.

## AI assistance

Implemented and reviewed with OpenAI Codex using GPT-5.6.