### PR TITLE
Fix replacement Android surface rendering

### DIFF
--- a/lib/maplibre-compose/src/androidDeviceTest/AndroidManifest.xml
+++ b/lib/maplibre-compose/src/androidDeviceTest/AndroidManifest.xml
@@ -6,5 +6,10 @@
       android:exported="false"
       android:theme="@android:style/Theme.Material.Light.NoActionBar"
     />
+    <activity
+      android:name="org.maplibre.compose.mlnffi.SurfaceReplacementActivity"
+      android:exported="false"
+      android:theme="@android:style/Theme.Material.Light.NoActionBar"
+    />
   </application>
 </manifest>

--- a/lib/maplibre-compose/src/androidDeviceTest/kotlin/org/maplibre/compose/mlnffi/AndroidSurfaceReplacementTest.kt
+++ b/lib/maplibre-compose/src/androidDeviceTest/kotlin/org/maplibre/compose/mlnffi/AndroidSurfaceReplacementTest.kt
@@ -1,0 +1,107 @@
+package org.maplibre.compose.mlnffi
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.test.core.app.ActivityScenario
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import org.maplibre.compose.map.MapPresentationCallbacks
+import org.maplibre.compose.map.MaplibreMap
+import org.maplibre.compose.map.rememberMapState
+import org.maplibre.compose.overlay.MapOverlay
+import org.maplibre.compose.style.BaseStyle
+
+class AndroidSurfaceReplacementTest {
+
+  @Test
+  fun a_surface_map_without_an_overlay_produces_a_frame_after_replacement() {
+    val cacheFile = FfiTestPlatform.createCacheFile()
+    MlnFfiApplication.configure(
+      MlnFfiRuntimeOptions(cacheFile = cacheFile, maximumCacheSizeBytes = null)
+    )
+
+    try {
+      // Screen capture and Compose test synchronization invalidate the window and mask this
+      // failure. Removing the #1150 workaround prevents this passive frame callback.
+      ActivityScenario.launch(SurfaceReplacementActivity::class.java).use { scenario ->
+        lateinit var activity: SurfaceReplacementActivity
+        scenario.onActivity { activity = it }
+        assertTrue(
+          activity.initialFrame.await(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS),
+          "the initial surface map did not produce a frame",
+        )
+
+        scenario.onActivity { it.showReplacement() }
+        assertTrue(
+          activity.replacementFrame.await(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS),
+          "the replacement surface map did not produce a frame",
+        )
+      }
+    } finally {
+      MlnFfiApplication.resetForTest()
+      FfiTestPlatform.deleteCacheFile(cacheFile)
+    }
+  }
+
+  private companion object {
+    const val TIMEOUT_MILLIS = 10_000L
+  }
+}
+
+class SurfaceReplacementActivity : ComponentActivity() {
+  var showingReplacement by mutableStateOf(false)
+    private set
+
+  val initialFrame = CountDownLatch(1)
+  val replacementFrame = CountDownLatch(1)
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    setContent {
+      if (showingReplacement) {
+        TestMap(
+          overlay = MapOverlay.None,
+          onFrame = { replacementFrame.countDown() },
+        )
+      } else {
+        TestMap(
+          overlay = MapOverlay.Default,
+          onFrame = { initialFrame.countDown() },
+        )
+      }
+    }
+  }
+
+  fun showReplacement() {
+    showingReplacement = true
+  }
+}
+
+@Composable
+private fun TestMap(overlay: MapOverlay, onFrame: () -> Unit) {
+  val state = rememberMapState(initialBaseStyle = SOLID_STYLE)
+  MaplibreMap(
+    state = state,
+    modifier = Modifier.fillMaxSize(),
+    callbacks = MapPresentationCallbacks(onFrame = { onFrame() }),
+    overlay = overlay,
+  )
+}
+
+private val SOLID_STYLE =
+  BaseStyle.Json(
+    """
+    {"version":8,"sources":{},"layers":[
+      {"id":"background","type":"background","paint":{"background-color":"#336699"}}
+    ]}
+    """
+  )

--- a/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/mlnffi/AndroidMlnFfiSurface.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/mlnffi/AndroidMlnFfiSurface.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalDensity
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
@@ -92,7 +93,9 @@ internal fun AndroidMlnFfiSurface(
       }
     AndroidMapSurfaceKind.Surface ->
       AndroidExternalSurface(
-        modifier = modifier,
+        // Work around #1150: Compose can delay a replacement SurfaceView until another window
+        // invalidation. The graphics layer forces that traversal when the map has no overlay.
+        modifier = modifier.graphicsLayer(),
         // Never opaque: before its first swap the hole would otherwise read as black.
         isOpaque = false,
         // Behind the window, matching MapLibre's MapView: Compose overlays draw on top of the map.


### PR DESCRIPTION
## Description

Adds a graphics layer so replacement Android Surface maps render without a later window invalidation, includes a passive regression test for the behavior, and fixes #1150.

## Validation

Validated with the focused Android device test on an API 36 arm64 emulator, `mise run check`, and `mise run lint:android`.

## AI assistance

Used OpenAI Codex with GPT-5 for diagnosis, implementation, test development, and review.