### PR TITLE
Separate location provider setup from tracking failures

### DIFF
--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/LocationDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/LocationDemo.kt
@@ -22,6 +22,7 @@ import org.maplibre.compose.demoapp.DemoPointerPin
 import org.maplibre.compose.demoapp.design.ButtonRow
 import org.maplibre.compose.demoapp.design.SegmentedRow
 import org.maplibre.compose.demoapp.design.SwitchRow
+import org.maplibre.compose.location.LocationBackendAvailability
 import org.maplibre.compose.location.LocationPermission
 import org.maplibre.compose.location.LocationPuck
 import org.maplibre.compose.location.LocationState
@@ -166,17 +167,23 @@ object LocationDemo : Demo {
   }
 }
 
-private fun LocationState.statusMessage(): String =
-  when (val status = this.status) {
+private fun LocationState.statusMessage(): String {
+  val permission = permission as? LocationPermission.NotGranted
+  return when {
+    availability == LocationBackendAvailability.Unsupported ->
+      "Location is not available on this device"
+    availability is LocationBackendAvailability.Misconfigured ->
+      "Location is misconfigured on this device"
+    permission?.canRequest == false ->
+      "Location permission was denied; turn it on in the system settings"
+    permission != null -> "Waiting for location permission"
+    else -> trackingStatusMessage()
+  }
+}
+
+private fun LocationState.trackingStatusMessage(): String =
+  when (val status = status) {
     LocationTrackingStatus.Stopped -> "Location is off"
-    LocationTrackingStatus.WaitingForPermission -> {
-      val permission = this.permission
-      if (permission is LocationPermission.NotGranted && permission.canRequest == false) {
-        "Location permission was denied; turn it on in the system settings"
-      } else {
-        "Waiting for location permission"
-      }
-    }
     LocationTrackingStatus.Starting -> "Finding your location"
     LocationTrackingStatus.Tracking -> "Tracking your location"
     is LocationTrackingStatus.Unavailable ->

--- a/docs/src/content/docs/location.mdx
+++ b/docs/src/content/docs/location.mdx
@@ -18,8 +18,8 @@ in sync with location changes:
 <Code code={region(location, "puck")} lang="kotlin" title="App.kt" />
 
 All platforms provide default location providers. Android and iOS also provide
-default heading providers. <Api of="LocationState.status" /> reports an
-unsupported or misconfigured platform without throwing.
+default heading providers. <Api of="LocationState.availability" /> reports an
+unsupported or misconfigured provider before the application requests permission.
 
 `locationState.lastLocation` is null until the first measurement arrives, so the puck
 initially draws nothing. Afterward, the state retains the last measurement when
@@ -110,4 +110,4 @@ that Apple requires. On Linux, location comes from the desktop portal on the
 D-Bus session bus, commonly backed by
 [GeoClue](https://gitlab.freedesktop.org/geoclue/geoclue). On Windows, location
 comes from Windows Runtime geolocation. A missing backend reports an
-unsupported status through `LocationState.status`.
+unsupported value through <Api of="LocationState.availability" />.

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/location/LocationState.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/location/LocationState.kt
@@ -26,13 +26,16 @@ import org.maplibre.spatialk.units.extensions.degrees
 /**
  * Lifecycle-aware state for foreground location and heading tracking.
  *
- * [lastLocation] and [lastHeading] retain their most recently received measurements when collection
- * stops. [status] separately describes whether updates are active, so retained data is not mistaken
- * for a live update.
+ * [availability] describes the provider setup for its lifetime. [permission] describes the current
+ * foreground authorization. [status] describes only an active tracking session. [lastLocation] and
+ * [lastHeading] retain their most recently received measurements when collection stops.
  */
 @Stable
 public class LocationState
-internal constructor(initialPermission: LocationPermission = LocationPermission.NotGranted(null)) {
+internal constructor(
+  initialAvailability: LocationBackendAvailability = LocationBackendAvailability.Available,
+  initialPermission: LocationPermission = LocationPermission.NotGranted(null),
+) {
   /** The user's last known location measurement. */
   public var lastLocation: LocationMeasurement? by mutableStateOf(null)
     internal set
@@ -44,6 +47,9 @@ internal constructor(initialPermission: LocationPermission = LocationPermission.
   /** Process-local monotonic mark for [lastLocation], or `null` before the first measurement. */
   public var lastLocationMeasurementMark: TimeMark? by mutableStateOf(null)
     internal set
+
+  /** Whether the provider has a usable platform implementation. */
+  public val availability: LocationBackendAvailability = initialAvailability
 
   /** Current foreground location authorization. */
   public var permission: LocationPermission by mutableStateOf(initialPermission)
@@ -105,16 +111,13 @@ public sealed interface LocationTrackingStatus {
   /** No platform location request is active. */
   public data object Stopped : LocationTrackingStatus
 
-  /** Tracking is enabled but foreground permission is not granted. */
-  public data object WaitingForPermission : LocationTrackingStatus
-
   /** A platform location request is active and has not delivered its first measurement. */
   public data object Starting : LocationTrackingStatus
 
   /** The active location request has delivered at least one measurement. */
   public data object Tracking : LocationTrackingStatus
 
-  /** An expected or unexpected condition currently prevents delivery. */
+  /** An expected or unexpected condition prevents the active request from delivering a location. */
   public data class Unavailable(
     val reason: LocationUnavailableReason,
     val cause: Throwable? = null,
@@ -127,8 +130,9 @@ public sealed interface LocationTrackingStatus {
  * Location updates are collected while [enabled] is `true` and the lifecycle is active. This
  * function never requests permission automatically; the application chooses when to call
  * [LocationState.requestPermission]. Stopping collection releases the platform request while
- * retaining the last measurements in [LocationState]. An unsupported or misconfigured provider is
- * reported through [LocationState.status] before permission is requested.
+ * retaining the last measurements in [LocationState]. [LocationState.availability] reports static
+ * provider setup, [LocationState.permission] reports foreground authorization, and
+ * [LocationState.status] reports only the tracking session.
  *
  * @param enabled Whether location and heading updates should run while lifecycle-active.
  * @param provider The [LocationProvider] to use for obtaining location updates and for observing
@@ -157,7 +161,13 @@ public fun rememberLocationState(
   minActiveState: Lifecycle.State = Lifecycle.State.STARTED,
   coroutineContext: CoroutineContext = EmptyCoroutineContext,
 ): LocationState {
-  val state = remember(provider) { LocationState(provider.permission.value) }
+  val state =
+    remember(provider) {
+      LocationState(
+        initialAvailability = provider.backendAvailability,
+        initialPermission = provider.permission.value,
+      )
+    }
   val permission by provider.permission.collectAsState()
   SideEffect {
     state.permission = permission
@@ -175,64 +185,51 @@ public fun rememberLocationState(
     minActiveState,
     coroutineContext,
   ) {
-    when (val availability = provider.backendAvailability) {
-      is LocationBackendAvailability.Misconfigured -> {
-        state.status =
-          LocationTrackingStatus.Unavailable(
-            LocationUnavailableReason.Misconfigured,
-            availability.cause,
-          )
-      }
-      LocationBackendAvailability.Unsupported -> {
-        state.status = LocationTrackingStatus.Unavailable(LocationUnavailableReason.Unsupported)
-      }
-      LocationBackendAvailability.Available ->
-        when {
-          !enabled -> state.status = LocationTrackingStatus.Stopped
-          permission !is LocationPermission.Granted -> {
-            state.status = LocationTrackingStatus.WaitingForPermission
-          }
-          else -> {
-            state.status = LocationTrackingStatus.Stopped
-            lifecycleOwner.lifecycle.repeatOnLifecycle(minActiveState) {
-              try {
-                state.status = LocationTrackingStatus.Starting
-                val collectSession: suspend () -> Unit = {
-                  provider
-                    .updates(request)
-                    .catch { error ->
-                      if (error is CancellationException) throw error
-                      emit(
-                        LocationEvent.Unavailable(
-                          LocationUnavailableReason.UnexpectedFailure,
-                          error,
-                        )
-                      )
-                    }
-                    .collect { event ->
-                      when (event) {
-                        is LocationEvent.Update -> state.accept(event)
-                        is LocationEvent.Unavailable ->
-                          state.status =
-                            LocationTrackingStatus.Unavailable(event.reason, event.cause)
-                      }
-                    }
-                }
-                if (coroutineContext == EmptyCoroutineContext) collectSession()
-                else withContext(coroutineContext) { collectSession() }
-                if (
-                  state.status == LocationTrackingStatus.Starting ||
-                    state.status == LocationTrackingStatus.Tracking
-                ) {
-                  state.status = LocationTrackingStatus.Stopped
-                }
-              } catch (error: CancellationException) {
-                state.status = LocationTrackingStatus.Stopped
-                throw error
+    if (
+      !enabled ||
+        state.availability != LocationBackendAvailability.Available ||
+        permission !is LocationPermission.Granted
+    ) {
+      state.status = LocationTrackingStatus.Stopped
+      return@LaunchedEffect
+    }
+
+    state.status = LocationTrackingStatus.Stopped
+    lifecycleOwner.lifecycle.repeatOnLifecycle(minActiveState) {
+      try {
+        state.status = LocationTrackingStatus.Starting
+        val collectSession: suspend () -> Unit = {
+          provider
+            .updates(request)
+            .catch { error ->
+              if (error is CancellationException) throw error
+              emit(
+                LocationEvent.Unavailable(
+                  LocationUnavailableReason.UnexpectedFailure,
+                  error,
+                )
+              )
+            }
+            .collect { event ->
+              when (event) {
+                is LocationEvent.Update -> state.accept(event)
+                is LocationEvent.Unavailable ->
+                  state.status = LocationTrackingStatus.Unavailable(event.reason, event.cause)
               }
             }
-          }
         }
+        if (coroutineContext == EmptyCoroutineContext) collectSession()
+        else withContext(coroutineContext) { collectSession() }
+        if (
+          state.status == LocationTrackingStatus.Starting ||
+            state.status == LocationTrackingStatus.Tracking
+        ) {
+          state.status = LocationTrackingStatus.Stopped
+        }
+      } catch (error: CancellationException) {
+        state.status = LocationTrackingStatus.Stopped
+        throw error
+      }
     }
   }
 

--- a/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/location/LocationStateTest.kt
+++ b/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/location/LocationStateTest.kt
@@ -52,10 +52,8 @@ class LocationStateTest {
           )
       }
 
-      waitUntil {
-        state?.status ==
-          LocationTrackingStatus.Unavailable(LocationUnavailableReason.Misconfigured, cause)
-      }
+      waitUntil { state?.availability == LocationBackendAvailability.Misconfigured(cause) }
+      assertEquals(LocationTrackingStatus.Stopped, state?.status)
       assertFalse(provider.active)
     }
   }
@@ -76,7 +74,10 @@ class LocationStateTest {
           )
       }
 
-      waitUntil { state?.status == LocationTrackingStatus.WaitingForPermission }
+      waitUntil {
+        state?.permission == LocationPermission.NotGranted(canRequest = true) &&
+          state.status == LocationTrackingStatus.Stopped
+      }
       assertFalse(locationProvider.active)
       runOnIdle { state?.requestPermission() }
       assertEquals(1, provider.requestCount)
@@ -90,9 +91,7 @@ class LocationStateTest {
       runOnIdle {
         provider.permission.value = LocationPermission.NotGranted(canRequest = false)
       }
-      waitUntil {
-        !locationProvider.active && state?.status == LocationTrackingStatus.WaitingForPermission
-      }
+      waitUntil { !locationProvider.active && state?.status == LocationTrackingStatus.Stopped }
       assertTrue(locationProvider.stopCount > 0)
     }
   }
@@ -113,7 +112,7 @@ class LocationStateTest {
           )
       }
 
-      waitUntil { state?.status == LocationTrackingStatus.WaitingForPermission }
+      waitUntil { state?.permission == LocationPermission.NotGranted(canRequest = true) }
       assertEquals(0, headingProvider.activeCollectors)
 
       runOnIdle {
@@ -244,6 +243,34 @@ class LocationStateTest {
         headingProvider.attempts == 2 &&
           state?.lastHeading == expected &&
           state.headingStatus == HeadingTrackingStatus.Tracking
+      }
+    }
+  }
+
+  @Test
+  fun retryRestartsLocationAfterUnavailableSession() = withMainDispatcher {
+    runComposeUiTest {
+      val expected = location(13.0)
+      val provider = RetryableLocationProvider(expected)
+      var state: LocationState? = null
+
+      setContent {
+        state =
+          rememberLocationState(
+            provider = provider,
+            lifecycleOwner = ResumedLifecycleOwner(),
+          )
+      }
+
+      waitUntil {
+        state?.status ==
+          LocationTrackingStatus.Unavailable(LocationUnavailableReason.ServicesDisabled)
+      }
+      runOnIdle { state?.retry() }
+      waitUntil {
+        provider.attempts == 2 &&
+          state?.lastLocation == expected &&
+          state.status == LocationTrackingStatus.Tracking
       }
     }
   }
@@ -479,6 +506,26 @@ private class RetryableHeadingProvider(private val heading: HeadingMeasurement) 
     attempts++
     if (attempts == 1) throw IllegalStateException("sensor failed")
     emit(heading)
+    awaitCancellation()
+  }
+}
+
+private class RetryableLocationProvider(private val location: LocationMeasurement) :
+  LocationProvider {
+  var attempts = 0
+
+  override fun updates(request: LocationRequest): Flow<LocationEvent> = flow {
+    attempts++
+    if (attempts == 1) {
+      emit(LocationEvent.Unavailable(LocationUnavailableReason.ServicesDisabled))
+      return@flow
+    }
+    emit(
+      LocationEvent.Update(
+        measurement = location,
+        measurementMark = TimeSource.Monotonic.markNow(),
+      )
+    )
     awaitCancellation()
   }
 }


### PR DESCRIPTION
## Description

`LocationState.availability` now reports the provider's stable setup (`Available`, `Unsupported`, or `Misconfigured`), `permission` continues to report user authorization, and `status` reports only the active request because failures such as disabled system location services are discovered when tracking starts and appear as `Unavailable(ServicesDisabled)`.

## Validation

Validated on macOS with `mise run fix`, `mise run check`, desktop and Android tests, and the full documentation build.

## AI assistance

Implemented with OpenAI Codex using GPT-5 in the Codex desktop app.