### PR TITLE
Expose generation-bound style handles

### DIFF
--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/LayerHandle.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/LayerHandle.kt
@@ -1,0 +1,90 @@
+package org.maplibre.compose.layers
+
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import org.maplibre.compose.style.LayerPropertyKind
+import org.maplibre.compose.style.StyleBinding
+import org.maplibre.compose.style.StyleHandleException
+import org.maplibre.compose.style.StyleHandleOperationGuard
+import org.maplibre.compose.style.StyleIdentity
+import org.maplibre.compose.style.StyleMutationException
+
+/**
+ * Imperative property access to one layer in one loaded base-style generation.
+ *
+ * A mutation that MapLibre refuses throws [StyleHandleException].
+ */
+public class LayerHandle
+internal constructor(
+  public val id: String,
+  public val type: String,
+  private val style: StyleBinding,
+  private val operations: StyleHandleOperationGuard,
+) {
+  private val identity: StyleIdentity = style.identity
+
+  /** Returns the current value of [name], or null when the layer has no value for that property. */
+  public fun getProperty(name: String): JsonElement? {
+    return operation { style.layerProperty(id, name) }
+  }
+
+  /** Sets one layout [property][name] for this loaded style. */
+  public fun setLayoutProperty(name: String, value: JsonElement) {
+    setProperty(name, value, LayerPropertyKind.LAYOUT)
+  }
+
+  /** Sets one paint [property][name] for this loaded style. */
+  public fun setPaintProperty(name: String, value: JsonElement) {
+    setProperty(name, value, LayerPropertyKind.PAINT)
+  }
+
+  /** Sets one top-level [property][name], such as `minzoom`, for this loaded style. */
+  public fun setRootProperty(name: String, value: JsonElement) {
+    operation {
+      mutate(name) {
+        if (name == "filter") style.setLayerFilter(id, value)
+        else style.setLayerProperty(id, name, value, LayerPropertyKind.ROOT)
+      }
+    }
+  }
+
+  /** Removes the layer filter for this loaded style. */
+  public fun clearFilter() {
+    operation { mutate("filter") { style.setLayerFilter(id, JsonNull) } }
+  }
+
+  private fun setProperty(name: String, value: JsonElement, kind: LayerPropertyKind) {
+    operation { mutate(name) { style.setLayerProperty(id, name, value, kind) } }
+  }
+
+  private fun requireCurrent() {
+    style.requireCurrent(identity)
+    val currentType = style.getLayer(id)?.definition()?.type
+    check(currentType == type) { "Layer '$id' is no longer the $type layer owned by this handle" }
+  }
+
+  private fun <T> operation(action: () -> T): T = operations.run {
+    requireCurrent()
+    action()
+  }
+
+  private inline fun mutate(property: String, action: () -> Unit) {
+    try {
+      action()
+    } catch (error: StyleMutationException) {
+      throw StyleHandleException(
+        "Could not set '$property' on $type layer '$id': ${error.message}",
+        error,
+      )
+    }
+  }
+}
+
+internal fun StyleBinding.layerHandle(
+  id: String,
+  operations: StyleHandleOperationGuard,
+): LayerHandle? {
+  requireCurrent()
+  val layer = getLayer(id) ?: return null
+  return LayerHandle(id, layer.definition().type, this, operations)
+}

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapAdapter.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapAdapter.kt
@@ -158,7 +158,9 @@ internal object EmptyMapAdapterCallbacks : MapAdapter.Callbacks {
 }
 
 internal class DurableStyleCallbacks(private val owner: MapState) : MapAdapter.Callbacks {
-  override fun onStyleChanged(map: MapAdapter, style: StyleBinding?) = Unit
+  override fun onStyleChanged(map: MapAdapter, style: StyleBinding?) {
+    owner.updateLoadedStyle(map, style)
+  }
 
   override fun onMapFinishedLoading(map: MapAdapter) {
     owner.markStyleReady(map)

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.unit.DpRect
 import androidx.compose.ui.unit.dp
 import co.touchlab.kermit.Logger
 import kotlin.concurrent.atomics.AtomicLong
+import kotlin.concurrent.atomics.AtomicReference
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.concurrent.atomics.incrementAndFetch
 import kotlin.jvm.JvmInline
@@ -45,8 +46,14 @@ import org.maplibre.compose.expressions.ast.Expression
 import org.maplibre.compose.expressions.ast.ExpressionContext
 import org.maplibre.compose.expressions.dsl.const
 import org.maplibre.compose.expressions.value.BooleanValue
+import org.maplibre.compose.layers.LayerHandle
+import org.maplibre.compose.layers.layerHandle
+import org.maplibre.compose.sources.SourceHandle
+import org.maplibre.compose.sources.sourceHandle
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.compose.style.DesiredStyleRevision
+import org.maplibre.compose.style.StyleBinding
+import org.maplibre.compose.style.StyleHandleOperationGuard
 import org.maplibre.compose.style.StyleState
 import org.maplibre.compose.util.VisibleRegion
 import org.maplibre.spatialk.geojson.BoundingBox
@@ -109,6 +116,7 @@ public sealed interface StyleLoadState {
 /** Desired and applied style state for one [MapState]. */
 public class MapStyleState internal constructor(initialBaseStyle: BaseStyle) {
   private var owner: MapState? = null
+  private val loadedStyle = AtomicReference<StyleBinding?>(null)
   private var baseStyleState: BaseStyle by
     mutableStateOf(initialBaseStyle, structuralEqualityPolicy())
 
@@ -121,6 +129,25 @@ public class MapStyleState internal constructor(initialBaseStyle: BaseStyle) {
   public var loadState: StyleLoadState by mutableStateOf(StyleLoadState.Pending)
     internal set
 
+  /** Returns a generation-bound handle for [id], or null until the style is ready or if absent. */
+  public fun source(id: String): SourceHandle? {
+    if (loadState != StyleLoadState.Ready) return null
+    val current = loadedStyle.load() ?: return null
+    return current.sourceHandle(
+      id = id,
+      definition = owner?.desiredSourceDefinition(id),
+      currentDefinition = { owner?.desiredSourceDefinition(id) },
+      operations = operationGuard(current),
+    )
+  }
+
+  /** Returns a generation-bound handle for [id], or null until the style is ready or if absent. */
+  public fun layer(id: String): LayerHandle? {
+    if (loadState != StyleLoadState.Ready) return null
+    val current = loadedStyle.load() ?: return null
+    return current.layerHandle(id, operationGuard(current))
+  }
+
   internal fun attach(owner: MapState) {
     this.owner = owner
   }
@@ -128,6 +155,28 @@ public class MapStyleState internal constructor(initialBaseStyle: BaseStyle) {
   internal fun setBaseStyleState(value: BaseStyle) {
     baseStyleState = value
   }
+
+  internal fun updateLoadedStyle(style: StyleBinding?) {
+    loadedStyle.store(style)
+  }
+
+  internal fun invalidateLoadedStyle() {
+    loadedStyle.exchange(null)?.invalidate()
+  }
+
+  internal fun isCurrentLoadedStyle(style: StyleBinding): Boolean = loadedStyle.load() === style
+
+  private fun operationGuard(style: StyleBinding): StyleHandleOperationGuard =
+    object : StyleHandleOperationGuard {
+      override fun <T> run(action: () -> T): T =
+        owner?.runStyleHandleOperation(style, action) ?: action()
+
+      override fun checkpoint(): Long = owner?.styleHandleCheckpoint(style) ?: 0L
+
+      override fun requireUnchanged(checkpoint: Long) {
+        owner?.requireStyleHandleUnchanged(style, checkpoint)
+      }
+    }
 }
 
 /** One temporary connection between a [MapState] and a map surface. */
@@ -321,6 +370,7 @@ internal constructor(
   private val retiringAdapters = linkedSetOf<MapAdapter>()
   private val pendingCleanupFailures = mutableListOf<Throwable>()
   private var closed = false
+  private var styleHandleEpoch = 0L
   private var closedState: Boolean by mutableStateOf(false)
 
   internal val cameraState = CameraState(initialCameraPosition)
@@ -354,6 +404,8 @@ internal constructor(
         retainedAdapter = null
         retiringAdapters.clear()
         pendingCleanupFailures.clear()
+        styleHandleEpoch++
+        style.invalidateLoadedStyle()
         Snapshot.withMutableSnapshot {
           closedState = true
           presentation?.invalidate()
@@ -443,6 +495,10 @@ internal constructor(
       if (adapter.retainsEngineBetweenPresentations) retainedAdapter = adapter
       if (replaced != null) retiringAdapters += replaced
       cameraState.map = adapter
+      if (!reusesRetainedAdapter) {
+        styleHandleEpoch++
+        style.invalidateLoadedStyle()
+      }
       adapter.setBaseStyle(style.baseStyle)
       if (!reusesRetainedAdapter) style.loadState = StyleLoadState.Loading
       MapPresentation(this, token, adapter, options).also { presentation = it }
@@ -502,6 +558,15 @@ internal constructor(
     }
   }
 
+  internal fun updateLoadedStyle(adapter: MapAdapter, loadedStyle: StyleBinding?) {
+    lock.withLock {
+      if (!closed && (attachment?.adapter === adapter || retainedAdapter === adapter)) {
+        styleHandleEpoch++
+        style.updateLoadedStyle(loadedStyle)
+      }
+    }
+  }
+
   internal fun markStyleFailed(adapter: MapAdapter, reason: String?) {
     lock.withLock {
       if (!closed && (attachment?.adapter === adapter || retainedAdapter === adapter)) {
@@ -513,6 +578,7 @@ internal constructor(
   internal fun beginStyleRevision(adapter: MapAdapter, revision: DesiredStyleRevision) {
     lock.withLock {
       if (!closed && (attachment?.adapter === adapter || retainedAdapter === adapter)) {
+        styleHandleEpoch++
         desiredStyleRevision = revision
         style.loadState = StyleLoadState.Loading
       }
@@ -523,7 +589,9 @@ internal constructor(
     lock.withLock {
       requireOpenLocked()
       if (style.baseStyle == value) return
+      styleHandleEpoch++
       style.setBaseStyleState(value)
+      style.invalidateLoadedStyle()
       val adapter = attachment?.adapter ?: retainedAdapter
       if (adapter == null) {
         style.loadState = StyleLoadState.Pending
@@ -531,6 +599,36 @@ internal constructor(
         style.loadState = StyleLoadState.Loading
         adapter.setBaseStyle(value)
       }
+    }
+  }
+
+  internal fun desiredSourceDefinition(id: String) =
+    desiredStyleRevision.sources.firstOrNull { it.id == id }
+
+  internal fun <T> runStyleHandleOperation(binding: StyleBinding, action: () -> T): T =
+    lock.withLock {
+      requireStyleHandleLocked(binding)
+      action()
+    }
+
+  internal fun styleHandleCheckpoint(binding: StyleBinding): Long = lock.withLock {
+    requireStyleHandleLocked(binding)
+    styleHandleEpoch
+  }
+
+  internal fun requireStyleHandleUnchanged(binding: StyleBinding, checkpoint: Long) {
+    lock.withLock {
+      requireStyleHandleLocked(binding)
+      check(styleHandleEpoch == checkpoint) {
+        "Style operation crossed a loaded-style resource change"
+      }
+    }
+  }
+
+  private fun requireStyleHandleLocked(binding: StyleBinding) {
+    requireOpenLocked()
+    check(style.loadState == StyleLoadState.Ready && style.isCurrentLoadedStyle(binding)) {
+      "Style operation belongs to a stale or unready loaded-style identity"
     }
   }
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MaplibreMap.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MaplibreMap.kt
@@ -252,6 +252,7 @@ private fun MaplibreMapPresentation(
 
         override fun onStyleChanged(map: MapAdapter, style: StyleBinding?) {
           rememberedStyle = style
+          stateAttachment?.state?.updateLoadedStyle(map, style)
           synchronizeCamera(map)
         }
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/sources/SourceHandle.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/sources/SourceHandle.kt
@@ -1,0 +1,364 @@
+@file:OptIn(ExperimentalAtomicApi::class)
+
+package org.maplibre.compose.sources
+
+import androidx.compose.ui.graphics.ImageBitmap
+import kotlin.concurrent.atomics.AtomicLong
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+import kotlin.concurrent.atomics.incrementAndFetch
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import org.maplibre.compose.expressions.ast.Expression
+import org.maplibre.compose.expressions.dsl.const
+import org.maplibre.compose.expressions.value.BooleanValue
+import org.maplibre.compose.style.SourceDefinition
+import org.maplibre.compose.style.StyleBinding
+import org.maplibre.compose.style.StyleHandleException
+import org.maplibre.compose.style.StyleHandleOperationGuard
+import org.maplibre.compose.style.StyleIdentity
+import org.maplibre.compose.style.StyleMutationException
+import org.maplibre.compose.util.PositionQuad
+import org.maplibre.spatialk.geojson.BoundingBox
+import org.maplibre.spatialk.geojson.Feature
+import org.maplibre.spatialk.geojson.FeatureCollection
+import org.maplibre.spatialk.geojson.Geometry
+
+/** Imperative access to one source in one loaded base-style generation. */
+public sealed class SourceHandle
+protected constructor(
+  public val id: String,
+  internal val style: StyleBinding,
+  private val expectedKind: String?,
+  private val currentKind: () -> String?,
+  private val operations: StyleHandleOperationGuard,
+) {
+  private val identity: StyleIdentity = style.identity
+
+  private fun requireCurrent() {
+    style.requireCurrent(identity)
+    val actualKind = currentKind()
+    check(actualKind != null && (expectedKind == null || actualKind == expectedKind)) {
+      "Source '$id' is no longer the $expectedKind source owned by this handle"
+    }
+  }
+
+  /** The source attribution that the current loaded style reports. */
+  public val attributionHtml: String
+    get() = operation { style.getSource(id)?.attributionHtml.orEmpty() }
+
+  protected fun writeFeatureState(sourceLayerId: String?, featureId: String, state: JsonObject) {
+    operation { style.setFeatureState(id, sourceLayerId, featureId, state) }
+  }
+
+  protected fun readFeatureState(sourceLayerId: String?, featureId: String): JsonObject {
+    return operation { style.featureState(id, sourceLayerId, featureId) }
+  }
+
+  protected fun clearFeatureState(
+    sourceLayerId: String?,
+    featureId: String,
+    stateKey: String?,
+  ) {
+    operation { style.removeFeatureState(id, sourceLayerId, featureId, stateKey) }
+  }
+
+  protected fun clearFeatureStates(sourceLayerId: String?) {
+    operation { style.resetFeatureStates(id, sourceLayerId) }
+  }
+
+  protected fun <T> operation(action: () -> T): T = operations.run {
+    requireCurrent()
+    action()
+  }
+
+  protected suspend fun <T> suspendingOperation(action: suspend () -> T): T {
+    val checkpoint = operations.checkpoint()
+    operation {}
+    val result = action()
+    operations.requireUnchanged(checkpoint)
+    operation {}
+    return result
+  }
+}
+
+/**
+ * Imperative access to one GeoJSON source in one loaded base-style generation.
+ *
+ * A mutation that MapLibre refuses throws [StyleHandleException].
+ */
+public class GeoJsonSourceHandle
+internal constructor(
+  id: String,
+  style: StyleBinding,
+  private val options: GeoJsonOptions,
+  currentKind: () -> String?,
+  operations: StyleHandleOperationGuard,
+) :
+  SourceHandle(
+    id,
+    style,
+    expectedKind = "geojson",
+    currentKind = currentKind,
+    operations = operations,
+  ) {
+  private val requestedData = AtomicLong(0L)
+  private val installedData = AtomicLong(0L)
+
+  /** Replaces the transient data in this loaded style. A base-style reload discards the change. */
+  public fun setData(data: GeoJsonData) {
+    operation {
+      val generation = requestedData.incrementAndFetch()
+      if (data is GeoJsonData.Uri) {
+        mutate("set data") { style.setGeoJsonSourceUrl(id, data.uri) { claimData(generation) } }
+      } else {
+        mutate("set data") {
+          style.prepareGeoJsonUpdate(id, data, options).use { prepared ->
+            style.setGeoJsonSourceData(id, prepared) { claimData(generation) }
+          }
+        }
+      }
+    }
+  }
+
+  /** Whether [feature] represents a cluster created by this source. */
+  public fun isCluster(feature: Feature<*, JsonObject?>): Boolean =
+    CLUSTER_ID_PROPERTY in feature.properties.orEmpty()
+
+  /** The zoom at which [feature]'s cluster breaks apart, or zero for a non-cluster feature. */
+  public suspend fun getClusterExpansionZoom(feature: Feature<*, JsonObject?>): Double =
+    suspendingOperation {
+      style.clusterExpansionZoom(id, feature) ?: 0.0
+    }
+
+  /** The features one level below [feature]'s cluster, or an empty collection for a non-cluster. */
+  public suspend fun getClusterChildren(
+    feature: Feature<*, JsonObject?>
+  ): FeatureCollection<Geometry, JsonObject?> = suspendingOperation {
+    style.clusterChildren(id, feature) ?: FeatureCollection(emptyList())
+  }
+
+  /** The original points in [feature]'s cluster, or an empty collection for a non-cluster. */
+  public suspend fun getClusterLeaves(
+    feature: Feature<*, JsonObject?>,
+    limit: Long,
+    offset: Long,
+  ): FeatureCollection<Geometry, JsonObject?> = suspendingOperation {
+    style.clusterLeaves(id, feature, limit, offset) ?: FeatureCollection(emptyList())
+  }
+
+  /** Merges [state] into the runtime state of the feature identified by [featureId]. */
+  public fun setFeatureState(featureId: String, state: JsonObject) {
+    writeFeatureState(sourceLayerId = null, featureId, state)
+  }
+
+  /** Returns the runtime state of the feature identified by [featureId]. */
+  public fun getFeatureState(featureId: String): JsonObject =
+    readFeatureState(sourceLayerId = null, featureId)
+
+  /** Removes [stateKey], or every state key when [stateKey] is null. */
+  public fun removeFeatureState(featureId: String, stateKey: String? = null) {
+    clearFeatureState(sourceLayerId = null, featureId, stateKey)
+  }
+
+  /** Removes runtime state from every feature in this source. */
+  public fun resetFeatureStates() {
+    clearFeatureStates(sourceLayerId = null)
+  }
+
+  private fun claimData(generation: Long): Boolean {
+    if (!style.isLoaded || generation != requestedData.load()) return false
+    while (true) {
+      val installed = installedData.load()
+      if (generation <= installed) return false
+      if (installedData.compareAndSet(installed, generation)) return true
+    }
+  }
+
+  private inline fun mutate(operation: String, action: () -> Unit) {
+    try {
+      action()
+    } catch (error: StyleMutationException) {
+      throw StyleHandleException(
+        "Could not $operation on GeoJSON source '$id': ${error.message}",
+        error,
+      )
+    }
+  }
+}
+
+/** Imperative access to one vector source in one loaded base-style generation. */
+public open class VectorSourceHandle
+internal constructor(
+  id: String,
+  style: StyleBinding,
+  expectedKind: String = "vector",
+  currentKind: () -> String?,
+  operations: StyleHandleOperationGuard,
+) : SourceHandle(id, style, expectedKind, currentKind, operations) {
+  /** Returns loaded features from [sourceLayerIds] that match [predicate]. */
+  public fun querySourceFeatures(
+    sourceLayerIds: Set<String>,
+    predicate: Expression<BooleanValue> = const(true),
+  ): List<Feature<Geometry, JsonObject?>> {
+    return operation { style.querySourceFeatures(id, sourceLayerIds, predicate.toFilterJson()) }
+  }
+
+  /** Merges [state] into the runtime state of one feature. */
+  public fun setFeatureState(sourceLayerId: String, featureId: String, state: JsonObject) {
+    writeFeatureState(sourceLayerId, featureId, state)
+  }
+
+  /** Returns the runtime state of one feature. */
+  public fun getFeatureState(sourceLayerId: String, featureId: String): JsonObject =
+    readFeatureState(sourceLayerId, featureId)
+
+  /** Removes [stateKey], or every state key when [stateKey] is null. */
+  public fun removeFeatureState(
+    sourceLayerId: String,
+    featureId: String,
+    stateKey: String? = null,
+  ) {
+    clearFeatureState(sourceLayerId, featureId, stateKey)
+  }
+
+  /** Removes runtime state from every feature in [sourceLayerId]. */
+  public fun resetFeatureStates(sourceLayerId: String) {
+    clearFeatureStates(sourceLayerId)
+  }
+}
+
+/** Imperative access to one application-supplied vector source. */
+public class CustomVectorSourceHandle
+internal constructor(
+  id: String,
+  style: StyleBinding,
+  currentKind: () -> String?,
+  operations: StyleHandleOperationGuard,
+) :
+  VectorSourceHandle(
+    id,
+    style,
+    expectedKind = "custom-vector",
+    currentKind = currentKind,
+    operations = operations,
+  ) {
+  /** Requests new data for [tile]. */
+  public fun invalidateTile(tile: TileCoordinate) {
+    operation { style.invalidateCustomVectorSourceTile(id, tile) }
+  }
+}
+
+/** Imperative access to one application-supplied geometry source. */
+public class CustomGeometrySourceHandle
+internal constructor(
+  id: String,
+  style: StyleBinding,
+  currentKind: () -> String?,
+  operations: StyleHandleOperationGuard,
+) : SourceHandle(id, style, "custom-geometry", currentKind, operations) {
+  /** Requests new features for tiles that intersect [bounds]. */
+  public fun invalidateBounds(bounds: BoundingBox) {
+    operation { style.invalidateCustomGeometrySourceBounds(id, bounds) }
+  }
+
+  /** Requests new features for [tile]. */
+  public fun invalidateTile(tile: TileCoordinate) {
+    operation { style.invalidateCustomGeometrySourceTile(id, tile) }
+  }
+}
+
+/** Imperative access to one image source in one loaded base-style generation. */
+public class ImageSourceHandle
+internal constructor(
+  id: String,
+  style: StyleBinding,
+  currentKind: () -> String?,
+  operations: StyleHandleOperationGuard,
+) : SourceHandle(id, style, "image", currentKind, operations) {
+  /** Updates the geographic corners of the image. */
+  public fun setBounds(bounds: PositionQuad) {
+    operation {
+      style.setImageSourceCoordinates(
+        id,
+        listOf(bounds.topLeft, bounds.topRight, bounds.bottomRight, bounds.bottomLeft),
+      )
+    }
+  }
+
+  /** Replaces the source image with [image]. */
+  public fun setImage(image: ImageBitmap) {
+    operation { style.setImageSourceImage(id, image) }
+  }
+
+  /** Replaces the source image URI with [uri]. */
+  public fun setUri(uri: String) {
+    operation { style.setImageSourceUrl(id, uri) }
+  }
+}
+
+/** Imperative access to one raster source in one loaded base-style generation. */
+public class RasterSourceHandle
+internal constructor(
+  id: String,
+  style: StyleBinding,
+  currentKind: () -> String?,
+  operations: StyleHandleOperationGuard,
+) : SourceHandle(id, style, "raster", currentKind, operations)
+
+/** Imperative access to one raster DEM source in one loaded base-style generation. */
+public class RasterDemSourceHandle
+internal constructor(
+  id: String,
+  style: StyleBinding,
+  currentKind: () -> String?,
+  operations: StyleHandleOperationGuard,
+) : SourceHandle(id, style, "raster-dem", currentKind, operations)
+
+/** Imperative access to a source type with no specialized common handle. */
+public class UnknownSourceHandle
+internal constructor(
+  id: String,
+  style: StyleBinding,
+  currentKind: () -> String?,
+  operations: StyleHandleOperationGuard,
+) : SourceHandle(id, style, null, currentKind, operations)
+
+internal fun StyleBinding.sourceHandle(
+  id: String,
+  definition: SourceDefinition?,
+  currentDefinition: () -> SourceDefinition?,
+  operations: StyleHandleOperationGuard,
+): SourceHandle? {
+  requireCurrent()
+  val source = getSource(id) ?: return null
+  val kind = sourceKind(definition, source)
+  val composed = definition != null
+  val currentKind = {
+    val current = currentDefinition()
+    if (composed && current == null) null else sourceKind(current, getSource(id))
+  }
+  return when (kind) {
+    "geojson" ->
+      GeoJsonSourceHandle(
+        id,
+        this,
+        (definition as? SourceDefinition.GeoJson)?.options ?: GeoJsonOptions(),
+        currentKind,
+        operations,
+      )
+    "custom-vector" -> CustomVectorSourceHandle(id, this, currentKind, operations)
+    "custom-geometry" -> CustomGeometrySourceHandle(id, this, currentKind, operations)
+    "image" -> ImageSourceHandle(id, this, currentKind, operations)
+    "raster" -> RasterSourceHandle(id, this, currentKind, operations)
+    "raster-dem" -> RasterDemSourceHandle(id, this, currentKind, operations)
+    "vector" -> VectorSourceHandle(id, this, currentKind = currentKind, operations = operations)
+    else -> UnknownSourceHandle(id, this, currentKind, operations)
+  }
+}
+
+private fun sourceKind(definition: SourceDefinition?, source: Source?): String? =
+  when (definition) {
+    is SourceDefinition.CustomGeometry -> "custom-geometry"
+    is SourceDefinition.CustomVector -> "custom-vector"
+    else -> (source?.toJson()?.get("type") as? JsonPrimitive)?.content
+  }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleBinding.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleBinding.kt
@@ -45,6 +45,12 @@ internal interface StyleBinding {
     }
   }
 
+  fun requireCurrent(expectedIdentity: StyleIdentity) {
+    check(identity === expectedIdentity && isLoaded) {
+      "Style operation belongs to a stale loaded-style identity"
+    }
+  }
+
   val logger: Logger?
 
   fun addImage(definition: StyleImageDefinition)
@@ -220,6 +226,13 @@ internal interface StyleBinding {
    * stays off the map's owner thread. A URL installs through [setGeoJsonSourceUrl] instead.
    */
   fun prepareGeoJson(data: GeoJsonData, options: GeoJsonOptions): PreparedGeoJson
+
+  /** Prepares an update with the options currently applied to [sourceId]. */
+  fun prepareGeoJsonUpdate(
+    sourceId: String,
+    data: GeoJsonData,
+    fallbackOptions: GeoJsonOptions,
+  ): PreparedGeoJson = prepareGeoJson(data, fallbackOptions)
 
   /**
    * Installs [prepared] on a live GeoJSON source when [claim] answers true.

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleHandleException.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleHandleException.kt
@@ -1,0 +1,13 @@
+package org.maplibre.compose.style
+
+/** A live style handle operation that MapLibre refused. */
+public class StyleHandleException(message: String, cause: Throwable? = null) :
+  IllegalStateException(message, cause)
+
+internal interface StyleHandleOperationGuard {
+  fun <T> run(action: () -> T): T
+
+  fun checkpoint(): Long
+
+  fun requireUnchanged(checkpoint: Long)
+}

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
@@ -9,6 +9,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
+import kotlin.test.assertIs
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration
@@ -20,17 +21,33 @@ import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.supervisorScope
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
 import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.camera.Viewport
 import org.maplibre.compose.expressions.ast.CompiledExpression
 import org.maplibre.compose.expressions.value.BooleanValue
+import org.maplibre.compose.layers.BackgroundLayer
+import org.maplibre.compose.layers.LayerHandle
+import org.maplibre.compose.sources.GeoJsonData
+import org.maplibre.compose.sources.GeoJsonOptions
+import org.maplibre.compose.sources.GeoJsonSource
+import org.maplibre.compose.sources.GeoJsonSourceHandle
+import org.maplibre.compose.sources.VectorSource
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.compose.style.DesiredStyleRevision
+import org.maplibre.compose.style.RecordingStyleBinding
 import org.maplibre.compose.util.VisibleRegion
 import org.maplibre.spatialk.geojson.BoundingBox
 import org.maplibre.spatialk.geojson.Feature
 import org.maplibre.spatialk.geojson.Geometry
+import org.maplibre.spatialk.geojson.Point
 import org.maplibre.spatialk.geojson.Position
+import org.maplibre.spatialk.geojson.dsl.addFeature
+import org.maplibre.spatialk.geojson.dsl.buildFeatureCollection
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class MapPresentationTest {
@@ -130,6 +147,184 @@ class MapPresentationTest {
     assertTrue(state.style.loadState is StyleLoadState.Failed)
     state.close()
     runtime.close()
+  }
+
+  @Test
+  fun a_live_source_handle_is_ready_bound_and_cannot_target_a_replacement_style() {
+    val fixture = presentationFixture()
+    val firstStyle =
+      RecordingStyleBinding(
+        sources =
+          listOf(
+            GeoJsonSource(
+              id = "points",
+              data = GeoJsonData.JsonString("""{"type":"FeatureCollection","features":[]}"""),
+              options = GeoJsonOptions(),
+            )
+          )
+      )
+
+    assertNull(fixture.state.style.source("points"))
+    fixture.state.durableStyleCallbacks().onStyleChanged(fixture.adapter, firstStyle)
+    assertNull(fixture.state.style.source("points"))
+    fixture.state.durableStyleCallbacks().onMapFinishedLoading(fixture.adapter)
+
+    val handle = assertIs<GeoJsonSourceHandle>(fixture.state.style.source("points"))
+    assertNull(fixture.state.style.source("missing"))
+    handle.setFeatureState("7", buildJsonObject { put("selected", true) })
+    assertEquals(
+      true,
+      firstStyle.featureState("points", null, "7")["selected"]?.jsonPrimitive?.boolean,
+    )
+
+    fixture.state.style.baseStyle = BaseStyle.Json("replacement")
+    assertFailsWith<IllegalStateException> {
+      handle.setFeatureState("7", buildJsonObject { put("stale", true) })
+    }
+    val replacement =
+      RecordingStyleBinding(
+        sources =
+          listOf(
+            GeoJsonSource(
+              id = "points",
+              data = GeoJsonData.JsonString("""{"type":"FeatureCollection","features":[]}"""),
+              options = GeoJsonOptions(),
+            )
+          )
+      )
+    fixture.state.durableStyleCallbacks().onStyleChanged(fixture.adapter, replacement)
+    fixture.state.durableStyleCallbacks().onMapFinishedLoading(fixture.adapter)
+
+    assertFailsWith<IllegalStateException> {
+      handle.setFeatureState("7", buildJsonObject { put("stale", true) })
+    }
+    assertEquals(JsonObject(emptyMap()), replacement.featureState("points", null, "7"))
+    fixture.close()
+  }
+
+  @Test
+  fun a_typed_source_handle_rejects_a_same_id_source_type_replacement() {
+    val fixture = presentationFixture()
+    val geoJson =
+      GeoJsonSource(
+        id = "shared",
+        data = GeoJsonData.JsonString("""{"type":"FeatureCollection","features":[]}"""),
+        options = GeoJsonOptions(),
+      )
+    fixture.state.desiredStyleRevision =
+      DesiredStyleRevision(
+        sources = listOf(geoJson.definition()),
+        layers = emptyList(),
+        images = emptyList(),
+      )
+    val loadedStyle = RecordingStyleBinding(sources = listOf(geoJson))
+    fixture.state.durableStyleCallbacks().onStyleChanged(fixture.adapter, loadedStyle)
+    fixture.state.durableStyleCallbacks().onMapFinishedLoading(fixture.adapter)
+    val handle = assertIs<GeoJsonSourceHandle>(fixture.state.style.source("shared"))
+    val vector = VectorSource("shared", "https://example.com/tiles.json")
+
+    fixture.state.beginStyleRevision(
+      fixture.adapter,
+      DesiredStyleRevision(
+        sources = listOf(vector.definition()),
+        layers = emptyList(),
+        images = emptyList(),
+      ),
+    )
+    assertFailsWith<IllegalStateException> {
+      handle.setFeatureState("7", buildJsonObject { put("stale", true) })
+    }
+    assertEquals(JsonObject(emptyMap()), loadedStyle.featureState("shared", null, "7"))
+
+    loadedStyle.replaceSource(vector)
+    fixture.state.markStyleReady(fixture.adapter)
+
+    assertFailsWith<IllegalStateException> { handle.getFeatureState("7") }
+    assertEquals(JsonObject(emptyMap()), loadedStyle.featureState("shared", null, "7"))
+    fixture.close()
+  }
+
+  @Test
+  fun geojson_cluster_queries_have_empty_fallbacks_for_a_non_cluster_feature() = runTest {
+    val fixture = presentationFixture()
+    val loadedStyle =
+      RecordingStyleBinding(
+        sources =
+          listOf(
+            GeoJsonSource(
+              id = "points",
+              data = GeoJsonData.JsonString("""{"type":"FeatureCollection","features":[]}"""),
+              options = GeoJsonOptions(),
+            )
+          )
+      )
+    fixture.state.durableStyleCallbacks().onStyleChanged(fixture.adapter, loadedStyle)
+    fixture.state.durableStyleCallbacks().onMapFinishedLoading(fixture.adapter)
+    val handle = assertIs<GeoJsonSourceHandle>(fixture.state.style.source("points"))
+    val point =
+      buildFeatureCollection<Geometry, JsonObject?> {
+          addFeature(geometry = Point(Position(0.0, 0.0)))
+        }
+        .features
+        .single()
+
+    assertFalse(handle.isCluster(point))
+    assertEquals(0.0, handle.getClusterExpansionZoom(point))
+    assertTrue(handle.getClusterChildren(point).features.isEmpty())
+    assertTrue(handle.getClusterLeaves(point, limit = 1, offset = 0).features.isEmpty())
+    fixture.close()
+  }
+
+  @Test
+  fun replacing_a_retained_engine_invalidates_its_style_handles_before_publication() = runTest {
+    val runtime = mapRuntimeForTest()
+    val state = runtime.createMapState()
+    val firstToken = state.reservePresentation()
+    val first = RetainedAdapter(failOnClose = false)
+    state.publishPresentation(firstToken, first)
+    val firstStyle =
+      RecordingStyleBinding(
+        sources =
+          listOf(
+            GeoJsonSource(
+              id = "points",
+              data = GeoJsonData.JsonString("""{"type":"FeatureCollection","features":[]}"""),
+              options = GeoJsonOptions(),
+            )
+          )
+      )
+    state.durableStyleCallbacks().onStyleChanged(first, firstStyle)
+    state.durableStyleCallbacks().onMapFinishedLoading(first)
+    val handle = assertIs<GeoJsonSourceHandle>(state.style.source("points"))
+    state.releasePresentation(firstToken, first)
+    testScheduler.advanceUntilIdle()
+
+    val secondToken = state.reservePresentation()
+    state.publishPresentation(secondToken, RetainedAdapter(failOnClose = false))
+
+    assertFailsWith<IllegalStateException> {
+      handle.setFeatureState("7", buildJsonObject { put("stale", true) })
+    }
+    assertEquals(JsonObject(emptyMap()), firstStyle.featureState("points", null, "7"))
+    state.close()
+    runtime.close()
+  }
+
+  @Test
+  fun a_live_layer_handle_reads_and_writes_only_its_loaded_style() {
+    val fixture = presentationFixture()
+    val loadedStyle = RecordingStyleBinding(layers = listOf(BackgroundLayer("background")))
+    fixture.state.durableStyleCallbacks().onStyleChanged(fixture.adapter, loadedStyle)
+    fixture.state.durableStyleCallbacks().onMapFinishedLoading(fixture.adapter)
+
+    val handle = assertIs<LayerHandle>(fixture.state.style.layer("background"))
+    assertNull(fixture.state.style.layer("missing"))
+    handle.setPaintProperty("background-opacity", JsonPrimitive(0.5))
+    assertEquals(JsonPrimitive(0.5), handle.getProperty("background-opacity"))
+
+    loadedStyle.invalidate()
+    assertFailsWith<IllegalStateException> { handle.getProperty("background-opacity") }
+    fixture.close()
   }
 
   @Test

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/style/RecordingStyleBinding.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/style/RecordingStyleBinding.kt
@@ -40,6 +40,7 @@ internal class RecordingStyleBinding(
   private val baseSources = sources.associateBy { it.id }.toMutableMap()
   private val baseLayers = layers.associateBy { it.id }.toMutableMap()
   private val orderedLayerIds = mutableListOf<String>()
+  private val featureStates = mutableMapOf<Triple<String, String?, String>, JsonObject>()
 
   override var isLoaded: Boolean = true
     private set
@@ -227,35 +228,74 @@ internal class RecordingStyleBinding(
     name: String,
     value: JsonElement,
     kind: LayerPropertyKind,
-  ) = Unit
+  ) {
+    val layer = checkNotNull(layers[layerId]) { "Layer ID '$layerId' not found in style" }
+    val section =
+      when (kind) {
+        LayerPropertyKind.LAYOUT -> "layout"
+        LayerPropertyKind.PAINT -> "paint"
+        LayerPropertyKind.ROOT -> null
+      }
+    layers[layerId] =
+      if (section == null) JsonObject(layer + (name to value))
+      else {
+        val properties = (layer[section] as? JsonObject).orEmpty()
+        JsonObject(layer + (section to JsonObject(properties + (name to value))))
+      }
+  }
 
-  override fun setLayerFilter(layerId: String, filter: JsonElement) = Unit
+  override fun setLayerFilter(layerId: String, filter: JsonElement) {
+    val layer = checkNotNull(layers[layerId]) { "Layer ID '$layerId' not found in style" }
+    layers[layerId] =
+      if (filter is kotlinx.serialization.json.JsonNull) JsonObject(layer - "filter")
+      else JsonObject(layer + ("filter" to filter))
+  }
 
-  override fun layerProperty(layerId: String, name: String): JsonElement? = null
+  override fun layerProperty(layerId: String, name: String): JsonElement? {
+    val layer = layers[layerId] ?: return null
+    return layer[name]
+      ?: (layer["layout"] as? JsonObject)?.get(name)
+      ?: (layer["paint"] as? JsonObject)?.get(name)
+  }
 
-  override fun layerExists(layerId: String): Boolean = false
+  override fun layerExists(layerId: String): Boolean = layerId in layers
 
   override fun setFeatureState(
     sourceId: String,
     sourceLayerId: String?,
     featureId: String,
     state: JsonObject,
-  ) = Unit
+  ) {
+    val key = Triple(sourceId, sourceLayerId, featureId)
+    val previous = featureStates[key].orEmpty()
+    val removed = state.filterValues { it is kotlinx.serialization.json.JsonNull }.keys
+    featureStates[key] =
+      JsonObject(
+        (previous - removed) + state.filterValues { it !is kotlinx.serialization.json.JsonNull }
+      )
+  }
 
   override fun featureState(
     sourceId: String,
     sourceLayerId: String?,
     featureId: String,
-  ): JsonObject = JsonObject(emptyMap())
+  ): JsonObject =
+    featureStates[Triple(sourceId, sourceLayerId, featureId)] ?: JsonObject(emptyMap())
 
   override fun removeFeatureState(
     sourceId: String,
     sourceLayerId: String?,
     featureId: String,
     stateKey: String?,
-  ) = Unit
+  ) {
+    val key = Triple(sourceId, sourceLayerId, featureId)
+    if (stateKey == null) featureStates.remove(key)
+    else featureStates[key]?.let { featureStates[key] = JsonObject(it - stateKey) }
+  }
 
-  override fun resetFeatureStates(sourceId: String, sourceLayerId: String?) = Unit
+  override fun resetFeatureStates(sourceId: String, sourceLayerId: String?) {
+    featureStates.keys.removeAll { it.first == sourceId && it.second == sourceLayerId }
+  }
 
   override fun querySourceFeatures(
     sourceId: String,

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
@@ -190,6 +190,7 @@ internal class GlJsMapSession(
         endCameraMove(engine, lease)
       } finally {
         surface = null
+        invalidateStyleBinding()
         lifecycle.beginEngineReplacement(engine, lease)
       }
     } else {
@@ -368,9 +369,7 @@ internal class GlJsMapSession(
     hasReconciledStyle = false
     hasUsableViewport = false
     hasReplayedPresentationState = false
-    callbacks.onStyleChanged(this, null)
-    styleBinding?.invalidate()
-    styleBinding = null
+    invalidateStyleBinding()
     styleLoadSubscription?.cancel()
     styleLoadSubscription = null
     styleErrorSubscription?.cancel()
@@ -396,6 +395,12 @@ internal class GlJsMapSession(
     container?.let { runCatching { it.remove() } }
     container = null
     resumeStrandedTransitions()
+  }
+
+  private fun invalidateStyleBinding() {
+    callbacks.onStyleChanged(this, null)
+    styleBinding?.invalidate()
+    styleBinding = null
   }
 
   private fun applyExtent(map: MaplibreMap, extent: MapExtent) {

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/style/GlJsStyleBinding.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/style/GlJsStyleBinding.kt
@@ -310,13 +310,17 @@ internal class GlJsStyleBinding(
   ) {
     if (!claim()) return
     requireLoaded()
-    map.getSource<GlJsGeoJsonSource>(sourceId)?.setData((prepared as GlJsPreparedGeoJson).data)
+    mutate("set data on source '$sourceId'") {
+      map.getSource<GlJsGeoJsonSource>(sourceId)?.setData((prepared as GlJsPreparedGeoJson).data)
+    }
   }
 
   override fun setGeoJsonSourceUrl(sourceId: String, url: String, claim: () -> Boolean) {
     if (!claim()) return
     requireLoaded()
-    map.getSource<GlJsGeoJsonSource>(sourceId)?.setData(url.unsafeCast<GeoJsonSourceData>())
+    mutate("set data on source '$sourceId'") {
+      map.getSource<GlJsGeoJsonSource>(sourceId)?.setData(url.unsafeCast<GeoJsonSourceData>())
+    }
   }
 
   override suspend fun clusterExpansionZoom(

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/testing/GlJsMapFixture.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/testing/GlJsMapFixture.kt
@@ -36,7 +36,7 @@ internal class GlJsMapFixture(private val extent: MapExtent) : MapFixture {
     GlJsMapSession(recorder, Logger.withTag("gljs-map"), LayoutDirection.Ltr)
 
   private val runtime = mapRuntimeForTest()
-  private val state =
+  override val state =
     runtime.createMapState(
       initialCameraPosition = CameraPosition(zoom = 0.0),
       initialBaseStyle = BaseStyle.Empty,
@@ -88,6 +88,8 @@ internal class GlJsMapFixture(private val extent: MapExtent) : MapFixture {
   }
 
   override suspend fun loadStyle(style: BaseStyle, timeout: Duration) {
+    state.style.loadState = org.maplibre.compose.map.StyleLoadState.Loading
+    state.updateLoadedStyle(glJsSession, null)
     val styleLoadsBefore = events.count { it == MapFixture.STYLE_LOADED }
     glJsSession.setBaseStyle(style)
     if (recorder.style?.isLoaded != true) {
@@ -96,6 +98,8 @@ internal class GlJsMapFixture(private val extent: MapExtent) : MapFixture {
       }
     }
     glJsSession.reconcileStyleRevision(DesiredStyleRevision.Empty)
+    state.updateLoadedStyle(glJsSession, recorder.style)
+    state.markStyleReady(glJsSession)
   }
 
   internal fun fireStyleError(message: String) {

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/layers/LayerHandlePropertyTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/layers/LayerHandlePropertyTest.kt
@@ -1,0 +1,45 @@
+package org.maplibre.compose.layers
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlinx.serialization.json.JsonPrimitive
+import org.maplibre.compose.style.BaseStyle
+import org.maplibre.compose.style.StyleHandleException
+import org.maplibre.compose.testing.MapTestResult
+import org.maplibre.compose.testing.createMapFixture
+import org.maplibre.compose.testing.runMapTest
+
+class LayerHandlePropertyTest {
+  @Test
+  fun a_layer_handle_updates_and_reads_a_paint_property(): MapTestResult = runMapTest {
+    createMapFixture().use { fixture ->
+      fixture.loadStyle(STYLE)
+      val handle = assertNotNull(fixture.state.style.layer("background"))
+
+      handle.setPaintProperty("background-opacity", JsonPrimitive(0.25))
+
+      assertEquals(JsonPrimitive(0.25), handle.getProperty("background-opacity"))
+    }
+  }
+
+  @Test
+  fun a_rejected_layer_property_has_a_public_handle_error(): MapTestResult = runMapTest {
+    createMapFixture().use { fixture ->
+      fixture.loadStyle(STYLE)
+      val handle = assertNotNull(fixture.state.style.layer("background"))
+
+      assertFailsWith<StyleHandleException> {
+        handle.setPaintProperty("not-a-style-property", JsonPrimitive(0.25))
+      }
+    }
+  }
+
+  private companion object {
+    val STYLE =
+      BaseStyle.Json(
+        """{"version":8,"sources":{},"layers":[{"id":"background","type":"background"}]}"""
+      )
+  }
+}

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/sources/FeatureStateTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/sources/FeatureStateTest.kt
@@ -1,0 +1,111 @@
+package org.maplibre.compose.sources
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import org.maplibre.compose.camera.CameraPosition
+import org.maplibre.compose.expressions.ast.ExpressionContext
+import org.maplibre.compose.expressions.dsl.asBoolean
+import org.maplibre.compose.expressions.dsl.condition
+import org.maplibre.compose.expressions.dsl.const
+import org.maplibre.compose.expressions.dsl.feature
+import org.maplibre.compose.expressions.dsl.switch
+import org.maplibre.compose.expressions.value.BooleanValue
+import org.maplibre.compose.layers.CircleLayer
+import org.maplibre.compose.style.BaseStyle
+import org.maplibre.compose.style.install
+import org.maplibre.compose.testing.MapTestResult
+import org.maplibre.compose.testing.RgbaPixel
+import org.maplibre.compose.testing.createMapFixture
+import org.maplibre.compose.testing.pumpUntilPixel
+import org.maplibre.compose.testing.runMapTest
+import org.maplibre.spatialk.geojson.Geometry
+import org.maplibre.spatialk.geojson.Point
+import org.maplibre.spatialk.geojson.Position
+import org.maplibre.spatialk.geojson.dsl.addFeature
+import org.maplibre.spatialk.geojson.dsl.buildFeatureCollection
+
+class FeatureStateTest {
+  @Test
+  fun a_geojson_handle_updates_feature_state_and_the_rendered_style(): MapTestResult = runMapTest {
+    createMapFixture().use { fixture ->
+      fixture.loadStyle(BLACK_STYLE)
+      fixture.presentation.setCameraPosition(
+        CameraPosition(target = Position(0.0, 0.0), zoom = 1.0)
+      )
+      val binding = checkNotNull(fixture.style)
+      val source =
+        GeoJsonSource(
+          id = "points",
+          data =
+            GeoJsonData.Features(
+              buildFeatureCollection<Geometry, JsonObject?> {
+                addFeature(geometry = Point(Position(0.0, 0.0))) { setId(1) }
+              }
+            ),
+          options = GeoJsonOptions(),
+        )
+      binding.install(source)
+      val layer = CircleLayer("circles", source)
+      layer.setCircleRadius(const(48.dp).compile(ExpressionContext.None))
+      layer.setCircleColor(
+        switch(
+            condition(
+              feature.state<BooleanValue>("selected").asBoolean(const(false)),
+              const(Color.Red),
+            ),
+            fallback = const(Color.Blue),
+          )
+          .compile(ExpressionContext.None)
+      )
+      binding.install(layer)
+      val handle = assertIs<GeoJsonSourceHandle>(fixture.state.style.source("points"))
+
+      fixture.pumpUntilPixel("the default circle", CENTER, CENTER, BLUE)
+      handle.setFeatureState(
+        "1",
+        buildJsonObject {
+          put("selected", true)
+          put("rank", 1)
+        },
+      )
+      handle.setFeatureState("1", buildJsonObject { put("label", "chosen") })
+      assertEquals(true, handle.getFeatureState("1")["selected"]?.jsonPrimitive?.boolean)
+      assertEquals(1, handle.getFeatureState("1")["rank"]?.jsonPrimitive?.content?.toInt())
+      assertEquals("chosen", handle.getFeatureState("1")["label"]?.jsonPrimitive?.content)
+      fixture.pumpUntilPixel("the selected circle", CENTER, CENTER, RED)
+
+      handle.removeFeatureState("1", "rank")
+      assertEquals(null, handle.getFeatureState("1")["rank"])
+      assertEquals(true, handle.getFeatureState("1")["selected"]?.jsonPrimitive?.boolean)
+      handle.removeFeatureState("1")
+      assertEquals(JsonObject(emptyMap()), handle.getFeatureState("1"))
+      handle.setFeatureState("1", buildJsonObject { put("selected", true) })
+      handle.resetFeatureStates()
+      fixture.pumpUntilPixel("the reset circle", CENTER, CENTER, BLUE)
+      assertEquals(JsonObject(emptyMap()), handle.getFeatureState("1"))
+    }
+  }
+
+  private companion object {
+    const val CENTER = 256
+    val RED = RgbaPixel(255, 0, 0, 255)
+    val BLUE = RgbaPixel(0, 0, 255, 255)
+    val BLACK_STYLE =
+      BaseStyle.Json(
+        """
+        {"version":8,"sources":{},"layers":[
+          {"id":"background","type":"background","paint":{"background-color":"#000000"}}
+        ]}
+        """
+          .trimIndent()
+      )
+  }
+}

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/sources/GeoJsonClusterTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/sources/GeoJsonClusterTest.kt
@@ -1,0 +1,72 @@
+package org.maplibre.compose.sources
+
+import androidx.compose.ui.unit.DpRect
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.JsonObject
+import org.maplibre.compose.camera.CameraPosition
+import org.maplibre.compose.layers.CircleLayer
+import org.maplibre.compose.style.BaseStyle
+import org.maplibre.compose.style.install
+import org.maplibre.compose.testing.MapTestResult
+import org.maplibre.compose.testing.createMapFixture
+import org.maplibre.compose.testing.runMapTest
+import org.maplibre.spatialk.geojson.Feature
+import org.maplibre.spatialk.geojson.FeatureCollection
+import org.maplibre.spatialk.geojson.Geometry
+import org.maplibre.spatialk.geojson.Point
+import org.maplibre.spatialk.geojson.Position
+import org.maplibre.spatialk.geojson.dsl.addFeature
+import org.maplibre.spatialk.geojson.dsl.buildFeatureCollection
+
+/** The rendered query preserves the engine-specific numeric type of the cluster identifier. */
+class GeoJsonClusterTest {
+  @Test
+  fun a_geojson_handle_answers_cluster_queries(): MapTestResult = runMapTest {
+    createMapFixture().use { fixture ->
+      fixture.loadStyle(BaseStyle.Empty)
+      fixture.presentation.setCameraPosition(
+        CameraPosition(target = Position(0.0, 0.0), zoom = ZOOM)
+      )
+      val binding = checkNotNull(fixture.style)
+      val source =
+        GeoJsonSource(
+          id = "points",
+          data = GeoJsonData.Features(nearbyPoints()),
+          options = GeoJsonOptions(cluster = true, clusterRadius = 200, clusterMaxZoom = 14),
+        )
+      binding.install(source)
+      binding.install(CircleLayer("clusters", source))
+      val handle = assertIs<GeoJsonSourceHandle>(fixture.state.style.source("points"))
+
+      suspend fun rendered(): List<Feature<Geometry, JsonObject?>> =
+        fixture.presentation.queryRenderedFeatures(
+          DpRect(0.dp, 0.dp, 512.dp, 512.dp),
+          layerIds = null,
+        )
+
+      fixture.awaitMapReady()
+      fixture.pumpUntil("a cluster to render") { rendered().any(handle::isCluster) }
+      val cluster = rendered().first(handle::isCluster)
+
+      assertTrue(handle.getClusterExpansionZoom(cluster) > ZOOM)
+      assertTrue(handle.getClusterChildren(cluster).features.isNotEmpty())
+      assertEquals(2, handle.getClusterLeaves(cluster, limit = 2, offset = 0).features.size)
+      assertEquals(POINT_COUNT - 1, handle.getClusterLeaves(cluster, 10, 1).features.size)
+    }
+  }
+
+  private fun nearbyPoints(): FeatureCollection<Geometry, JsonObject?> = buildFeatureCollection {
+    repeat(POINT_COUNT) { index ->
+      addFeature(geometry = Point(Position(index * 0.001, 0.0)))
+    }
+  }
+
+  private companion object {
+    const val POINT_COUNT = 3
+    const val ZOOM = 4.0
+  }
+}

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/style/BaseStyleSourceReadTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/style/BaseStyleSourceReadTest.kt
@@ -1,0 +1,42 @@
+package org.maplibre.compose.style
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import org.maplibre.compose.sources.GeoJsonSourceHandle
+import org.maplibre.compose.testing.MapTestResult
+import org.maplibre.compose.testing.createMapFixture
+import org.maplibre.compose.testing.runMapTest
+
+class BaseStyleSourceReadTest {
+  @Test
+  fun a_base_style_source_is_acquired_by_id_after_the_style_is_ready(): MapTestResult = runMapTest {
+    createMapFixture().use { fixture ->
+      fixture.loadStyle(ATTRIBUTED_STYLE)
+
+      val source = assertIs<GeoJsonSourceHandle>(fixture.state.style.source("attributed"))
+
+      assertEquals("inline attribution", source.attributionHtml)
+    }
+  }
+
+  private companion object {
+    val ATTRIBUTED_STYLE =
+      BaseStyle.Json(
+        """
+        {
+          "version": 8,
+          "sources": {
+            "attributed": {
+              "type": "geojson",
+              "attribution": "inline attribution",
+              "data": { "type": "FeatureCollection", "features": [] }
+            }
+          },
+          "layers": []
+        }
+        """
+          .trimIndent()
+      )
+  }
+}

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/testing/MapFixture.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/testing/MapFixture.kt
@@ -11,6 +11,7 @@ import org.maplibre.compose.map.GestureTarget
 import org.maplibre.compose.map.MapAdapter
 import org.maplibre.compose.map.MapExtent
 import org.maplibre.compose.map.MapPresentation
+import org.maplibre.compose.map.MapState
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.compose.style.StyleBinding
 import org.maplibre.spatialk.geojson.Position
@@ -22,6 +23,9 @@ import org.maplibre.spatialk.geojson.Position
 internal interface MapFixture : AutoCloseable {
 
   val session: MapAdapter
+
+  /** Public logical-map surface exercised by style-handle tests. */
+  val state: MapState
 
   /** Public lease surface exercised by viewport-bound tests. */
   val presentation: MapPresentation

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/style/MlnFfiStyleBinding.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/style/MlnFfiStyleBinding.kt
@@ -8,8 +8,11 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonObjectBuilder
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.add
+import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.doubleOrNull
+import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
 import org.maplibre.compose.layers.Layer
@@ -88,6 +91,8 @@ internal open class MlnFfiStyleBinding(
   @Volatile private var loaded = true
   private val unloadActions = mutableSetOf<() -> Unit>()
   private val unloadActionsLock = MlnFfiLock()
+  private val geoJsonOptions = mutableMapOf<String, GeoJsonOptions>()
+  private val geoJsonOptionsLock = MlnFfiLock()
 
   /** Feature state retained for this loaded style. */
   open val featureStateStore: MlnFfiFeatureStateStore? = MlnFfiFeatureStateStore()
@@ -339,6 +344,7 @@ internal open class MlnFfiStyleBinding(
       reportSourceChanged(sourceId)
     }
     tileCoordinators?.remove(sourceId)
+    geoJsonOptionsLock.withLock { geoJsonOptions.remove(sourceId) }
   }
 
   override fun addCustomGeometrySource(
@@ -502,9 +508,12 @@ internal open class MlnFfiStyleBinding(
   ): Boolean {
     val ffiOptions = options.toFfiOptions()
     if (data is GeoJsonData.Uri) {
-      return addSourceWith(sourceId) { map ->
-        map.addGeoJsonSourceUrl(sourceId, data.uri, ffiOptions)
-      }
+      val added =
+        addSourceWith(sourceId) { map ->
+          map.addGeoJsonSourceUrl(sourceId, data.uri, ffiOptions)
+        }
+      if (added) rememberGeoJsonOptions(sourceId, options)
+      return added
     }
     // The parse reports a bad document the same way the add reports a bad source.
     val prepared =
@@ -513,16 +522,69 @@ internal open class MlnFfiStyleBinding(
       } catch (error: MaplibreException) {
         throw StyleMutationException(error.message, error)
       }
-    return prepared.use { handle ->
+    val added = prepared.use { handle ->
       addSourceWith(sourceId) { map -> map.addGeoJsonSourceData(sourceId, handle) }
     }
+    if (added) rememberGeoJsonOptions(sourceId, options)
+    return added
   }
 
   /** Prepared with the options the source was added with; a mismatch is rejected at install. */
   override fun prepareGeoJson(data: GeoJsonData, options: GeoJsonOptions): PreparedGeoJson =
-    MlnFfiPreparedGeoJson(
-      GeoJsonSourceDataHandle.create(data.toInlineUtf8()!!, options.toFfiOptions())
-    )
+    prepareGeoJson(data, options.toFfiOptions())
+
+  override fun prepareGeoJsonUpdate(
+    sourceId: String,
+    data: GeoJsonData,
+    fallbackOptions: GeoJsonOptions,
+  ): PreparedGeoJson {
+    val applied = geoJsonOptionsLock.withLock { geoJsonOptions[sourceId]?.toFfiOptions() }
+    val baseStyle = applied ?: readMap { loadedGeoJsonOptions(it, sourceId) }
+    return prepareGeoJson(data, baseStyle ?: fallbackOptions.toFfiOptions())
+  }
+
+  private fun prepareGeoJson(
+    data: GeoJsonData,
+    options: GeoJsonSourceOptions,
+  ): PreparedGeoJson =
+    try {
+      MlnFfiPreparedGeoJson(GeoJsonSourceDataHandle.create(data.toInlineUtf8()!!, options))
+    } catch (error: MaplibreException) {
+      throw StyleMutationException(error.message, error)
+    }
+
+  private fun rememberGeoJsonOptions(sourceId: String, options: GeoJsonOptions) {
+    geoJsonOptionsLock.withLock {
+      geoJsonOptions[sourceId] = options.copy(clusterProperties = options.clusterProperties.toMap())
+    }
+  }
+
+  private fun loadedGeoJsonOptions(map: MapHandle, sourceId: String): GeoJsonSourceOptions? {
+    val document = runCatching { map.loadedStyleJson().toJsonElement() }.getOrNull() as? JsonObject
+    val sources = document?.get("sources") as? JsonObject
+    val source = sources?.get(sourceId) as? JsonObject ?: return null
+    if ((source["type"] as? JsonPrimitive)?.content != "geojson") return null
+    val defaults = GeoJsonOptions()
+    val maxZoom = (source["maxzoom"] as? JsonPrimitive)?.doubleOrNull ?: defaults.maxZoom.toDouble()
+    return GeoJsonSourceOptions().also { options ->
+      options.minZoom = defaults.minZoom.toDouble()
+      options.maxZoom = maxZoom
+      options.tolerance =
+        (source["tolerance"] as? JsonPrimitive)?.doubleOrNull ?: defaults.tolerance.toDouble()
+      options.buffer = (source["buffer"] as? JsonPrimitive)?.intOrNull ?: defaults.buffer
+      options.cluster = (source["cluster"] as? JsonPrimitive)?.booleanOrNull ?: defaults.cluster
+      options.clusterRadius =
+        (source["clusterRadius"] as? JsonPrimitive)?.intOrNull ?: defaults.clusterRadius
+      options.clusterMaxZoom =
+        (source["clusterMaxZoom"] as? JsonPrimitive)?.doubleOrNull ?: maxZoom - 1.0
+      options.clusterMinPoints =
+        (source["clusterMinPoints"] as? JsonPrimitive)?.intOrNull ?: defaults.clusterMinPoints
+      options.lineMetrics =
+        (source["lineMetrics"] as? JsonPrimitive)?.booleanOrNull ?: defaults.lineMetrics
+      options.synchronousTiling = defaults.synchronousUpdate
+      options.clusterProperties = (source["clusterProperties"] as? JsonObject)?.toJsonBytes()
+    }
+  }
 
   /**
    * [claim] runs on the owner thread, which serializes installs. mutateMap waits until the owner
@@ -535,12 +597,26 @@ internal open class MlnFfiStyleBinding(
   ) {
     val handle = (prepared as MlnFfiPreparedGeoJson).handle
     mutateMap(abandon = { claim() }) { map ->
-      if (claim()) map.setGeoJsonSourceData(sourceId, handle)
+      if (claim()) {
+        try {
+          map.setGeoJsonSourceData(sourceId, handle)
+        } catch (error: MaplibreException) {
+          throw StyleMutationException(error.message, error)
+        }
+      }
     }
   }
 
   override fun setGeoJsonSourceUrl(sourceId: String, url: String, claim: () -> Boolean) {
-    mutateMap(abandon = { claim() }) { map -> if (claim()) map.setGeoJsonSourceUrl(sourceId, url) }
+    mutateMap(abandon = { claim() }) { map ->
+      if (claim()) {
+        try {
+          map.setGeoJsonSourceUrl(sourceId, url)
+        } catch (error: MaplibreException) {
+          throw StyleMutationException(error.message, error)
+        }
+      }
+    }
   }
 
   override suspend fun clusterExpansionZoom(
@@ -715,7 +791,13 @@ internal open class MlnFfiStyleBinding(
   }
 
   override fun setLayerFilter(layerId: String, filter: JsonElement) {
-    mutateMap { map -> map.setLayerFilter(layerId, filter.toJsonBytes()) }
+    mutateMap { map ->
+      try {
+        map.setLayerFilter(layerId, filter.toJsonBytes())
+      } catch (error: MaplibreException) {
+        throw StyleMutationException(error.message, error)
+      }
+    }
   }
 
   override fun layerProperty(layerId: String, name: String): JsonElement? = readMap { map ->

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/sources/CustomGeometrySourceTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/sources/CustomGeometrySourceTest.kt
@@ -19,9 +19,12 @@ import org.maplibre.compose.layers.FillLayer
 import org.maplibre.compose.mlnffi.BridgeMapFixture
 import org.maplibre.compose.mlnffi.FfiTestPlatform
 import org.maplibre.compose.style.BaseStyle
+import org.maplibre.compose.style.DesiredStyleRevision
 import org.maplibre.compose.style.MlnFfiStyleBinding
 import org.maplibre.compose.style.install
+import org.maplibre.compose.testing.MlnFfiMapFixture
 import org.maplibre.compose.testing.RecordingList
+import org.maplibre.compose.testing.createMapFixture
 import org.maplibre.spatialk.geojson.BoundingBox
 import org.maplibre.spatialk.geojson.Feature
 import org.maplibre.spatialk.geojson.FeatureCollection
@@ -47,6 +50,46 @@ class CustomGeometrySourceTest {
       assertEquals(setOf("name"), feature.properties?.keys)
       assertEquals(emptyList(), fixture.errors, "the map should report nothing")
       assertEquals(TileCoordinate(0, 0, 0).bounds, requests.first { it.zoomLevel == 0 }.bounds)
+    }
+  }
+
+  @Test
+  fun a_custom_geometry_handle_invalidates_a_tile() = runBlocking {
+    requireCustomGeometrySourceCallbacks()
+    val fixture = createMapFixture() as MlnFfiMapFixture
+    fixture.use {
+      val handle = fixture.attachCustomGeometryHandle()
+      fixture.awaitCustomFeatures()
+      val answered = requests.size
+      featureName = SECOND_NAME
+
+      handle.invalidateTile(TileCoordinate(zoomLevel = 0, x = 0, y = 0))
+
+      fixture.pumpUntil("the invalidated tile to be requested again") { requests.size > answered }
+      fixture.pumpUntil("the provider's new features to render") {
+        fixture.queryCenter().any { feature ->
+          feature.properties?.get("name")?.jsonPrimitive?.content == SECOND_NAME
+        }
+      }
+    }
+  }
+
+  @Test
+  fun a_custom_geometry_handle_invalidates_intersecting_bounds() = runBlocking {
+    requireCustomGeometrySourceCallbacks()
+    val fixture = createMapFixture() as MlnFfiMapFixture
+    fixture.use {
+      val handle = fixture.attachCustomGeometryHandle()
+      fixture.awaitCustomFeatures()
+      val answered = requests.size
+
+      handle.invalidateBounds(
+        BoundingBox(southwest = Position(-10.0, -10.0), northeast = Position(10.0, 10.0))
+      )
+
+      fixture.pumpUntil("the invalidated bounds to be requested again") {
+        requests.size > answered
+      }
     }
   }
 
@@ -120,10 +163,33 @@ class CustomGeometrySourceTest {
     return source
   }
 
+  private suspend fun MlnFfiMapFixture.attachCustomGeometryHandle(): CustomGeometrySourceHandle {
+    loadStyle(BaseStyle.Empty)
+    val binding = checkNotNull(style)
+    val source =
+      CustomGeometrySource(id = SOURCE_ID, options = CustomGeometrySourceOptions()) { tile ->
+        requests += tile
+        cover(tile.bounds, featureName)
+      }
+    binding.install(source)
+    binding.install(FillLayer(id = "custom-fill", source = source))
+    state.desiredStyleRevision =
+      DesiredStyleRevision(listOf(source.definition()), emptyList(), emptyList())
+    return assertIs<CustomGeometrySourceHandle>(state.style.source(SOURCE_ID))
+  }
+
   private suspend fun BridgeMapFixture.queryCenter() =
     session.queryRenderedFeatures(offset = CENTER, layerIds = null, predicate = null)
 
+  private suspend fun MlnFfiMapFixture.queryCenter() =
+    presentation.queryRenderedFeatures(offset = CENTER)
+
   private fun BridgeMapFixture.awaitCustomFeatures() {
+    pumpUntil("the custom geometry source to request a tile") { requests.isNotEmpty() }
+    pumpUntil("the answered custom geometry tile to be queryable") { queryCenter().isNotEmpty() }
+  }
+
+  private suspend fun MlnFfiMapFixture.awaitCustomFeatures() {
     pumpUntil("the custom geometry source to request a tile") { requests.isNotEmpty() }
     pumpUntil("the answered custom geometry tile to be queryable") { queryCenter().isNotEmpty() }
   }

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/sources/CustomVectorSourceNativeTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/sources/CustomVectorSourceNativeTest.kt
@@ -2,10 +2,13 @@ package org.maplibre.compose.sources
 
 import kotlin.test.Test
 import kotlin.test.assertFalse
+import kotlin.test.assertIs
 import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 import kotlinx.coroutines.CompletableDeferred
 import org.maplibre.compose.layers.CircleLayer
 import org.maplibre.compose.style.BaseStyle
+import org.maplibre.compose.style.DesiredStyleRevision
 import org.maplibre.compose.style.install
 import org.maplibre.compose.testing.MapTestResult
 import org.maplibre.compose.testing.MlnFfiMapFixture
@@ -41,6 +44,18 @@ class CustomVectorSourceNativeTest {
       assertFalse(isMapFullyLoaded())
       release.complete(Unit)
       fixture.pumpUntil("the empty custom MVT tile to finish loading") { isMapFullyLoaded() }
+
+      fixture.state.desiredStyleRevision =
+        DesiredStyleRevision(listOf(source.definition()), emptyList(), emptyList())
+      val handle = assertIs<CustomVectorSourceHandle>(fixture.state.style.source("empty"))
+      assertTrue(handle.querySourceFeatures(setOf("points")).isEmpty())
+      val answered = requests.size
+
+      handle.invalidateTile(TileCoordinate(zoomLevel = 0, x = 0, y = 0))
+
+      fixture.pumpUntil("the invalidated custom MVT tile to be requested again") {
+        requests.size > answered
+      }
     }
   }
 }

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/sources/GeoJsonSourceStyleReloadTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/sources/GeoJsonSourceStyleReloadTest.kt
@@ -1,0 +1,43 @@
+package org.maplibre.compose.sources
+
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import kotlinx.serialization.json.JsonObject
+import org.maplibre.compose.style.BaseStyle
+import org.maplibre.compose.style.install
+import org.maplibre.compose.testing.MapTestResult
+import org.maplibre.compose.testing.createMapFixture
+import org.maplibre.compose.testing.runMapTest
+import org.maplibre.spatialk.geojson.FeatureCollection
+import org.maplibre.spatialk.geojson.Geometry
+
+class GeoJsonSourceStyleReloadTest {
+  @Test
+  fun a_source_handle_fails_after_a_real_base_style_reload(): MapTestResult = runMapTest {
+    createMapFixture().use { fixture ->
+      fixture.loadStyle(BaseStyle.Empty)
+      val source =
+        GeoJsonSource(
+          id = "points",
+          data = GeoJsonData.Features(FeatureCollection<Geometry, JsonObject?>(emptyList())),
+          options = GeoJsonOptions(),
+        )
+      checkNotNull(fixture.style).install(source)
+      val handle = assertIs<GeoJsonSourceHandle>(fixture.state.style.source("points"))
+
+      fixture.loadStyle(REPLACEMENT_STYLE)
+
+      assertFailsWith<IllegalStateException> {
+        handle.setData(GeoJsonData.Features(FeatureCollection<Geometry, JsonObject?>(emptyList())))
+      }
+    }
+  }
+
+  private companion object {
+    val REPLACEMENT_STYLE =
+      BaseStyle.Json(
+        """{"version":8,"sources":{},"layers":[{"id":"background","type":"background"}]}"""
+      )
+  }
+}

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/sources/GeoJsonSourceUpdateTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/sources/GeoJsonSourceUpdateTest.kt
@@ -6,18 +6,17 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
-import kotlin.time.Duration.Companion.seconds
-import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.JsonObject
 import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.expressions.ast.ExpressionContext
 import org.maplibre.compose.expressions.dsl.const
 import org.maplibre.compose.layers.CircleLayer
-import org.maplibre.compose.mlnffi.BridgeMapFixture
 import org.maplibre.compose.style.BaseStyle
-import org.maplibre.compose.style.MlnFfiStyleBinding
 import org.maplibre.compose.style.install
+import org.maplibre.compose.testing.MapTestResult
 import org.maplibre.compose.testing.RgbaPixel
+import org.maplibre.compose.testing.createMapFixture
+import org.maplibre.compose.testing.runMapTest
 import org.maplibre.spatialk.geojson.FeatureCollection
 import org.maplibre.spatialk.geojson.Geometry
 import org.maplibre.spatialk.geojson.Point
@@ -25,45 +24,94 @@ import org.maplibre.spatialk.geojson.Position
 import org.maplibre.spatialk.geojson.dsl.addFeature
 import org.maplibre.spatialk.geojson.dsl.buildFeatureCollection
 
-/** Sensitive engine coverage for a declarative GeoJSON revision after installation. */
+/** Sensitive engine coverage for an imperative GeoJSON update after installation. */
 class GeoJsonSourceUpdateTest {
   @Test
-  fun an_update_moves_a_rendered_point_and_requests_an_on_demand_frame() = runBlocking {
-    BridgeMapFixture.create().use { fixture ->
-      fixture.loadStyle(STYLE)
-      fixture.session.setCameraPosition(CameraPosition(target = ORIGIN, zoom = 14.0))
-      val style = assertIs<MlnFfiStyleBinding>(fixture.style, "Errors: ${fixture.errors}")
-      val source =
-        GeoJsonSource(
-          SOURCE_ID,
-          GeoJsonData.Features(pointAt(ORIGIN)),
-          GeoJsonOptions(),
+  fun an_update_moves_a_rendered_point_and_requests_an_on_demand_frame(): MapTestResult =
+    runMapTest {
+      createMapFixture().use { fixture ->
+        fixture.loadStyle(STYLE)
+        fixture.presentation.setCameraPosition(CameraPosition(target = ORIGIN, zoom = 14.0))
+        val style = checkNotNull(fixture.style) { "Errors: ${fixture.errors}" }
+        val source =
+          GeoJsonSource(
+            SOURCE_ID,
+            GeoJsonData.Features(pointAt(ORIGIN)),
+            GeoJsonOptions(),
+          )
+        style.install(source)
+        val layer = CircleLayer(LAYER_ID, source)
+        layer.setCircleRadius(const(16.dp).compile(ExpressionContext.None))
+        layer.setCircleColor(const(Color.Black))
+        layer.setCircleOpacity(const(1.0f))
+        style.install(layer)
+        val sourceHandle = assertIs<GeoJsonSourceHandle>(fixture.state.style.source(SOURCE_ID))
+
+        val centerX = 256
+        val centerY = 256
+        fixture.pumpUntil("the initial point to render") {
+          fixture.readPixel(centerX, centerY).isNear(CIRCLE)
+        }
+
+        sourceHandle.setData(GeoJsonData.Features(pointAt(FAR_AWAY)))
+
+        // Real hosts draw only requested frames. No unconditional pump may mask a missing repaint.
+        fixture.settle()
+        assertTrue(
+          fixture.readPixel(centerX, centerY).isNear(BACKGROUND),
+          "the update did not render without pumping: ${fixture.errors}",
         )
-      val sourceHandle = style.install(source)
-      val layer = CircleLayer(LAYER_ID, source)
-      layer.setCircleRadius(const(16.dp).compile(ExpressionContext.None))
-      layer.setCircleColor(const(Color.Black))
-      layer.setCircleOpacity(const(1.0f))
-      style.install(layer)
-
-      val centerX = BridgeMapFixture.DEFAULT_EXTENT.physicalWidth / 2
-      val centerY = BridgeMapFixture.DEFAULT_EXTENT.physicalHeight / 2
-      fixture.pumpUntil("the initial point to render", 30.seconds) {
-        fixture.hasRendered && fixture.readPixel(centerX, centerY).isNear(CIRCLE)
+        assertEquals(emptyList(), fixture.errors, "the map should report nothing")
       }
-
-      source.setDesiredData(GeoJsonData.Features(pointAt(FAR_AWAY)))
-      sourceHandle.update(source.definition())
-
-      // Real hosts draw only requested frames. No unconditional pump may mask a missing repaint.
-      fixture.settle()
-      assertTrue(
-        fixture.readPixel(centerX, centerY).isNear(BACKGROUND),
-        "the update did not render without pumping: ${fixture.errors}",
-      )
-      assertEquals(emptyList(), fixture.errors, "the map should report nothing")
     }
-  }
+
+  @Test
+  fun a_base_style_update_uses_the_loaded_sources_non_default_options(): MapTestResult =
+    runMapTest {
+      createMapFixture().use { fixture ->
+        fixture.loadStyle(CLUSTERED_STYLE)
+        fixture.presentation.setCameraPosition(CameraPosition(target = ORIGIN, zoom = 14.0))
+        val handle = assertIs<GeoJsonSourceHandle>(fixture.state.style.source(SOURCE_ID))
+        fixture.pumpUntil("the base-style point to render") {
+          fixture.readPixel(256, 256).isNear(CIRCLE)
+        }
+
+        handle.setData(GeoJsonData.Features(pointAt(FAR_AWAY)))
+
+        fixture.settle()
+        assertTrue(fixture.readPixel(256, 256).isNear(BACKGROUND))
+        assertEquals(emptyList(), fixture.errors)
+      }
+    }
+
+  @Test
+  fun a_cached_handle_uses_reconciled_options_after_a_same_id_replacement(): MapTestResult =
+    runMapTest {
+      createMapFixture().use { fixture ->
+        fixture.loadStyle(STYLE)
+        val style = checkNotNull(fixture.style)
+        style.install(
+          GeoJsonSource(
+            SOURCE_ID,
+            GeoJsonData.Features(pointAt(ORIGIN)),
+            GeoJsonOptions(),
+          )
+        )
+        val handle = assertIs<GeoJsonSourceHandle>(fixture.state.style.source(SOURCE_ID))
+        style.removeSource(SOURCE_ID)
+        style.install(
+          GeoJsonSource(
+            SOURCE_ID,
+            GeoJsonData.Features(pointAt(ORIGIN)),
+            GeoJsonOptions(cluster = true, clusterRadius = 123, clusterMaxZoom = 10),
+          )
+        )
+
+        handle.setData(GeoJsonData.Features(pointAt(FAR_AWAY)))
+
+        assertEquals(emptyList(), fixture.errors)
+      }
+    }
 
   private fun pointAt(position: Position): FeatureCollection<Geometry, JsonObject?> =
     buildFeatureCollection {
@@ -83,6 +131,19 @@ class GeoJsonSourceUpdateTest {
         {"version":8,"sources":{},"layers":[
           {"id":"background","type":"background","paint":{"background-color":"#336699"}}
         ]}
+        """
+          .trimIndent()
+      )
+    val CLUSTERED_STYLE =
+      BaseStyle.Json(
+        """
+        {"version":8,"sources":{"points":{"type":"geojson","data":{
+          "type":"FeatureCollection","features":[{"type":"Feature","geometry":{
+            "type":"Point","coordinates":[0,0]},"properties":{}}]},
+          "cluster":true,"clusterRadius":123,"clusterMaxZoom":10}},"layers":[
+          {"id":"background","type":"background","paint":{"background-color":"#336699"}},
+          {"id":"points-layer","type":"circle","source":"points","paint":{
+            "circle-radius":16,"circle-color":"#000000"}}]}
         """
           .trimIndent()
       )

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/sources/VectorSourceQueryTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/sources/VectorSourceQueryTest.kt
@@ -1,0 +1,40 @@
+package org.maplibre.compose.sources
+
+import kotlin.test.Test
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import org.maplibre.compose.style.BaseStyle
+import org.maplibre.compose.testing.MapTestResult
+import org.maplibre.compose.testing.createMapFixture
+import org.maplibre.compose.testing.runMapTest
+
+class VectorSourceQueryTest {
+  @Test
+  fun a_vector_handle_queries_the_loaded_source(): MapTestResult = runMapTest {
+    createMapFixture().use { fixture ->
+      fixture.loadStyle(VECTOR_STYLE)
+      val handle = assertIs<VectorSourceHandle>(fixture.state.style.source("vector"))
+
+      assertTrue(handle.querySourceFeatures(setOf("places")).isEmpty())
+    }
+  }
+
+  private companion object {
+    val VECTOR_STYLE =
+      BaseStyle.Json(
+        """
+        {
+          "version": 8,
+          "sources": {
+            "vector": {
+              "type": "vector",
+              "tiles": ["https://example.invalid/{z}/{x}/{y}.pbf"]
+            }
+          },
+          "layers": []
+        }
+        """
+          .trimIndent()
+      )
+  }
+}

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/testing/MlnFfiMapFixture.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/testing/MlnFfiMapFixture.kt
@@ -18,7 +18,7 @@ internal class MlnFfiMapFixture(val bridge: BridgeMapFixture, private val extent
   MapFixture {
 
   private val runtime = mapRuntimeForTest()
-  private val state =
+  override val state =
     runtime.createMapState(
       initialCameraPosition = CameraPosition(zoom = 0.0),
       initialBaseStyle = BaseStyle.Empty,
@@ -52,12 +52,16 @@ internal class MlnFfiMapFixture(val bridge: BridgeMapFixture, private val extent
     get() = bridge.errors
 
   override suspend fun loadStyle(style: BaseStyle, timeout: Duration) {
+    state.style.loadState = org.maplibre.compose.map.StyleLoadState.Loading
+    state.updateLoadedStyle(bridge.session, null)
     val finishedLoadsBefore = events.count { it == MapFixture.LOAD_FINISHED }
     bridge.loadStyle(style, timeout, extent)
     bridge.session.reconcileStyleRevision(DesiredStyleRevision.Empty)
     bridge.pumpUntil("style $style to finish reconciliation", timeout, extent) {
       events.count { it == MapFixture.LOAD_FINISHED } > finishedLoadsBefore
     }
+    state.updateLoadedStyle(bridge.session, bridge.style)
+    state.markStyleReady(bridge.session)
   }
 
   override suspend fun awaitMapReady(timeout: Duration) {


### PR DESCRIPTION
## Description

Adds generation-bound typed source and layer handles with ready-state acquisition, lifecycle invalidation, feature-state and GeoJSON mutation support, and cross-platform implementations.

## Validation

Validated with `mise run check`, `mise run style-spec:parity --check`, `mise run test:android`, `mise run test:desktop`, `mise run test:ios`, and `caffeinate -dimsu mise run test:js`.

## AI assistance

Implemented with OpenAI Codex using GPT-5 in the Codex desktop app.