### PR TITLE
Fix location review findings from PR 1168

### DIFF
--- a/lib/location-runtime-macos/src/main/kotlin/org/maplibre/compose/location/desktop/macos/MacosLocationBackend.kt
+++ b/lib/location-runtime-macos/src/main/kotlin/org/maplibre/compose/location/desktop/macos/MacosLocationBackend.kt
@@ -87,7 +87,10 @@ internal constructor(
   private val requester = MacosLocationPermissionRequester(client)
   private val mutableLocationServices = MutableStateFlow(LocationServicesStatus.Unknown)
 
-  override val availability: LocationProviderAvailability = client.backendAvailability
+  override val availability: LocationProviderAvailability
+    get() =
+      requester.allocationError?.let { LocationProviderAvailability.Misconfigured(it) }
+        ?: client.backendAvailability
 
   override val permission: StateFlow<LocationPermission>
     get() = requester.status
@@ -208,8 +211,9 @@ internal constructor(
  * [`requestWhenInUseAuthorization()`](https://developer.apple.com/documentation/corelocation/cllocationmanager/requestwheninuseauthorization())
  * and starts location updates so macOS can present the system prompt.
  *
- * If the manager cannot be allocated, [status] remains [LocationPermission.Unknown]. A later
- * permission request retries the allocation.
+ * If the manager cannot be allocated, [status] remains [LocationPermission.Unknown] and the
+ * provider reports [LocationProviderAvailability.Misconfigured]. A later permission request retries
+ * the allocation.
  */
 public class MacosLocationPermissionRequester
 internal constructor(private val client: CoreLocationClient) : AutoCloseable {
@@ -224,6 +228,8 @@ internal constructor(private val client: CoreLocationClient) : AutoCloseable {
   // Allocation is fallible and must not throw from construction, so manager() retries it when the
   // requester needs the manager.
   private var manager: CoreLocationManager? = null
+  internal var allocationError: Throwable? = null
+    private set
 
   private fun manager(): CoreLocationManager? =
     manager
@@ -231,9 +237,11 @@ internal constructor(private val client: CoreLocationClient) : AutoCloseable {
         client.createManager().also {
           it.setDelegate(delegate)
           manager = it
+          allocationError = null
           mutableStatus.value = readPermission(it.authorizationStatus, it.accuracyAuthorization)
         }
       } catch (error: Throwable) {
+        allocationError = error
         null
       }
 

--- a/lib/location-runtime-macos/src/test/kotlin/org/maplibre/compose/location/desktop/macos/MacosLocationProviderTest.kt
+++ b/lib/location-runtime-macos/src/test/kotlin/org/maplibre/compose/location/desktop/macos/MacosLocationProviderTest.kt
@@ -296,6 +296,8 @@ class MacosLocationProviderTest {
     val provider = MacosLocationProvider(client, Dispatchers.Unconfined)
 
     assertEquals(LocationPermission.Unknown, provider.permission.value)
+    val availability = assertIs<LocationProviderAvailability.Misconfigured>(provider.availability)
+    assertIs<IllegalStateException>(availability.cause)
     provider.requestPermission()
     val event = assertIs<LocationEvent.Unavailable>(provider.updates(LocationRequest()).first())
     assertEquals(LocationUnavailableReason.UnexpectedFailure, event.reason)

--- a/lib/location/src/iosMain/kotlin/org/maplibre/compose/location/IosLocationPermissionRequester.kt
+++ b/lib/location/src/iosMain/kotlin/org/maplibre/compose/location/IosLocationPermissionRequester.kt
@@ -32,6 +32,7 @@ public class IosLocationPermissionRequester {
   /** Current foreground location permission, updated when Core Location reports a change. */
   public val status: StateFlow<LocationPermission> = mutableStatus
   private var requestPending = false
+  internal var onAuthorizationChanged: (() -> Unit)? = null
 
   private val delegate =
     object : NSObject(), CLLocationManagerDelegateProtocol {
@@ -39,6 +40,7 @@ public class IosLocationPermissionRequester {
         val value = readStatus(manager)
         mutableStatus.value = value
         requestPending = false
+        onAuthorizationChanged?.invoke()
       }
     }
 

--- a/lib/location/src/iosMain/kotlin/org/maplibre/compose/location/IosLocationProvider.kt
+++ b/lib/location/src/iosMain/kotlin/org/maplibre/compose/location/IosLocationProvider.kt
@@ -31,7 +31,10 @@ import platform.darwin.NSObject
  * [`CLLocationManager`](https://developer.apple.com/documentation/corelocation/cllocationmanager).
  *
  * [LocationProvider.permission] and [LocationProvider.requestPermission] delegate to an
- * [IosLocationPermissionRequester].
+ * [IosLocationPermissionRequester]. [LocationProvider.locationServices] reports
+ * [`locationServicesEnabled`](https://developer.apple.com/documentation/corelocation/cllocationmanager/locationservicesenabled()).
+ * The provider refreshes that status when Core Location reports an authorization change and when
+ * collection starts.
  *
  * Each collection creates a
  * [`CLLocationManager`](https://developer.apple.com/documentation/corelocation/cllocationmanager)
@@ -61,27 +64,26 @@ import platform.darwin.NSObject
  */
 public class IosLocationProvider : LocationProvider {
   private val requester = IosLocationPermissionRequester()
-  private val mutableLocationServices =
-    MutableStateFlow(
-      if (CLLocationManager.locationServicesEnabled()) LocationServicesStatus.Enabled
-      else LocationServicesStatus.Disabled
-    )
+  private val mutableLocationServices = MutableStateFlow(readLocationServicesStatus())
 
   override val permission: StateFlow<LocationPermission>
     get() = requester.status
 
   override val locationServices: StateFlow<LocationServicesStatus> = mutableLocationServices
 
+  init {
+    requester.onAuthorizationChanged = ::refreshLocationServices
+  }
+
   override fun requestPermission(): Unit = requester.requestForegroundPermission()
 
   override fun updates(request: LocationRequest): Flow<LocationEvent> = callbackFlow {
-    if (!CLLocationManager.locationServicesEnabled()) {
-      mutableLocationServices.value = LocationServicesStatus.Disabled
+    refreshLocationServices()
+    if (mutableLocationServices.value == LocationServicesStatus.Disabled) {
       trySend(LocationEvent.Unavailable(LocationUnavailableReason.ServicesDisabled))
       close()
       return@callbackFlow
     }
-    mutableLocationServices.value = LocationServicesStatus.Enabled
 
     val manager = CLLocationManager()
     val delegate = Delegate(channel, mutableLocationServices)
@@ -134,7 +136,18 @@ public class IosLocationProvider : LocationProvider {
       manager.delegate = null
     }
   }
+
+  private fun refreshLocationServices() {
+    mutableLocationServices.value = readLocationServicesStatus()
+  }
 }
+
+private fun readLocationServicesStatus(): LocationServicesStatus =
+  if (CLLocationManager.locationServicesEnabled()) {
+    LocationServicesStatus.Enabled
+  } else {
+    LocationServicesStatus.Disabled
+  }
 
 internal fun NSError.asUnavailableReason(
   locationServicesEnabled: Boolean = CLLocationManager.locationServicesEnabled()

--- a/lib/location/src/iosTest/kotlin/org/maplibre/compose/location/IosLocationProviderTest.kt
+++ b/lib/location/src/iosTest/kotlin/org/maplibre/compose/location/IosLocationProviderTest.kt
@@ -2,6 +2,7 @@ package org.maplibre.compose.location
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import platform.CoreLocation.CLLocationManager
 import platform.CoreLocation.kCLErrorDenied
 import platform.CoreLocation.kCLErrorDomain
 import platform.CoreLocation.kCLErrorLocationUnknown
@@ -9,6 +10,17 @@ import platform.CoreLocation.kCLErrorNetwork
 import platform.Foundation.NSError
 
 class IosLocationProviderTest {
+  @Test
+  fun reportsCurrentLocationServicesStatus() {
+    val expected =
+      if (CLLocationManager.locationServicesEnabled()) {
+        LocationServicesStatus.Enabled
+      } else {
+        LocationServicesStatus.Disabled
+      }
+    assertEquals(expected, IosLocationProvider().locationServices.value)
+  }
+
   @Test
   fun exposesPermissionFromItsRequester() {
     assertEquals(

--- a/lib/location/src/jsMain/kotlin/org/maplibre/compose/location/BrowserLocationProvider.kt
+++ b/lib/location/src/jsMain/kotlin/org/maplibre/compose/location/BrowserLocationProvider.kt
@@ -283,9 +283,9 @@ internal class BrowserLocationPermissionState {
   }
 
   fun acceptDenial() {
-    if (mutableStatus.value is LocationPermission.Granted) {
-      mutableStatus.value = LocationPermission.Required(canRequest = null)
-    }
+    val current = mutableStatus.value
+    if (current is LocationPermission.Required && current.canRequest == false) return
+    mutableStatus.value = LocationPermission.Required(canRequest = null)
   }
 }
 

--- a/lib/location/src/jsTest/kotlin/org/maplibre/compose/location/BrowserLocationProviderTest.kt
+++ b/lib/location/src/jsTest/kotlin/org/maplibre/compose/location/BrowserLocationProviderTest.kt
@@ -165,11 +165,25 @@ class BrowserLocationProviderTest {
     runCurrent()
     provider.requestPermission()
     runCurrent()
-    assertEquals(LocationPermission.Required(canRequest = true), provider.permission.value)
+    assertEquals(LocationPermission.Required(canRequest = null), provider.permission.value)
     provider.requestPermission()
     runCurrent()
     assertEquals(2, boundary.requestedOptions.size)
     assertEquals(listOf(1.seconds, 1.seconds), boundary.requestedOptions.map { it.timeout })
+  }
+
+  @Test
+  fun explicitDenialWhilePermissionIsUnknownRecordsRequired() = runTest {
+    val boundary = FakeBrowserGeolocationBoundary()
+    boundary.permission.value = BrowserPermission.Unknown
+    boundary.requestPositionAction = { BrowserResult.Error(BrowserError.PermissionDenied) }
+    val provider = BrowserLocationProvider(boundary, backgroundScope)
+    runCurrent()
+
+    assertEquals(LocationPermission.Unknown, provider.permission.value)
+    provider.requestPermission()
+    runCurrent()
+    assertEquals(LocationPermission.Required(canRequest = null), provider.permission.value)
   }
 
   @Test


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Location services stay live State on Android and Apple, stay Unknown elsewhere, and Android observes the setting through one process-wide receiver that does not retain Activity-scoped providers.

## Validation

Linux, Windows, macOS, LocationState, and browser location tests passed earlier. Android host tests were not run here; this environment has no Android SDK.

## AI assistance

Cursor Grok 4.6 in Cursor Cloud.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-591c5d4c-7014-4410-9db6-a724d6911a71?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-591c5d4c-7014-4410-9db6-a724d6911a71&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

