### PR TITLE
Migrate docs and platform tests to ownership API

### DIFF
--- a/.agents/scratch/api-redesign/issues/13-migrate-docs-platform-tests.md
+++ b/.agents/scratch/api-redesign/issues/13-migrate-docs-platform-tests.md
@@ -6,25 +6,25 @@ lifecycle semantics in common fake-adapter tests.
 
 **Blocked by:** 10, 11
 
-**Status:** ready-for-agent
+**Status:** resolved
 
-- [ ] The changed test area contains no redundant, impossible,
+- [x] The changed test area contains no redundant, impossible,
       compatibility-only, or implementation-shape scenarios.
-- [ ] Documentation and compiled snippets show only MapRuntime, MapState,
+- [x] Documentation and compiled snippets show only MapRuntime, MapState,
       MapPresentation, and StyleComposition.
-- [ ] This ticket solely owns `docs/` and every
+- [x] This ticket solely owns `docs/` and every
       `demo-app/common/src/*/kotlin/org/maplibre/compose/docsnippets` package.
-- [ ] Native tests cover compatible retention, incompatible engine replacement,
+- [x] Native tests cover compatible retention, incompatible engine replacement,
       and durable-state replay through the public API.
-- [ ] Browser tests cover destruction, recreation, replay, and readiness through
+- [x] Browser tests cover destruction, recreation, replay, and readiness through
       the public API.
-- [ ] Desktop tests cover presentation-host replacement independently from
+- [x] Desktop tests cover presentation-host replacement independently from
       runtime and logical-map lifetime.
-- [ ] Platform tests that duplicate common behavior without testing an engine
+- [x] Platform tests that duplicate common behavior without testing an engine
       boundary are deleted.
-- [ ] Documentation builds and the focused native, browser, and desktop tests
+- [x] Documentation builds and the focused native, browser, and desktop tests
       pass.
-- [ ] The PR contains a final table classifying every affected platform test as
+- [x] The PR contains a final table classifying every affected platform test as
       retained, rewritten, consolidated, or deleted.
 
 ## Test ledger
@@ -40,3 +40,76 @@ lifecycle semantics in common fake-adapter tests.
 - Run `mise run build:docs`, `mise run test:android`,
   `mise run test:android:device`, `mise run test:desktop`, `mise run test:ios`,
   and `mise run test:js`.
+
+## Answer
+
+The documentation now describes the runtime, logical map, presentation, and
+style-composition ownership model. Generated examples wrap every source and
+layer region in `StyleComposition` and pass that value to `MaplibreMap`. The
+pages no longer reconstruct the removed `MaplibreMap { ... }` overload or name
+the superseded camera and style state APIs.
+
+The browser attribution tests now observe `MapState.style`, the public
+`MapStyleState`, instead of the internal compatibility `StyleState`. The native
+retention, native replacement, Web recreation, readiness, and desktop host tests
+already exercised the required public seams and remain unchanged. The Android
+device-test manifest now registers `MapStateRecreationActivity`, which restores
+the activity-recreation test after its ownership-API rename.
+
+The inventory found no platform test that duplicated a common lifecycle contract
+without also observing a platform boundary. The following table records every
+live-map test and every browser map, style, source, rendering, or input test. A
+retained row covers every test function in that file.
+
+| Classification | Test                                                        | Platform boundary                                                            |
+| -------------- | ----------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| Retained       | `BrowserStyleStateTest`: detached map and viewport tests    | Web recreation, replay, and presentation readiness                           |
+| Rewritten      | `BrowserStyleStateTest`: four source and style-switch tests | Public Web style state and TileJSON metadata                                 |
+| Retained       | `AndroidMapStateRecreationTest`                             | Android activity recreation and saveable camera restoration                  |
+| Retained       | `MlnFfiMapCompositionTest`                                  | Native retention, incompatible replacement, replay, and rendering            |
+| Retained       | `MlnFfiMapInputTest`                                        | Native Compose pointer and keyboard input                                    |
+| Retained       | `MlnFfiStyleSwitchTest`                                     | Native asynchronous style loading and reconciliation                         |
+| Retained       | `DesktopPresentationHostLifetimeTest`                       | Desktop host replacement independent from runtime and logical-map lifetime   |
+| Retained       | `MlnFfiGestureTokenOrderingTest`                            | Native owner-thread gesture ordering                                         |
+| Retained       | `MlnFfiMapIdleTest`                                         | Native frame scheduling                                                      |
+| Retained       | `MlnFfiMapPixelTest`                                        | Native render-target pixels                                                  |
+| Retained       | `MlnFfiMapRepaintTest`                                      | Native redraw requests after style mutations                                 |
+| Retained       | `MlnFfiMapResizeTest`                                       | Native resize and render-session retention                                   |
+| Retained       | `MlnFfiProjectionTest`                                      | Native projection and owner-thread snapshots                                 |
+| Retained       | `MlnFfiStyleFailureTest`                                    | Native URL-style failure reporting                                           |
+| Retained       | `MlnFfiSurfaceLossTest`                                     | Native surface loss, restoration, and cleanup                                |
+| Retained       | `MlnFfiTileLodTest`                                         | Native tile-LOD option propagation                                           |
+| Retained       | `LayerHandlePropertyTest`                                   | Live-engine imperative layer handles                                         |
+| Retained       | `LayerPropertyRoundTripTest`                                | Live-engine style-spec property round trips                                  |
+| Retained       | `CameraMoveReportingTest`                                   | Live-engine gesture and programmatic camera events                           |
+| Retained       | `MapCameraTransitionTest`                                   | Live-engine camera animation, fit, constraint, and cancellation behavior     |
+| Retained       | `MapQueryTest`                                              | Live rendered-feature queries and viewport readiness                         |
+| Retained       | `MapVisibleAreaTest`                                        | Live viewport, projection, and visible-region geometry                       |
+| Retained       | `SourceChangeReportingTest`                                 | Live source-change callbacks                                                 |
+| Retained       | `MapOverlayTest`                                            | Map-overlay composition and placement lifecycle                              |
+| Retained       | `MaplibreLogoTest`                                          | Map-overlay logo composition                                                 |
+| Retained       | `CustomVectorSourceTest`                                    | Live custom-protocol rendering and cancellation                              |
+| Retained       | `FeatureStateTest`                                          | Live feature-state rendering through a source handle                         |
+| Retained       | `GeoJsonClusterTest`                                        | Live cluster queries through a source handle                                 |
+| Retained       | `ImageSourceDrawTest`                                       | Live image-source pixels and coordinates                                     |
+| Retained       | `BaseStyleSourceReadTest`                                   | Live base-style source handles and metadata                                  |
+| Retained       | `ExpressionSplitJoinEngineTest`                             | Live expression acceptance by the engines                                    |
+| Retained       | `BrowserCompositingTest`                                    | Shared WebGL state, targets, resize, and Skia interop                        |
+| Retained       | `BrowserMapLifecycleTest`                                   | GL JS destruction, recreation, camera replay, and surface readiness          |
+| Retained       | `BrowserStyleConformanceTest`                               | GL JS base and composed style behavior                                       |
+| Retained       | `SameOriginWorkerUrlTest`                                   | Browser worker URL and blob behavior                                         |
+| Retained       | `BrowserCameraTransitionLifecycleTest`                      | GL JS transition cancellation and stale-engine rejection                     |
+| Retained       | `BrowserMapStateTest`                                       | Browser default runtime, presentation publication, and rival-session refusal |
+| Retained       | `BrowserStyleFailureTest`                                   | GL JS style and source failure isolation                                     |
+| Retained       | `ScrollNotchesTest`                                         | Browser wheel and trackpad normalization                                     |
+| Retained       | `BrowserCustomVectorSourceTest`                             | GL JS protocol URL isolation and failure propagation                         |
+| Retained       | `BrowserRasterDemSourceTest`                                | GL JS raster-dem option acceptance                                           |
+| Retained       | `BrowserStyleUriTest`                                       | Browser style loading from a URL                                             |
+| Retained       | `GlJsImageTest`                                             | GL JS image conversion                                                       |
+| Consolidated   | None                                                        | Shared lifecycle behavior remains in common fake-adapter tests               |
+| Deleted        | None                                                        | Every inventoried test observes a distinct platform boundary                 |
+
+Validation passed with `mise run check`, `mise run build:docs`,
+`mise run test:android`, `mise run test:android:device`,
+`mise run test:desktop`, `mise run test:ios`, and
+`caffeinate -dimsu mise run test:js`.

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Composition.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Composition.kt
@@ -5,6 +5,7 @@ package org.maplibre.compose.docsnippets
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import org.maplibre.compose.map.MaplibreMap
+import org.maplibre.compose.map.rememberMapRuntime
 import org.maplibre.compose.map.rememberMapState
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.compose.style.StyleComposition
@@ -12,9 +13,11 @@ import org.maplibre.compose.style.StyleComposition
 @Composable
 fun Composition() {
   // #region base-plus-content
+  val runtime = rememberMapRuntime()
   val state =
     rememberMapState(
-      initialBaseStyle = BaseStyle.Uri("https://tiles.openfreemap.org/styles/liberty")
+      runtime = runtime,
+      initialBaseStyle = BaseStyle.Uri("https://tiles.openfreemap.org/styles/liberty"),
     )
   val composition = remember {
     StyleComposition {

--- a/docs/src/content/docs/composition.mdx
+++ b/docs/src/content/docs/composition.mdx
@@ -24,10 +24,9 @@ stack.
 
 <Code code={region(composition, "base-plus-content")} lang="kotlin" title="App.kt" />
 
-The library manages the sources and layers that you declare in the content
-block, and does not modify the rest of the base style. To change a base style
-layer, replace it with <Api of="Anchor.Replace" /> and declare its replacement
-yourself.
+The library manages the sources and layers in the `StyleComposition` block. It
+does not modify the rest of the base style. To change a base style layer,
+replace it with <Api of="Anchor.Replace" /> and declare its replacement yourself.
 
 ## Recomposition updates the style
 

--- a/docs/src/content/docs/controls.mdx
+++ b/docs/src/content/docs/controls.mdx
@@ -20,8 +20,8 @@ bar and the compass appear only while they are relevant.
 
 <Aside type="caution">
   Most tile sources require attribution. `MapOverlay.Default` reads it from
-  `StyleState.attributions()`. If you replace the overlay, show that attribution
-  yourself.
+  `MapStyleState.attributions()`. If you replace the overlay, show that
+  attribution yourself.
 </Aside>
 
 ## Choose an overlay
@@ -36,8 +36,7 @@ A <Api of="MapOverlay" /> block draws the controls you list in it.
 
 <Code code={region(controls, "custom")} lang="kotlin" title="App.kt" />
 
-1. The block can read the map's `cameraState` and `styleState`, so a control
-   inside it takes no state arguments.
+1. The block provides the `mapState`, current `presentation`, and `styleState`.
 
 ## Theme the controls with Material 3
 

--- a/docs/src/content/docs/expressions.mdx
+++ b/docs/src/content/docs/expressions.mdx
@@ -5,7 +5,7 @@ description: The expression DSL that computes layer properties from feature data
 
 import { Code } from "@astrojs/starlight/components";
 import Api from "../../components/Api.astro";
-import { region } from "../../snippets";
+import { region, styleComposition } from "../../snippets";
 
 import expressions from "../../../../demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Expressions.kt?raw";
 
@@ -23,7 +23,7 @@ sizes, `Color` for colors, and `DpOffset` for offsets.
 A constant value must also be an expression. Wrap a plain value in
 <Api of="const" />:
 
-<Code code={region(expressions, "constants")} lang="kotlin" title="App.kt" />
+<Code code={styleComposition(region(expressions, "constants"))} lang="kotlin" title="App.kt" />
 
 ## Read feature data
 
@@ -32,7 +32,7 @@ The result is untyped, so convert it with functions such as `asNumber()` or
 `asString()`. Functions such as <Api of="step" /> and <Api of="switch" />
 select an output from the value:
 
-<Code code={region(expressions, "feature-data")} lang="kotlin" title="App.kt" />
+<Code code={styleComposition(region(expressions, "feature-data"))} lang="kotlin" title="App.kt" />
 
 The map evaluates this formula once per feature: each earthquake receives a
 radius and a color computed from its own magnitude.
@@ -42,14 +42,14 @@ radius and a color computed from its own magnitude.
 <Api of="zoom" /> is the current zoom level. <Api of="interpolate" /> computes
 a smooth value between stops:
 
-<Code code={region(expressions, "zoom")} lang="kotlin" title="App.kt" />
+<Code code={styleComposition(region(expressions, "zoom"))} lang="kotlin" title="App.kt" />
 
 ## Filter features
 
 The `filter` parameter takes a boolean expression. The layer renders only the
 features for which it is true:
 
-<Code code={region(expressions, "filter")} lang="kotlin" title="App.kt" />
+<Code code={styleComposition(region(expressions, "filter"))} lang="kotlin" title="App.kt" />
 
 ## Where the code runs
 

--- a/docs/src/content/docs/images.mdx
+++ b/docs/src/content/docs/images.mdx
@@ -5,7 +5,7 @@ description: Draw icons from Compose painters or the style sprite, and place an 
 
 import { Code } from "@astrojs/starlight/components";
 import Api from "../../components/Api.astro";
-import { inside, region } from "../../snippets";
+import { region, styleComposition } from "../../snippets";
 
 import images from "../../../../demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Images.kt?raw";
 
@@ -19,18 +19,18 @@ Pass a painter to `image()`. The library rasterizes it and registers it with
 the style. This works with `painterResource`, vector drawables, and any other
 painter:
 
-<Code code={inside("MaplibreMap {", region(images, "icon-painter"))} lang="kotlin" title="App.kt" />
+<Code code={styleComposition(region(images, "icon-painter"))} lang="kotlin" title="App.kt" />
 
 ## Draw icons from the style sprite
 
 Base styles usually bundle a sprite: a named set of icons. Pass the icon name
 to `image()`:
 
-<Code code={inside("MaplibreMap {", region(images, "icon-sprite"))} lang="kotlin" title="App.kt" />
+<Code code={styleComposition(region(images, "icon-sprite"))} lang="kotlin" title="App.kt" />
 
 ## Place an image on the map
 
 An <Api of="ImageSource" /> positions one image on the map by its four corner
 coordinates. A <Api of="RasterLayer" /> draws it:
 
-<Code code={inside("MaplibreMap {", region(images, "image-source"))} lang="kotlin" title="App.kt" />
+<Code code={styleComposition(region(images, "image-source"))} lang="kotlin" title="App.kt" />

--- a/docs/src/content/docs/interaction.mdx
+++ b/docs/src/content/docs/interaction.mdx
@@ -5,7 +5,7 @@ description: Configure gestures, and respond to clicks on the map and on layers.
 
 import { Code } from "@astrojs/starlight/components";
 import Api from "../../components/Api.astro";
-import { inside, region } from "../../snippets";
+import { region, styleComposition } from "../../snippets";
 
 import interaction from "../../../../demo-app/common/src/androidMain/kotlin/org/maplibre/compose/docsnippets/Interaction.kt?raw";
 import layers from "../../../../demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Layers.kt?raw";
@@ -35,10 +35,10 @@ click on to the layer listeners:
 
 ## Layer clicks
 
-Layer composables have click listeners of their own, which receive the features
-that were clicked in that layer:
+Layer composables in a `StyleComposition` have click listeners that receive the
+features that were clicked in that layer:
 
-<Code code={inside("MaplibreMap {", region(layers, "interaction"))} lang="kotlin" title="App.kt" />
+<Code code={styleComposition(region(layers, "interaction"))} lang="kotlin" title="App.kt" />
 
 Click listeners run on the map first, then on layers from the top to the bottom
 of the map. The first listener that returns <Api of="ClickResult.Consume" />

--- a/docs/src/content/docs/layers.mdx
+++ b/docs/src/content/docs/layers.mdx
@@ -5,13 +5,14 @@ description: Declare sources and layers as composables, and anchor them in the l
 
 import { Code } from "@astrojs/starlight/components";
 import Api from "../../components/Api.astro";
-import { inside, region } from "../../snippets";
+import { region, styleComposition } from "../../snippets";
 
 import layers from "../../../../demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Layers.kt?raw";
 
 The base style defines the map's content. To show your own data on top of it,
-declare sources and layers inside the `MaplibreMap` block. A source holds the
-data, and a layer draws data from a source.
+declare sources and layers in a <Api of="StyleComposition" />, then pass that
+value to <Api of="MaplibreMap" />. A source holds the data, and a layer draws
+data from a source.
 
 ## Reference a base style source
 
@@ -25,7 +26,7 @@ layer of yours can draw data that the style already loads:
 <Api of="rememberGeoJsonSource" /> creates a source from a GeoJSON URI or
 string. Layers reference the source object directly:
 
-<Code code={inside("MaplibreMap {", region(layers, "amtrak-1"))} lang="kotlin" title="App.kt" />
+<Code code={styleComposition(region(layers, "amtrak-1"))} lang="kotlin" title="App.kt" />
 
 Other source types cover vector tiles, raster tiles, and images. The API
 reference documents them under <Api of="org.maplibre.compose.sources" />.
@@ -36,7 +37,7 @@ Layer properties accept expressions: formulas that the map evaluates at render
 time. Wrap a constant value in <Api of="const" />. Functions such as
 <Api of="interpolate" /> and <Api of="zoom" /> build dynamic values:
 
-<Code code={region(layers, "amtrak-2")} lang="kotlin" title="App.kt" />
+<Code code={styleComposition(region(layers, "amtrak-2"))} lang="kotlin" title="App.kt" />
 
 [Expressions in Kotlin](/maplibre-compose/expressions/) explains the expression
 system. The [MapLibre Style Specification][spec-layers] documents every layer
@@ -48,6 +49,6 @@ By default, your layers draw above the base style layers. <Api of="Anchor" />
 inserts a layer at another position: at the `Bottom`, at the `Top`, `Above` or
 `Below` a named base layer, or as a `Replace`ment for a base layer:
 
-<Code code={region(layers, "anchors")} lang="kotlin" title="App.kt" />
+<Code code={styleComposition(region(layers, "anchors"))} lang="kotlin" title="App.kt" />
 
 [spec-layers]: https://maplibre.org/maplibre-style-spec/layers/

--- a/docs/src/content/docs/styling.mdx
+++ b/docs/src/content/docs/styling.mdx
@@ -20,8 +20,8 @@ Free and commercial tile providers are listed in the
 
 ## Use a style
 
-Pass the style URI to the <Api of="MaplibreMap" /> composable as a
-<Api of="BaseStyle" />:
+Create a <Api of="MapState" /> with the style URI as its initial
+<Api of="BaseStyle" />, then pass that state to <Api of="MaplibreMap" />:
 
 <Code code={region(styling, "simple")} lang="kotlin" title="App.kt" />
 

--- a/docs/src/snippets.ts
+++ b/docs/src/snippets.ts
@@ -27,18 +27,13 @@ export function region(source: string, name: string): string {
   return dedent(trimBlankEdges(body)).join("\n");
 }
 
-/**
- * Nests a region inside the block it belongs to.
- *
- * Some regions sit inside a `MaplibreMap { ... }` in the source, where the
- * surrounding call is context the page needs but the region should not repeat.
- */
-export function inside(opening: string, body: string): string {
+/** Wraps a region in the style composition and map call that consume it. */
+export function styleComposition(body: string): string {
   const indented = body
     .split("\n")
-    .map((line) => (line.trim() === "" ? line : `  ${line}`))
+    .map((line) => (line.trim() === "" ? line : `    ${line}`))
     .join("\n");
-  return `${opening}\n${indented}\n}`;
+  return `val composition = remember {\n  StyleComposition {\n${indented}\n  }\n}\nMaplibreMap(styleComposition = composition)`;
 }
 
 function isMarker(line: string, kind: string, name?: string): boolean {

--- a/lib/maplibre-compose/src/androidDeviceTest/AndroidManifest.xml
+++ b/lib/maplibre-compose/src/androidDeviceTest/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <application>
     <activity
-      android:name="org.maplibre.compose.camera.CameraStateRecreationActivity"
+      android:name="org.maplibre.compose.camera.MapStateRecreationActivity"
       android:exported="false"
       android:theme="@android:style/Theme.Material.Light.NoActionBar"
     />

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserStyleStateTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserStyleStateTest.kt
@@ -21,6 +21,7 @@ import org.maplibre.compose.layers.RasterLayer
 import org.maplibre.compose.map.GlJsMapSession
 import org.maplibre.compose.map.MapRuntimeOptions
 import org.maplibre.compose.map.MapState
+import org.maplibre.compose.map.MapStyleState
 import org.maplibre.compose.map.MaplibreMap
 import org.maplibre.compose.map.StyleLoadState
 import org.maplibre.compose.map.createMapRuntime
@@ -30,7 +31,6 @@ import org.maplibre.compose.style.BaseStyle
 import org.maplibre.compose.style.LocalStyleNode
 import org.maplibre.compose.style.StyleComposition
 import org.maplibre.compose.style.StyleIdentity
-import org.maplibre.compose.style.StyleState
 
 @OptIn(ExperimentalTestApi::class)
 class BrowserStyleStateTest {
@@ -239,12 +239,12 @@ class BrowserStyleStateTest {
   fun a_source_reports_the_attribution_its_tilejson_carries(): Promise<*> = runBrowserMapTest {
     val restoreFetch = installSlowTileJson()
     try {
-      var state: StyleState? = null
+      var styleState: MapStyleState? = null
       var mapState: MapState? = null
       setBrowserMapContent {
         val current = rememberMapState(initialBaseStyle = tileJsonStyle)
         mapState = current
-        state = current.compatibilityStyleState
+        styleState = current.style
         MaplibreMap(state = current, modifier = Modifier)
       }
       waitUntilMap("the map to report that it finished loading") {
@@ -253,7 +253,7 @@ class BrowserStyleStateTest {
 
       assertEquals(
         listOf("fetched attribution"),
-        state?.sources?.values?.map { it.attributionHtml },
+        styleState?.sources?.values?.map { it.attributionHtml },
         "loading is only finished once a source's TileJSON has arrived; the attribution UI reads " +
           "this the moment it is told",
       )
@@ -267,12 +267,12 @@ class BrowserStyleStateTest {
     val restoreFetch = installSlowTileJson()
     try {
       val current = mutableStateOf(styleWith("first", "first-source"))
-      var state: StyleState? = null
+      var styleState: MapStyleState? = null
       var mapState: MapState? = null
       setBrowserMapContent {
         val logicalMap = rememberMapState(initialBaseStyle = current.value)
         mapState = logicalMap
-        state = logicalMap.compatibilityStyleState
+        styleState = logicalMap.style
         SideEffect { logicalMap.style.baseStyle = current.value }
         MaplibreMap(state = logicalMap, modifier = Modifier)
       }
@@ -282,7 +282,7 @@ class BrowserStyleStateTest {
 
       current.value = tileJsonStyle
       waitUntilMap("the switched style's attribution to be reported") {
-        state?.sources?.values?.map { it.attributionHtml } == listOf("fetched attribution")
+        styleState?.sources?.values?.map { it.attributionHtml } == listOf("fetched attribution")
       }
     } finally {
       restoreFetch()
@@ -296,12 +296,12 @@ class BrowserStyleStateTest {
       try {
         val showLateSource = mutableStateOf(false)
         val source = RasterSource("late-source", "https://tilejson.test/x.json")
-        var state: StyleState? = null
+        var styleState: MapStyleState? = null
         var mapState: MapState? = null
         setBrowserMapContent {
           val logicalMap = rememberMapState(initialBaseStyle = BaseStyle.Empty)
           mapState = logicalMap
-          state = logicalMap.compatibilityStyleState
+          styleState = logicalMap.style
           val composition = remember {
             StyleComposition {
               if (showLateSource.value) {
@@ -321,16 +321,16 @@ class BrowserStyleStateTest {
 
         showLateSource.value = true
 
-        waitUntilMap("the late source's initial snapshot") { state?.sources?.size == 1 }
-        assertEquals(listOf(""), state?.sources?.values?.map { it.attributionHtml })
-        val initialSource = state?.sources?.values?.single()
+        waitUntilMap("the late source's initial snapshot") { styleState?.sources?.size == 1 }
+        assertEquals(listOf(""), styleState?.sources?.values?.map { it.attributionHtml })
+        val initialSource = styleState?.sources?.values?.single()
 
         waitUntilMap("MapLibre to request the TileJSON") { tileJson.isRequested() }
         tileJson.resolve()
         waitUntilMap("the late source's attribution") {
-          state?.sources?.values?.map { it.attributionHtml } == listOf("fetched attribution")
+          styleState?.sources?.values?.map { it.attributionHtml } == listOf("fetched attribution")
         }
-        assertNotSame(initialSource, state?.sources?.values?.single())
+        assertNotSame(initialSource, styleState?.sources?.values?.single())
         assertEquals(
           StyleLoadState.Ready,
           mapState?.style?.loadState,
@@ -344,13 +344,13 @@ class BrowserStyleStateTest {
   @Test
   fun switching_styles_keeps_the_sources_visible(): Promise<*> = runBrowserMapTest {
     val current = mutableStateOf(styleWith("first", "first-source"))
-    var state: StyleState? = null
+    var styleState: MapStyleState? = null
     var identity: StyleIdentity? = null
     var mapState: MapState? = null
     setBrowserMapContent {
       val logicalMap = rememberMapState(initialBaseStyle = current.value)
       mapState = logicalMap
-      state = logicalMap.compatibilityStyleState
+      styleState = logicalMap.style
       SideEffect { logicalMap.style.baseStyle = current.value }
       val composition = remember {
         StyleComposition { identity = LocalStyleNode.current.style.identity }
@@ -362,20 +362,27 @@ class BrowserStyleStateTest {
       )
     }
     waitUntilMap("the first style to load") {
-      mapState?.style?.loadState == StyleLoadState.Ready && state?.sources?.isNotEmpty() == true
+      mapState?.style?.loadState == StyleLoadState.Ready &&
+        styleState?.sources?.isNotEmpty() == true
     }
     val firstIdentity = identity
-    assertEquals(listOf("first attribution"), state?.sources?.values?.map { it.attributionHtml })
+    assertEquals(
+      listOf("first attribution"),
+      styleState?.sources?.values?.map { it.attributionHtml },
+    )
 
     val observed = mutableListOf<List<String>>()
     current.value = styleWith("second", "second-source")
     waitUntilMap("the second style's sources to be reported") {
-      state?.sources?.values?.map { it.attributionHtml }?.let { observed += it }
+      styleState?.sources?.values?.map { it.attributionHtml }?.let { observed += it }
       mapState?.style?.loadState == StyleLoadState.Ready &&
-        state?.sources?.keys == setOf("second-source")
+        styleState?.sources?.keys == setOf("second-source")
     }
 
-    assertEquals(listOf("second attribution"), state?.sources?.values?.map { it.attributionHtml })
+    assertEquals(
+      listOf("second attribution"),
+      styleState?.sources?.values?.map { it.attributionHtml },
+    )
     assertNotSame(firstIdentity, identity)
     assertTrue(
       observed.none { attributions -> attributions.any { it.isEmpty() } },


### PR DESCRIPTION
## Description

Migrate public documentation, compiled snippets, and platform tests to the new map ownership API, and record the final platform-test classification in resolved ticket 13.

## Validation

Passed `mise run check`, `mise run build:docs`, `mise run test:android`, `mise run test:android:device`, `mise run test:desktop`, `mise run test:ios`, and `caffeinate -dimsu mise run test:js`.

## AI assistance

Implemented with OpenAI Codex using GPT-5.6.