### PR TITLE
Fix number formatting on older Safari

### DIFF
--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/util/NumberFormatter.js.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/util/NumberFormatter.js.kt
@@ -13,7 +13,9 @@ actual constructor(locale: Locale, maximumFractionDigits: Int) {
       options =
         NumberFormatOptions(
           // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#maximumfractiondigits
-          maximumFractionDigits = maximumFractionDigits.coerceAtMost(100)
+          // Safari raised this limit from 20 to 100 in Safari Technology Preview 178.
+          // https://developer.apple.com/documentation/safari-technology-preview-release-notes/stp-release-178
+          maximumFractionDigits = maximumFractionDigits.coerceAtMost(20)
         ),
     )
 


### PR DESCRIPTION
## Description

Clamp the web number formatter to Safari's interoperable 20-digit limit so that older Safari versions can render the demo; fixes #1164.

## Validation

<img width="400" alt="image" src="https://github.com/user-attachments/assets/366d2447-6ffb-472f-a9d8-79a490148711" />


## AI assistance

OpenAI Codex researched the compatibility boundary, diagnosed the failure, implemented the fix, and ran the validation.
