### PR TITLE
Replay Web maps between presentations

### DIFF
--- a/.agents/scratch/api-redesign/issues/05-replay-web-map.md
+++ b/.agents/scratch/api-redesign/issues/05-replay-web-map.md
@@ -6,24 +6,24 @@ next presentation.
 
 **Blocked by:** 03
 
-**Status:** ready-for-agent
+**Status:** resolved
 
-- [ ] The changed test area contains no redundant, impossible,
+- [x] The changed test area contains no redundant, impossible,
       compatibility-only, or implementation-shape scenarios.
-- [ ] Web destroys the GL JS map after detachment.
-- [ ] MapState retains the desired camera position and base style.
-- [ ] Detachment changes style load state to Pending without discarding desired
+- [x] Web destroys the GL JS map after detachment.
+- [x] MapState retains the desired camera position and base style.
+- [x] Detachment changes style load state to Pending without discarding desired
       style configuration.
-- [ ] Reattachment creates a new GL JS map identity.
-- [ ] The new map receives the retained desired state before its first visible
+- [x] Reattachment creates a new GL JS map identity.
+- [x] The new map receives the retained desired state before its first visible
       frame.
-- [ ] MapState publishes a presentation when its host and viewport are usable,
+- [x] MapState publishes a presentation when its host and viewport are usable,
       while the surface remains hidden until style reconciliation succeeds.
-- [ ] Style failure leaves the presentation attached, reports failure through
+- [x] Style failure leaves the presentation attached, reports failure through
       MapStyleState, and keeps the placeholder visible.
-- [ ] Events from the destroyed map cannot update MapState.
-- [ ] A cached Web presentation fails after detachment.
-- [ ] Browser tests prove destruction, recreation, replay, and stale-event
+- [x] Events from the destroyed map cannot update MapState.
+- [x] A cached Web presentation fails after detachment.
+- [x] Browser tests prove destruction, recreation, replay, and stale-event
       rejection.
 
 ## Test ledger
@@ -34,3 +34,27 @@ next presentation.
 - Delete browser cases that only assert obsolete session callback storage or
   composition structure.
 - Run `mise run test:js` under `caffeinate -dimsu` on macOS.
+
+## Answer
+
+Web map sessions now wait for a non-empty viewport before they publish a
+presentation. The session applies the retained camera and presentation state
+before it starts the initial style request. The Compose surface remains hidden
+until both replay and style reconciliation complete.
+
+Detachment destroys the GL JS map and resets the viewport, replay, and style
+readiness state. `MapState` retains the desired camera and base style, reports
+the style as `Pending`, and applies both values to a new GL JS map after the
+next attachment. Events from the destroyed map and operations on its cached
+presentation cannot modify the logical map.
+
+The browser lifecycle, style-state, and camera-transition tests add coverage
+through `MapState` and `MapPresentation`. They cover engine destruction and
+recreation, camera and style replay, viewport-ready publication, style failure,
+and stale event rejection. The tests retain the distinct attribution and queued
+transition contracts. The removed cases duplicated detachment and recreation
+behavior through the superseded compatibility callbacks.
+
+Validation passed with `mise run check` and
+`caffeinate -dimsu mise run test:js`. A sensitivity run failed when viewport
+readiness was bypassed, as required.

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
@@ -125,15 +125,22 @@ internal class GlJsMapSession(
   /** Transitions MapLibre would cancel while applying the first style's camera. */
   private val pendingInitialStyleActions = mutableListOf<PendingMapAction>()
 
-  /** Readiness belongs to a map instance, not to its current, replaceable style. */
+  /** Whether the current engine map has loaded its first base style. */
   private var hasLoadedInitialStyle = false
 
-  /**
-   * True once this session has loaded a style. The surface presents no frame while this is false,
-   * and it stays true so a later style switch does not blank a live map.
-   */
-  internal var hasLoadedFirstStyle by mutableStateOf(false)
+  /** Whether the current engine map has reconciled the latest requested style. */
+  private var hasReconciledStyle by mutableStateOf(false)
     private set
+
+  /** True after the current engine map has applied a non-empty presentation viewport. */
+  internal var hasUsableViewport by mutableStateOf(false)
+    private set
+
+  private var hasReplayedPresentationState by mutableStateOf(false)
+
+  /** Whether the current engine map may be copied onto the visible Compose surface. */
+  internal val canPresentFrames: Boolean
+    get() = hasReconciledStyle && hasReplayedPresentationState
 
   private var requestedStyle: BaseStyle? = null
   private var appliedStyle: BaseStyle? = null
@@ -343,7 +350,6 @@ internal class GlJsMapSession(
     map = created
     hasLoadedInitialStyle = false
     appliedExtent = MapExtent.Empty
-    applyRequestedStyle(created)
     cameraConstraints?.let { applyCameraConstraints(created, it) }
     runPending(pendingMapActions, created)
     return created
@@ -353,6 +359,9 @@ internal class GlJsMapSession(
     hasLoadedInitialStyle = false
     val current = map ?: return
     map = null
+    hasReconciledStyle = false
+    hasUsableViewport = false
+    hasReplayedPresentationState = false
     callbacks.onStyleChanged(this, null)
     styleBinding?.invalidate()
     styleBinding = null
@@ -391,12 +400,24 @@ internal class GlJsMapSession(
     }
     map.setPixelRatio(extent.scaleFactor)
     map.resize()
+    hasUsableViewport = true
     // resize() may also fire `move`; a second onCameraMoved is how overlays learn the viewport
     // changed when the camera position did not.
     withLifecyclePresentation { engine, lease ->
       lifecycleCallbacks.onCameraMoved(engine, lease, this)
     }
   }
+
+  /** Records that the current engine map has applied the logical map's desired state. */
+  internal fun markPresentationStateReplayed() {
+    if (hasReplayedPresentationState) return
+    hasReplayedPresentationState = true
+    map?.let(::applyRequestedStyle)
+    surface?.requestFrame()
+  }
+
+  /** The current GL JS engine-map instance, exposed only to browser boundary tests. */
+  internal fun engineMapForTest(): MaplibreMap? = map
 
   private fun maxTextureSize(gl: dynamic): Array<Double> {
     val size = (gl.getParameter(gl.MAX_TEXTURE_SIZE) as? Int)?.toDouble() ?: 4096.0
@@ -460,7 +481,9 @@ internal class GlJsMapSession(
     val trackerRequest = appliedStyleRequest ?: return
     val identity = styleBinding?.identity ?: return
     if (styleLoadTracker?.reconciled(trackerRequest, identity) == true) {
-      lifecycleCallbacks.onMapFinishedLoading(engine, style, this)
+      if (lifecycleCallbacks.onMapFinishedLoading(engine, style, this)) {
+        hasReconciledStyle = true
+      }
     }
   }
 
@@ -538,6 +561,7 @@ internal class GlJsMapSession(
 
   override fun setBaseStyle(style: BaseStyle) {
     if (style == requestedStyle) return
+    hasReconciledStyle = false
     // Must precede the new style: the old style's sources and layers would otherwise recompose
     // against base layers being replaced.
     styleBinding?.invalidate()
@@ -552,7 +576,7 @@ internal class GlJsMapSession(
       lifecycleStyleRequestIdentity = lifecycleCallbacks.beginStyleRequest(it, this)
     }
     lifecycleStyleIdentity = null
-    onMap(::applyRequestedStyle)
+    if (hasReplayedPresentationState) onMap(::applyRequestedStyle)
   }
 
   private fun applyRequestedStyle(map: MaplibreMap) {
@@ -588,7 +612,6 @@ internal class GlJsMapSession(
           lifecycleCallbacks.onStyleChanged(engine, lifecycleRequest, this, binding)
         if (acceptedStyle != null) {
           styleLoadPending = false
-          hasLoadedFirstStyle = true
           styleBinding?.invalidate()
           styleBinding = binding
           lifecycleStyleIdentity = acceptedStyle

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/JsMapView.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/JsMapView.kt
@@ -36,7 +36,11 @@ internal actual fun ComposableMapView(
 
   val session =
     remember(scaleFactor) {
-      GlJsMapSession(callbacks = callbacks, logger = logger, layoutDirection = layoutDirection)
+      GlJsMapSession(
+        callbacks = callbacks,
+        logger = logger,
+        layoutDirection = layoutDirection,
+      )
     }
 
   session.callbacks = callbacks
@@ -47,7 +51,12 @@ internal actual fun ComposableMapView(
   // Must run in the apply phase, not from a coroutine: the unload has to precede the content
   // subcomposition inserting layers, or a style switch crashes on anchor validation (see #269).
   SideEffect { session.setBaseStyle(style) }
-  SideEffect { update(session) }
+  if (session.hasUsableViewport) {
+    SideEffect {
+      update(session)
+      session.markPresentationStateReplayed()
+    }
+  }
 
   LaunchedEffect(session) { session.start() }
 
@@ -69,7 +78,7 @@ internal actual fun ComposableMapView(
       modifier =
         modifier.mapInput(session, options.gestureOptions, density, focusRequester, continuation),
       logger = logger,
-      presentFrames = session.hasLoadedFirstStyle,
+      presentFrames = session.canPresentFrames,
     )
   }
 }

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserMapLifecycleTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserMapLifecycleTest.kt
@@ -1,113 +1,158 @@
 package org.maplibre.compose.gljs
 
-import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.test.ExperimentalTestApi
-import androidx.compose.ui.unit.Density
+import kotlin.js.Promise
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotSame
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import org.maplibre.compose.camera.CameraPosition
-import org.maplibre.compose.camera.CameraState
+import org.maplibre.compose.map.GlJsMapSession
+import org.maplibre.compose.map.MapRuntimeOptions
 import org.maplibre.compose.map.MaplibreMap
+import org.maplibre.compose.map.StyleLoadState
+import org.maplibre.compose.map.createMapRuntime
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.spatialk.geojson.Position
 
 @OptIn(ExperimentalTestApi::class)
 class BrowserMapLifecycleTest {
 
-  private val style = BaseStyle.Json("""{"version":8,"name":"a","sources":{},"layers":[]}""")
-
-  private val otherStyle =
-    BaseStyle.Json(
-      """{"version":8,"name":"b","sources":{},
-         "layers":[{"id":"bg","type":"background","paint":{"background-color":"#123456"}}]}"""
+  private fun installDeferredReplayStyle(): DeferredReplayStyle {
+    val global = js("window")
+    val original = global.fetch
+    var resolveStyle: ((dynamic) -> Unit)? = null
+    var resolveSource: ((dynamic) -> Unit)? = null
+    global.fetch = { input: dynamic, init: dynamic ->
+      val url = if (jsTypeOf(input) == "string") input as String else input.url as String
+      when {
+        url.endsWith("/style.json") -> Promise<dynamic> { resolve, _ -> resolveStyle = resolve }
+        url.endsWith("/source.json") -> Promise<dynamic> { resolve, _ -> resolveSource = resolve }
+        else -> original.call(global, input, init)
+      }
+    }
+    return DeferredReplayStyle(
+      restore = { global.fetch = original },
+      isStyleRequested = { resolveStyle != null },
+      resolveStyle = {
+        val body = REPLAY_STYLE_JSON
+        val response = js("new Response(body, { headers: { 'content-type': 'application/json' } })")
+        checkNotNull(resolveStyle).invoke(response)
+      },
+      isSourceRequested = { resolveSource != null },
+      resolveSource = {
+        val body = REPLAY_SOURCE_JSON
+        val response = js("new Response(body, { headers: { 'content-type': 'application/json' } })")
+        checkNotNull(resolveSource).invoke(response)
+      },
     )
-
-  @Test
-  fun a_map_can_be_taken_out_of_the_composition() = runBrowserMapTest {
-    var visible by mutableStateOf(true)
-    var loaded = false
-    setBrowserMapContent {
-      if (visible) {
-        MaplibreMap(modifier = Modifier, baseStyle = style, onMapLoadFinished = { loaded = true })
-      }
-    }
-    waitUntilMap("the map to load") { loaded }
-
-    visible = false
-    waitForIdle()
-    repeat(5) {
-      yieldToBrowser()
-      waitForIdle()
-    }
   }
 
-  @Test
-  fun a_map_can_be_taken_out_and_put_back() = runBrowserMapTest {
-    var visible by mutableStateOf(true)
-    var loads = 0
-    setBrowserMapContent {
-      if (visible) {
-        MaplibreMap(modifier = Modifier, baseStyle = style, onMapLoadFinished = { loads += 1 })
-      }
-    }
-    waitUntilMap("the first map to load") { loads >= 1 }
-
-    visible = false
-    repeat(5) {
-      yieldToBrowser()
-      waitForIdle()
-    }
-    visible = true
-    waitUntilMap("the replacement map to load") { loads >= 2 }
-  }
+  private class DeferredReplayStyle(
+    val restore: () -> Unit,
+    val isStyleRequested: () -> Boolean,
+    val resolveStyle: () -> Unit,
+    val isSourceRequested: () -> Boolean,
+    val resolveSource: () -> Unit,
+  )
 
   @Test
-  fun changing_density_rebuilds_the_map_and_keeps_its_camera() = runBrowserMapTest {
-    var density by mutableStateOf(Density(1f))
-    var loads = 0
-    val expectedCamera =
-      CameraPosition(target = Position(longitude = 11.0, latitude = 47.0), zoom = 8.0)
-    val cameraState = CameraState(expectedCamera)
-
-    setBrowserMapContent {
-      CompositionLocalProvider(LocalDensity provides density) {
-        MaplibreMap(
-          modifier = Modifier,
-          baseStyle = style,
-          cameraState = cameraState,
-          onMapLoadFinished = { loads += 1 },
+  fun a_web_map_is_destroyed_and_recreated_with_its_durable_camera(): Promise<*> =
+    runBrowserMapTest {
+      val runtime = createMapRuntime(MapRuntimeOptions())
+      val initialCamera =
+        CameraPosition(target = Position(longitude = 11.0, latitude = 47.0), zoom = 8.0)
+      val replayedCamera =
+        CameraPosition(
+          bearing = 20.0,
+          target = Position(longitude = -122.4, latitude = 37.8),
+          tilt = 30.0,
+          zoom = 10.0,
         )
+      val state =
+        runtime.createMapState(
+          initialCameraPosition = initialCamera,
+          initialBaseStyle = STYLE_A,
+        )
+      val presented = mutableStateOf(true)
+
+      setBrowserMapContent { if (presented.value) MaplibreMap(state) }
+      waitUntilMap("the first Web presentation to become ready") {
+        state.presentation != null && state.style.loadState == StyleLoadState.Ready
       }
+      val firstPresentation = requireNotNull(state.presentation)
+      val firstSession = firstPresentation.adapter as GlJsMapSession
+      val firstEngine = requireNotNull(firstSession.engineMapForTest())
+
+      firstPresentation.setCameraPosition(replayedCamera)
+      waitUntilMap("the logical map to accept the camera") {
+        state.cameraPosition.isNear(replayedCamera)
+      }
+
+      runOnIdle { presented.value = false }
+      waitUntilMap("the departed GL JS map to be destroyed") {
+        state.presentation == null && firstSession.engineMapForTest() == null
+      }
+
+      assertTrue(!firstPresentation.isValid)
+      assertNull(firstSession.engineMapForTest())
+      assertEquals(StyleLoadState.Pending, state.style.loadState)
+
+      val deferredStyle = installDeferredReplayStyle()
+      try {
+        state.style.baseStyle = REPLAY_STYLE
+        runOnIdle { presented.value = true }
+        waitUntilMap("the replacement Web map to request its retained style") {
+          state.presentation != null && deferredStyle.isStyleRequested()
+        }
+        val replacementSession = requireNotNull(state.presentation).adapter as GlJsMapSession
+
+        assertNotSame(firstSession, replacementSession)
+        assertNotSame(firstEngine, replacementSession.engineMapForTest())
+        assertEquals(StyleLoadState.Loading, state.style.loadState)
+        assertTrue(replacementSession.getCameraPosition().isNear(replayedCamera))
+        assertTrue(!replacementSession.canPresentFrames)
+
+        deferredStyle.resolveStyle()
+        waitUntilMap("the replacement style to request its source metadata") {
+          deferredStyle.isSourceRequested()
+        }
+
+        assertEquals(StyleLoadState.Loading, state.style.loadState)
+        assertTrue(!replacementSession.canPresentFrames)
+
+        deferredStyle.resolveSource()
+        waitUntilMap("the replacement Web presentation to replay the logical map") {
+          state.presentation != null &&
+            state.style.loadState == StyleLoadState.Ready &&
+            state.cameraPosition.isNear(replayedCamera)
+        }
+
+        assertTrue(state.cameraPosition.isNear(replayedCamera))
+        assertTrue(replacementSession.canPresentFrames)
+        assertEquals(
+          listOf("replayed"),
+          requireNotNull(replacementSession.engineMapForTest()).getStyle().layers.map { it.id },
+        )
+      } finally {
+        deferredStyle.restore()
+      }
+
+      runtime.close()
+      runtime.awaitClosed()
     }
-    waitUntilMap("the first map to load") { loads >= 1 }
-    val firstViewport = cameraState.viewport
 
-    density = Density(2f)
-    waitUntilMap("the replacement map to load at the new density") { loads >= 2 }
-
-    assertNotSame(firstViewport, cameraState.viewport, "the camera should attach to a new map")
-    assertEquals(expectedCamera.target, cameraState.position.target, "camera target")
-    assertEquals(expectedCamera.zoom, cameraState.position.zoom, 0.001, "camera zoom")
-  }
-
-  @Test
-  fun switching_the_base_style_reports_loading_finished_again() = runBrowserMapTest {
-    var current by mutableStateOf(style)
-    var loads = 0
-    setBrowserMapContent {
-      MaplibreMap(modifier = Modifier, baseStyle = current, onMapLoadFinished = { loads += 1 })
-    }
-    waitUntilMap("the first style to load") { loads >= 1 }
-
-    current = otherStyle
-    waitUntilMap("the second style to report that it finished loading") { loads >= 2 }
-    assertTrue(loads >= 2, "every style load should report finishing, not only the first")
+  private companion object {
+    val STYLE_A =
+      BaseStyle.Json(
+        """{"version":8,"name":"a","sources":{},"layers":[{"id":"a","type":"background"}]}"""
+      )
+    val REPLAY_STYLE = BaseStyle.Uri("https://replay-style.test/style.json")
+    const val REPLAY_STYLE_JSON =
+      """{"version":8,"sources":{"replay-source":{"type":"vector","url":"https://replay-style.test/source.json"}},"layers":[{"id":"replayed","type":"background"}]}"""
+    const val REPLAY_SOURCE_JSON =
+      """{"tilejson":"3.0.0","tiles":["https://example.invalid/{z}/{x}/{y}.pbf"]}"""
   }
 }

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserMapTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserMapTest.kt
@@ -16,6 +16,7 @@ import kotlin.time.Duration.Companion.seconds
 import kotlinx.browser.window
 import kotlinx.coroutines.await
 import org.jetbrains.skiko.wasm.onWasmReady
+import org.maplibre.compose.camera.CameraPosition
 
 /**
  * The worker URL Karma serves the suite, copied next to the test bundle by
@@ -69,6 +70,15 @@ internal suspend fun ComposeUiTest.waitUntilMap(
     yieldToBrowser()
   }
 }
+
+internal fun CameraPosition.isNear(other: CameraPosition): Boolean =
+  target.longitude.isNear(other.target.longitude) &&
+    target.latitude.isNear(other.target.latitude) &&
+    zoom.isNear(other.zoom) &&
+    bearing.isNear(other.bearing) &&
+    tilt.isNear(other.tilt)
+
+private fun Double.isNear(other: Double): Boolean = kotlin.math.abs(this - other) < 0.001
 
 /** Gives the browser's own event loop a turn, which the test dispatcher otherwise never does. */
 internal suspend fun yieldToBrowser() {

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserStyleStateTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserStyleStateTest.kt
@@ -1,18 +1,25 @@
 package org.maplibre.compose.gljs
 
-import androidx.compose.runtime.getValue
+import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.unit.dp
 import kotlin.js.Promise
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertNotSame
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlinx.browser.window
 import org.maplibre.compose.layers.RasterLayer
+import org.maplibre.compose.map.GlJsMapSession
+import org.maplibre.compose.map.MapRuntimeOptions
 import org.maplibre.compose.map.MaplibreMap
+import org.maplibre.compose.map.StyleLoadState
+import org.maplibre.compose.map.createMapRuntime
 import org.maplibre.compose.sources.RasterSource
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.compose.style.LocalStyleNode
@@ -111,6 +118,76 @@ class BrowserStyleStateTest {
     js("new Response(body, { status: 200, headers: { 'content-type': 'application/json' } })")
 
   @Test
+  fun a_detached_web_map_keeps_its_desired_style_pending_and_replays_it(): Promise<*> =
+    runBrowserMapTest {
+      val runtime = createMapRuntime(MapRuntimeOptions())
+      val state = runtime.createMapState(initialBaseStyle = STYLE_A)
+      val presented = mutableStateOf(true)
+
+      setBrowserMapContent { if (presented.value) MaplibreMap(state) }
+      waitUntilMap("style A to become ready") {
+        state.presentation != null && state.style.loadState == StyleLoadState.Ready
+      }
+
+      runOnIdle { presented.value = false }
+      waitUntilMap("the Web map to detach") { state.presentation == null }
+      runOnIdle { state.style.baseStyle = STYLE_B }
+
+      assertEquals(STYLE_B, state.style.baseStyle)
+      assertEquals(StyleLoadState.Pending, state.style.loadState)
+
+      runOnIdle { presented.value = true }
+      waitUntilMap("style B to load on the replacement map") {
+        state.presentation != null && state.style.loadState == StyleLoadState.Ready
+      }
+      val session = requireNotNull(state.presentation).adapter as GlJsMapSession
+
+      assertEquals(
+        listOf("b"),
+        requireNotNull(session.engineMapForTest()).getStyle().layers.map { it.id },
+      )
+
+      runtime.close()
+      runtime.awaitClosed()
+    }
+
+  @Test
+  fun a_web_presentation_waits_for_a_viewport_and_survives_style_failure(): Promise<*> =
+    runBrowserMapTest {
+      val runtime = createMapRuntime(MapRuntimeOptions())
+      val state = runtime.createMapState(initialBaseStyle = STYLE_A)
+      val size = mutableStateOf(0.dp)
+
+      setBrowserMapContent { MaplibreMap(state, Modifier.size(size.value)) }
+      waitForIdle()
+
+      assertNull(state.presentation)
+      assertEquals(StyleLoadState.Pending, state.style.loadState)
+
+      runOnIdle { size.value = 128.dp }
+      waitUntilMap("the attached style to become ready") {
+        state.presentation != null && state.style.loadState == StyleLoadState.Ready
+      }
+      val presentation = requireNotNull(state.presentation)
+      val session = requireNotNull(state.presentation).adapter as GlJsMapSession
+
+      assertNotNull(session.engineMapForTest())
+      assertTrue(session.canPresentFrames)
+
+      runOnIdle { state.style.baseStyle = INVALID_STYLE }
+      waitUntilMap("the replacement style request to fail") {
+        state.style.loadState is StyleLoadState.Failed
+      }
+
+      assertTrue(state.presentation === presentation)
+      assertTrue(presentation.isValid)
+      assertFalse(session.canPresentFrames, "the failed map surface must remain hidden")
+
+      runtime.close()
+      runtime.awaitClosed()
+    }
+
+  @Test
   fun a_source_reports_the_attribution_its_tilejson_carries(): Promise<*> = runBrowserMapTest {
     val restoreFetch = installSlowTileJson()
     try {
@@ -143,7 +220,7 @@ class BrowserStyleStateTest {
   fun switching_to_a_tilejson_style_keeps_the_attribution(): Promise<*> = runBrowserMapTest {
     val restoreFetch = installSlowTileJson()
     try {
-      var current by mutableStateOf(styleWith("first", "first-source"))
+      val current = mutableStateOf(styleWith("first", "first-source"))
       var state: StyleState? = null
       var loads = 0
       setBrowserMapContent {
@@ -151,14 +228,14 @@ class BrowserStyleStateTest {
         state = styleState
         MaplibreMap(
           modifier = Modifier,
-          baseStyle = current,
+          baseStyle = current.value,
           styleState = styleState,
           onMapLoadFinished = { loads += 1 },
         )
       }
       waitUntilMap("the first style to load") { loads >= 1 }
 
-      current = tileJsonStyle
+      current.value = tileJsonStyle
       waitUntilMap("the switched style's attribution to be reported") {
         state?.sources?.values?.map { it.attributionHtml } == listOf("fetched attribution")
       }
@@ -213,7 +290,7 @@ class BrowserStyleStateTest {
 
   @Test
   fun switching_styles_keeps_the_sources_visible(): Promise<*> = runBrowserMapTest {
-    var current by mutableStateOf(styleWith("first", "first-source"))
+    val current = mutableStateOf(styleWith("first", "first-source"))
     var state: StyleState? = null
     var identity: StyleIdentity? = null
     var loads = 0
@@ -222,21 +299,21 @@ class BrowserStyleStateTest {
       state = styleState
       MaplibreMap(
         modifier = Modifier,
-        baseStyle = current,
+        baseStyle = current.value,
         styleState = styleState,
         onMapLoadFinished = { loads += 1 },
       ) {
         identity = LocalStyleNode.current.style.identity
       }
     }
-    waitUntilMap("the first style to load") { loads >= 1 && state?.sources?.isNotEmpty() == true }
+    waitUntilMap("the first style to load") {
+      loads >= 1 && state?.sources?.isNotEmpty() == true
+    }
     val firstIdentity = identity
     assertEquals(listOf("first attribution"), state?.sources?.values?.map { it.attributionHtml })
 
-    // Sampled per frame, not just at the end: a window where the attribution is empty would flicker
-    // the attribution UI.
     val observed = mutableListOf<List<String>>()
-    current = styleWith("second", "second-source")
+    current.value = styleWith("second", "second-source")
     waitUntilMap("the second style's sources to be reported") {
       state?.sources?.values?.map { it.attributionHtml }?.let { observed += it }
       loads >= 2 && state?.sources?.keys == setOf("second-source")
@@ -251,6 +328,15 @@ class BrowserStyleStateTest {
   }
 
   private companion object {
+    val STYLE_A =
+      BaseStyle.Json(
+        """{"version":8,"name":"a","sources":{},"layers":[{"id":"a","type":"background"}]}"""
+      )
+    val STYLE_B =
+      BaseStyle.Json(
+        """{"version":8,"name":"b","sources":{},"layers":[{"id":"b","type":"background"}]}"""
+      )
+    val INVALID_STYLE = BaseStyle.Json("""{"version":7,"sources":{},"layers":[]}""")
     const val TILE_JSON =
       """{"tilejson":"2.2.0","tiles":["https://example.invalid/{z}/{x}/{y}.pbf"],""" +
         """"attribution":"fetched attribution"}"""

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/CompositedMap.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/CompositedMap.kt
@@ -39,8 +39,11 @@ internal class CompositedMap(style: BaseStyle, private val scaleFactor: Double =
   }
 
   /** Synchronous, so a caller can bracket it with GL of its own. */
-  fun drawOnce(target: GlJsRenderTarget): Boolean =
-    session.render(GlJsFrameTarget.Composited(target), extentOf(target))
+  fun drawOnce(target: GlJsRenderTarget): Boolean {
+    val rendered = session.render(GlJsFrameTarget.Composited(target), extentOf(target))
+    session.markPresentationStateReplayed()
+    return rendered
+  }
 
   fun setOverdrawInspector(enabled: Boolean) {
     session.setRenderSettings(RenderOptions(isOverdrawInspectorEnabled = enabled))

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserCameraTransitionLifecycleTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserCameraTransitionLifecycleTest.kt
@@ -1,7 +1,11 @@
 package org.maplibre.compose.map
 
-import kotlin.math.abs
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.test.ExperimentalTestApi
+import js.objects.unsafeJso
+import kotlin.js.Promise
 import kotlin.test.Test
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
@@ -10,12 +14,18 @@ import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.maplibre.compose.camera.CameraPosition
+import org.maplibre.compose.gljs.MapEvent
+import org.maplibre.compose.gljs.isNear
+import org.maplibre.compose.gljs.runBrowserMapTest
+import org.maplibre.compose.gljs.setBrowserMapContent
+import org.maplibre.compose.gljs.waitUntilMap
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.compose.testing.MapTestResult
 import org.maplibre.compose.testing.createMapFixture
 import org.maplibre.compose.testing.runMapTest
 import org.maplibre.spatialk.geojson.Position
 
+@OptIn(ExperimentalTestApi::class)
 class BrowserCameraTransitionLifecycleTest {
 
   @Test
@@ -25,7 +35,7 @@ class BrowserCameraTransitionLifecycleTest {
         it.session.setBaseStyle(BaseStyle.Empty)
         val animation =
           CoroutineScope(Dispatchers.Default).launch(start = CoroutineStart.UNDISPATCHED) {
-            it.session.animateCameraPosition(TARGET, 60.seconds)
+            it.session.animateCameraPosition(STALE_CAMERA, 60.seconds)
           }
 
         assertFalse(animation.isCompleted, "the animation should be queued before cancellation")
@@ -37,7 +47,7 @@ class BrowserCameraTransitionLifecycleTest {
 
         assertFalse(animation.isCancelled, "transition cancellation should resume the waiter")
         assertTrue(
-          abs(it.session.getCameraPosition().zoom) < 0.01,
+          kotlin.math.abs(it.session.getCameraPosition().zoom) < 0.01,
           "the cancelled animation should not start after the style loads",
         )
       }
@@ -49,16 +59,10 @@ class BrowserCameraTransitionLifecycleTest {
       it.session.setBaseStyle(BaseStyle.Json("{ this is not json"))
       val animation =
         CoroutineScope(Dispatchers.Default).launch(start = CoroutineStart.UNDISPATCHED) {
-          it.session.animateCameraPosition(
-            TARGET,
-            60.seconds,
-          )
+          it.session.animateCameraPosition(STALE_CAMERA, 60.seconds)
         }
 
-      assertFalse(
-        animation.isCompleted,
-        "the animation should wait for the initial style result",
-      )
+      assertFalse(animation.isCompleted, "the animation should wait for the initial style result")
       it.pumpUntil("the failed style to release the queued animation") {
         it.errors.isNotEmpty() && animation.isCompleted
       }
@@ -67,7 +71,43 @@ class BrowserCameraTransitionLifecycleTest {
     }
   }
 
+  @Test
+  fun a_destroyed_web_map_cannot_move_the_logical_map_or_a_cached_presentation(): Promise<*> =
+    runBrowserMapTest {
+      val runtime = createMapRuntime(MapRuntimeOptions())
+      val state =
+        runtime.createMapState(initialCameraPosition = CURRENT_CAMERA, initialBaseStyle = STYLE)
+      val presented = mutableStateOf(true)
+
+      setBrowserMapContent { if (presented.value) MaplibreMap(state) }
+      waitUntilMap("the Web presentation to become ready") {
+        state.presentation != null && state.style.loadState == StyleLoadState.Ready
+      }
+      val departedPresentation = requireNotNull(state.presentation)
+      val departedSession = departedPresentation.adapter as GlJsMapSession
+      val departedEngine = requireNotNull(departedSession.engineMapForTest())
+
+      runOnIdle { presented.value = false }
+      waitUntilMap("the GL JS map to be destroyed") {
+        state.presentation == null && departedSession.engineMapForTest() == null
+      }
+
+      assertFailsWith<IllegalStateException> {
+        departedPresentation.setCameraPosition(STALE_CAMERA)
+      }
+      departedSession.setCameraPosition(STALE_CAMERA)
+      departedEngine.fire("move", unsafeJso<MapEvent>())
+      waitForIdle()
+
+      assertTrue(state.cameraPosition.isNear(CURRENT_CAMERA))
+
+      runtime.close()
+      runtime.awaitClosed()
+    }
+
   private companion object {
-    val TARGET = CameraPosition(target = Position(11.0, 47.0), zoom = 8.0)
+    val STYLE = BaseStyle.Json("""{"version":8,"sources":{},"layers":[]}""")
+    val CURRENT_CAMERA = CameraPosition(target = Position(11.0, 47.0), zoom = 8.0)
+    val STALE_CAMERA = CameraPosition(target = Position(-122.4, 37.8), zoom = 12.0)
   }
 }

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/testing/GlJsMapFixture.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/testing/GlJsMapFixture.kt
@@ -65,7 +65,9 @@ internal class GlJsMapFixture(private val extent: MapExtent) : MapFixture {
 
   private fun frame(): Boolean {
     frameRequested = false
-    return glJsSession.render(GlJsFrameTarget.Detached, extent).also { if (it) hasRendered = true }
+    val rendered = glJsSession.render(GlJsFrameTarget.Detached, extent)
+    glJsSession.markPresentationStateReplayed()
+    return rendered.also { if (it) hasRendered = true }
   }
 
   override suspend fun loadStyle(style: BaseStyle, timeout: Duration) {


### PR DESCRIPTION
## Description

Destroy detached GL JS maps and replay each logical map’s retained camera and style on a replacement engine before its surface becomes visible.

## Validation

Validated on macOS with `mise run check` and `caffeinate -dimsu mise run test:js`, including a sensitivity mutation that failed the new reconciliation assertion.

## AI assistance

OpenAI Codex with GPT-5 in the desktop harness assisted with implementation, browser testing, and code review.