### PR TITLE
fix(map): clear review debt before style handles

### DIFF
--- a/.agents/scratch/api-redesign/spec.md
+++ b/.agents/scratch/api-redesign/spec.md
@@ -266,9 +266,12 @@ rendered viewport. Native platforms can expose this interval. Web can publish
 with a usable viewport because GL JS map creation requires a rendering target.
 
 Presentation callbacks begin after publication and apply only to that render
-lease. The lifecycle authority ignores callbacks after detachment. Platform
-events before publication can update internal durable state, but they do not
-invoke presentation callbacks.
+lease. After detachment the lifecycle authority accepts viewport, camera,
+gesture, click, frame, and surface events only for the current render lease.
+Durable native base-style load, failure, and source-state events remain accepted
+under the current engine-map and style-request identities. Platform events
+before publication can update internal durable state, but they do not invoke
+presentation callbacks.
 
 Presentation readiness is independent from style readiness. The map surface
 remains hidden behind the composable placeholder until the requested base style
@@ -341,9 +344,12 @@ part of `StyleComposition`. Changing the base style has this order:
 6. Report the applied style as ready.
 
 Each accepted base-style change receives an internal monotonically increasing
-request identity. Assigning an equal `BaseStyle` is a no-op. A newer request
-supersedes an older request at once, and callbacks from the older request cannot
-change public state. `MapStyleState.loadState` has these public states:
+request identity. Assigning a `BaseStyle` that equals the current desired value
+is a no-op. Engine apply is keyed on the accepted request identity. An A-B-A
+cycle is three requests, and the third request loads A again even when the
+engine last applied A. A newer request supersedes an older request at once, and
+callbacks from the older request cannot change public state.
+`MapStyleState.loadState` has these public states:
 
 - `Pending` means the desired base style is recorded but no engine can currently
   load it, as on a detached Web map.
@@ -554,6 +560,10 @@ The transition to `Closing` is the closure commit point. After it:
 - New attachments fail.
 - Platform callbacks are ignored.
 - Cleanup continues despite caller cancellation.
+
+A `MaplibreMap` that remains composed after its `MapState` closes stays inert.
+Internal publication and attach attempts have no effect. Public `MapState` and
+`MapPresentation` operations still fail.
 
 All suspending public engine operations can be called from any coroutine
 dispatcher. The lifecycle authority marshals them to the owner context. Callers

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapAdapter.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapAdapter.kt
@@ -134,3 +134,52 @@ internal interface MapAdapter {
     fun onFrame(fps: Double)
   }
 }
+
+internal object EmptyMapAdapterCallbacks : MapAdapter.Callbacks {
+  override fun onStyleChanged(map: MapAdapter, style: StyleBinding?) = Unit
+
+  override fun onMapFinishedLoading(map: MapAdapter) = Unit
+
+  override fun onSourceChanged(map: MapAdapter, sourceId: String?) = Unit
+
+  override fun onMapFailLoading(map: MapAdapter, reason: String?) = Unit
+
+  override fun onCameraMoveStarted(map: MapAdapter, reason: CameraMoveReason) = Unit
+
+  override fun onCameraMoved(map: MapAdapter) = Unit
+
+  override fun onCameraMoveEnded(map: MapAdapter) = Unit
+
+  override fun onClick(map: MapAdapter, latLng: Position, offset: DpOffset) = Unit
+
+  override fun onLongClick(map: MapAdapter, latLng: Position, offset: DpOffset) = Unit
+
+  override fun onFrame(fps: Double) = Unit
+}
+
+/** Style-load events for a retained engine after its presentation has left composition. */
+internal class DurableStyleCallbacks(private val owner: MapState) : MapAdapter.Callbacks {
+  override fun onStyleChanged(map: MapAdapter, style: StyleBinding?) = Unit
+
+  override fun onMapFinishedLoading(map: MapAdapter) {
+    owner.markStyleReady(map)
+  }
+
+  override fun onSourceChanged(map: MapAdapter, sourceId: String?) = Unit
+
+  override fun onMapFailLoading(map: MapAdapter, reason: String?) {
+    owner.markStyleFailed(map, reason)
+  }
+
+  override fun onCameraMoveStarted(map: MapAdapter, reason: CameraMoveReason) = Unit
+
+  override fun onCameraMoved(map: MapAdapter) = Unit
+
+  override fun onCameraMoveEnded(map: MapAdapter) = Unit
+
+  override fun onClick(map: MapAdapter, latLng: Position, offset: DpOffset) = Unit
+
+  override fun onLongClick(map: MapAdapter, latLng: Position, offset: DpOffset) = Unit
+
+  override fun onFrame(fps: Double) = Unit
+}

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapAdapter.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapAdapter.kt
@@ -157,7 +157,6 @@ internal object EmptyMapAdapterCallbacks : MapAdapter.Callbacks {
   override fun onFrame(fps: Double) = Unit
 }
 
-/** Style-load events for a retained engine after its presentation has left composition. */
 internal class DurableStyleCallbacks(private val owner: MapState) : MapAdapter.Callbacks {
   override fun onStyleChanged(map: MapAdapter, style: StyleBinding?) = Unit
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleAuthority.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleAuthority.kt
@@ -419,10 +419,22 @@ internal class MapLifecycleAuthority(
       }
     } else if (outcome.isFailure && stillAttaching) {
       val error = checkNotNull(outcome.exceptionOrNull())
+      if (serialized { current.load() !== attaching }) {
+        attaching.result.complete(
+          Result.failure(MapLeaseInvalidatedException().also { error.let(it::addSuppressed) })
+        )
+        return
+      }
       if (attachAttempted) {
         runCatching { adapter.detach(attaching.engine, attaching.lease) }
           .exceptionOrNull()
           ?.let(error::addSuppressed)
+      }
+      if (serialized { current.load() !== attaching }) {
+        attaching.result.complete(
+          Result.failure(MapLeaseInvalidatedException().also { error.let(it::addSuppressed) })
+        )
+        return
       }
       val destroyEngine =
         !attaching.engineCreated.load() || adapter.engineRetention == EngineRetention.DESTROY

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
@@ -319,6 +319,7 @@ internal constructor(
   private var attachment: Attachment? = null
   private var retainedAdapter: MapAdapter? = null
   private val retiringAdapters = linkedSetOf<MapAdapter>()
+  private val pendingCleanupFailures = mutableListOf<Throwable>()
   private var closed = false
   private var closedState: Boolean by mutableStateOf(false)
 
@@ -339,32 +340,38 @@ internal constructor(
 
   /** Marks this state as closed and starts cleanup of the current presentation. */
   public fun close() {
-    val maps = lock.withLock {
-      if (closed) return
-      closed = true
-      val maps = buildSet {
-        retainedAdapter?.let(::add)
-        attachment?.adapter?.let(::add)
-        addAll(retiringAdapters)
+    val (maps, recordedFailures) =
+      lock.withLock {
+        if (closed) return
+        closed = true
+        val maps = buildSet {
+          retainedAdapter?.let(::add)
+          attachment?.adapter?.let(::add)
+          addAll(retiringAdapters)
+        }
+        val recordedFailures = pendingCleanupFailures.toList()
+        attachment = null
+        retainedAdapter = null
+        retiringAdapters.clear()
+        pendingCleanupFailures.clear()
+        Snapshot.withMutableSnapshot {
+          closedState = true
+          presentation?.invalidate()
+          presentation = null
+        }
+        maps to recordedFailures
       }
-      attachment = null
-      retainedAdapter = null
-      retiringAdapters.clear()
-      Snapshot.withMutableSnapshot {
-        closedState = true
-        presentation?.invalidate()
-        presentation = null
-      }
-      maps
-    }
     cameraState.map = null
     if (maps.isEmpty()) {
-      completeClosure(Result.success(Unit))
+      completeClosure(
+        if (recordedFailures.isEmpty()) Result.success(Unit)
+        else Result.failure(MapStateCleanupException(recordedFailures))
+      )
       return
     }
     maps.forEach(MapAdapter::close)
     runtime.physicalScope.launch(start = CoroutineStart.UNDISPATCHED) {
-      val failures = mutableListOf<Throwable>()
+      val failures = recordedFailures.toMutableList()
       maps.forEach { map ->
         runCatching { map.awaitClosed() }.exceptionOrNull()?.let(failures::add)
       }
@@ -417,6 +424,7 @@ internal constructor(
     options: MapPresentationOptions = MapPresentationOptions(),
   ) {
     val replaced = lock.withLock {
+      if (closed) return
       requireOpenLocked()
       val current = attachment
       check(current?.token == token && !current.releasing) {
@@ -443,8 +451,11 @@ internal constructor(
     if (replaced != null) {
       replaced.close()
       runtime.physicalScope.launch {
-        runCatching { replaced.awaitClosed() }
-        lock.withLock { retiringAdapters.remove(replaced) }
+        val failure = runCatching { replaced.awaitClosed() }.exceptionOrNull()
+        lock.withLock {
+          retiringAdapters.remove(replaced)
+          if (failure != null && !closed) pendingCleanupFailures += failure
+        }
       }
     }
   }
@@ -480,6 +491,8 @@ internal constructor(
         adapter.presentationCompatibilityKey == compatibilityKey
     }
   }
+
+  internal fun durableStyleCallbacks(): MapAdapter.Callbacks = DurableStyleCallbacks(this)
 
   internal fun markStyleReady(adapter: MapAdapter) {
     lock.withLock {

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MaplibreMap.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MaplibreMap.kt
@@ -351,23 +351,24 @@ private fun MaplibreMapPresentation(
       runtime = stateAttachment?.runtime,
       state = stateAttachment?.state,
       style = baseStyle,
-      update = { map ->
-        map.setCameraPadding(cameraPadding)
-        map.setCameraConstraints(
-          CameraConstraints(
-            minZoom = zoomRange.start.toDouble(),
-            maxZoom = zoomRange.endInclusive.toDouble(),
-            minPitch = pitchRange.start.toDouble(),
-            maxPitch = pitchRange.endInclusive.toDouble(),
-            boundingBox = boundingBox,
+      update = update@{ map ->
+          if (stateAttachment?.state?.isClosed == true) return@update
+          map.setCameraPadding(cameraPadding)
+          map.setCameraConstraints(
+            CameraConstraints(
+              minZoom = zoomRange.start.toDouble(),
+              maxZoom = zoomRange.endInclusive.toDouble(),
+              minPitch = pitchRange.start.toDouble(),
+              maxPitch = pitchRange.endInclusive.toDouble(),
+              boundingBox = boundingBox,
+            )
           )
-        )
-        map.setRenderSettings(options.renderOptions)
-        map.setGestureSettings(options.gestureOptions)
-        map.setTileLodSettings(options.tileLodOptions)
-        cameraState.map = map
-        stateAttachment?.publish(map, options)
-      },
+          map.setRenderSettings(options.renderOptions)
+          map.setGestureSettings(options.gestureOptions)
+          map.setTileLodSettings(options.tileLodOptions)
+          cameraState.map = map
+          stateAttachment?.publish(map, options)
+        },
       onReset = {
         stateAttachment?.release(cameraState.map)
         cameraState.map = null

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/sources/RasterDemSource.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/sources/RasterDemSource.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.json.add
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
+import org.maplibre.compose.style.RasterDemCapabilities
 import org.maplibre.compose.style.SourceDefinition
 import org.maplibre.compose.style.StyleMutationException
 
@@ -58,29 +59,31 @@ public class RasterDemSource : Source {
   ) : super(id) {
     val tileSet = TileSet(tiles.toList(), options, tileSize, demEncoding)
     this.tileSet = tileSet
-    json = tileSet.toJson(customEncoding = true, includeScheme = true)
+    json =
+      rasterDemSourceJson(
+        tiles = tileSet.tiles,
+        options = tileSet.options,
+        tileSize = tileSet.tileSize,
+        demEncoding = tileSet.demEncoding,
+        capabilities =
+          RasterDemCapabilities(
+            supportsCustomDemEncoding = true,
+            supportsRasterDemScheme = true,
+          ),
+      )
   }
 
   override fun toJson(): JsonObject = json
 
   override fun definition(): SourceDefinition {
     val tileSet = tileSet ?: return super.definition()
-    return SourceDefinition.RasterDem(id) { capabilities ->
-      if (
-        !capabilities.supportsRasterDemScheme &&
-          tileSet.options.tileCoordinateSystem != TileCoordinateSystem.XYZ
-      ) {
-        throw StyleMutationException(
-          "this engine has no scheme on a raster-dem source and reads only XYZ tiles; use " +
-            "TileCoordinateSystem.XYZ",
-          null,
-        )
-      }
-      tileSet.toJson(
-        customEncoding = capabilities.supportsCustomDemEncoding,
-        includeScheme = capabilities.supportsRasterDemScheme,
-      )
-    }
+    return SourceDefinition.RasterDem(
+      id = id,
+      tiles = tileSet.tiles,
+      options = tileSet.options,
+      tileSize = tileSet.tileSize,
+      demEncoding = tileSet.demEncoding,
+    )
   }
 
   private class TileSet(
@@ -88,26 +91,44 @@ public class RasterDemSource : Source {
     val options: TileSetOptions,
     val tileSize: Int,
     val demEncoding: RasterDemEncoding,
+  )
+}
+
+internal fun rasterDemSourceJson(
+  tiles: List<String>,
+  options: TileSetOptions,
+  tileSize: Int,
+  demEncoding: RasterDemEncoding,
+  capabilities: RasterDemCapabilities,
+): JsonObject {
+  if (
+    !capabilities.supportsRasterDemScheme &&
+      options.tileCoordinateSystem != TileCoordinateSystem.XYZ
   ) {
-    fun toJson(customEncoding: Boolean, includeScheme: Boolean): JsonObject = buildJsonObject {
-      put("type", "raster-dem")
-      putJsonArray("tiles") { tiles.forEach { add(it) } }
-      put("tileSize", tileSize)
-      val custom = demEncoding as? RasterDemEncoding.Custom
-      // An engine that does not implement the custom factors decodes as Mapbox instead.
-      put(
-        "encoding",
-        if (custom != null && !customEncoding) RasterDemEncoding.Mapbox.value
-        else demEncoding.value,
-      )
-      if (custom != null && customEncoding) {
-        put("redFactor", custom.redFactor)
-        put("greenFactor", custom.greenFactor)
-        put("blueFactor", custom.blueFactor)
-        put("baseShift", custom.baseShift)
-      }
-      putTileSetOptions(options, includeScheme = includeScheme)
+    throw StyleMutationException(
+      "this engine has no scheme on a raster-dem source and reads only XYZ tiles; use " +
+        "TileCoordinateSystem.XYZ",
+      null,
+    )
+  }
+  val customEncoding = capabilities.supportsCustomDemEncoding
+  val includeScheme = capabilities.supportsRasterDemScheme
+  return buildJsonObject {
+    put("type", "raster-dem")
+    putJsonArray("tiles") { tiles.forEach { add(it) } }
+    put("tileSize", tileSize)
+    val custom = demEncoding as? RasterDemEncoding.Custom
+    put(
+      "encoding",
+      if (custom != null && !customEncoding) RasterDemEncoding.Mapbox.value else demEncoding.value,
+    )
+    if (custom != null && customEncoding) {
+      put("redFactor", custom.redFactor)
+      put("greenFactor", custom.greenFactor)
+      put("blueFactor", custom.blueFactor)
+      put("baseShift", custom.baseShift)
     }
+    putTileSetOptions(options, includeScheme = includeScheme)
   }
 }
 
@@ -164,7 +185,7 @@ public fun rememberRasterDemSource(
   tileSize: Int = SourceDefaults.RASTER_TILE_SIZE,
   encoding: RasterDemEncoding = RasterDemEncoding.Mapbox,
 ): RasterDemSource =
-  key(tiles, options, tileSize) {
+  key(tiles, options, tileSize, encoding) {
     rememberUserSource(
       factory = {
         RasterDemSource(

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleBinding.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleBinding.kt
@@ -16,6 +16,7 @@ import org.maplibre.compose.sources.Source
 import org.maplibre.compose.sources.TileCoordinate
 import org.maplibre.compose.sources.VectorTileProvider
 import org.maplibre.compose.sources.putGeoJsonOptions
+import org.maplibre.compose.sources.rasterDemSourceJson
 import org.maplibre.compose.sources.toDataJson
 import org.maplibre.compose.util.ImageStretch
 import org.maplibre.spatialk.geojson.BoundingBox
@@ -147,8 +148,13 @@ internal interface StyleBinding {
       is SourceDefinition.RasterDem ->
         addSource(
           definition.id,
-          definition.createJson(
-            RasterDemCapabilities(supportsCustomDemEncoding, supportsRasterDemScheme)
+          rasterDemSourceJson(
+            tiles = definition.tiles,
+            options = definition.options,
+            tileSize = definition.tileSize,
+            demEncoding = definition.demEncoding,
+            capabilities =
+              RasterDemCapabilities(supportsCustomDemEncoding, supportsRasterDemScheme),
           ),
         )
     }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleDefinitions.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleDefinitions.kt
@@ -45,7 +45,6 @@ internal sealed interface SourceDefinition {
     val provider: VectorTileProvider,
   ) : SourceDefinition
 
-  /** A tiled raster DEM definition. Engine JSON is resolved at install time. */
   data class RasterDem(
     override val id: String,
     val tiles: List<String>,

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleDefinitions.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleDefinitions.kt
@@ -7,6 +7,8 @@ import org.maplibre.compose.sources.CustomVectorSourceOptions
 import org.maplibre.compose.sources.GeoJsonData
 import org.maplibre.compose.sources.GeoJsonOptions
 import org.maplibre.compose.sources.GeometryTileProvider
+import org.maplibre.compose.sources.RasterDemEncoding
+import org.maplibre.compose.sources.TileSetOptions
 import org.maplibre.compose.sources.VectorTileProvider
 import org.maplibre.compose.util.ImageStretch
 import org.maplibre.compose.util.toImageBitmap
@@ -43,10 +45,13 @@ internal sealed interface SourceDefinition {
     val provider: VectorTileProvider,
   ) : SourceDefinition
 
-  /** A raster DEM definition whose JSON depends on the loaded engine's style capabilities. */
+  /** A tiled raster DEM definition. Engine JSON is resolved at install time. */
   data class RasterDem(
     override val id: String,
-    val createJson: (RasterDemCapabilities) -> JsonObject,
+    val tiles: List<String>,
+    val options: TileSetOptions,
+    val tileSize: Int,
+    val demEncoding: RasterDemEncoding,
   ) : SourceDefinition
 }
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleIdentity.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleIdentity.kt
@@ -77,6 +77,10 @@ internal class StyleLoadTracker(initialStyle: BaseStyle, engineAvailable: Boolea
   fun beginLoading(): StyleRequestId =
     if (state is TrackedStyleLoadState.Pending) engineBecameAvailable() else currentRequest
 
+  /** True when this request has not yet been sent to the engine. */
+  fun shouldApplyToEngine(appliedRequest: StyleRequestId?): Boolean =
+    appliedRequest != currentRequest
+
   /** Starts reconciliation of a new complete revision against the loaded base style. */
   fun beginReconciliation(): StyleRequestId {
     check(loadedIdentity != null) { "No loaded style is available for reconciliation" }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleIdentity.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleIdentity.kt
@@ -77,7 +77,6 @@ internal class StyleLoadTracker(initialStyle: BaseStyle, engineAvailable: Boolea
   fun beginLoading(): StyleRequestId =
     if (state is TrackedStyleLoadState.Pending) engineBecameAvailable() else currentRequest
 
-  /** True when this request has not yet been sent to the engine. */
   fun shouldApplyToEngine(appliedRequest: StyleRequestId?): Boolean =
     appliedRequest != currentRequest
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleReconciler.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleReconciler.kt
@@ -59,8 +59,9 @@ internal class StyleReconciler {
       .groupByTo(linkedMapOf()) { it.anchor }
       .forEach { (anchor, group) ->
         var previousId: String? = null
-        group.forEach { desired ->
+        group.forEachIndexed { index, desired ->
           val id = desired.definition.id
+          val nextDesiredId = group.getOrNull(index + 1)?.definition?.id
           var applied = layers[id]
           if (applied == null) {
             val before = beforeLayerId(style, anchor, previousId, id)
@@ -84,8 +85,10 @@ internal class StyleReconciler {
           } else {
             applied.handle.update(desired.definition)
             applied.definition = desired.definition
-            val before = beforeLayerId(style, anchor, previousId, id)
-            if (style.layerIds().positionBefore(id) != before) applied.handle.move(before)
+            if (shouldMoveLayer(style, anchor, previousId, id, nextDesiredId)) {
+              val before = beforeLayerId(style, anchor, previousId, id)
+              if (before != id) applied.handle.move(before)
+            }
           }
           previousId = id
         }
@@ -136,6 +139,20 @@ internal class StyleReconciler {
         images[definition.id] = definition
       }
     }
+  }
+
+  private fun shouldMoveLayer(
+    style: StyleBinding,
+    anchor: Anchor,
+    previousId: String?,
+    id: String,
+    nextDesiredId: String?,
+  ): Boolean {
+    val ids = style.layerIds()
+    if (previousId != null) return ids.idAbove(previousId) != id
+    if (nextDesiredId != null) return ids.positionBefore(id) != nextDesiredId
+    val before = beforeLayerId(style, anchor, previousId = null, desiredId = id)
+    return before != id && ids.positionBefore(id) != before
   }
 
   private fun beforeLayerId(

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
@@ -83,6 +83,56 @@ class MapPresentationTest {
   }
 
   @Test
+  fun publishing_into_a_closed_state_is_inert() {
+    val fixture = presentationFixture()
+    fixture.state.close()
+
+    fixture.state.publishPresentation(fixture.token, fixture.adapter)
+
+    assertTrue(fixture.state.isClosed)
+    assertNull(fixture.state.presentation)
+    fixture.runtime.close()
+  }
+
+  @Test
+  fun replacement_cleanup_failures_are_reported_on_close() = runTest {
+    val runtime = mapRuntimeForTest()
+    val state = runtime.createMapState()
+    val firstToken = state.reservePresentation()
+    val first = RetainedAdapter(failOnClose = true)
+    state.publishPresentation(firstToken, first)
+    state.releasePresentation(firstToken, first)
+    testScheduler.advanceUntilIdle()
+
+    val secondToken = state.reservePresentation()
+    val second = RetainedAdapter(failOnClose = false)
+    state.publishPresentation(secondToken, second)
+    testScheduler.advanceUntilIdle()
+
+    state.close()
+    val failure = assertFailsWith<MapStateCleanupException> { state.awaitClosed() }
+    assertTrue(failure.message.orEmpty().contains("cleanup failed"))
+    runtime.close()
+  }
+
+  @Test
+  fun a_durable_callback_updates_style_load_state_after_the_presentation_leaves() = runTest {
+    val runtime = mapRuntimeForTest()
+    val state = runtime.createMapState()
+    val token = state.reservePresentation()
+    val adapter = RetainedAdapter(failOnClose = false)
+    state.publishPresentation(token, adapter)
+    state.releasePresentation(token, adapter)
+    testScheduler.advanceUntilIdle()
+
+    state.durableStyleCallbacks().onMapFailLoading(adapter, "style refused")
+
+    assertTrue(state.style.loadState is StyleLoadState.Failed)
+    state.close()
+    runtime.close()
+  }
+
+  @Test
   fun publication_happens_after_the_adapter_accepts_initial_map_state() {
     val runtime = mapRuntimeForTest()
     val state = runtime.createMapState()
@@ -184,7 +234,17 @@ private fun presentationFixture(): PresentationFixture {
   return PresentationFixture(runtime, state, token, adapter, requireNotNull(state.presentation))
 }
 
-private class PresentationTestAdapter(
+private class RetainedAdapter(private val failOnClose: Boolean) : PresentationTestAdapter() {
+  override val retainsEngineBetweenPresentations: Boolean = true
+
+  override suspend fun detachPresentation() = Unit
+
+  override suspend fun awaitClosed() {
+    if (failOnClose) error("cleanup failed")
+  }
+}
+
+private open class PresentationTestAdapter(
   private val currentPresentation: () -> MapPresentation? = { null }
 ) : MapAdapter {
   var lastCameraPosition = CameraPosition()
@@ -195,7 +255,7 @@ private class PresentationTestAdapter(
 
   override fun close() = Unit
 
-  override suspend fun awaitClosed() = Unit
+  open override suspend fun awaitClosed() = Unit
 
   override suspend fun animateCameraPosition(finalPosition: CameraPosition, duration: Duration) {
     animationStarted.complete(Unit)

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/sources/RasterDemSourceJsonTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/sources/RasterDemSourceJsonTest.kt
@@ -112,6 +112,14 @@ class RasterDemSourceJsonTest {
   }
 
   @Test
+  fun tiled_definitions_from_the_same_source_compare_equal() {
+    val source = RasterDemSource(id = "dem", tiles = listOf(TILE_TEMPLATE))
+
+    assertEquals(source.definition(), source.definition())
+    assertEquals(source.definition().hashCode(), source.definition().hashCode())
+  }
+
+  @Test
   fun a_tile_json_source_carries_neither_key() {
     val binding = RecordingStyleBinding(supportsRasterDemScheme = false)
     val source = RasterDemSource(id = "dem", uri = "https://example.invalid/tiles.json")

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/style/StyleCompositionOrderTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/style/StyleCompositionOrderTest.kt
@@ -4,6 +4,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlinx.coroutines.test.runTest
 import org.maplibre.compose.layers.Anchor
+import org.maplibre.compose.layers.BackgroundLayer
 import org.maplibre.compose.layers.RasterLayer
 import org.maplibre.compose.sources.RasterSource
 
@@ -30,5 +31,64 @@ class StyleCompositionOrderTest {
 
     assertEquals(listOf("first-layer", "second-layer"), revision.layers.map { it.definition.id })
     assertEquals(listOf("first-layer", "second-layer"), style.layerIds())
+  }
+
+  @Test
+  fun a_second_apply_does_not_move_already_placed_layers() = runTest {
+    val anchors =
+      listOf(
+        Anchor.Top,
+        Anchor.Bottom,
+        Anchor.Above("water"),
+        Anchor.Below("roads"),
+        Anchor.Replace("park"),
+      )
+    for (anchor in anchors) {
+      val source =
+        RasterSource("composed-source", listOf("https://example.invalid/{z}/{x}/{y}.png"))
+      val first = RasterLayer("first-layer", source)
+      val second = RasterLayer("second-layer", source)
+      val revision =
+        DesiredStyleRevision(
+          sources = listOf(source.definition()),
+          layers =
+            listOf(
+              DesiredStyleLayer(first.definition(), anchor, null, null),
+              DesiredStyleLayer(second.definition(), anchor, null, null),
+            ),
+          images = emptyList(),
+        )
+      val style =
+        RecordingStyleBinding(
+          layers =
+            listOf(BackgroundLayer("water"), BackgroundLayer("park"), BackgroundLayer("roads"))
+        )
+      val reconciler = StyleReconciler()
+
+      reconciler.apply(style, revision)
+      val afterFirst = style.layerIds()
+      reconciler.apply(style, revision)
+
+      assertEquals(afterFirst, style.layerIds(), "anchor $anchor")
+    }
+  }
+
+  @Test
+  fun a_single_above_layer_does_not_move_onto_itself() = runTest {
+    val source = RasterSource("composed-source", listOf("https://example.invalid/{z}/{x}/{y}.png"))
+    val layer = RasterLayer("hillshade", source)
+    val revision =
+      DesiredStyleRevision(
+        sources = listOf(source.definition()),
+        layers = listOf(DesiredStyleLayer(layer.definition(), Anchor.Above("water"), null, null)),
+        images = emptyList(),
+      )
+    val style = RecordingStyleBinding(layers = listOf(BackgroundLayer("water")))
+    val reconciler = StyleReconciler()
+
+    reconciler.apply(style, revision)
+    reconciler.apply(style, revision)
+
+    assertEquals(listOf("water", "hillshade"), style.layerIds())
   }
 }

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/style/StyleDefinitionAndIdentityTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/style/StyleDefinitionAndIdentityTest.kt
@@ -95,6 +95,22 @@ class StyleDefinitionAndIdentityTest {
   }
 
   @Test
+  fun cycling_back_to_the_same_style_value_is_a_new_engine_apply() {
+    val first = BaseStyle.Json("A")
+    val second = BaseStyle.Json("B")
+    val tracker = StyleLoadTracker(first, engineAvailable = true)
+    val firstRequest = tracker.requestId
+
+    assertTrue(tracker.shouldApplyToEngine(appliedRequest = null))
+    tracker.request(second, engineAvailable = true)
+    val thirdRequest = tracker.request(first, engineAvailable = true)
+
+    assertTrue(tracker.shouldApplyToEngine(firstRequest))
+    assertEquals(thirdRequest, tracker.requestId)
+    assertFalse(tracker.shouldApplyToEngine(thirdRequest))
+  }
+
+  @Test
   fun superseded_requests_cannot_publish_state() {
     val firstStyle = BaseStyle.Json("first")
     val secondStyle = BaseStyle.Json("second")

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/style/StyleNodeTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/style/StyleNodeTest.kt
@@ -6,7 +6,9 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 import kotlinx.coroutines.test.runTest
 import org.maplibre.compose.layers.Anchor
+import org.maplibre.compose.layers.HillshadeLayer
 import org.maplibre.compose.layers.RasterLayer
+import org.maplibre.compose.sources.RasterDemSource
 import org.maplibre.compose.sources.RasterSource
 
 class StyleNodeTest {
@@ -59,6 +61,28 @@ class StyleNodeTest {
     reconciler.apply(recording, revision)
     assertTrue(recording.additions.isEmpty())
     assertEquals(listOf("raster"), style.layerIds())
+  }
+
+  @Test
+  fun a_second_raster_dem_revision_does_not_replace_the_source() = runTest {
+    val style = RecordingStyleBinding()
+    val recording = RecordingOperations(style)
+    val reconciler = StyleReconciler()
+    val source = RasterDemSource("dem", listOf("https://example.invalid/{z}/{x}/{y}.png"))
+    val layer = HillshadeLayer("hillshade", source)
+    val revision =
+      DesiredStyleRevision(
+        sources = listOf(source.definition()),
+        layers = listOf(DesiredStyleLayer(layer.definition(), Anchor.Top, null, null)),
+        images = emptyList(),
+      )
+
+    reconciler.apply(recording, revision)
+    recording.additions.clear()
+    reconciler.apply(recording, revision)
+
+    assertTrue(recording.additions.isEmpty())
+    assertEquals(listOf("hillshade"), style.layerIds())
   }
 
   @Test

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
@@ -629,10 +629,11 @@ internal class GlJsMapSession(
 
   private fun applyRequestedStyle(map: MaplibreMap) {
     val style = requestedStyle ?: return
-    if (style == appliedStyle) return
     if (styleLoadPending) return
+    val tracker = styleLoadTracker ?: return
+    val trackerRequest = tracker.beginLoading()
+    if (!tracker.shouldApplyToEngine(appliedStyleRequest)) return
     appliedStyle = style
-    val trackerRequest = styleLoadTracker?.beginLoading() ?: return
     appliedStyleRequest = trackerRequest
     styleLoadPending = true
     val engine = lifecycleEngineIdentity ?: return

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapRuntimeLoop.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapRuntimeLoop.kt
@@ -66,6 +66,8 @@ internal class MlnFfiMapRuntimeLoop(
   /** Work for the owner thread; [OwnerTask.abandon] runs instead if it never gets to run. */
   private class OwnerTask(val run: (MapHandle) -> Unit, val abandon: () -> Unit)
 
+  private class DrainBarrier(val run: () -> Unit, val abandon: () -> Unit)
+
   /**
    * The owner thread. A parked pump ignores interruption, so [close] is the only way to stop it.
    */
@@ -78,7 +80,7 @@ internal class MlnFfiMapRuntimeLoop(
   private val acceptLock = MlnFfiOwnerLock(thread)
   private val tasks = ArrayDeque<OwnerTask>()
   /** Test callbacks that run after the next native pump and event drain. Owner thread only. */
-  private val eventDrainBarriers = mutableListOf<() -> Unit>()
+  private val eventDrainBarriers = mutableListOf<DrainBarrier>()
   private var accepting = true
   private var wake: WakeSource? = null
 
@@ -164,7 +166,7 @@ internal class MlnFfiMapRuntimeLoop(
 
   /** Queues a callback that runs after the next native pump and event drain. */
   fun postEventDrainBarrier(action: () -> Unit, abandon: () -> Unit = {}): Boolean =
-    post(action = { eventDrainBarriers += action }, abandon = abandon)
+    post(action = { eventDrainBarriers += DrainBarrier(action, abandon) }, abandon = abandon)
 
   private fun submit(run: (MapHandle) -> Unit, abandon: () -> Unit): Boolean = acceptLock.withLock {
     if (!accepting) return false
@@ -237,7 +239,10 @@ internal class MlnFfiMapRuntimeLoop(
     while (!stopRequested) {
       // Queued work first: a task posted before the source was published set no wake flag.
       val ranTasks = runTasks(map)
-      if (stopRequested) break
+      if (stopRequested) {
+        abandonDrainBarriers()
+        break
+      }
       check(!acceptLock.isHeldByOwnerThread) { "the pump must not run under acceptLock" }
       // A batch that ran must not park: a task queuing nothing for native has nothing to wake it.
       runtime.pump(if (ranTasks) 0L else PUMP_PARK_MILLIS, PUMP_BUDGET_MILLIS)
@@ -272,7 +277,7 @@ internal class MlnFfiMapRuntimeLoop(
       .onFailure { logger?.e(it) { "Failed to finish handling a MapLibre event batch" } }
     val barriers = eventDrainBarriers.toList()
     eventDrainBarriers.clear()
-    barriers.forEach { runCatching(it) }
+    barriers.forEach { runCatching { it.run() } }
   }
 
   /** Runs everything queued, reporting whether anything ran. */
@@ -316,10 +321,17 @@ internal class MlnFfiMapRuntimeLoop(
     }
     // Released rather than run: a caller blocked in call() would otherwise never be resumed.
     abandoned.forEach { runCatching { it.abandon() } }
+    abandonDrainBarriers()
     // A wake source is its own native handle, so closing the runtime does not release it.
     source?.let { closing ->
       runCatching { closing.close() }
         .onFailure { logger?.w(it) { "Failed to close the map runtime's wake source" } }
     }
+  }
+
+  private fun abandonDrainBarriers() {
+    val barriers = eventDrainBarriers.toList()
+    eventDrainBarriers.clear()
+    barriers.forEach { runCatching { it.abandon() } }
   }
 }

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -160,6 +160,7 @@ internal class MlnFfiMapSession(
 ) : MapAdapter, MlnFfiMapRenderer, GestureTarget, MapLifecyclePlatformAdapter {
 
   @Volatile internal var callbacks: MapAdapter.Callbacks = callbacks
+  @Volatile internal var durableCallbacks: MapAdapter.Callbacks = EmptyMapAdapterCallbacks
   private val lifecycle = MapLifecycleAuthority(this)
   private val lifecycleCallbacks = MapLifecycleCallbacks(lifecycle) { this.callbacks }
   @Volatile private var lifecycleEngineIdentity: EngineMapIdentity? = null
@@ -475,6 +476,7 @@ internal class MlnFfiMapSession(
   }
 
   override suspend fun detach(identity: EngineMapIdentity, lease: RenderLease) {
+    callbacks = durableCallbacks
     if (lifecycleRenderLease == lease) lifecycleRenderLease = null
     // This must happen before the first suspension. A host may tear down its renderer thread as
     // soon as close() returns, but the native handle can only be closed through that thread.
@@ -495,7 +497,18 @@ internal class MlnFfiMapSession(
     closePlatform()
   }
 
-  override suspend fun closeResources() = Unit
+  override suspend fun closeResources() {
+    val abandoned = stateLock.withLock {
+      buildList {
+        addAll(pendingMapActions)
+        pendingMapActions.clear()
+        addAll(pendingViewportActions)
+        pendingViewportActions.clear()
+      }
+    }
+    abandoned.forEach { it.abandon() }
+    resumeStrandedTransitions()
+  }
 
   private fun closePlatform() {
     try {
@@ -1202,15 +1215,16 @@ internal class MlnFfiMapSession(
   private fun applyRequestedStyle(map: MapHandle, load: RequestedStyleLoad) {
     if (load !== requestedStyleLoad) return
     val style = load.style
-    if (style == appliedStyle) return
     if (styleLoadPending) return
     val engine = lifecycleEngineIdentity ?: return
     val lifecycleRequest = load.lifecycleRequest ?: lifecycleStyleRequestIdentity ?: return
     if (load.lifecycleRequest != null && load.lifecycleRequest != lifecycleStyleRequestIdentity) {
       return
     }
-    val request = styleLoadTracker?.beginLoading() ?: return
+    val tracker = styleLoadTracker ?: return
+    val request = tracker.beginLoading()
     if (load.trackerRequest != null && load.trackerRequest != request) return
+    if (!tracker.shouldApplyToEngine(appliedStyleRequest)) return
     appliedStyleRequest = request
     styleLoadPending = true
     // Replacing the native style disconnects the preceding style event producer. The runtime loop
@@ -1528,6 +1542,7 @@ internal class MlnFfiMapSession(
     transitionWaiters.clear()
     currentTransitionId = null
     waiters.forEach { waiter -> runCatching { waiter.resume(Unit) } }
+    flushTransitionResumes()
   }
 
   override fun setCameraConstraints(value: CameraConstraints) {

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapView.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapView.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.testTag
 import co.touchlab.kermit.Logger
+import kotlinx.coroutines.CancellationException
 import org.maplibre.compose.mlnffi.EnsureMlnFfiConfigured
 import org.maplibre.compose.mlnffi.MapRenderBackend
 import org.maplibre.compose.mlnffi.MlnFfiApplication
@@ -119,6 +120,7 @@ internal fun MlnFfiMapView(
       }
   val session = remember(unpreparedSession) { unpreparedSession.apply { preparePresentation() } }
 
+  session.durableCallbacks = state?.durableStyleCallbacks() ?: EmptyMapAdapterCallbacks
   session.callbacks = callbacks
   session.logger = logger
   session.layoutDirection = layoutDirection
@@ -130,7 +132,19 @@ internal fun MlnFfiMapView(
   // Publish the adapter before another thread can close a runtime whose composition has applied.
   SideEffect { update(session) }
 
-  LaunchedEffect(session) { session.attachPresentation() }
+  LaunchedEffect(session) {
+    try {
+      session.attachPresentation()
+    } catch (error: CancellationException) {
+      throw error
+    } catch (_: MapClosedException) {
+      // A still-mounted UI on a closed map is inert.
+    } catch (_: MapLeaseInvalidatedException) {
+      // Detach or close won before attach finished.
+    } catch (error: Throwable) {
+      callbacks.onMapFailLoading(session, error.message)
+    }
+  }
 
   DisposableEffect(session) {
     onDispose {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

This clears the Keep-status review items from tickets 1–8 that still fire after #1155, and records the matching lifetime rules in the redesign spec so ticket 9 can add style handles on a stable surface.

## Validation

`./gradlew :lib:maplibre-compose:jvmTest --tests org.maplibre.compose.style.StyleCompositionOrderTest --tests org.maplibre.compose.style.StyleNodeTest --tests org.maplibre.compose.style.StyleDefinitionAndIdentityTest --tests org.maplibre.compose.sources.RasterDemSourceJsonTest --tests org.maplibre.compose.map.MapPresentationTest --tests org.maplibre.compose.map.MapLifecycleAuthorityTest --tests org.maplibre.compose.map.MapRuntimeTest` passed on the JVM, and `:lib:maplibre-compose:compileKotlinJs` compiled the GL JS session change.

## AI assistance

Cursor Grok 4.6 in Cloud Agent wrote the change from the #1149 Keep-status ledger.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aa4d439f-8760-4be1-92d2-7779315f800a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aa4d439f-8760-4be1-92d2-7779315f800a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

