### PR TITLE
Unify map lifecycle authority

### DIFF
--- a/.agents/scratch/api-redesign/issues/19-unify-map-lifecycle-authority.md
+++ b/.agents/scratch/api-redesign/issues/19-unify-map-lifecycle-authority.md
@@ -1,0 +1,52 @@
+# 19: Unify the map lifecycle authority
+
+**What to build:** Correct the lifecycle split introduced when `MapState` was
+added after the session lifecycle authority. Route logical presentation
+reservations, engine transitions, closure, and callback acceptance through one
+`MapState`-owned authority. Platform sessions execute commands for that
+authority and retain no independent lifecycle state machine.
+
+**Blocked by:** 14
+
+**Status:** resolved
+
+- [x] `MapState` owns the only lifecycle authority for its logical map.
+- [x] Native and Web sessions receive that authority instead of creating one.
+- [x] One serialized transition model decides presentation reservation,
+      attachment, detachment, engine retention or replacement, and closure.
+- [x] Platform callbacks use identities from the `MapState` authority.
+- [x] Rival presentations and departed leases retain their specified behavior.
+- [x] Native maps remain reusable across compatible presentations.
+- [x] Web maps and incompatible native maps replace their engines without
+      replacing `MapState`.
+- [x] Closure collects every platform cleanup failure and completes once.
+- [x] Common tests exercise public `MapState` behavior through fake adapters.
+- [x] Native surface-loss and Web recreation tests retain their distinct engine
+      coverage.
+- [x] Static checks and the full supported platform test matrix pass.
+
+## Test ledger
+
+- Preserve the existing public `MapState` presentation and closure tests as the
+  primary seam.
+- Keep the physical engine and lease transition table on an authority-owned fake
+  binding. The binding tests retain distinct coverage of races below the public
+  API that presentation tests cannot replace.
+- Retain native engine-retention and Web engine-replacement tests.
+- Run `mise run check`, `mise run style-spec:parity --check`, and the complete
+  platform matrix from the specification.
+
+## Answer
+
+`MapState` now owns presentation reservations, bound platform lifecycle
+controllers, retained adapters, and closure. Native and Web sessions bind to
+that owner instead of constructing an independent authority. The binding lock
+serializes callback validation with delivery, while the owner lock stays
+released across platform commands. This ordering prevents closure from racing an
+accepted callback without creating cross-lock deadlocks. Versioned camera and
+base-style writes replay the newest durable value when an older platform call
+finishes late.
+
+Static checks, style-spec parity, documentation, publishing, Android host and
+device, iOS simulator and device, Web, and Desktop tests pass. The Desktop
+matrix covers macOS, Linux x64 and Arm64, and Windows x64 and Arm64.

--- a/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/layers/LayerClickOrderTest.kt
+++ b/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/layers/LayerClickOrderTest.kt
@@ -12,9 +12,6 @@ import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performMouseInput
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.unit.DpOffset
-import kotlin.concurrent.atomics.AtomicInt
-import kotlin.concurrent.atomics.ExperimentalAtomicApi
-import kotlin.concurrent.atomics.incrementAndFetch
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -22,7 +19,6 @@ import kotlin.test.assertNotNull
 import kotlinx.coroutines.runBlocking
 import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.expressions.dsl.const
-import org.maplibre.compose.map.MapPresentationCallbacks
 import org.maplibre.compose.map.MapState
 import org.maplibre.compose.map.MaplibreMap
 import org.maplibre.compose.map.rememberMapState
@@ -135,13 +131,11 @@ class LayerClickOrderTest {
    * [BACK] in the style. [frontResult] is what [FRONT]'s handlers return, so a test can either stop
    * the event there or let it fall through.
    */
-  @OptIn(ExperimentalAtomicApi::class)
   private fun runLayerClickTest(
     composeFrontLayerFirst: Boolean,
     frontResult: ClickResult = ClickResult.Consume,
     body: ComposeUiTest.(center: Offset) -> Unit,
   ) = runFfiComposeUiTest {
-    val frames = AtomicInt(0)
     lateinit var mapState: MapState
 
     setFfiTestMapContent(runtimeOptions) {
@@ -153,7 +147,6 @@ class LayerClickOrderTest {
       MaplibreMap(
         state = mapState,
         modifier = Modifier.fillMaxSize(),
-        callbacks = MapPresentationCallbacks(onFrame = { frames.incrementAndFetch() }),
         styleComposition =
           StyleComposition {
             val source = rememberGeoJsonSource(data = GeoJsonData.JsonString(WORLD_POLYGON))
@@ -201,8 +194,7 @@ class LayerClickOrderTest {
       )
     }
 
-    waitUntil(timeoutMillis = TIMEOUT) { frames.load() > 0 }
-
+    waitUntil(timeoutMillis = TIMEOUT) { mapState.presentation != null }
     val presentation = assertNotNull(mapState.presentation, "the map never published a lease")
     val size = onRoot().fetchSemanticsNode().size
     val centerDp = with(density) { DpOffset((size.width / 2).toDp(), (size.height / 2).toDp()) }

--- a/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MapLifecycleCallbackRaceTest.kt
+++ b/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MapLifecycleCallbackRaceTest.kt
@@ -1,0 +1,225 @@
+package org.maplibre.compose.map
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.concurrent.thread
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.JsonObject
+import org.maplibre.compose.style.BaseStyle
+import org.maplibre.compose.style.RecordingStyleBinding
+
+class MapLifecycleCallbackRaceTest {
+  @Test
+  fun accepted_callback_delivery_completes_before_closure_commits() = runBlocking {
+    val runtime = mapRuntimeForTest()
+    val state = runtime.createMapState()
+    val binding = state.lifecycle.bind(CallbackRacePlatformAdapter())
+    binding.attach()
+    val engine = requireNotNull(binding.engineIdentity)
+    val callbackEntered = CountDownLatch(1)
+    val releaseCallback = CountDownLatch(1)
+    val closeStarted = CountDownLatch(1)
+    val closeReturned = CountDownLatch(1)
+
+    val callbackThread = thread {
+      assertTrue(
+        binding.acceptEngineEvent(engine) {
+          callbackEntered.countDown()
+          assertTrue(releaseCallback.await(5, TimeUnit.SECONDS))
+        }
+      )
+    }
+    assertTrue(callbackEntered.await(5, TimeUnit.SECONDS))
+    val closeThread = thread {
+      closeStarted.countDown()
+      binding.close()
+      closeReturned.countDown()
+    }
+
+    assertTrue(closeStarted.await(5, TimeUnit.SECONDS))
+    assertFalse(closeReturned.await(100, TimeUnit.MILLISECONDS))
+    releaseCallback.countDown()
+    callbackThread.join()
+    assertTrue(closeReturned.await(5, TimeUnit.SECONDS))
+    closeThread.join()
+    binding.awaitClosed()
+    state.close()
+    state.awaitClosed()
+    runtime.close()
+  }
+
+  @Test
+  fun a_late_platform_style_write_replays_the_latest_durable_style() {
+    val runtime = mapRuntimeForTest()
+    val state = runtime.createMapState()
+    val firstStyle = BaseStyle.Json("first")
+    val secondStyle = BaseStyle.Json("second")
+    val adapter = BlockingStyleAdapter(firstStyle)
+    val token = state.reservePresentation()
+    state.publishPresentation(token, adapter)
+
+    val firstThread = thread { state.setBaseStyle(firstStyle) }
+    assertTrue(adapter.firstWriteEntered.await(5, TimeUnit.SECONDS))
+    val secondStarted = CountDownLatch(1)
+    val secondFinished = CountDownLatch(1)
+    val secondThread = thread {
+      secondStarted.countDown()
+      state.setBaseStyle(secondStyle)
+      secondFinished.countDown()
+    }
+
+    assertTrue(secondStarted.await(5, TimeUnit.SECONDS))
+    assertTrue(secondFinished.await(5, TimeUnit.SECONDS))
+    assertEquals(secondStyle, state.style.baseStyle)
+    adapter.releaseFirstWrite.countDown()
+    firstThread.join()
+    secondThread.join()
+
+    assertEquals(secondStyle, state.style.baseStyle)
+    assertEquals(secondStyle, adapter.lastStyle)
+    state.close()
+    runtime.close()
+  }
+
+  @Test
+  fun presentation_configuration_replays_a_newer_style_after_a_late_initial_write() {
+    val runtime = mapRuntimeForTest()
+    val state = runtime.createMapState()
+    val adapter = BlockingStyleAdapter(BaseStyle.Demo)
+    val token = state.reservePresentation()
+    val publicationFinished = CountDownLatch(1)
+    val publicationThread = thread {
+      state.publishPresentation(token, adapter)
+      publicationFinished.countDown()
+    }
+    assertTrue(adapter.firstWriteEntered.await(5, TimeUnit.SECONDS))
+    val latest = BaseStyle.Json("latest")
+
+    state.setBaseStyle(latest)
+    adapter.releaseFirstWrite.countDown()
+    assertTrue(publicationFinished.await(5, TimeUnit.SECONDS))
+    publicationThread.join()
+
+    assertEquals(latest, state.style.baseStyle)
+    assertEquals(latest, adapter.lastStyle)
+    state.close()
+    runtime.close()
+  }
+
+  @Test
+  fun departed_presentation_configuration_cannot_write_its_style() {
+    val runtime = mapRuntimeForTest()
+    val state = runtime.createMapState()
+    val owner = MapPresentationOwnerToken()
+    val first = BlockingConfigurationAdapter()
+    val firstToken = state.reservePresentation(owner)
+    val firstPublicationFinished = CountDownLatch(1)
+    val firstPublicationThread = thread {
+      state.publishPresentation(firstToken, first)
+      firstPublicationFinished.countDown()
+    }
+    assertTrue(first.cameraWriteEntered.await(5, TimeUnit.SECONDS))
+    val replacement = PresentationTestAdapter()
+    val replacementToken = state.reservePresentation(owner)
+
+    state.publishPresentation(replacementToken, replacement)
+    first.releaseCameraWrite.countDown()
+    assertTrue(firstPublicationFinished.await(5, TimeUnit.SECONDS))
+    firstPublicationThread.join()
+
+    assertEquals(0, first.styleWrites)
+    assertTrue(state.presentation?.adapter === replacement)
+    state.close()
+    runtime.close()
+  }
+
+  @Test
+  fun a_style_action_cannot_silently_target_the_replacement_style() {
+    val runtime = mapRuntimeForTest()
+    val state = runtime.createMapState()
+    val adapter = PresentationTestAdapter()
+    val token = state.reservePresentation()
+    state.publishPresentation(token, adapter)
+    val firstStyle = RecordingStyleBinding()
+    assertTrue(state.updateLoadedStyle(adapter, firstStyle))
+    assertTrue(state.markStyleReady(adapter))
+    val actionEntered = CountDownLatch(1)
+    val releaseAction = CountDownLatch(1)
+    val actionFailure = AtomicReference<Throwable?>()
+    val actionThread = thread {
+      actionFailure.set(
+        runCatching {
+          state.runStyleHandleOperation(firstStyle) {
+            actionEntered.countDown()
+            assertTrue(releaseAction.await(5, TimeUnit.SECONDS))
+            firstStyle.addSource("old-only", JsonObject(emptyMap()))
+          }
+        }
+          .exceptionOrNull()
+      )
+    }
+    assertTrue(actionEntered.await(5, TimeUnit.SECONDS))
+    val replacement = RecordingStyleBinding()
+
+    state.setBaseStyle(BaseStyle.Json("replacement"))
+    assertTrue(state.updateLoadedStyle(adapter, replacement))
+    assertTrue(state.markStyleReady(adapter))
+    releaseAction.countDown()
+    actionThread.join()
+
+    assertTrue(actionFailure.get() is IllegalStateException)
+    assertTrue(firstStyle.sourceExists("old-only"))
+    assertFalse(replacement.sourceExists("old-only"))
+    state.close()
+    runtime.close()
+  }
+}
+
+private class BlockingStyleAdapter(private val blockedStyle: BaseStyle) :
+  PresentationTestAdapter() {
+  val firstWriteEntered = CountDownLatch(1)
+  val releaseFirstWrite = CountDownLatch(1)
+  var lastStyle: BaseStyle? = null
+
+  override fun setBaseStyle(style: BaseStyle) {
+    if (style == blockedStyle) {
+      firstWriteEntered.countDown()
+      assertTrue(releaseFirstWrite.await(5, TimeUnit.SECONDS))
+    }
+    lastStyle = style
+  }
+}
+
+private class BlockingConfigurationAdapter : PresentationTestAdapter() {
+  val cameraWriteEntered = CountDownLatch(1)
+  val releaseCameraWrite = CountDownLatch(1)
+  var styleWrites = 0
+
+  override fun setCameraPosition(cameraPosition: org.maplibre.compose.camera.CameraPosition) {
+    cameraWriteEntered.countDown()
+    assertTrue(releaseCameraWrite.await(5, TimeUnit.SECONDS))
+  }
+
+  override fun setBaseStyle(style: BaseStyle) {
+    styleWrites++
+  }
+}
+
+private class CallbackRacePlatformAdapter : MapLifecyclePlatformAdapter {
+  override val engineRetention = EngineRetention.RETAIN
+
+  override suspend fun createEngine(identity: EngineMapIdentity) = Unit
+
+  override suspend fun attach(identity: EngineMapIdentity, lease: RenderLease) = Unit
+
+  override suspend fun detach(identity: EngineMapIdentity, lease: RenderLease) = Unit
+
+  override suspend fun destroyEngine(identity: EngineMapIdentity) = Unit
+
+  override suspend fun closeResources() = Unit
+}

--- a/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MlnFfiMapCompositionTest.kt
+++ b/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MlnFfiMapCompositionTest.kt
@@ -110,6 +110,8 @@ class MlnFfiMapCompositionTest {
     }
 
     assertTrue(state.presentation?.isValid == true)
+    val session = state.presentation?.adapter as MlnFfiMapSession
+    assertEquals(1, session.presentationPublicationCount)
     assertTrue(
       onAllNodesWithTag(MAP_LOAD_PLACEHOLDER_TAG).fetchSemanticsNodes().isEmpty(),
       "the load placeholder should be absent after the base style is ready",

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleAuthority.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleAuthority.kt
@@ -51,6 +51,9 @@ internal interface MapLifecyclePlatformAdapter {
   suspend fun closeResources()
 }
 
+/** A platform map session whose physical lifecycle belongs to a [MapState]. */
+internal interface MapLifecycleSession : MapAdapter, MapLifecyclePlatformAdapter
+
 /** The externally observable logical states of one map lifecycle. */
 internal sealed interface MapLifecycleState {
   data class OpenDetached(val engine: EngineMapIdentity?) : MapLifecycleState
@@ -86,13 +89,297 @@ internal data class PendingAttachment(
   val completion: CompletableDeferred<Result<RenderLease>>,
 )
 
-/**
- * The serialized authority for engine creation, leased presentation attachment, and closure.
- * Platform adapters execute commands but do not decide or mirror the logical state.
- */
+/** Owns every logical and physical lifecycle transition for one [MapState]. */
 internal class MapLifecycleAuthority(
+  private val owner: MapState,
+  private val physicalScope: CoroutineScope,
+) {
+  private val lock = reentrantLock()
+  private val platforms = mutableMapOf<MapLifecycleSession, MapLifecycleBinding>()
+  private val closure = CompletableDeferred<Result<Unit>>()
+  private var attachment: Attachment? = null
+  private var retainedAdapter: MapAdapter? = null
+  private val retiringAdapters = linkedSetOf<MapAdapter>()
+  private val releaseCleanups = linkedSetOf<CompletableDeferred<Result<Unit>>>()
+  private val pendingCleanupFailures = mutableListOf<Throwable>()
+  private var closed = false
+
+  val isClosed: Boolean
+    get() = serialized { closed }
+
+  fun close() {
+    val (maps, releases, recordedFailures) =
+      serialized {
+        if (closed) return
+        closed = true
+        val maps = buildSet {
+          retainedAdapter?.let(::add)
+          attachment?.adapter?.let(::add)
+          addAll(retiringAdapters)
+          addAll(platforms.keys)
+        }
+        val recordedFailures = pendingCleanupFailures.toList()
+        val releases = releaseCleanups.toList()
+        attachment = null
+        retainedAdapter = null
+        retiringAdapters.clear()
+        pendingCleanupFailures.clear()
+        owner.commitClosed()
+        Triple(maps, releases, recordedFailures)
+      }
+    if (maps.isEmpty() && releases.isEmpty()) {
+      val failures = mutableListOf<Throwable>()
+      recordedFailures.forEach { addCleanupFailure(failures, it) }
+      completeClosure(
+        if (failures.isEmpty()) Result.success(Unit)
+        else Result.failure(MapStateCleanupException(failures))
+      )
+      return
+    }
+    maps.forEach(MapAdapter::close)
+    physicalScope.launch(start = CoroutineStart.UNDISPATCHED) {
+      val failures = mutableListOf<Throwable>()
+      recordedFailures.forEach { addCleanupFailure(failures, it) }
+      releases.forEach { release ->
+        release.await().exceptionOrNull()?.let { addCleanupFailure(failures, it) }
+      }
+      maps.forEach { map ->
+        runCatching { map.awaitClosed() }.exceptionOrNull()?.let { addCleanupFailure(failures, it) }
+      }
+      completeClosure(
+        if (failures.isEmpty()) Result.success(Unit)
+        else Result.failure(MapStateCleanupException(failures))
+      )
+    }
+  }
+
+  suspend fun awaitClosed() {
+    closure.await().getOrThrow()
+  }
+
+  fun reservePresentation(ownerToken: MapPresentationOwnerToken): MapPresentationToken {
+    var replaced: MapAdapter? = null
+    val token = serialized {
+      requireOpen()
+      val current = attachment
+      check(current == null || current.releasing || current.owner === ownerToken) {
+        "The map state already has a presentation"
+      }
+      replaced = current?.adapter?.takeUnless { current.releasing }
+      if (replaced != null) owner.invalidatePresentation(replaced)
+      val token = MapPresentationToken(nextPresentationToken.incrementAndFetch())
+      attachment = Attachment(ownerToken, token)
+      token
+    }
+    replaced?.let { adapter ->
+      physicalScope.launch(start = CoroutineStart.UNDISPATCHED) {
+        runCatching { adapter.detachPresentation() }
+      }
+    }
+    return token
+  }
+
+  fun publishPresentation(
+    token: MapPresentationToken,
+    adapter: MapAdapter,
+    options: MapPresentationOptions,
+  ) {
+    val preparation = serialized {
+      if (closed) return
+      requireOpen()
+      val current = attachment
+      check(current?.token == token && !current.releasing) {
+        "The map presentation reservation is no longer current"
+      }
+      if (current.adapter === adapter) {
+        owner.presentation?.updateOptions(options)
+        return
+      }
+      check(current.adapter == null) { "The map state already has a presentation" }
+      current.adapter = adapter
+      val reusesRetainedAdapter = retainedAdapter === adapter
+      val replaced = retainedAdapter?.takeUnless { retained ->
+        retained === adapter || !adapter.retainsEngineBetweenPresentations
+      }
+      PresentationPreparation(reusesRetainedAdapter, replaced)
+    }
+    try {
+      owner.configurePresentationAdapter(adapter)
+    } catch (error: Throwable) {
+      serialized {
+        if (attachment?.token == token && attachment?.adapter === adapter) {
+          attachment?.adapter = null
+        }
+      }
+      throw error
+    }
+    val replaced = serialized {
+      val current = attachment
+      if (closed || current?.token != token || current.releasing || current.adapter !== adapter) {
+        return
+      }
+      if (adapter.retainsEngineBetweenPresentations) retainedAdapter = adapter
+      preparation.replaced?.let(retiringAdapters::add)
+      owner.commitPresentation(
+        token = token,
+        adapter = adapter,
+        options = options,
+        reusesRetainedAdapter = preparation.reusesRetainedAdapter,
+      )
+      preparation.replaced
+    }
+    if (replaced != null) {
+      replaced.close()
+      physicalScope.launch {
+        val failure = runCatching { replaced.awaitClosed() }.exceptionOrNull()
+        serialized {
+          retiringAdapters.remove(replaced)
+          if (failure != null && !closed) pendingCleanupFailures += failure
+        }
+      }
+    }
+  }
+
+  fun releasePresentation(token: MapPresentationToken, adapter: MapAdapter?) {
+    val release = serialized {
+      val current = attachment ?: return
+      if (current.token != token) return
+      if (adapter != null && current.adapter !== adapter) return
+      if (current.releasing) return
+      current.releasing = true
+      owner.invalidatePresentation(current.adapter)
+      current.adapter?.let { closingAdapter ->
+        ReleaseCleanup(
+          closingAdapter,
+          CompletableDeferred<Result<Unit>>().also(releaseCleanups::add),
+        )
+      }
+    }
+    if (release == null) {
+      serialized { if (attachment?.token == token) attachment = null }
+      return
+    }
+    physicalScope.launch(start = CoroutineStart.UNDISPATCHED) {
+      val result = runCatching { release.adapter.detachPresentation() }
+      serialized {
+        releaseCleanups.remove(release.completion)
+        if (!closed) result.exceptionOrNull()?.let(pendingCleanupFailures::add)
+        if (attachment?.token == token) attachment = null
+      }
+      release.completion.complete(result)
+    }
+  }
+
+  fun retainedAdapter(compatibilityKey: Any): MapAdapter? = serialized {
+    retainedAdapter?.takeIf { adapter ->
+      adapter.retainsEngineBetweenPresentations &&
+        adapter.presentationCompatibilityKey == compatibilityKey
+    }
+  }
+
+  fun acceptsAdapter(adapter: MapAdapter): Boolean = serialized {
+    !closed &&
+      (attachment?.adapter === adapter ||
+        retainedAdapter === adapter ||
+        (adapter is MapLifecycleSession && platforms.containsKey(adapter)))
+  }
+
+  fun acceptsPresentation(adapter: MapAdapter): Boolean = serialized {
+    !closed && attachment?.adapter === adapter && owner.presentation?.adapter === adapter
+  }
+
+  fun currentAdapter(): MapAdapter? = serialized { attachment?.adapter ?: retainedAdapter }
+
+  fun isCurrent(token: MapPresentationToken, adapter: MapAdapter): Boolean = serialized {
+    !closed && attachment?.token == token && attachment?.adapter === adapter
+  }
+
+  fun bind(adapter: MapLifecyclePlatformAdapter): MapLifecycleBinding {
+    val session = adapter as? MapLifecycleSession
+    val lifecycle = lock.withLock {
+      session?.let(platforms::get)?.let {
+        return it
+      }
+      MapLifecycleBinding(adapter, physicalScope) { binding ->
+          if (session != null) retireClosingSession(session, binding)
+        }
+        .also { binding ->
+          if (closed) binding.close() else if (session != null) platforms[session] = binding
+        }
+    }
+    if (session != null) {
+      physicalScope.launch(start = CoroutineStart.UNDISPATCHED) {
+        val failure = runCatching { lifecycle.awaitClosed() }.exceptionOrNull()
+        serialized {
+          if (platforms[session] === lifecycle) platforms.remove(session)
+          retiringAdapters.remove(session)
+          if (failure != null && !closed) pendingCleanupFailures += failure
+        }
+      }
+    }
+    return lifecycle
+  }
+
+  private fun retireClosingSession(
+    session: MapLifecycleSession,
+    binding: MapLifecycleBinding,
+  ) {
+    serialized {
+      if (platforms[session] === binding) platforms.remove(session)
+      val wasAttached = attachment?.adapter === session
+      val wasRetained = retainedAdapter === session
+      if (wasAttached || wasRetained) owner.invalidateClosedAdapter(session)
+      if (wasAttached) attachment = null
+      if (wasRetained) retainedAdapter = null
+      retiringAdapters += session
+    }
+  }
+
+  inline fun <T> serialized(action: () -> T): T = lock.withLock(action)
+
+  private fun requireOpen() {
+    if (closed) throw MapStateClosedException()
+  }
+
+  private fun completeClosure(result: Result<Unit>) {
+    if (closure.complete(result)) owner.runtime.childClosed(owner)
+  }
+
+  private fun addCleanupFailure(failures: MutableList<Throwable>, failure: Throwable) {
+    if (failure is MapLifecycleCleanupException) {
+      failure.failures.forEach { addCleanupFailure(failures, it) }
+    } else if (failures.none { it === failure }) {
+      failures += failure
+    }
+  }
+
+  private class Attachment(
+    val owner: MapPresentationOwnerToken,
+    val token: MapPresentationToken,
+    var adapter: MapAdapter? = null,
+    var releasing: Boolean = false,
+  )
+
+  private data class PresentationPreparation(
+    val reusesRetainedAdapter: Boolean,
+    val replaced: MapAdapter?,
+  )
+
+  private data class ReleaseCleanup(
+    val adapter: MapAdapter,
+    val completion: CompletableDeferred<Result<Unit>>,
+  )
+
+  private companion object {
+    val nextPresentationToken = AtomicLong(0L)
+  }
+}
+
+/** An authority-owned binding from engine and render-lease transitions to platform commands. */
+internal class MapLifecycleBinding(
   private val adapter: MapLifecyclePlatformAdapter,
   private val physicalScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
+  private val onClosing: (MapLifecycleBinding) -> Unit = {},
 ) {
   private val nextIdentity = AtomicLong(0L)
   private val current = AtomicReference<InternalState>(InternalState.OpenDetached(null))
@@ -302,6 +589,7 @@ internal class MapLifecycleAuthority(
         current.store(closing)
         closing
       } ?: return
+    onClosing(this)
     physicalScope.launch(start = CoroutineStart.UNDISPATCHED) { performClose(closing) }
   }
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleCallbacks.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleCallbacks.kt
@@ -7,7 +7,7 @@ import org.maplibre.spatialk.geojson.Position
 
 /** Filters platform callbacks through identities captured by their platform producer. */
 internal class MapLifecycleCallbacks(
-  private val lifecycle: MapLifecycleAuthority,
+  private val lifecycle: MapLifecycleBinding,
   private val delegate: () -> MapAdapter.Callbacks,
 ) {
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
@@ -17,10 +17,8 @@ import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.DpRect
 import androidx.compose.ui.unit.dp
 import co.touchlab.kermit.Logger
-import kotlin.concurrent.atomics.AtomicLong
 import kotlin.concurrent.atomics.AtomicReference
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
-import kotlin.concurrent.atomics.incrementAndFetch
 import kotlin.jvm.JvmInline
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
@@ -389,13 +387,9 @@ internal constructor(
   initialCameraPosition: CameraPosition,
   initialBaseStyle: BaseStyle,
 ) {
-  private val lock = reentrantLock()
-  private val closure = CompletableDeferred<Result<Unit>>()
-  private var attachment: Attachment? = null
-  private var retainedAdapter: MapAdapter? = null
-  private val retiringAdapters = linkedSetOf<MapAdapter>()
-  private val pendingCleanupFailures = mutableListOf<Throwable>()
-  private var closed = false
+  internal val lifecycle = MapLifecycleAuthority(this, runtime.physicalScope)
+  private var baseStyleCommandRevision = 0L
+  private var cameraCommandRevision = 0L
   private var styleHandleEpoch = 0L
   private var closedState: Boolean by mutableStateOf(false)
   private var cameraPositionState: CameraPosition by
@@ -409,207 +403,71 @@ internal constructor(
     get() = cameraPositionState
 
   public var presentation: MapPresentation? by mutableStateOf(null)
-    private set
+    internal set
 
   public val isClosed: Boolean
     get() = closedState
 
   /** Marks this state as closed and starts cleanup of the current presentation. */
-  public fun close() {
-    val (maps, recordedFailures) =
-      lock.withLock {
-        if (closed) return
-        closed = true
-        val maps = buildSet {
-          retainedAdapter?.let(::add)
-          attachment?.adapter?.let(::add)
-          addAll(retiringAdapters)
-        }
-        val recordedFailures = pendingCleanupFailures.toList()
-        attachment = null
-        retainedAdapter = null
-        retiringAdapters.clear()
-        pendingCleanupFailures.clear()
-        styleHandleEpoch++
-        style.invalidateLoadedStyle()
-        Snapshot.withMutableSnapshot {
-          closedState = true
-          presentation?.invalidate()
-          presentation = null
-        }
-        maps to recordedFailures
-      }
-    if (maps.isEmpty()) {
-      completeClosure(
-        if (recordedFailures.isEmpty()) Result.success(Unit)
-        else Result.failure(MapStateCleanupException(recordedFailures))
-      )
-      return
-    }
-    maps.forEach(MapAdapter::close)
-    runtime.physicalScope.launch(start = CoroutineStart.UNDISPATCHED) {
-      val failures = recordedFailures.toMutableList()
-      maps.forEach { map ->
-        runCatching { map.awaitClosed() }.exceptionOrNull()?.let(failures::add)
-      }
-      completeClosure(
-        if (failures.isEmpty()) Result.success(Unit)
-        else Result.failure(MapStateCleanupException(failures))
-      )
-    }
-  }
+  public fun close(): Unit = lifecycle.close()
 
   /** Waits until presentation cleanup has completed. */
-  public suspend fun awaitClosed() {
-    closure.await().getOrThrow()
-  }
+  public suspend fun awaitClosed(): Unit = lifecycle.awaitClosed()
 
   internal fun reservePresentation(
     owner: MapPresentationOwnerToken = MapPresentationOwnerToken()
-  ): MapPresentationToken {
-    var replaced: MapAdapter? = null
-    val token = lock.withLock {
-      requireOpenLocked()
-      val current = attachment
-      check(current == null || current.owner === owner) {
-        "The map state already has a presentation"
-      }
-      replaced = current?.adapter
-      if (replaced != null) {
-        presentation?.invalidate()
-        presentation = null
-        if (!replaced.retainsEngineBetweenPresentations) {
-          style.loadState = StyleLoadState.Pending
-        }
-      }
-      val token = MapPresentationToken(nextPresentationToken.incrementAndFetch())
-      attachment = Attachment(owner, token)
-      token
-    }
-    replaced?.let { adapter ->
-      runtime.physicalScope.launch(start = CoroutineStart.UNDISPATCHED) {
-        runCatching { adapter.detachPresentation() }
-      }
-    }
-    return token
-  }
+  ): MapPresentationToken = lifecycle.reservePresentation(owner)
 
   internal fun publishPresentation(
     token: MapPresentationToken,
     adapter: MapAdapter,
     options: MapPresentationOptions = MapPresentationOptions(),
-  ) {
-    val replaced = lock.withLock {
-      if (closed) return
-      requireOpenLocked()
-      val current = attachment
-      check(current?.token == token && !current.releasing) {
-        "The map presentation reservation is no longer current"
-      }
-      if (current.adapter === adapter) {
-        presentation?.updateOptions(options)
-        return
-      }
-      check(current.adapter == null) { "The map state already has a presentation" }
-      current.adapter = adapter
-      val reusesRetainedAdapter = retainedAdapter === adapter
-      val replaced = retainedAdapter?.takeUnless { retained ->
-        retained === adapter || !adapter.retainsEngineBetweenPresentations
-      }
-      if (adapter.retainsEngineBetweenPresentations) retainedAdapter = adapter
-      if (replaced != null) retiringAdapters += replaced
-      adapter.setCameraPosition(cameraPositionState)
-      if (!reusesRetainedAdapter) {
-        styleHandleEpoch++
-        style.invalidateLoadedStyle()
-      }
-      adapter.setBaseStyle(style.baseStyle)
-      if (!reusesRetainedAdapter) style.loadState = StyleLoadState.Loading
-      MapPresentation(this, token, adapter, options).also { presentation = it }
-      replaced
-    }
-    if (replaced != null) {
-      replaced.close()
-      runtime.physicalScope.launch {
-        val failure = runCatching { replaced.awaitClosed() }.exceptionOrNull()
-        lock.withLock {
-          retiringAdapters.remove(replaced)
-          if (failure != null && !closed) pendingCleanupFailures += failure
-        }
-      }
-    }
-  }
+  ) = lifecycle.publishPresentation(token, adapter, options)
 
-  internal fun releasePresentation(token: MapPresentationToken, adapter: MapAdapter? = null) {
-    val closingAdapter = lock.withLock {
-      val current = attachment ?: return
-      if (current.token != token) return
-      if (adapter != null && current.adapter !== adapter) return
-      if (current.releasing) return
-      current.releasing = true
-      presentation?.invalidate()
-      presentation = null
-      if (current.adapter?.retainsEngineBetweenPresentations != true) {
-        style.loadState = StyleLoadState.Pending
-      }
-      current.adapter
-    }
-    if (closingAdapter == null) {
-      lock.withLock { if (attachment?.token == token) attachment = null }
-      return
-    }
-    runtime.physicalScope.launch(start = CoroutineStart.UNDISPATCHED) {
-      runCatching { closingAdapter.detachPresentation() }
-      lock.withLock { if (attachment?.token == token) attachment = null }
-    }
-  }
+  internal fun releasePresentation(token: MapPresentationToken, adapter: MapAdapter? = null) =
+    lifecycle.releasePresentation(token, adapter)
 
-  internal fun retainedAdapter(compatibilityKey: Any): MapAdapter? = lock.withLock {
-    retainedAdapter?.takeIf { adapter ->
-      adapter.retainsEngineBetweenPresentations &&
-        adapter.presentationCompatibilityKey == compatibilityKey
-    }
-  }
+  internal fun retainedAdapter(compatibilityKey: Any): MapAdapter? =
+    lifecycle.retainedAdapter(compatibilityKey)
 
   internal fun durableStyleCallbacks(): MapAdapter.Callbacks = DurableStyleCallbacks(this)
 
-  internal fun markStyleReady(adapter: MapAdapter): Boolean = lock.withLock {
-    if (closed || (attachment?.adapter !== adapter && retainedAdapter !== adapter)) return false
+  internal fun markStyleReady(adapter: MapAdapter): Boolean = lifecycle.serialized {
+    if (!lifecycle.acceptsAdapter(adapter)) return false
     style.loadState = StyleLoadState.Ready
     style.refreshSources()
     true
   }
 
-  internal fun acceptsPresentationEvent(adapter: MapAdapter): Boolean = lock.withLock {
-    !closed && attachment?.adapter === adapter && presentation?.adapter === adapter
-  }
+  internal fun acceptsPresentationEvent(adapter: MapAdapter): Boolean =
+    lifecycle.acceptsPresentation(adapter)
 
   internal fun refreshStyleSources(adapter: MapAdapter, sourceId: String?): Boolean =
-    lock.withLock {
-      if (closed || (attachment?.adapter !== adapter && retainedAdapter !== adapter)) return false
+    lifecycle.serialized {
+      if (!lifecycle.acceptsAdapter(adapter)) return false
       if (sourceId == null) style.refreshSources() else style.refreshSource(sourceId)
       true
     }
 
   internal fun updateLoadedStyle(adapter: MapAdapter, loadedStyle: StyleBinding?): Boolean =
-    lock.withLock {
-      if (closed || (attachment?.adapter !== adapter && retainedAdapter !== adapter)) return false
+    lifecycle.serialized {
+      if (!lifecycle.acceptsAdapter(adapter)) return false
       styleHandleEpoch++
       style.updateLoadedStyle(loadedStyle)
       true
     }
 
   internal fun markStyleFailed(adapter: MapAdapter, reason: String?) {
-    lock.withLock {
-      if (!closed && (attachment?.adapter === adapter || retainedAdapter === adapter)) {
+    lifecycle.serialized {
+      if (lifecycle.acceptsAdapter(adapter)) {
         style.loadState = StyleLoadState.Failed(reason)
       }
     }
   }
 
   internal fun beginStyleRevision(adapter: MapAdapter, revision: DesiredStyleRevision) {
-    lock.withLock {
-      if (!closed && (attachment?.adapter === adapter || retainedAdapter === adapter)) {
+    lifecycle.serialized {
+      if (lifecycle.acceptsAdapter(adapter)) {
         styleHandleEpoch++
         desiredStyleRevision = revision
         style.loadState = StyleLoadState.Loading
@@ -618,38 +476,42 @@ internal constructor(
   }
 
   internal fun setBaseStyle(value: BaseStyle) {
-    lock.withLock {
+    val command = lifecycle.serialized {
       requireOpenLocked()
       if (style.baseStyle == value) return
       styleHandleEpoch++
       style.setBaseStyleState(value)
       style.invalidateLoadedStyle()
-      val adapter = attachment?.adapter ?: retainedAdapter
+      val adapter = lifecycle.currentAdapter()
       if (adapter == null) {
         style.loadState = StyleLoadState.Pending
+        baseStyleCommandRevision++
+        return
       } else {
         style.loadState = StyleLoadState.Loading
-        adapter.setBaseStyle(value)
       }
+      BaseStyleCommand(adapter, value, ++baseStyleCommandRevision)
     }
+    applyBaseStyleCommand(command)
   }
 
   internal fun desiredSourceDefinition(id: String) =
     desiredStyleRevision.sources.firstOrNull { it.id == id }
 
-  internal fun <T> runStyleHandleOperation(binding: StyleBinding, action: () -> T): T =
-    lock.withLock {
-      requireStyleHandleLocked(binding)
-      action()
-    }
+  internal fun <T> runStyleHandleOperation(binding: StyleBinding, action: () -> T): T {
+    lifecycle.serialized { requireStyleHandleLocked(binding) }
+    val result = action()
+    lifecycle.serialized { requireStyleHandleLocked(binding) }
+    return result
+  }
 
-  internal fun styleHandleCheckpoint(binding: StyleBinding): Long = lock.withLock {
+  internal fun styleHandleCheckpoint(binding: StyleBinding): Long = lifecycle.serialized {
     requireStyleHandleLocked(binding)
     styleHandleEpoch
   }
 
   internal fun requireStyleHandleUnchanged(binding: StyleBinding, checkpoint: Long) {
-    lock.withLock {
+    lifecycle.serialized {
       requireStyleHandleLocked(binding)
       check(styleHandleEpoch == checkpoint) {
         "Style operation crossed a loaded-style resource change"
@@ -665,54 +527,150 @@ internal constructor(
   }
 
   internal fun setCameraPosition(candidate: MapPresentation, position: CameraPosition) {
-    withCurrent(candidate) {
-      candidate.adapter.setCameraPosition(position)
+    lifecycle.serialized { requireCurrentLocked(candidate) }
+    candidate.adapter.setCameraPosition(position)
+    lifecycle.serialized {
+      requireCurrentLocked(candidate)
       cameraPositionState = position
+      cameraCommandRevision++
     }
   }
 
-  internal fun synchronizeCamera(adapter: MapAdapter): MapPresentation? = lock.withLock {
-    if (closed || attachment?.adapter !== adapter) return null
-    cameraPositionState = adapter.getCameraPosition()
-    val current = presentation ?: return null
+  internal fun synchronizeCamera(adapter: MapAdapter): MapPresentation? {
+    if (!lifecycle.acceptsPresentation(adapter)) return null
+    val cameraPosition = adapter.getCameraPosition()
     val viewport = adapter.getViewport() ?: return null
-    current.cameraMoved(viewport)
-    current
+    return lifecycle.serialized {
+      if (!lifecycle.acceptsPresentation(adapter)) return@serialized null
+      cameraPositionState = cameraPosition
+      val current = presentation ?: return@serialized null
+      current.cameraMoved(viewport)
+      current
+    }
   }
 
   internal fun requireCurrent(candidate: MapPresentation) {
-    lock.withLock { requireCurrentLocked(candidate) }
+    lifecycle.serialized { requireCurrentLocked(candidate) }
   }
 
-  internal fun <T> withCurrent(candidate: MapPresentation, block: () -> T): T = lock.withLock {
-    requireCurrentLocked(candidate)
-    block()
+  internal fun <T> withCurrent(candidate: MapPresentation, block: () -> T): T {
+    lifecycle.serialized { requireCurrentLocked(candidate) }
+    val result = block()
+    lifecycle.serialized { requireCurrentLocked(candidate) }
+    return result
   }
 
   private fun requireCurrentLocked(candidate: MapPresentation) {
-    if (closed || presentation !== candidate || attachment?.token != candidate.token) {
+    if (presentation !== candidate || !lifecycle.isCurrent(candidate.token, candidate.adapter)) {
       throw MapPresentationDetachedException()
     }
   }
 
   private fun requireOpenLocked() {
-    if (closed) throw MapStateClosedException()
+    if (lifecycle.isClosed) throw MapStateClosedException()
   }
 
-  private fun completeClosure(result: Result<Unit>) {
-    if (closure.complete(result)) runtime.childClosed(this)
+  internal fun commitClosed() {
+    styleHandleEpoch++
+    style.invalidateLoadedStyle()
+    Snapshot.withMutableSnapshot {
+      closedState = true
+      presentation?.invalidate()
+      presentation = null
+    }
   }
 
-  private class Attachment(
-    val owner: MapPresentationOwnerToken,
-    val token: MapPresentationToken,
-    var adapter: MapAdapter? = null,
-    var releasing: Boolean = false,
+  internal fun invalidatePresentation(adapter: MapAdapter?) {
+    Snapshot.withMutableSnapshot {
+      presentation?.invalidate()
+      presentation = null
+      if (adapter?.retainsEngineBetweenPresentations != true) {
+        style.loadState = StyleLoadState.Pending
+      }
+    }
+  }
+
+  internal fun invalidateClosedAdapter(adapter: MapAdapter) {
+    Snapshot.withMutableSnapshot {
+      styleHandleEpoch++
+      style.invalidateLoadedStyle()
+      style.loadState = StyleLoadState.Pending
+      if (presentation?.adapter === adapter) {
+        presentation?.invalidate()
+        presentation = null
+      }
+    }
+  }
+
+  internal fun configurePresentationAdapter(adapter: MapAdapter) {
+    val configuration = lifecycle.serialized {
+      if (!lifecycle.acceptsAdapter(adapter)) return
+      PresentationConfiguration(
+        camera = CameraCommand(adapter, cameraPositionState, cameraCommandRevision),
+        baseStyle = BaseStyleCommand(adapter, style.baseStyle, baseStyleCommandRevision),
+      )
+    }
+    applyCameraCommand(configuration.camera)
+    if (!lifecycle.acceptsAdapter(adapter)) return
+    applyBaseStyleCommand(configuration.baseStyle)
+  }
+
+  private fun applyBaseStyleCommand(initial: BaseStyleCommand) {
+    var command = initial
+    while (true) {
+      if (lifecycle.currentAdapter() !== command.adapter) return
+      command.adapter.setBaseStyle(command.value)
+      command = lifecycle.serialized {
+        if (lifecycle.currentAdapter() !== command.adapter) return
+        if (baseStyleCommandRevision == command.revision) return
+        BaseStyleCommand(command.adapter, style.baseStyle, baseStyleCommandRevision)
+      }
+    }
+  }
+
+  private fun applyCameraCommand(initial: CameraCommand) {
+    var command = initial
+    while (true) {
+      if (lifecycle.currentAdapter() !== command.adapter) return
+      command.adapter.setCameraPosition(command.value)
+      command = lifecycle.serialized {
+        if (lifecycle.currentAdapter() !== command.adapter) return
+        if (cameraCommandRevision == command.revision) return
+        CameraCommand(command.adapter, cameraPositionState, cameraCommandRevision)
+      }
+    }
+  }
+
+  internal fun commitPresentation(
+    token: MapPresentationToken,
+    adapter: MapAdapter,
+    options: MapPresentationOptions,
+    reusesRetainedAdapter: Boolean,
+  ) {
+    if (!reusesRetainedAdapter) {
+      styleHandleEpoch++
+      style.invalidateLoadedStyle()
+    }
+    if (!reusesRetainedAdapter) style.loadState = StyleLoadState.Loading
+    presentation = MapPresentation(this, token, adapter, options)
+  }
+
+  private data class PresentationConfiguration(
+    val camera: CameraCommand,
+    val baseStyle: BaseStyleCommand,
   )
 
-  private companion object {
-    val nextPresentationToken = AtomicLong(0L)
-  }
+  private data class CameraCommand(
+    val adapter: MapAdapter,
+    val value: CameraPosition,
+    val revision: Long,
+  )
+
+  private data class BaseStyleCommand(
+    val adapter: MapAdapter,
+    val value: BaseStyle,
+    val revision: Long,
+  )
 }
 
 internal class MapStateCleanupException(failures: List<Throwable>) :
@@ -860,9 +818,13 @@ internal class MapRuntimeCleanupException(failures: List<Throwable>) :
   }
 }
 
-internal fun mapRuntimeForTest(closeResources: suspend () -> Unit = {}): MapRuntime =
+internal fun mapRuntimeForTest(
+  physicalScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
+  closeResources: suspend () -> Unit = {},
+): MapRuntime =
   RuntimeImplementation(
     platformOptions = null,
     resources = MapRuntimeResources(closeResources),
     logger = null,
+    physicalScope = physicalScope,
   )

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapLifecycleBindingTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapLifecycleBindingTest.kt
@@ -9,16 +9,20 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class MapLifecycleAuthorityTest {
+class MapLifecycleBindingTest {
+
+  private fun TestScope.bindLifecycle(adapter: MapLifecyclePlatformAdapter): MapLifecycleBinding =
+    mapRuntimeForTest(physicalScope = backgroundScope).createMapState().lifecycle.bind(adapter)
 
   @Test
   fun a_map_attaches_with_an_engine_identity_and_render_lease() = runTest {
     val adapter = FakeMapLifecycleAdapter()
-    val lifecycle = MapLifecycleAuthority(adapter, backgroundScope)
+    val lifecycle = bindLifecycle(adapter)
 
     assertEquals(MapLifecycleState.OpenDetached(null), lifecycle.state)
 
@@ -32,7 +36,7 @@ class MapLifecycleAuthorityTest {
   @Test
   fun a_rival_attachment_fails_without_waiting_or_changing_platform_state() = runTest {
     val adapter = FakeMapLifecycleAdapter().apply { allowAttach = CompletableDeferred() }
-    val lifecycle = MapLifecycleAuthority(adapter, backgroundScope)
+    val lifecycle = bindLifecycle(adapter)
     val first = async { lifecycle.attach() }
     adapter.attachStarted.await()
 
@@ -47,7 +51,7 @@ class MapLifecycleAuthorityTest {
   @Test
   fun detaching_invalidates_the_lease_before_retained_engine_cleanup_finishes() = runTest {
     val adapter = FakeMapLifecycleAdapter()
-    val lifecycle = MapLifecycleAuthority(adapter, backgroundScope)
+    val lifecycle = bindLifecycle(adapter)
     val lease = lifecycle.attach()
     val engine = checkNotNull(lifecycle.engineIdentity)
     adapter.allowDetach = CompletableDeferred()
@@ -67,7 +71,7 @@ class MapLifecycleAuthorityTest {
   @Test
   fun attach_failure_cleans_partial_resources_and_returns_to_open_detached() = runTest {
     val adapter = FakeMapLifecycleAdapter().apply { attachFailure = TestFailure("attach") }
-    val lifecycle = MapLifecycleAuthority(adapter, backgroundScope)
+    val lifecycle = bindLifecycle(adapter)
 
     assertFailsWith<TestFailure> { lifecycle.attach() }
 
@@ -90,7 +94,7 @@ class MapLifecycleAuthorityTest {
         retention = EngineRetention.DESTROY
         attachFailure = TestFailure("attach")
       }
-    val lifecycle = MapLifecycleAuthority(adapter, backgroundScope)
+    val lifecycle = bindLifecycle(adapter)
 
     assertFailsWith<TestFailure> { lifecycle.attach() }
 
@@ -101,7 +105,7 @@ class MapLifecycleAuthorityTest {
   @Test
   fun detach_during_attach_invalidates_the_lease_and_cleans_the_partial_attachment() = runTest {
     val adapter = FakeMapLifecycleAdapter().apply { allowAttach = CompletableDeferred() }
-    val lifecycle = MapLifecycleAuthority(adapter, backgroundScope)
+    val lifecycle = bindLifecycle(adapter)
     val attaching = async { runCatching { lifecycle.attach() } }
     adapter.attachStarted.await()
     val state = lifecycle.state as MapLifecycleState.Attaching
@@ -120,7 +124,7 @@ class MapLifecycleAuthorityTest {
   @Test
   fun close_commits_immediately_and_repeated_callers_join_one_cleanup() = runTest {
     val adapter = FakeMapLifecycleAdapter().apply { allowDetach = CompletableDeferred() }
-    val lifecycle = MapLifecycleAuthority(adapter, backgroundScope)
+    val lifecycle = bindLifecycle(adapter)
     val lease = lifecycle.attach()
     val engine = checkNotNull(lifecycle.engineIdentity)
     val style = lifecycle.claimStyle(engine)
@@ -151,7 +155,7 @@ class MapLifecycleAuthorityTest {
         destroyFailure = TestFailure("engine")
         resourcesFailure = TestFailure("resources")
       }
-    val lifecycle = MapLifecycleAuthority(adapter, backgroundScope)
+    val lifecycle = bindLifecycle(adapter)
     lifecycle.attach()
 
     lifecycle.close()
@@ -164,7 +168,7 @@ class MapLifecycleAuthorityTest {
   @Test
   fun cancelling_an_attach_caller_invalidates_the_lease_but_physical_cleanup_continues() = runTest {
     val adapter = FakeMapLifecycleAdapter().apply { allowAttach = CompletableDeferred() }
-    val lifecycle = MapLifecycleAuthority(adapter, backgroundScope)
+    val lifecycle = bindLifecycle(adapter)
     val caller = async { lifecycle.attach() }
     adapter.attachStarted.await()
     val attaching = lifecycle.state as MapLifecycleState.Attaching
@@ -180,7 +184,7 @@ class MapLifecycleAuthorityTest {
   @Test
   fun durable_engine_and_current_style_events_are_accepted_while_native_is_detached() = runTest {
     val adapter = FakeMapLifecycleAdapter()
-    val lifecycle = MapLifecycleAuthority(adapter, backgroundScope)
+    val lifecycle = bindLifecycle(adapter)
     val lease = lifecycle.attach()
     val engine = checkNotNull(lifecycle.engineIdentity)
     val firstStyle = lifecycle.claimStyle(engine)
@@ -201,7 +205,7 @@ class MapLifecycleAuthorityTest {
   @Test
   fun the_fake_rejects_a_superseded_style_request_identity() = runTest {
     val adapter = FakeMapLifecycleAdapter()
-    val lifecycle = MapLifecycleAuthority(adapter, backgroundScope)
+    val lifecycle = bindLifecycle(adapter)
     lifecycle.attach()
     val engine = checkNotNull(lifecycle.engineIdentity)
     val superseded = checkNotNull(lifecycle.claimStyleRequestIdentity(engine))
@@ -222,7 +226,7 @@ class MapLifecycleAuthorityTest {
         allowDetach = CompletableDeferred()
         detachFailure = TestFailure("detach")
       }
-    val lifecycle = MapLifecycleAuthority(adapter, backgroundScope)
+    val lifecycle = bindLifecycle(adapter)
     val lease = lifecycle.attach()
     val detaching = async { runCatching { lifecycle.detach(lease) } }
     adapter.detachStarted.await()
@@ -240,7 +244,7 @@ class MapLifecycleAuthorityTest {
   @Test
   fun destroying_detach_invalidates_engine_and_style_identities_before_reattachment() = runTest {
     val adapter = FakeMapLifecycleAdapter().apply { retention = EngineRetention.DESTROY }
-    val lifecycle = MapLifecycleAuthority(adapter, backgroundScope)
+    val lifecycle = bindLifecycle(adapter)
     val firstLease = lifecycle.attach()
     val firstEngine = checkNotNull(lifecycle.engineIdentity)
     val firstStyle = lifecycle.claimStyle(firstEngine)
@@ -260,7 +264,7 @@ class MapLifecycleAuthorityTest {
   @Test
   fun destroy_on_detach_engine_replacement_keeps_the_lease_but_changes_engine_identity() = runTest {
     val adapter = FakeMapLifecycleAdapter().apply { retention = EngineRetention.DESTROY }
-    val lifecycle = MapLifecycleAuthority(adapter, backgroundScope)
+    val lifecycle = bindLifecycle(adapter)
     val lease = lifecycle.attach()
     val departedEngine = checkNotNull(lifecycle.engineIdentity)
     val departedStyle = lifecycle.claimStyle(departedEngine)
@@ -281,7 +285,7 @@ class MapLifecycleAuthorityTest {
   @Test
   fun a_departed_lease_cannot_detach_a_later_presentation() = runTest {
     val adapter = FakeMapLifecycleAdapter()
-    val lifecycle = MapLifecycleAuthority(adapter, backgroundScope)
+    val lifecycle = bindLifecycle(adapter)
     val departed = lifecycle.attach()
     lifecycle.detach(departed)
     val current = lifecycle.attach()
@@ -297,7 +301,7 @@ class MapLifecycleAuthorityTest {
   @Test
   fun close_during_attach_invalidates_the_lease_and_joins_its_cleanup() = runTest {
     val adapter = FakeMapLifecycleAdapter().apply { allowAttach = CompletableDeferred() }
-    val lifecycle = MapLifecycleAuthority(adapter, backgroundScope)
+    val lifecycle = bindLifecycle(adapter)
     val attaching = async { runCatching { lifecycle.attach() } }
     adapter.attachStarted.await()
 
@@ -314,7 +318,7 @@ class MapLifecycleAuthorityTest {
   @Test
   fun closing_a_never_attached_map_still_exposes_closing_until_shared_cleanup_finishes() = runTest {
     val adapter = FakeMapLifecycleAdapter().apply { allowResources = CompletableDeferred() }
-    val lifecycle = MapLifecycleAuthority(adapter, backgroundScope)
+    val lifecycle = bindLifecycle(adapter)
 
     lifecycle.close()
 
@@ -332,7 +336,7 @@ class MapLifecycleAuthorityTest {
         allowCreate = CompletableDeferred()
         createFailure = TestFailure("create")
       }
-    val lifecycle = MapLifecycleAuthority(adapter, backgroundScope)
+    val lifecycle = bindLifecycle(adapter)
     val attaching = async { runCatching { lifecycle.attach() } }
     adapter.createStarted.await()
     val lease = (lifecycle.state as MapLifecycleState.Attaching).lease
@@ -403,27 +407,27 @@ private class FakeMapLifecycleAdapter : MapLifecyclePlatformAdapter {
   }
 
   fun emitEngineEvent(
-    lifecycle: MapLifecycleAuthority,
+    lifecycle: MapLifecycleBinding,
     engine: EngineMapIdentity,
     event: () -> Unit,
   ): Boolean = lifecycle.acceptEngineEvent(engine, event)
 
   fun emitStyleEvent(
-    lifecycle: MapLifecycleAuthority,
+    lifecycle: MapLifecycleBinding,
     engine: EngineMapIdentity,
     style: StyleIdentity,
     event: () -> Unit,
   ): Boolean = lifecycle.acceptStyleEvent(engine, style, event)
 
   fun emitStyleRequestEvent(
-    lifecycle: MapLifecycleAuthority,
+    lifecycle: MapLifecycleBinding,
     engine: EngineMapIdentity,
     request: StyleRequestIdentity,
     event: () -> Unit,
   ): Boolean = lifecycle.acceptStyleRequestEvent(engine, request, event)
 
   fun emitPresentationEvent(
-    lifecycle: MapLifecycleAuthority,
+    lifecycle: MapLifecycleBinding,
     engine: EngineMapIdentity,
     lease: RenderLease,
     event: () -> Unit,
@@ -432,7 +436,7 @@ private class FakeMapLifecycleAdapter : MapLifecyclePlatformAdapter {
 
 private class TestFailure(message: String) : RuntimeException(message)
 
-private fun MapLifecycleAuthority.claimStyle(engine: EngineMapIdentity): StyleIdentity {
+private fun MapLifecycleBinding.claimStyle(engine: EngineMapIdentity): StyleIdentity {
   val request = checkNotNull(claimStyleRequestIdentity(engine))
   return checkNotNull(claimStyleIdentity(engine, request))
 }

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
@@ -11,6 +11,7 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNull
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
@@ -64,6 +65,187 @@ class MapPresentationTest {
     assertTrue(state.isClosed)
     runtime.close()
     assertTrue(runtime.isClosed)
+  }
+
+  @Test
+  fun closing_map_state_closes_a_bound_session_before_it_is_published() = runTest {
+    val runtime = mapRuntimeForTest(physicalScope = backgroundScope)
+    val state = runtime.createMapState()
+    val session = BoundLifecycleSession()
+    session.lifecycle = state.lifecycle.bind(session)
+    session.lifecycle.attach()
+
+    state.close()
+    state.awaitClosed()
+
+    assertEquals(
+      listOf("create", "attach", "detach", "destroy", "close resources"),
+      session.commands,
+    )
+    runtime.close()
+  }
+
+  @Test
+  fun a_session_that_closes_itself_is_retired_and_its_failure_reaches_map_closure() = runTest {
+    val runtime = mapRuntimeForTest(physicalScope = backgroundScope)
+    val state = runtime.createMapState()
+    val finishCleanup = CompletableDeferred<Unit>()
+    val session = BoundLifecycleSession(failOnClose = true, finishCleanup = finishCleanup)
+    session.lifecycle = state.lifecycle.bind(session)
+    session.lifecycle.attach()
+    val token = state.reservePresentation()
+    state.publishPresentation(token, session)
+    assertSame(session, state.presentation?.adapter)
+    assertTrue(state.markStyleReady(session))
+    assertEquals(StyleLoadState.Ready, state.style.loadState)
+
+    session.close()
+
+    assertNull(state.presentation)
+    assertNull(state.retainedAdapter(session.presentationCompatibilityKey))
+    assertFalse(state.acceptsPresentationEvent(session))
+    assertEquals(StyleLoadState.Pending, state.style.loadState)
+    assertFalse(session.lifecycle.state == MapLifecycleState.Closed)
+    finishCleanup.complete(Unit)
+    assertFailsWith<MapLifecycleCleanupException> { session.awaitClosed() }
+    testScheduler.runCurrent()
+
+    state.durableStyleCallbacks().onMapFailLoading(session, "stale callback")
+    assertFalse(state.style.loadState is StyleLoadState.Failed)
+
+    val replacement = PresentationTestAdapter()
+    val replacementToken = state.reservePresentation()
+    state.publishPresentation(replacementToken, replacement)
+    assertSame(replacement, state.presentation?.adapter)
+
+    state.close()
+    val failure = assertFailsWith<MapStateCleanupException> { state.awaitClosed() }
+    assertTrue(
+      generateSequence(failure as Throwable) { it.cause }
+        .any { it.message.orEmpty().contains("bound session cleanup failed") }
+    )
+    runtime.close()
+  }
+
+  @Test
+  fun a_detached_retained_session_that_closes_itself_invalidates_its_style() = runTest {
+    val runtime = mapRuntimeForTest(physicalScope = backgroundScope)
+    val state = runtime.createMapState()
+    val finishCleanup = CompletableDeferred<Unit>()
+    val session = BoundLifecycleSession(finishCleanup = finishCleanup)
+    session.lifecycle = state.lifecycle.bind(session)
+    session.lifecycle.attach()
+    val token = state.reservePresentation()
+    state.publishPresentation(token, session)
+    assertTrue(state.markStyleReady(session))
+
+    state.releasePresentation(token, session)
+    testScheduler.runCurrent()
+    assertNull(state.presentation)
+    assertSame(session, state.retainedAdapter(session.presentationCompatibilityKey))
+    assertEquals(StyleLoadState.Ready, state.style.loadState)
+
+    session.close()
+
+    assertNull(state.retainedAdapter(session.presentationCompatibilityKey))
+    assertEquals(StyleLoadState.Pending, state.style.loadState)
+    assertFalse(session.lifecycle.state == MapLifecycleState.Closed)
+    finishCleanup.complete(Unit)
+    session.awaitClosed()
+    state.close()
+    state.awaitClosed()
+    runtime.close()
+  }
+
+  @Test
+  fun a_new_presentation_can_reserve_while_the_previous_one_is_still_detaching() = runTest {
+    val runtime = mapRuntimeForTest(physicalScope = backgroundScope)
+    val state = runtime.createMapState()
+    val first = BlockingDetachAdapter()
+    val firstToken = state.reservePresentation(MapPresentationOwnerToken())
+    state.publishPresentation(firstToken, first)
+
+    state.releasePresentation(firstToken, first)
+    first.detachStarted.await()
+    assertNull(state.presentation)
+
+    val replacement = PresentationTestAdapter()
+    val replacementToken = state.reservePresentation(MapPresentationOwnerToken())
+    state.publishPresentation(replacementToken, replacement)
+    assertSame(replacement, state.presentation?.adapter)
+
+    first.finishDetach.complete(Unit)
+    testScheduler.runCurrent()
+    assertSame(replacement, state.presentation?.adapter)
+    state.close()
+    state.awaitClosed()
+    runtime.close()
+  }
+
+  @Test
+  fun closure_reports_a_superseded_presentations_in_flight_detach_failure() = runTest {
+    val runtime = mapRuntimeForTest(physicalScope = backgroundScope)
+    val state = runtime.createMapState()
+    val first = BlockingDetachAdapter(failOnDetach = true)
+    val firstToken = state.reservePresentation(MapPresentationOwnerToken())
+    state.publishPresentation(firstToken, first)
+    state.releasePresentation(firstToken, first)
+    first.detachStarted.await()
+
+    val replacement = PresentationTestAdapter()
+    val replacementToken = state.reservePresentation(MapPresentationOwnerToken())
+    state.publishPresentation(replacementToken, replacement)
+    state.close()
+
+    first.finishDetach.complete(Unit)
+    val failure = assertFailsWith<MapStateCleanupException> { state.awaitClosed() }
+    assertTrue(
+      generateSequence(failure as Throwable) { it.cause }.any { it.message == "detach failed" }
+    )
+    runtime.close()
+  }
+
+  @Test
+  fun closure_reports_an_in_flight_session_detach_failure_once() = runTest {
+    val runtime = mapRuntimeForTest(physicalScope = backgroundScope)
+    val state = runtime.createMapState()
+    val finishDetach = CompletableDeferred<Unit>()
+    val detachStarted = CompletableDeferred<Unit>()
+    val session =
+      BoundLifecycleSession(
+        failOnDetach = true,
+        finishDetach = finishDetach,
+        detachStarted = detachStarted,
+      )
+    session.lifecycle = state.lifecycle.bind(session)
+    session.lifecycle.attach()
+    val token = state.reservePresentation()
+    state.publishPresentation(token, session)
+
+    state.releasePresentation(token, session)
+    detachStarted.await()
+    state.close()
+    finishDetach.complete(Unit)
+
+    val failure = assertFailsWith<MapStateCleanupException> { state.awaitClosed() }
+    assertEquals("Map state cleanup failed in 1 resource(s)", failure.message)
+    assertEquals("detach failed", failure.cause?.message)
+    runtime.close()
+  }
+
+  @Test
+  fun closure_during_presentation_configuration_makes_publication_inert() = runTest {
+    val runtime = mapRuntimeForTest(physicalScope = backgroundScope)
+    val state = runtime.createMapState()
+    val token = state.reservePresentation()
+    val adapter = ClosingDuringConfigurationAdapter(state::close)
+
+    state.publishPresentation(token, adapter)
+
+    assertTrue(state.isClosed)
+    assertNull(state.presentation)
+    state.awaitClosed()
+    runtime.close()
   }
 
   @Test
@@ -476,7 +658,81 @@ private class RetainedAdapter(private val failOnClose: Boolean) : PresentationTe
   }
 }
 
-private open class PresentationTestAdapter(
+private class BlockingDetachAdapter(private val failOnDetach: Boolean = false) :
+  PresentationTestAdapter() {
+  val detachStarted = CompletableDeferred<Unit>()
+  val finishDetach = CompletableDeferred<Unit>()
+
+  override suspend fun detachPresentation() {
+    detachStarted.complete(Unit)
+    finishDetach.await()
+    if (failOnDetach) error("detach failed")
+  }
+}
+
+private class BoundLifecycleSession(
+  private val failOnClose: Boolean = false,
+  private val finishCleanup: CompletableDeferred<Unit>? = null,
+  private val failOnDetach: Boolean = false,
+  private val finishDetach: CompletableDeferred<Unit>? = null,
+  private val detachStarted: CompletableDeferred<Unit>? = null,
+) : PresentationTestAdapter(), MapLifecycleSession {
+  lateinit var lifecycle: MapLifecycleBinding
+  val commands = mutableListOf<String>()
+
+  override val retainsEngineBetweenPresentations = true
+  override val presentationCompatibilityKey: Any = Any()
+
+  override val engineRetention: EngineRetention = EngineRetention.RETAIN
+
+  override suspend fun createEngine(identity: EngineMapIdentity) {
+    commands += "create"
+  }
+
+  override suspend fun attach(identity: EngineMapIdentity, lease: RenderLease) {
+    commands += "attach"
+  }
+
+  override suspend fun detach(identity: EngineMapIdentity, lease: RenderLease) {
+    commands += "detach"
+    detachStarted?.complete(Unit)
+    finishDetach?.await()
+    if (failOnDetach) error("detach failed")
+  }
+
+  override suspend fun destroyEngine(identity: EngineMapIdentity) {
+    commands += "destroy"
+  }
+
+  override suspend fun closeResources() {
+    commands += "close resources"
+    finishCleanup?.await()
+    if (failOnClose) error("bound session cleanup failed")
+  }
+
+  override suspend fun detachPresentation() {
+    lifecycle.detachCurrentPresentation()
+  }
+
+  override fun close() = lifecycle.close()
+
+  override suspend fun awaitClosed() = lifecycle.awaitClosed()
+}
+
+private class ClosingDuringConfigurationAdapter(private val closeState: () -> Unit) :
+  PresentationTestAdapter() {
+  private var closed = false
+
+  override fun setCameraPosition(cameraPosition: CameraPosition) {
+    super.setCameraPosition(cameraPosition)
+    if (!closed) {
+      closed = true
+      closeState()
+    }
+  }
+}
+
+internal open class PresentationTestAdapter(
   private val currentPresentation: () -> MapPresentation? = { null }
 ) : MapAdapter {
   var lastCameraPosition = CameraPosition()
@@ -486,7 +742,7 @@ private open class PresentationTestAdapter(
   val animationStarted = CompletableDeferred<Unit>()
   val finishAnimation = CompletableDeferred<Unit>()
 
-  override fun close() = Unit
+  open override fun close() = Unit
 
   open override suspend fun awaitClosed() = Unit
 

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
@@ -87,17 +87,18 @@ private const val FRAME_INTERVAL_SLACK = 0.1
  * calls before then are queued and reads answer from what was last asked for.
  */
 internal class GlJsMapSession(
+  private val lifecycleAuthority: MapLifecycleAuthority,
   callbacks: MapAdapter.Callbacks,
   internal var logger: Logger?,
   internal var layoutDirection: LayoutDirection,
-) : MapAdapter, GlJsMapRenderer, GestureTarget, MapLifecyclePlatformAdapter {
+) : MapLifecycleSession, GlJsMapRenderer, GestureTarget {
 
   init {
     createdCount += 1
   }
 
   internal var callbacks: MapAdapter.Callbacks = callbacks
-  private val lifecycle = MapLifecycleAuthority(this)
+  private val lifecycle = lifecycleAuthority.bind(this)
   private val lifecycleCallbacks = MapLifecycleCallbacks(lifecycle) { this.callbacks }
   private var lifecycleEngineIdentity: EngineMapIdentity? = null
   private var lifecycleRenderLease: RenderLease? = null

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/JsMapView.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/JsMapView.kt
@@ -36,6 +36,7 @@ internal actual fun ComposableMapView(
   val session =
     remember(scaleFactor) {
       GlJsMapSession(
+        lifecycleAuthority = state.lifecycle,
         callbacks = callbacks,
         logger = logger,
         layoutDirection = layoutDirection,

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/CompositedMap.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/CompositedMap.kt
@@ -12,6 +12,7 @@ import org.maplibre.compose.map.GlJsMapSession
 import org.maplibre.compose.map.MapAdapter
 import org.maplibre.compose.map.MapExtent
 import org.maplibre.compose.map.RenderOptions
+import org.maplibre.compose.map.mapRuntimeForTest
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.compose.style.DesiredStyleRevision
 import org.maplibre.compose.style.StyleBinding
@@ -25,11 +26,14 @@ internal class CompositedMap(style: BaseStyle, private val scaleFactor: Double =
   private var loadFailure: String? = null
   private var styleLoaded = false
   private val scope = MainScope()
+  private val runtime = mapRuntimeForTest()
+  private val state = runtime.createMapState()
 
   var frameRequests: Int = 0
     private set
 
-  private val session = GlJsMapSession(Callbacks(), logger = null, LayoutDirection.Ltr)
+  private val session =
+    GlJsMapSession(state.lifecycle, Callbacks(), logger = null, LayoutDirection.Ltr)
 
   init {
     session.start()
@@ -73,8 +77,9 @@ internal class CompositedMap(style: BaseStyle, private val scaleFactor: Double =
     styleLoaded && session.queryRenderedFeatures(DpOffset(x.dp, y.dp), setOf(layerId)).isNotEmpty()
 
   override fun close() {
+    state.close()
+    runtime.close()
     scope.cancel()
-    session.close()
   }
 
   private fun extentOf(target: GlJsRenderTarget) =

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/testing/GlJsMapFixture.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/testing/GlJsMapFixture.kt
@@ -31,16 +31,14 @@ import org.maplibre.compose.style.StyleBinding
 internal class GlJsMapFixture(private val extent: MapExtent) : MapFixture {
 
   private val recorder = RecordingMapCallbacks()
-
-  private val glJsSession =
-    GlJsMapSession(recorder, Logger.withTag("gljs-map"), LayoutDirection.Ltr)
-
   private val runtime = mapRuntimeForTest()
   override val state =
     runtime.createMapState(
       initialCameraPosition = CameraPosition(zoom = 0.0),
       initialBaseStyle = BaseStyle.Empty,
     )
+  private val glJsSession =
+    GlJsMapSession(state.lifecycle, recorder, Logger.withTag("gljs-map"), LayoutDirection.Ltr)
   private val token = state.reservePresentation()
 
   override val session: MapAdapter
@@ -175,8 +173,8 @@ internal class GlJsMapFixture(private val extent: MapExtent) : MapFixture {
 
   override fun close() {
     // Every map holds a WebGL context, and browsers cap how many may live at once.
+    state.close()
     runtime.close()
-    glJsSession.close()
   }
 }
 

--- a/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/desktop/bridge/LinuxVulkanOpenGlInteropTest.kt
+++ b/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/desktop/bridge/LinuxVulkanOpenGlInteropTest.kt
@@ -70,6 +70,7 @@ import org.maplibre.compose.desktop.OpenGlComposeGpuContext
 import org.maplibre.compose.map.MapAdapter
 import org.maplibre.compose.map.MapExtent
 import org.maplibre.compose.map.MlnFfiMapSession
+import org.maplibre.compose.map.mapRuntimeForTest
 import org.maplibre.compose.mlnffi.ComposeRenderBackend
 import org.maplibre.compose.mlnffi.MlnFfiFrameResult
 import org.maplibre.compose.mlnffi.MlnFfiMapDestination
@@ -271,8 +272,11 @@ class LinuxVulkanOpenGlInteropTest {
         override fun onFrame(fps: Double) {}
       }
 
+    private val runtime = mapRuntimeForTest()
+    private val state = runtime.createMapState()
     private val renderer =
       MlnFfiMapSession(
+        lifecycleAuthority = state.lifecycle,
         callbacks = callbacks,
         logger = null,
         renderBackend = host.backends.producer,
@@ -356,7 +360,8 @@ class LinuxVulkanOpenGlInteropTest {
     }
 
     override fun close() {
-      renderer.close()
+      state.close()
+      runtime.close()
       cacheDirectory.toFile().deleteRecursively()
     }
 

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/MapVisibleAreaTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/MapVisibleAreaTest.kt
@@ -102,6 +102,11 @@ class MapVisibleAreaTest {
       it.presentation.setCameraPosition(ROTATED_CAMERA)
       it.pumpUntil("the camera to rotate") { it.session.hasNativeCamera(ROTATED_CAMERA) }
 
+      it.pumpUntil("the public viewport to match the session") {
+        val publicBox = it.presentation.viewport?.visibleBoundingBox ?: return@pumpUntil false
+        boxesAreNear(it.presentation.getVisibleBoundingBox(), publicBox)
+      }
+
       val viewport = assertNotNull(it.presentation.viewport)
       assertNear(
         assertNotNull(it.presentation.getVisibleBoundingBox()),
@@ -149,6 +154,14 @@ class MapVisibleAreaTest {
     }
 
     fun assertNear(expected: BoundingBox, actual: BoundingBox) {
+      assertTrue(
+        boxesAreNear(expected, actual),
+        "the queried box should match the session's: $actual was not $expected",
+      )
+    }
+
+    fun boxesAreNear(expected: BoundingBox?, actual: BoundingBox): Boolean {
+      if (expected == null) return false
       val corners =
         listOf(
           expected.southwest.longitude to actual.southwest.longitude,
@@ -156,10 +169,7 @@ class MapVisibleAreaTest {
           expected.northeast.longitude to actual.northeast.longitude,
           expected.northeast.latitude to actual.northeast.latitude,
         )
-      assertTrue(
-        corners.all { (e, a) -> abs(e - a) < TOLERANCE },
-        "the queried box should match the session's: $actual was not $expected",
-      )
+      return corners.all { (e, a) -> abs(e - a) < TOLERANCE }
     }
   }
 }

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -150,6 +150,7 @@ internal data class NativeEngineCompatibility(
  * advances it from `onDidFinishRenderingFrame`.
  */
 internal class MlnFfiMapSession(
+  private val lifecycleAuthority: MapLifecycleAuthority,
   callbacks: MapAdapter.Callbacks,
   @Volatile internal var logger: Logger?,
   renderBackend: MapRenderBackend,
@@ -157,11 +158,11 @@ internal class MlnFfiMapSession(
   @Volatile internal var layoutDirection: LayoutDirection,
   private val cacheFile: Path,
   private val resourceProviderFactory: MlnFfiResourceProviderFactory = ::MlnFfiResourceProvider,
-) : MapAdapter, MlnFfiMapRenderer, GestureTarget, MapLifecyclePlatformAdapter {
+) : MapLifecycleSession, MlnFfiMapRenderer, GestureTarget {
 
   @Volatile internal var callbacks: MapAdapter.Callbacks = callbacks
   @Volatile internal var durableCallbacks: MapAdapter.Callbacks = EmptyMapAdapterCallbacks
-  private val lifecycle = MapLifecycleAuthority(this)
+  private val lifecycle = lifecycleAuthority.bind(this)
   private val lifecycleCallbacks = MapLifecycleCallbacks(lifecycle) { this.callbacks }
   @Volatile private var lifecycleEngineIdentity: EngineMapIdentity? = null
   @Volatile private var lifecycleRenderLease: RenderLease? = null
@@ -448,10 +449,34 @@ internal class MlnFfiMapSession(
 
   internal fun preparePresentation() {
     hasLoadedFirstStyle = false
+    presentationPublicationCount = 0
+  }
+
+  internal var presentationPublicationCount: Int = 0
+    private set
+
+  internal val isPresentationPublished: Boolean
+    get() = presentationPublicationCount > 0
+
+  /** Commits a render lease in the apply phase when no physical detachment must finish first. */
+  internal fun beginPresentationAttachment(): Boolean =
+    when (lifecycle.state) {
+      is MapLifecycleState.OpenDetached -> {
+        lifecycle.beginAttach()
+        true
+      }
+      is MapLifecycleState.Attaching,
+      is MapLifecycleState.Attached -> true
+      is MapLifecycleState.Detaching,
+      is MapLifecycleState.Closing,
+      MapLifecycleState.Closed -> false
+    }
+
+  internal fun markPresentationPublished() {
+    presentationPublicationCount++
   }
 
   override suspend fun attachPresentation() {
-    preparePresentation()
     lifecycle.attachRetainedEngine()
     styleBinding?.let { callbacks.onStyleChanged(this, it) }
   }

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapView.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapView.kt
@@ -103,6 +103,7 @@ internal fun MlnFfiMapView(
     retainedSession
       ?: remember(renderBackend, scaleFactor, applicationOptions, state) {
         MlnFfiMapSession(
+          lifecycleAuthority = state.lifecycle,
           callbacks = callbacks,
           logger = logger,
           renderBackend = renderBackend,
@@ -123,12 +124,19 @@ internal fun MlnFfiMapView(
   // Must run in the apply phase, not from a coroutine: the unload has to precede the content
   // subcomposition inserting layers, or a style switch fails anchor validation (see #269).
   SideEffect { session.setBaseStyle(style) }
-  // Publish the adapter before another thread can close a runtime whose composition has applied.
-  SideEffect { update(session) }
-
+  SideEffect {
+    if (session.beginPresentationAttachment()) {
+      update(session)
+      if (!session.isPresentationPublished) session.markPresentationPublished()
+    }
+  }
   LaunchedEffect(session) {
     try {
       session.attachPresentation()
+      if (!session.isPresentationPublished) {
+        update(session)
+        session.markPresentationPublished()
+      }
     } catch (error: CancellationException) {
       throw error
     } catch (_: MapClosedException) {

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/mlnffi/BridgeMapFixture.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/mlnffi/BridgeMapFixture.kt
@@ -14,6 +14,7 @@ import kotlinx.io.files.Path
 import org.maplibre.compose.map.MapExtent
 import org.maplibre.compose.map.MapPresentation
 import org.maplibre.compose.map.MlnFfiMapSession
+import org.maplibre.compose.map.mapRuntimeForTest
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.compose.style.StyleBinding
 import org.maplibre.compose.testing.MapFixture
@@ -48,9 +49,12 @@ private constructor(
 
   private var frameId = 0L
   private var frameRequested = true
+  private val runtime = mapRuntimeForTest()
+  private val state = runtime.createMapState()
 
   val session: MlnFfiMapSession =
     MlnFfiMapSession(
+      lifecycleAuthority = state.lifecycle,
       callbacks = recorder,
       logger = Logger.withTag("bridge-map"),
       renderBackend = driver.backends.producer,
@@ -247,8 +251,10 @@ private constructor(
 
   override fun close() {
     runCatching {
-      session.close()
-      runBlocking { session.awaitClosed() }
+      state.close()
+      runBlocking { state.awaitClosed() }
+      runtime.close()
+      runBlocking { runtime.awaitClosed() }
     }
     runCatching { driver.close() }
     FfiTestPlatform.deleteCacheFile(cacheFile)


### PR DESCRIPTION
## Description

Centralizes logical and physical map lifecycle authority in `MapState` and fixes closure, callback, publication, retained-session, stale-target, and outbound-write races found while auditing tickets 1–14.

## Validation

Passed `mise run check`, `mise run style-spec:parity --check`, `mise run test:android`, `mise run test:desktop`, `caffeinate -dimsu mise run test:js`, and `mise run test:ios`; the local Android device aggregate remained incomplete at 107/407 without failures and is left to CI.

## AI assistance

Used Codex to implement, test, and independently review the lifecycle correction.