### PR TITLE
Migrate demos to shared map runtime

### DIFF
--- a/.agents/scratch/api-redesign/issues/12-migrate-demos.md
+++ b/.agents/scratch/api-redesign/issues/12-migrate-demos.md
@@ -6,16 +6,16 @@ composition model.
 
 **Blocked by:** 10, 11
 
-**Status:** ready-for-agent
+**Status:** resolved
 
-- [ ] The changed test area contains no redundant, impossible,
+- [x] The changed test area contains no redundant, impossible,
       compatibility-only, or implementation-shape scenarios.
-- [ ] Every demo creates or remembers MapState through MapRuntime.
-- [ ] Files under `org/maplibre/compose/docsnippets` are excluded and remain the
+- [x] Every demo creates or remembers MapState through MapRuntime.
+- [x] Files under `org/maplibre/compose/docsnippets` are excluded and remain the
       sole responsibility of ticket 13.
-- [ ] Demo style content uses reusable StyleComposition values.
-- [ ] Viewport-dependent demo behavior uses the current MapPresentation.
-- [ ] Android, iOS, Desktop, and Web demos build successfully.
+- [x] Demo style content uses reusable StyleComposition values.
+- [x] Viewport-dependent demo behavior uses the current MapPresentation.
+- [x] Android, iOS, Desktop, and Web demos build successfully.
 
 ## Test ledger
 
@@ -23,3 +23,21 @@ composition model.
   surface changes; do not add behavioral copies of library tests.
 - Run `mise run build:android-app`, `mise run build:ios:device`,
   `mise run build:desktop-app`, and `mise run build:js-app`.
+
+## Answer
+
+`DemoAppState` remembers the process runtime and the shared logical map through
+that runtime. One application runtime owns the shared, benchmark, and
+magnifying-lens logical maps. Each logical map has an independent presentation.
+
+The demos supply style content as `StyleComposition` values and resolve
+viewport-dependent work through each map's current `MapPresentation`.
+Documentation snippets remain unchanged for ticket 13.
+
+`BenchmarkStatsTest.kt` remains unchanged because its statistics contract and
+caller surface did not change. The demo migration adds no behavior that needs a
+copy of the library ownership tests.
+
+Validation passed with `mise run build:android-app`,
+`mise run build:ios:device`, `mise run build:desktop-app`, and
+`mise run build:js-app`.

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoAppState.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoAppState.kt
@@ -13,7 +13,9 @@ import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.demoapp.benchmark.BenchmarkScenario
 import org.maplibre.compose.demoapp.benchmark.BenchmarkUiState
 import org.maplibre.compose.demoapp.benchmark.allBenchmarkScenarios
+import org.maplibre.compose.map.MapRuntime
 import org.maplibre.compose.map.MapState
+import org.maplibre.compose.map.rememberMapRuntime
 import org.maplibre.compose.map.rememberMapState
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.spatialk.geojson.Position
@@ -31,6 +33,7 @@ enum class DemoShell {
 /** The state the shell owns: the shared map, the selection, and the settings. */
 @Stable
 class DemoAppState(
+  val mapRuntime: MapRuntime,
   val mapState: MapState,
   val settings: DemoSettings,
   val frameRateState: FrameRateState,
@@ -114,8 +117,9 @@ internal data class StyleLoad(val count: Int, val base: BaseStyle?)
 
 @Composable
 fun rememberDemoAppState(): DemoAppState {
-  val mapState = rememberMapState(initialCameraPosition = StartPosition)
+  val mapRuntime = rememberMapRuntime()
+  val mapState = rememberMapState(runtime = mapRuntime, initialCameraPosition = StartPosition)
   val settings = rememberDemoSettings()
   val frameRateState = remember { FrameRateState() }
-  return remember { DemoAppState(mapState, settings, frameRateState) }
+  return remember { DemoAppState(mapRuntime, mapState, settings, frameRateState) }
 }

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/benchmark/BenchmarkMap.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/benchmark/BenchmarkMap.kt
@@ -56,7 +56,8 @@ internal fun BenchmarkMap(state: DemoAppState, viewportInsets: MapViewportInsets
   val scenario = state.selectedScenario
   val density = LocalDensity.current
   val prefetcher = rememberTilePrefetcher()
-  val mapState = rememberMapState(initialCameraPosition = scenario.camera)
+  val mapState =
+    rememberMapState(runtime = state.mapRuntime, initialCameraPosition = scenario.camera)
   SideEffect { mapState.style.baseStyle = scenario.style.base }
   val session =
     remember(mapState, prefetcher, density) {

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/MagnifyingLensDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/MagnifyingLensDemo.kt
@@ -93,7 +93,7 @@ object MagnifyingLensDemo : Demo {
 
   @Composable
   override fun MapOverlayScope.Overlay(state: DemoAppState) {
-    val lensState = rememberMapState()
+    val lensState = rememberMapState(runtime = state.mapRuntime)
     val appliedStyle = state.appliedStyle
     SideEffect { lensState.style.baseStyle = appliedStyle.base }
     val density = LocalDensity.current


### PR DESCRIPTION
## Description

Route the shared, benchmark, and magnifying-lens logical maps through one application-scoped `MapRuntime` and resolve local migration ticket 12.

## Validation

Validated with `mise run build:android-app`, `mise run build:ios:device`, `mise run build:desktop-app`, `mise run build:js-app`, and `mise run check`.

## AI assistance

Codex assisted with implementation, validation, and two-axis standards and specification review.