### PR TITLE
Complete API redesign cleanup

### DIFF
--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Layers.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Layers.kt
@@ -68,9 +68,11 @@ fun Layers() {
       // #endregion amtrak-1
 
       // #region amtrak-2
+      val detailedAmtrakRoutes =
+        rememberGeoJsonSource(GeoJsonData.Uri(Res.getUri("files/data/amtrak_routes.geojson")))
       LineLayer(
         id = "amtrak-routes",
-        source = amtrakRoutes,
+        source = detailedAmtrakRoutes,
         cap = const(LineCap.Round),
         join = const(LineJoin.Round),
         color = const(Color.Blue),
@@ -87,13 +89,19 @@ fun Layers() {
       // #endregion amtrak-2
 
       // #region anchors
-      Anchor.Above("road_motorway") { LineLayer(id = "amtrak-routes", source = amtrakRoutes) }
+      val anchoredAmtrakRoutes =
+        rememberGeoJsonSource(GeoJsonData.Uri(Res.getUri("files/data/amtrak_routes.geojson")))
+      Anchor.Above("road_motorway") {
+        LineLayer(id = "amtrak-routes", source = anchoredAmtrakRoutes)
+      }
       // #endregion anchors
 
       // #region interaction
+      val interactiveAmtrakStations =
+        rememberGeoJsonSource(GeoJsonData.Uri(Res.getUri("files/data/amtrak_stations.geojson")))
       CircleLayer(
         id = "amtrak-stations",
-        source = amtrakStations,
+        source = interactiveAmtrakStations,
         onClick = { features ->
           println("Clicked on ${features[0].toJson()}")
           ClickResult.Consume

--- a/docs/src/content/docs/controls.mdx
+++ b/docs/src/content/docs/controls.mdx
@@ -105,7 +105,7 @@ the ellipse.
 
 <Code code={region(controls, "placedTowards")} lang="kotlin" title="App.kt" />
 
-1. The state carries the placement that the overlay computed.
+1. The state stores the placement that the overlay computed.
 2. `angleDegrees` is the direction of the target, clockwise from screen-up.
 
 <Api of="PointerPinButton" /> from the Material 3 module is a styled consumer

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/org/maplibre/compose/material3/MapOverlay.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/org/maplibre/compose/material3/MapOverlay.kt
@@ -35,9 +35,9 @@ private val Material3Overlay = MapOverlay {
 }
 
 /**
- * The controls of [MapOverlay.Default], themed from the Material 3 color scheme and typography.
+ * Applies the Material 3 color scheme and typography to the controls from [MapOverlay.Default].
  *
- * The MapLibre logo is the same either way, because its artwork carries its own colors.
+ * The Material 3 theme does not change the MapLibre logo colors.
  */
 public val MapOverlay.Companion.Material3: MapOverlay
   get() = Material3Overlay

--- a/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MapLifecycleCallbackRaceTest.kt
+++ b/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MapLifecycleCallbackRaceTest.kt
@@ -10,6 +10,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.JsonObject
+import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.compose.style.RecordingStyleBinding
 
@@ -82,6 +83,33 @@ class MapLifecycleCallbackRaceTest {
 
     assertEquals(secondStyle, state.style.baseStyle)
     assertEquals(secondStyle, adapter.lastStyle)
+    state.close()
+    runtime.close()
+  }
+
+  @Test
+  fun a_late_camera_write_replays_the_latest_durable_camera() {
+    val runtime = mapRuntimeForTest()
+    val state = runtime.createMapState()
+    val adapter = BlockingCameraAdapter()
+    val token = state.reservePresentation()
+    state.publishPresentation(token, adapter)
+    val presentation = requireNotNull(state.presentation)
+    val first = CameraPosition(zoom = 4.0)
+    val second = CameraPosition(zoom = 8.0)
+    adapter.blockNextWrite = true
+
+    val firstThread = thread { presentation.setCameraPosition(first) }
+    assertTrue(adapter.blockedWriteEntered.await(5, TimeUnit.SECONDS))
+    val secondThread = thread { presentation.setCameraPosition(second) }
+    secondThread.join()
+    assertEquals(second, state.cameraPosition)
+
+    adapter.releaseBlockedWrite.countDown()
+    firstThread.join()
+
+    assertEquals(second, state.cameraPosition)
+    assertEquals(second, adapter.lastCamera)
     state.close()
     runtime.close()
   }
@@ -192,6 +220,22 @@ private class BlockingStyleAdapter(private val blockedStyle: BaseStyle) :
       assertTrue(releaseFirstWrite.await(5, TimeUnit.SECONDS))
     }
     lastStyle = style
+  }
+}
+
+private class BlockingCameraAdapter : PresentationTestAdapter() {
+  val blockedWriteEntered = CountDownLatch(1)
+  val releaseBlockedWrite = CountDownLatch(1)
+  @Volatile var blockNextWrite = false
+  @Volatile var lastCamera = CameraPosition()
+
+  override fun setCameraPosition(cameraPosition: CameraPosition) {
+    if (blockNextWrite) {
+      blockNextWrite = false
+      blockedWriteEntered.countDown()
+      assertTrue(releaseBlockedWrite.await(5, TimeUnit.SECONDS))
+    }
+    lastCamera = cameraPosition
   }
 }
 

--- a/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MlnFfiMapCompositionTest.kt
+++ b/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MlnFfiMapCompositionTest.kt
@@ -124,6 +124,29 @@ class MlnFfiMapCompositionTest {
   }
 
   @Test
+  fun presentation_options_update_without_replacing_the_native_map() = runFfiComposeUiTest {
+    val runtime = createNativeMapRuntime(runtimeOptions)
+    val state = runtime.createMapState(initialBaseStyle = BaseStyle.Empty)
+    var options by mutableStateOf(MapPresentationOptions())
+
+    setFfiTestMapContent(runtimeOptions) {
+      MaplibreMap(state, presentationOptions = options)
+    }
+    waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) { state.presentation != null }
+    val session = requireNotNull(state.presentation).adapter
+    val updated = MapPresentationOptions(zoomRange = 2f..18f, pitchRange = 3f..45f)
+
+    options = updated
+    waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) {
+      state.presentation?.options == updated
+    }
+
+    assertSame(session, requireNotNull(state.presentation).adapter)
+    runtime.close()
+    runtime.awaitClosed()
+  }
+
+  @Test
   fun one_style_composition_is_evaluated_independently_for_two_maps() = runFfiComposeUiTest {
     val runtime = createNativeMapRuntime(runtimeOptions)
     val first = runtime.createMapState(initialBaseStyle = BaseStyle.Empty)

--- a/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MlnFfiMapCompositionTest.kt
+++ b/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MlnFfiMapCompositionTest.kt
@@ -110,8 +110,6 @@ class MlnFfiMapCompositionTest {
     }
 
     assertTrue(state.presentation?.isValid == true)
-    val session = state.presentation?.adapter as MlnFfiMapSession
-    assertEquals(1, session.presentationPublicationCount)
     assertTrue(
       onAllNodesWithTag(MAP_LOAD_PLACEHOLDER_TAG).fetchSemanticsNodes().isEmpty(),
       "the load placeholder should be absent after the base style is ready",

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/Layer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/Layer.kt
@@ -84,20 +84,14 @@ internal sealed class Layer(val id: String) {
     root["filter"] = filter
   }
 
-  /** Property names asked for and not written, with why not; the live handle reports these once. */
+  /** Unsupported property names and their error messages. */
   private val unsupportedProperties = mutableMapOf<String, String>()
 
   /**
-   * Records a property [binding] will not accept, and says so once when attached; writing it anyway
-   * would make MapLibre refuse the entire layer. A null value asks for nothing and is not reported.
+   * Omits an unsupported [value] and records [reason] for one warning after attachment.
    *
-   * @return whether the property is unsupported and must not be written.
-   */
-  /**
-   * Drops a value MapLibre will not accept for a property it otherwise supports, and says so once.
-   * Properties an engine lacks outright belong in the loaded style's unsupported-property table.
-   *
-   * @param value the value that was asked for. A null literal asks for nothing and is not reported.
+   * A null literal does not set the property and does not produce a warning. Use the loaded style's
+   * unsupported-property table when an engine does not implement the property.
    */
   protected fun skipUnsupportedProperty(
     name: String,
@@ -109,8 +103,8 @@ internal sealed class Layer(val id: String) {
   }
 
   /**
-   * The complete layer object, as the style spec defines it. Null-valued properties are omitted;
-   * the spec has no null, and MapLibre rejects the whole layer over one.
+   * Returns the complete layer object defined by the style spec. This omits null-valued properties
+   * because the style spec does not permit null property values.
    */
   internal fun toJson(): JsonObject = buildJsonObject {
     // `id` and `type` first: MapLibre reads the type before the properties that depend on it.

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/LayerHandle.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/LayerHandle.kt
@@ -9,11 +9,7 @@ import org.maplibre.compose.style.StyleHandleOperationGuard
 import org.maplibre.compose.style.StyleIdentity
 import org.maplibre.compose.style.StyleMutationException
 
-/**
- * Imperative property access to one layer in one loaded base-style generation.
- *
- * A mutation that MapLibre refuses throws [StyleHandleException].
- */
+/** Provides imperative property access to a layer for one loaded base-style generation. */
 public class LayerHandle
 internal constructor(
   public val id: String,
@@ -28,17 +24,17 @@ internal constructor(
     return operation { style.layerProperty(id, name) }
   }
 
-  /** Sets one layout [property][name] for this loaded style. */
+  /** Sets the layout property [name] for this loaded style. */
   public fun setLayoutProperty(name: String, value: JsonElement) {
     setProperty(name, value, LayerPropertyKind.LAYOUT)
   }
 
-  /** Sets one paint [property][name] for this loaded style. */
+  /** Sets the paint property [name] for this loaded style. */
   public fun setPaintProperty(name: String, value: JsonElement) {
     setProperty(name, value, LayerPropertyKind.PAINT)
   }
 
-  /** Sets one top-level [property][name], such as `minzoom`, for this loaded style. */
+  /** Sets the top-level property [name], such as `minzoom`, for this loaded style. */
   public fun setRootProperty(name: String, value: JsonElement) {
     operation {
       mutate(name) {

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleAuthority.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleAuthority.kt
@@ -18,7 +18,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 
-/** Identifies one platform engine-map instance for exactly as long as that instance is alive. */
+/** Identifies one platform engine-map instance until its destruction. */
 @JvmInline internal value class EngineMapIdentity(private val value: Long)
 
 /** Identifies one temporary attachment of a logical map to a presentation. */
@@ -30,13 +30,13 @@ import kotlinx.coroutines.launch
 /** Identifies one requested base-style generation before it has loaded. */
 @JvmInline internal value class StyleRequestIdentity(private val value: Long)
 
-/** Whether detaching a presentation also destroys its engine map. */
+/** Specifies whether presentation detachment destroys its engine map. */
 internal enum class EngineRetention {
   RETAIN,
   DESTROY,
 }
 
-/** Commands performed for the one authority that owns the logical-map lifecycle. */
+/** Defines platform commands for the logical-map lifecycle authority. */
 internal interface MapLifecyclePlatformAdapter {
   val engineRetention: EngineRetention
 
@@ -51,10 +51,10 @@ internal interface MapLifecyclePlatformAdapter {
   suspend fun closeResources()
 }
 
-/** A platform map session whose physical lifecycle belongs to a [MapState]. */
+/** Defines a platform map session with a physical lifecycle controlled by [MapState]. */
 internal interface MapLifecycleSession : MapAdapter, MapLifecyclePlatformAdapter
 
-/** The externally observable logical states of one map lifecycle. */
+/** Defines the externally observable states of one logical map lifecycle. */
 internal sealed interface MapLifecycleState {
   data class OpenDetached(val engine: EngineMapIdentity?) : MapLifecycleState
 
@@ -77,12 +77,15 @@ internal class MapLeaseInvalidatedException :
 
 internal class MapClosedException : IllegalStateException("The map is closed")
 
-internal class MapLifecycleCleanupException internal constructor(val failures: List<Throwable>) :
-  RuntimeException("Map cleanup failed in ${failures.size} resource(s)", failures.first()) {
+internal open class AggregateCleanupException(message: String, failures: List<Throwable>) :
+  RuntimeException(message, failures.first()) {
   init {
     failures.drop(1).forEach(::addSuppressed)
   }
 }
+
+internal class MapLifecycleCleanupException internal constructor(val failures: List<Throwable>) :
+  AggregateCleanupException("Map cleanup failed in ${failures.size} resource(s)", failures)
 
 internal data class PendingAttachment(
   val lease: RenderLease,
@@ -192,6 +195,7 @@ internal class MapLifecycleAuthority(
         "The map presentation reservation is no longer current"
       }
       if (current.adapter === adapter) {
+        check(current.admitted) { "The map presentation is still being published" }
         owner.presentation?.updateOptions(options)
         return
       }
@@ -209,6 +213,7 @@ internal class MapLifecycleAuthority(
       serialized {
         if (attachment?.token == token && attachment?.adapter === adapter) {
           attachment?.adapter = null
+          attachment?.admitted = false
         }
       }
       throw error
@@ -220,6 +225,7 @@ internal class MapLifecycleAuthority(
       }
       if (adapter.retainsEngineBetweenPresentations) retainedAdapter = adapter
       preparation.replaced?.let(retiringAdapters::add)
+      current.admitted = true
       owner.commitPresentation(
         token = token,
         adapter = adapter,
@@ -279,19 +285,28 @@ internal class MapLifecycleAuthority(
 
   fun acceptsAdapter(adapter: MapAdapter): Boolean = serialized {
     !closed &&
-      (attachment?.adapter === adapter ||
-        retainedAdapter === adapter ||
-        (adapter is MapLifecycleSession && platforms.containsKey(adapter)))
+      ((attachment?.adapter === adapter && attachment?.admitted == true) ||
+        retainedAdapter === adapter)
+  }
+
+  fun isPendingPublication(adapter: MapAdapter): Boolean = serialized {
+    !closed && attachment?.adapter === adapter && attachment?.releasing == false
   }
 
   fun acceptsPresentation(adapter: MapAdapter): Boolean = serialized {
-    !closed && attachment?.adapter === adapter && owner.presentation?.adapter === adapter
+    !closed &&
+      attachment?.adapter === adapter &&
+      attachment?.admitted == true &&
+      owner.presentation?.adapter === adapter
   }
 
   fun currentAdapter(): MapAdapter? = serialized { attachment?.adapter ?: retainedAdapter }
 
   fun isCurrent(token: MapPresentationToken, adapter: MapAdapter): Boolean = serialized {
-    !closed && attachment?.token == token && attachment?.adapter === adapter
+    !closed &&
+      attachment?.token == token &&
+      attachment?.adapter === adapter &&
+      attachment?.admitted == true
   }
 
   fun bind(adapter: MapLifecyclePlatformAdapter): MapLifecycleBinding {
@@ -357,6 +372,7 @@ internal class MapLifecycleAuthority(
     val owner: MapPresentationOwnerToken,
     val token: MapPresentationToken,
     var adapter: MapAdapter? = null,
+    var admitted: Boolean = false,
     var releasing: Boolean = false,
   )
 
@@ -375,7 +391,7 @@ internal class MapLifecycleAuthority(
   }
 }
 
-/** An authority-owned binding from engine and render-lease transitions to platform commands. */
+/** Applies engine and render-lease transitions through platform commands. */
 internal class MapLifecycleBinding(
   private val adapter: MapLifecyclePlatformAdapter,
   private val physicalScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
@@ -518,24 +534,10 @@ internal class MapLifecycleBinding(
 
   /** Commits attachment before starting its physical commands. */
   fun beginAttach(): PendingAttachment {
-    val result = CompletableDeferred<Result<RenderLease>>()
-    val engine = EngineMapIdentity(nextIdentity.incrementAndFetch())
-    val lease = RenderLease(nextIdentity.incrementAndFetch())
-    val selected = serialized {
+    val start = serialized {
       val observed = current.load()
       when (observed) {
-        is InternalState.OpenDetached -> {
-          val selectedEngine = observed.engine ?: engine
-          val selected =
-            InternalState.Attaching(
-              engine = selectedEngine,
-              lease = lease,
-              result = result,
-              engineCreated = AtomicBoolean(observed.engine != null),
-            )
-          current.store(selected)
-          selected to (observed.engine == null)
-        }
+        is InternalState.OpenDetached -> createAttachmentStart(observed)
         is InternalState.Attaching,
         is InternalState.Attached,
         is InternalState.Detaching -> throw MapAlreadyAttachedException()
@@ -543,10 +545,53 @@ internal class MapLifecycleBinding(
         InternalState.Closed -> throw MapClosedException()
       }
     }
-    physicalScope.launch(start = CoroutineStart.UNDISPATCHED) {
-      performAttach(selected.first, selected.second)
+    launchAttachment(start)
+    return start.pending
+  }
+
+  /** Starts attachment atomically, or returns false after detachment or closure starts. */
+  fun beginAttachIfOpen(): Boolean {
+    var alreadyAttached = false
+    val start = serialized {
+      when (val observed = current.load()) {
+        is InternalState.OpenDetached -> createAttachmentStart(observed)
+        is InternalState.Attaching,
+        is InternalState.Attached -> {
+          alreadyAttached = true
+          null
+        }
+        is InternalState.Detaching,
+        is InternalState.Closing,
+        InternalState.Closed -> null
+      }
     }
-    return PendingAttachment(lease, result)
+    start?.let(::launchAttachment)
+    return alreadyAttached || start != null
+  }
+
+  private fun createAttachmentStart(observed: InternalState.OpenDetached): AttachmentStart {
+    val result = CompletableDeferred<Result<RenderLease>>()
+    val engine = EngineMapIdentity(nextIdentity.incrementAndFetch())
+    val lease = RenderLease(nextIdentity.incrementAndFetch())
+    val selected =
+      InternalState.Attaching(
+        engine = observed.engine ?: engine,
+        lease = lease,
+        result = result,
+        engineCreated = AtomicBoolean(observed.engine != null),
+      )
+    current.store(selected)
+    return AttachmentStart(
+      state = selected,
+      createEngine = observed.engine == null,
+      pending = PendingAttachment(lease, result),
+    )
+  }
+
+  private fun launchAttachment(start: AttachmentStart) {
+    physicalScope.launch(start = CoroutineStart.UNDISPATCHED) {
+      performAttach(start.state, start.createEngine)
+    }
   }
 
   /** Replaces a destroy-on-detach engine without transferring its current presentation lease. */
@@ -861,6 +906,12 @@ internal class MapLifecycleBinding(
   private data class StyleRequestClaim(
     val engine: EngineMapIdentity,
     val request: StyleRequestIdentity,
+  )
+
+  private data class AttachmentStart(
+    val state: InternalState.Attaching,
+    val createEngine: Boolean,
+    val pending: PendingAttachment,
   )
 
   private sealed interface InternalState {

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleAuthority.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleAuthority.kt
@@ -187,55 +187,47 @@ internal class MapLifecycleAuthority(
     adapter: MapAdapter,
     options: MapPresentationOptions,
   ) {
-    val preparation = serialized {
+    val retainedToReplace = serialized {
       if (closed) return
       requireOpen()
       val current = attachment
       check(current?.token == token && !current.releasing) {
         "The map presentation reservation is no longer current"
       }
-      if (current.adapter === adapter) {
-        check(current.admitted) { "The map presentation is still being published" }
+      if (current.adapter === adapter && owner.presentation?.adapter === adapter) {
         owner.presentation?.updateOptions(options)
         return
       }
-      check(current.adapter == null) { "The map state already has a presentation" }
-      current.adapter = adapter
-      val reusesRetainedAdapter = retainedAdapter === adapter
-      val replaced = retainedAdapter?.takeUnless { retained ->
+      selectAdapterLocked(current, adapter)
+      retainedAdapter?.takeUnless { retained ->
         retained === adapter || !adapter.retainsEngineBetweenPresentations
       }
-      PresentationPreparation(reusesRetainedAdapter, replaced)
     }
-    try {
-      owner.configurePresentationAdapter(adapter)
-    } catch (error: Throwable) {
-      serialized {
-        if (attachment?.token == token && attachment?.adapter === adapter) {
-          attachment?.adapter = null
-          attachment?.admitted = false
-        }
+    val configurationFailure =
+      try {
+        owner.configurePresentationAdapter(adapter)
+        null
+      } catch (error: CancellationException) {
+        throw error
+      } catch (error: Exception) {
+        error
       }
-      throw error
-    }
     val replaced = serialized {
       val current = attachment
       if (closed || current?.token != token || current.releasing || current.adapter !== adapter) {
         return
       }
       if (adapter.retainsEngineBetweenPresentations) retainedAdapter = adapter
-      preparation.replaced?.let(retiringAdapters::add)
-      current.admitted = true
+      retainedToReplace?.let(retiringAdapters::add)
       owner.commitPresentation(
         token = token,
         adapter = adapter,
         options = options,
-        reusesRetainedAdapter = preparation.reusesRetainedAdapter,
       )
-      current.pendingStyleFailure?.let { owner.commitStyleFailure(it.reason) }
-      current.pendingStyleFailure = null
-      preparation.replaced
+      retainedToReplace
     }
+    owner.seedPresentationViewport(token, adapter)
+    configurationFailure?.let { owner.markStyleFailed(adapter, it.message) }
     if (replaced != null) {
       replaced.close()
       physicalScope.launch {
@@ -285,24 +277,19 @@ internal class MapLifecycleAuthority(
     }
   }
 
-  fun acceptsAdapter(adapter: MapAdapter): Boolean = serialized {
-    !closed &&
-      ((attachment?.adapter === adapter && attachment?.admitted == true) ||
-        retainedAdapter === adapter)
+  fun selectAdapterForPresentation(adapter: MapAdapter): Boolean = serialized {
+    if (closed) return@serialized false
+    val current = attachment ?: return@serialized false
+    if (current.releasing) return@serialized false
+    selectAdapterLocked(current, adapter)
+    true
   }
 
-  fun reportStyleFailure(adapter: MapAdapter, reason: String?): Unit = serialized {
-    if (closed) return@serialized
+  fun acceptsAdapter(adapter: MapAdapter): Boolean = serialized {
     val current = attachment
-    if (current?.adapter === adapter && !current.releasing) {
-      if (current.admitted) {
-        owner.commitStyleFailure(reason)
-      } else {
-        current.pendingStyleFailure = PendingStyleFailure(reason)
-      }
-    } else if (retainedAdapter === adapter) {
-      owner.commitStyleFailure(reason)
-    }
+    !closed &&
+      ((current?.adapter === adapter && !current.releasing) ||
+        (current?.adapter == null && retainedAdapter === adapter))
   }
 
   fun isPendingPublication(adapter: MapAdapter): Boolean = serialized {
@@ -310,10 +297,7 @@ internal class MapLifecycleAuthority(
   }
 
   fun acceptsPresentation(adapter: MapAdapter): Boolean = serialized {
-    !closed &&
-      attachment?.adapter === adapter &&
-      attachment?.admitted == true &&
-      owner.presentation?.adapter === adapter
+    !closed && attachment?.adapter === adapter && owner.presentation?.adapter === adapter
   }
 
   fun currentAdapter(): MapAdapter? = serialized { attachment?.adapter ?: retainedAdapter }
@@ -322,7 +306,7 @@ internal class MapLifecycleAuthority(
     !closed &&
       attachment?.token == token &&
       attachment?.adapter === adapter &&
-      attachment?.admitted == true
+      owner.presentation?.let { it.token == token && it.adapter === adapter } == true
   }
 
   fun bind(adapter: MapLifecyclePlatformAdapter): MapLifecycleBinding {
@@ -372,6 +356,13 @@ internal class MapLifecycleAuthority(
     if (closed) throw MapStateClosedException()
   }
 
+  private fun selectAdapterLocked(current: Attachment, adapter: MapAdapter) {
+    if (current.adapter === adapter) return
+    check(current.adapter == null) { "The map state already has a presentation adapter" }
+    current.adapter = adapter
+    if (retainedAdapter !== adapter) owner.beginStyleLoadForNewAdapter()
+  }
+
   private fun completeClosure(result: Result<Unit>) {
     if (closure.complete(result)) owner.runtime.childClosed(owner)
   }
@@ -388,16 +379,7 @@ internal class MapLifecycleAuthority(
     val owner: MapPresentationOwnerToken,
     val token: MapPresentationToken,
     var adapter: MapAdapter? = null,
-    var admitted: Boolean = false,
     var releasing: Boolean = false,
-    var pendingStyleFailure: PendingStyleFailure? = null,
-  )
-
-  private data class PendingStyleFailure(val reason: String?)
-
-  private data class PresentationPreparation(
-    val reusesRetainedAdapter: Boolean,
-    val replaced: MapAdapter?,
   )
 
   private data class ReleaseCleanup(

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleAuthority.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleAuthority.kt
@@ -232,6 +232,8 @@ internal class MapLifecycleAuthority(
         options = options,
         reusesRetainedAdapter = preparation.reusesRetainedAdapter,
       )
+      current.pendingStyleFailure?.let { owner.commitStyleFailure(it.reason) }
+      current.pendingStyleFailure = null
       preparation.replaced
     }
     if (replaced != null) {
@@ -287,6 +289,20 @@ internal class MapLifecycleAuthority(
     !closed &&
       ((attachment?.adapter === adapter && attachment?.admitted == true) ||
         retainedAdapter === adapter)
+  }
+
+  fun reportStyleFailure(adapter: MapAdapter, reason: String?): Unit = serialized {
+    if (closed) return@serialized
+    val current = attachment
+    if (current?.adapter === adapter && !current.releasing) {
+      if (current.admitted) {
+        owner.commitStyleFailure(reason)
+      } else {
+        current.pendingStyleFailure = PendingStyleFailure(reason)
+      }
+    } else if (retainedAdapter === adapter) {
+      owner.commitStyleFailure(reason)
+    }
   }
 
   fun isPendingPublication(adapter: MapAdapter): Boolean = serialized {
@@ -374,7 +390,10 @@ internal class MapLifecycleAuthority(
     var adapter: MapAdapter? = null,
     var admitted: Boolean = false,
     var releasing: Boolean = false,
+    var pendingStyleFailure: PendingStyleFailure? = null,
   )
+
+  private data class PendingStyleFailure(val reason: String?)
 
   private data class PresentationPreparation(
     val reusesRetainedAdapter: Boolean,

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
@@ -469,11 +469,11 @@ internal constructor(
   }
 
   internal fun markStyleFailed(adapter: MapAdapter, reason: String?) {
-    lifecycle.reportStyleFailure(adapter, reason)
-  }
-
-  internal fun commitStyleFailure(reason: String?) {
-    style.loadState = StyleLoadState.Failed(reason)
+    lifecycle.serialized {
+      if (lifecycle.acceptsAdapter(adapter)) {
+        style.loadState = StyleLoadState.Failed(reason)
+      }
+    }
   }
 
   internal fun beginStyleRevision(adapter: MapAdapter, revision: DesiredStyleRevision) {
@@ -544,7 +544,6 @@ internal constructor(
       CameraCommand(candidate.adapter, position, ++cameraCommandRevision)
     }
     applyPresentationCameraCommand(candidate, command)
-    lifecycle.serialized { requireCurrentLocked(candidate) }
   }
 
   internal fun synchronizeCamera(adapter: MapAdapter): MapPresentation? {
@@ -626,6 +625,21 @@ internal constructor(
     applyBaseStyleCommand(configuration.baseStyle)
   }
 
+  internal fun beginStyleLoadForNewAdapter() {
+    styleHandleEpoch++
+    style.invalidateLoadedStyle()
+    style.loadState = StyleLoadState.Loading
+  }
+
+  internal fun seedPresentationViewport(token: MapPresentationToken, adapter: MapAdapter) {
+    val viewport = adapter.getViewport() ?: return
+    lifecycle.serialized {
+      val current = presentation ?: return@serialized
+      if (current.token != token || current.adapter !== adapter || current.viewport != null) return
+      current.updateViewport(viewport)
+    }
+  }
+
   private fun applyBaseStyleCommand(initial: BaseStyleCommand) {
     var command = initial
     while (true) {
@@ -672,13 +686,7 @@ internal constructor(
     token: MapPresentationToken,
     adapter: MapAdapter,
     options: MapPresentationOptions,
-    reusesRetainedAdapter: Boolean,
   ) {
-    if (!reusesRetainedAdapter) {
-      styleHandleEpoch++
-      style.invalidateLoadedStyle()
-    }
-    if (!reusesRetainedAdapter) style.loadState = StyleLoadState.Loading
     presentation = MapPresentation(this, token, adapter, options)
   }
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
@@ -469,11 +469,11 @@ internal constructor(
   }
 
   internal fun markStyleFailed(adapter: MapAdapter, reason: String?) {
-    lifecycle.serialized {
-      if (lifecycle.acceptsAdapter(adapter)) {
-        style.loadState = StyleLoadState.Failed(reason)
-      }
-    }
+    lifecycle.reportStyleFailure(adapter, reason)
+  }
+
+  internal fun commitStyleFailure(reason: String?) {
+    style.loadState = StyleLoadState.Failed(reason)
   }
 
   internal fun beginStyleRevision(adapter: MapAdapter, revision: DesiredStyleRevision) {

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
@@ -74,7 +74,7 @@ public interface MapRuntime {
     initialBaseStyle: BaseStyle = BaseStyle.Demo,
   ): MapState
 
-  /** Whether [close] has marked this runtime as closed. */
+  /** Returns true after [close] marks this runtime as closed. */
   public val isClosed: Boolean
 
   /** Marks this runtime as closed and starts child and shared-resource cleanup. */
@@ -94,18 +94,18 @@ public class MapStateClosedException : IllegalStateException("The map state is c
 public class MapPresentationDetachedException :
   IllegalStateException("The map presentation lease has ended")
 
-/** The load state for the desired base style of one logical map. */
+/** Reports the load state for the desired base style of one logical map. */
 public sealed interface StyleLoadState {
   /** No presentation can currently load the desired style. */
   public data object Pending : StyleLoadState
 
-  /** The current presentation is loading the desired style. */
+  /** Indicates that the current presentation is loading the desired style. */
   public data object Loading : StyleLoadState
 
-  /** The current presentation has loaded the desired style. */
+  /** Indicates that the current presentation loaded the desired style. */
   public data object Ready : StyleLoadState
 
-  /** The current presentation failed to load the desired style. */
+  /** Indicates that the current presentation failed to load the desired style. */
   public data class Failed(public val reason: String?) : StyleLoadState
 }
 
@@ -126,14 +126,13 @@ public class MapStyleState internal constructor(initialBaseStyle: BaseStyle) {
   public var loadState: StyleLoadState by mutableStateOf(StyleLoadState.Pending)
     internal set
 
-  /** The sources in the current loaded style, in style order. */
+  /** Contains the sources in the current loaded style, in style order. */
   public val sources: Map<String, SourceHandle>
-    get() = if (loadState == StyleLoadState.Ready) sourcesState else emptyMap()
+    get() = if (readyLoadedStyle() == null) emptyMap() else sourcesState
 
   /** Returns a generation-bound handle for [id], or null until the style is ready or if absent. */
   public fun source(id: String): SourceHandle? {
-    if (loadState != StyleLoadState.Ready) return null
-    val current = loadedStyle.load() ?: return null
+    val current = readyLoadedStyle() ?: return null
     return sourceHandle(current, id)
   }
 
@@ -147,10 +146,12 @@ public class MapStyleState internal constructor(initialBaseStyle: BaseStyle) {
 
   /** Returns a generation-bound handle for [id], or null until the style is ready or if absent. */
   public fun layer(id: String): LayerHandle? {
-    if (loadState != StyleLoadState.Ready) return null
-    val current = loadedStyle.load() ?: return null
+    val current = readyLoadedStyle() ?: return null
     return current.layerHandle(id, operationGuard(current))
   }
+
+  private fun readyLoadedStyle(): StyleBinding? =
+    owner?.readyLoadedStyle() ?: loadedStyle.load()?.takeIf { loadState == StyleLoadState.Ready }
 
   internal fun attach(owner: MapState) {
     this.owner = owner
@@ -171,6 +172,8 @@ public class MapStyleState internal constructor(initialBaseStyle: BaseStyle) {
   }
 
   internal fun isCurrentLoadedStyle(style: StyleBinding): Boolean = loadedStyle.load() === style
+
+  internal fun currentLoadedStyle(): StyleBinding? = loadedStyle.load()
 
   internal fun refreshSource(id: String) {
     val refreshed = source(id)
@@ -203,7 +206,7 @@ public class MapStyleState internal constructor(initialBaseStyle: BaseStyle) {
     }
 }
 
-/** One temporary connection between a [MapState] and a map surface. */
+/** Represents a temporary connection between a [MapState] and a map surface. */
 public class MapPresentation
 internal constructor(
   private val owner: MapState,
@@ -214,31 +217,30 @@ internal constructor(
   private val invalidated = CompletableDeferred<Unit>()
   private val cameraMutation = MutatorMutex()
   private var validState: Boolean by mutableStateOf(true)
-  private var viewportState: Viewport? by mutableStateOf(adapter.getViewport())
-  private val firstViewport =
-    CompletableDeferred<Viewport>().also { readiness -> viewportState?.let(readiness::complete) }
+  private var viewportState: Viewport? by mutableStateOf(null)
+  private val firstViewport = CompletableDeferred<Viewport>()
   private var cameraMovingState: Boolean by mutableStateOf(false)
   private var moveReasonState: CameraMoveReason by mutableStateOf(CameraMoveReason.NONE)
   private var optionsState: MapPresentationOptions by
     mutableStateOf(initialOptions, structuralEqualityPolicy())
 
-  /** Whether this presentation is still the current connection. */
+  /** Returns true while this presentation is the current connection. */
   public val isValid: Boolean
     get() = validState
 
-  /** The current viewport, or null before the presentation has rendered its first viewport. */
+  /** Contains the current viewport, or null before the first rendered viewport. */
   public val viewport: Viewport?
     get() = viewportState
 
-  /** Whether the current camera mutation is still in progress. */
+  /** Returns true while a camera mutation is in progress. */
   public val isCameraMoving: Boolean
     get() = cameraMovingState
 
-  /** The reason that the current or most recent camera mutation started. */
+  /** Contains the reason for the current or most recent camera mutation. */
   public val cameraMoveReason: CameraMoveReason
     get() = moveReasonState
 
-  /** The settings that the current [MaplibreMap] call applies to this render lease. */
+  /** Contains the settings that the current [MaplibreMap] call applies to this render lease. */
   public val options: MapPresentationOptions
     get() = optionsState
 
@@ -248,13 +250,14 @@ internal constructor(
   }
 
   /** Fits [boundingBox] in the current viewport and keeps the presentation camera padding. */
-  public fun setCameraPosition(
+  public suspend fun setCameraPosition(
     boundingBox: BoundingBox,
     bearing: Double = 0.0,
     tilt: Double = 0.0,
     padding: PaddingValues = PaddingValues(0.dp),
-  ) {
-    owner.withCurrent(this) { adapter.setCameraPosition(boundingBox, bearing, tilt, padding) }
+  ): Unit = runLeaseBound {
+    awaitViewportState()
+    adapter.setCameraPosition(boundingBox, bearing, tilt, padding)
   }
 
   /** Animates the camera to [position]. A new camera animation replaces the previous one. */
@@ -277,6 +280,7 @@ internal constructor(
   ) {
     cameraMutation.mutate {
       runLeaseBound {
+        awaitViewportState()
         adapter.animateCameraPosition(boundingBox, bearing, tilt, padding, duration)
       }
     }
@@ -380,7 +384,7 @@ internal constructor(
   }
 }
 
-/** One logical map, independent from its temporary UI presentation. */
+/** Represents a logical map independently from a temporary UI presentation. */
 public class MapState
 internal constructor(
   internal val runtime: RuntimeImplementation,
@@ -434,6 +438,7 @@ internal constructor(
 
   internal fun markStyleReady(adapter: MapAdapter): Boolean = lifecycle.serialized {
     if (!lifecycle.acceptsAdapter(adapter)) return false
+    if (style.currentLoadedStyle() == null) return false
     style.loadState = StyleLoadState.Ready
     style.refreshSources()
     true
@@ -452,10 +457,16 @@ internal constructor(
   internal fun updateLoadedStyle(adapter: MapAdapter, loadedStyle: StyleBinding?): Boolean =
     lifecycle.serialized {
       if (!lifecycle.acceptsAdapter(adapter)) return false
+      if (style.currentLoadedStyle() === loadedStyle) return true
       styleHandleEpoch++
+      style.loadState = StyleLoadState.Loading
       style.updateLoadedStyle(loadedStyle)
       true
     }
+
+  internal fun readyLoadedStyle(): StyleBinding? = lifecycle.serialized {
+    style.currentLoadedStyle()?.takeIf { style.loadState == StyleLoadState.Ready }
+  }
 
   internal fun markStyleFailed(adapter: MapAdapter, reason: String?) {
     lifecycle.serialized {
@@ -527,13 +538,13 @@ internal constructor(
   }
 
   internal fun setCameraPosition(candidate: MapPresentation, position: CameraPosition) {
-    lifecycle.serialized { requireCurrentLocked(candidate) }
-    candidate.adapter.setCameraPosition(position)
-    lifecycle.serialized {
+    val command = lifecycle.serialized {
       requireCurrentLocked(candidate)
       cameraPositionState = position
-      cameraCommandRevision++
+      CameraCommand(candidate.adapter, position, ++cameraCommandRevision)
     }
+    applyPresentationCameraCommand(candidate, command)
+    lifecycle.serialized { requireCurrentLocked(candidate) }
   }
 
   internal fun synchronizeCamera(adapter: MapAdapter): MapPresentation? {
@@ -604,14 +615,14 @@ internal constructor(
 
   internal fun configurePresentationAdapter(adapter: MapAdapter) {
     val configuration = lifecycle.serialized {
-      if (!lifecycle.acceptsAdapter(adapter)) return
+      if (!lifecycle.isPendingPublication(adapter)) return
       PresentationConfiguration(
         camera = CameraCommand(adapter, cameraPositionState, cameraCommandRevision),
         baseStyle = BaseStyleCommand(adapter, style.baseStyle, baseStyleCommandRevision),
       )
     }
     applyCameraCommand(configuration.camera)
-    if (!lifecycle.acceptsAdapter(adapter)) return
+    if (!lifecycle.isPendingPublication(adapter)) return
     applyBaseStyleCommand(configuration.baseStyle)
   }
 
@@ -635,6 +646,22 @@ internal constructor(
       command.adapter.setCameraPosition(command.value)
       command = lifecycle.serialized {
         if (lifecycle.currentAdapter() !== command.adapter) return
+        if (cameraCommandRevision == command.revision) return
+        CameraCommand(command.adapter, cameraPositionState, cameraCommandRevision)
+      }
+    }
+  }
+
+  private fun applyPresentationCameraCommand(
+    presentation: MapPresentation,
+    initial: CameraCommand,
+  ) {
+    var command = initial
+    while (true) {
+      if (!lifecycle.isCurrent(presentation.token, command.adapter)) return
+      command.adapter.setCameraPosition(command.value)
+      command = lifecycle.serialized {
+        if (!lifecycle.isCurrent(presentation.token, command.adapter)) return
         if (cameraCommandRevision == command.revision) return
         CameraCommand(command.adapter, cameraPositionState, cameraCommandRevision)
       }
@@ -674,11 +701,7 @@ internal constructor(
 }
 
 internal class MapStateCleanupException(failures: List<Throwable>) :
-  RuntimeException("Map state cleanup failed in ${failures.size} resource(s)", failures.first()) {
-  init {
-    failures.drop(1).forEach(::addSuppressed)
-  }
-}
+  AggregateCleanupException("Map state cleanup failed in ${failures.size} resource(s)", failures)
 
 @JvmInline internal value class MapPresentationToken(val value: Long)
 
@@ -812,19 +835,4 @@ internal class RuntimeImplementation(
 }
 
 internal class MapRuntimeCleanupException(failures: List<Throwable>) :
-  RuntimeException("Map runtime cleanup failed in ${failures.size} resource(s)", failures.first()) {
-  init {
-    failures.drop(1).forEach(::addSuppressed)
-  }
-}
-
-internal fun mapRuntimeForTest(
-  physicalScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
-  closeResources: suspend () -> Unit = {},
-): MapRuntime =
-  RuntimeImplementation(
-    platformOptions = null,
-    resources = MapRuntimeResources(closeResources),
-    logger = null,
-    physicalScope = physicalScope,
-  )
+  AggregateCleanupException("Map runtime cleanup failed in ${failures.size} resource(s)", failures)

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MaplibreMap.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MaplibreMap.kt
@@ -68,7 +68,7 @@ private class MapStateAttachment(
 /**
  * Displays [state] through one temporary presentation.
  *
- * The caller keeps [state] alive. This composable creates only the current presentation and
+ * The caller controls the lifetime of [state]. This composable creates the current presentation and
  * releases it when the call leaves composition.
  */
 @Composable
@@ -81,6 +81,11 @@ public fun MaplibreMap(
   contentWindowInsets: WindowInsets = WindowInsets.safeDrawing,
   overlay: MapOverlay = MapOverlay.Default,
 ) {
+  if (LocalInspectionMode.current) {
+    Box(modifier = modifier.fillMaxSize().background(Color.Gray))
+    return
+  }
+
   val presentationHostIdentity = mapPresentationHostIdentity()
   val presentationOwner = remember(state) { MapPresentationOwnerToken() }
   key(state, presentationHostIdentity) {
@@ -134,12 +139,6 @@ private fun MaplibreMapPresentation(
   contentWindowInsets: WindowInsets,
   overlay: MapOverlay,
 ) {
-  // In preview/inspection mode, show a placeholder instead of trying to render the map
-  if (LocalInspectionMode.current) {
-    Box(modifier = modifier.fillMaxSize().background(Color.Gray))
-    return
-  }
-
   var rememberedStyle by remember { mutableStateOf<StyleBinding?>(null) }
   val desiredRevision by
     rememberStyleComposition(

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/ScrollNotches.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/ScrollNotches.kt
@@ -3,10 +3,10 @@ package org.maplibre.compose.map
 import androidx.compose.ui.unit.Density
 
 /**
- * One scroll event's size, in wheel notches: 1.0 is one detent, and a trackpad reports fractions.
+ * Converts the size of one scroll event to wheel notches. A value of 1.0 is one wheel detent. A
+ * trackpad can produce a fractional value.
  *
- * Compose's `scrollDelta` carries no unit that holds across hosts, so each host converts its own.
- * [density] is passed because a host may have converted its raw delta to dp on the way here, which
- * an implementation may have to undo.
+ * Compose does not use the same `scrollDelta` unit on every host. Each host converts its value to
+ * wheel notches. A host can use [density] to reverse a dp conversion.
  */
 internal expect fun scrollNotches(scrollDelta: Float, density: Density): Double

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/MaplibreLogo.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/MaplibreLogo.kt
@@ -14,14 +14,13 @@ import org.maplibre.compose.generated.maplibre_logo
 import org.maplibre.compose.generated.maplibre_logo_description
 import org.maplibre.compose.util.tryOpenUri
 
-/** The address that [MaplibreLogo] opens when it is clicked. */
+/** Contains the address that [MaplibreLogo] opens when clicked. */
 public const val MaplibreWebsiteUrl: String = "https://maplibre.org/"
 
 /**
- * The MapLibre wordmark, drawn at its intrinsic size of 88x23 dp.
+ * Draws the MapLibre wordmark at its intrinsic size of 88x23 dp.
  *
- * The artwork carries its own drop shadow, so it reads over both light and dark basemaps without a
- * container behind it.
+ * The wordmark includes a drop shadow for contrast on light and dark basemaps.
  *
  * @param contentDescription Accessibility label for the logo.
  * @param onClick Called when the logo is clicked. Opens [MaplibreWebsiteUrl] by default. Pass

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/sources/GeoJsonSource.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/sources/GeoJsonSource.kt
@@ -15,10 +15,10 @@ import org.maplibre.spatialk.geojson.Feature
 import org.maplibre.spatialk.geojson.GeoJsonObject
 import org.maplibre.spatialk.geojson.toJson
 
-/** The style-spec property MapLibre stamps on a feature that stands in for a cluster. */
+/** Names the style-spec property that identifies a cluster feature. */
 internal const val CLUSTER_ID_PROPERTY = "cluster_id"
 
-/** A map data source consisting of geojson data. */
+/** Defines a map data source that contains GeoJSON data. */
 public class GeoJsonSource : Source {
 
   private val options: GeoJsonOptions
@@ -103,9 +103,10 @@ private fun GeoJsonData.snapshot(): GeoJsonData =
  *
  * @param lineMetrics Whether to calculate line distance metrics. This is required for
  *   [LineLayer][org.maplibre.compose.layers.LineLayer]s that specify a `gradient`.
- * @param synchronousUpdate Whether in-memory GeoJSON updates should be applied synchronously,
- *   reducing update latency at the possible cost of frame rate. Android, iOS, and desktop honor
- *   this; the browser ignores it.
+ * @param synchronousUpdate Whether native engines generate requested tiles during the update pass.
+ *   This can make submitted data available to the next rendered frame, but it can reduce frame
+ *   rate. This option does not change when [GeoJsonSourceHandle.setData] returns. Android, iOS, and
+ *   desktop honor this option. The browser ignores it.
  */
 @Immutable
 public data class GeoJsonOptions(

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/sources/SourceHandle.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/sources/SourceHandle.kt
@@ -103,10 +103,11 @@ internal constructor(
   /**
    * Submits [data] to replace the source data for this loaded style.
    *
-   * A successful return means that the update was submitted to the current source generation. This
-   * function does not wait for parsing, indexing, tiling, URL loading, or rendering. The engine can
-   * continue these operations after this function returns. A newer call supersedes an older pending
-   * update. Loading a new base style discards the submitted data.
+   * A successful return means only that the update was submitted to the current source generation.
+   * The function does not define when parsing, indexing, tiling, URL loading, or rendering
+   * completes. An implementation can perform part of this work before returning and continue it
+   * afterward. A newer call supersedes an older pending update. Loading a new base style discards
+   * the submitted data.
    *
    * @throws StyleHandleException if submission fails before this function returns.
    */

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/sources/SourceHandle.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/sources/SourceHandle.kt
@@ -23,7 +23,7 @@ import org.maplibre.spatialk.geojson.Feature
 import org.maplibre.spatialk.geojson.FeatureCollection
 import org.maplibre.spatialk.geojson.Geometry
 
-/** Imperative access to one source in one loaded base-style generation. */
+/** Provides imperative access to a source for one loaded base-style generation. */
 public sealed class SourceHandle
 protected constructor(
   public val id: String,
@@ -42,7 +42,7 @@ protected constructor(
     }
   }
 
-  /** The source attribution that the current loaded style reports. */
+  /** Contains the source attribution from the current loaded style. */
   public val attributionHtml: String
     get() = operation { style.getSource(id)?.attributionHtml.orEmpty() }
 
@@ -81,11 +81,7 @@ protected constructor(
   }
 }
 
-/**
- * Imperative access to one GeoJSON source in one loaded base-style generation.
- *
- * A mutation that MapLibre refuses throws [StyleHandleException].
- */
+/** Provides imperative access to a GeoJSON source for one loaded base-style generation. */
 public class GeoJsonSourceHandle
 internal constructor(
   id: String,
@@ -104,7 +100,16 @@ internal constructor(
   private val requestedData = AtomicLong(0L)
   private val installedData = AtomicLong(0L)
 
-  /** Replaces the transient data in this loaded style. A base-style reload discards the change. */
+  /**
+   * Submits [data] to replace the source data for this loaded style.
+   *
+   * A successful return means that the update was submitted to the current source generation. This
+   * function does not wait for parsing, indexing, tiling, URL loading, or rendering. The engine can
+   * continue these operations after this function returns. A newer call supersedes an older pending
+   * update. Loading a new base style discards the submitted data.
+   *
+   * @throws StyleHandleException if submission fails before this function returns.
+   */
   public fun setData(data: GeoJsonData) {
     operation {
       val generation = requestedData.incrementAndFetch()
@@ -120,24 +125,24 @@ internal constructor(
     }
   }
 
-  /** Whether [feature] represents a cluster created by this source. */
+  /** Returns true if [feature] represents a cluster created by this source. */
   public fun isCluster(feature: Feature<*, JsonObject?>): Boolean =
     CLUSTER_ID_PROPERTY in feature.properties.orEmpty()
 
-  /** The zoom at which [feature]'s cluster breaks apart, or zero for a non-cluster feature. */
+  /** Returns the cluster expansion zoom for [feature], or zero if [feature] is not a cluster. */
   public suspend fun getClusterExpansionZoom(feature: Feature<*, JsonObject?>): Double =
     suspendingOperation {
       style.clusterExpansionZoom(id, feature) ?: 0.0
     }
 
-  /** The features one level below [feature]'s cluster, or an empty collection for a non-cluster. */
+  /** Returns the cluster children for [feature], or an empty collection for a non-cluster. */
   public suspend fun getClusterChildren(
     feature: Feature<*, JsonObject?>
   ): FeatureCollection<Geometry, JsonObject?> = suspendingOperation {
     style.clusterChildren(id, feature) ?: FeatureCollection(emptyList())
   }
 
-  /** The original points in [feature]'s cluster, or an empty collection for a non-cluster. */
+  /** Returns the cluster leaves for [feature], or an empty collection for a non-cluster. */
   public suspend fun getClusterLeaves(
     feature: Feature<*, JsonObject?>,
     limit: Long,
@@ -186,7 +191,7 @@ internal constructor(
   }
 }
 
-/** Imperative access to one vector source in one loaded base-style generation. */
+/** Provides imperative access to a vector source for one loaded base-style generation. */
 public open class VectorSourceHandle
 internal constructor(
   id: String,
@@ -227,7 +232,7 @@ internal constructor(
   }
 }
 
-/** Imperative access to one application-supplied vector source. */
+/** Provides imperative access to an application-supplied vector source. */
 public class CustomVectorSourceHandle
 internal constructor(
   id: String,
@@ -248,7 +253,7 @@ internal constructor(
   }
 }
 
-/** Imperative access to one application-supplied geometry source. */
+/** Provides imperative access to an application-supplied geometry source. */
 public class CustomGeometrySourceHandle
 internal constructor(
   id: String,
@@ -267,7 +272,7 @@ internal constructor(
   }
 }
 
-/** Imperative access to one image source in one loaded base-style generation. */
+/** Provides imperative access to an image source for one loaded base-style generation. */
 public class ImageSourceHandle
 internal constructor(
   id: String,
@@ -296,7 +301,7 @@ internal constructor(
   }
 }
 
-/** Imperative access to one raster source in one loaded base-style generation. */
+/** Provides imperative access to a raster source for one loaded base-style generation. */
 public class RasterSourceHandle
 internal constructor(
   id: String,
@@ -305,7 +310,7 @@ internal constructor(
   operations: StyleHandleOperationGuard,
 ) : SourceHandle(id, style, "raster", currentKind, operations)
 
-/** Imperative access to one raster DEM source in one loaded base-style generation. */
+/** Provides imperative access to a raster DEM source for one loaded base-style generation. */
 public class RasterDemSourceHandle
 internal constructor(
   id: String,
@@ -314,7 +319,7 @@ internal constructor(
   operations: StyleHandleOperationGuard,
 ) : SourceHandle(id, style, "raster-dem", currentKind, operations)
 
-/** Imperative access to a source type with no specialized common handle. */
+/** Provides imperative access to a source type that has no specialized common handle. */
 public class UnknownSourceHandle
 internal constructor(
   id: String,

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleBinding.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleBinding.kt
@@ -26,12 +26,13 @@ import org.maplibre.spatialk.geojson.Geometry
 import org.maplibre.spatialk.geojson.Position
 
 /**
- * The engine binding for one loaded style, identified by one opaque generation. The binding stops
- * working when its style unloads. Operations on an invalidated binding fail with a stale-style
+ * Provides engine operations for one loaded style and its opaque generation identifier.
+ *
+ * Style unload invalidates the binding. An operation on an invalid binding produces a stale-style
  * error.
  */
 internal interface StyleBinding {
-  /** The loaded base-style generation associated with every operation on this binding. */
+  /** Identifies the loaded base-style generation for this binding. */
   val identity: StyleIdentity
 
   val isLoaded: Boolean
@@ -75,7 +76,7 @@ internal interface StyleBinding {
    * Adds a complete layer object directly below [beforeLayerId], or on top when that is empty.
    *
    * @return false if the style has unloaded, in which case nothing was added.
-   * @throws StyleMutationException if MapLibre refuses the layer.
+   * @throws StyleMutationException if the engine returns an error.
    */
   fun addLayer(layer: JsonObject, beforeLayerId: String): Boolean
 
@@ -86,57 +87,61 @@ internal interface StyleBinding {
 
   fun removeLayer(layerId: String)
 
-  /** Moves a layer to sit directly below [beforeLayerId], or on top when that is empty. */
+  /** Moves a layer directly below [beforeLayerId], or to the top when that ID is empty. */
   fun moveLayer(layerId: String, beforeLayerId: String)
 
   /**
    * Sets one property on a layer that is already in the style.
    *
-   * @param kind which of a layer object's three parts [name] belongs to; a name offered to the
-   *   wrong one is rejected.
-   * @throws StyleMutationException if MapLibre refuses [value]; the layer keeps its previous one.
+   * @param kind The section of the layer object that contains [name]. The engine returns an error
+   *   for an incorrect section.
+   * @throws StyleMutationException if the engine returns an error. An error does not change the
+   *   previous value.
    */
   fun setLayerProperty(layerId: String, name: String, value: JsonElement, kind: LayerPropertyKind)
 
   fun setLayerFilter(layerId: String, filter: JsonElement)
 
-  /** @return null if the style has unloaded, or the layer holds no value for [name]. */
+  /** @return null if the style has unloaded or the layer has no value for [name]. */
   fun layerProperty(layerId: String, name: String): JsonElement?
 
   /**
-   * Reports whether a live layer with [layerId] is in the style, so a duplicate can be refused on
-   * the caller with the message that names the cause.
+   * Checks whether the style contains a live layer with [layerId]. Callers use the result to report
+   * a specific duplicate-layer error.
    *
-   * @return null if the style has unloaded or the answer could not be determined; the add still
-   *   refuses a duplicate in that case.
+   * @return null if the style has unloaded or the implementation cannot determine the result. The
+   *   engine still rejects a duplicate during insertion.
    */
   fun layerExists(layerId: String): Boolean?
 
   /**
-   * Why this engine cannot take a layer property, or null when it can. The style spec is shared,
-   * but each engine implements it at its own pace; a non-null reason keeps the property out of
-   * every write to this binding, and the layer reports it once instead.
+   * Returns the reason that this engine does not support a layer property.
+   *
+   * A null result means that the property is supported. A non-null result omits the property from
+   * writes and produces one warning for the layer.
    */
   fun unsupportedLayerPropertyReason(layerType: String, name: String): String? = null
 
   /**
-   * Whether this engine decodes a raster-dem source's custom encoding factors; an engine that does
-   * not takes the Mapbox encoding instead.
+   * Returns true if this engine decodes custom encoding factors for raster DEM sources. An
+   * unsupported custom encoding uses the Mapbox encoding.
    */
   val supportsCustomDemEncoding: Boolean
 
-  /** Whether this engine takes a `scheme` on a raster-dem source; the style spec has none. */
+  /**
+   * Returns true if this engine accepts `scheme` on a raster DEM source. The style spec omits it.
+   */
   val supportsRasterDemScheme: Boolean
 
   /**
    * Adds a source from its style-spec definition.
    *
    * @return false if the style has unloaded, in which case nothing was added.
-   * @throws StyleMutationException if MapLibre refuses the source.
+   * @throws StyleMutationException if the engine returns an error.
    */
   fun addSource(sourceId: String, source: JsonObject): Boolean
 
-  /** Installs one immutable source definition in this loaded style. */
+  /** Installs an immutable source definition in this loaded style. */
   fun addSource(definition: SourceDefinition): Boolean {
     requireCurrent()
     return when (definition) {
@@ -166,25 +171,25 @@ internal interface StyleBinding {
     }
   }
 
-  /** Removes a source and forgets the feature state that belonged to it. */
+  /** Removes a source and its feature state. */
   fun removeSource(sourceId: String)
 
   /**
-   * Reports whether a live source with [sourceId] is in the style, so a duplicate can be refused on
-   * the caller with the message that names the cause.
+   * Checks whether the style contains a live source with [sourceId]. Callers use the result to
+   * report a specific duplicate-source error.
    *
-   * @return null if the style has unloaded or the answer could not be determined; the add still
-   *   refuses a duplicate in that case.
+   * @return null if the style has unloaded or the implementation cannot determine the result. The
+   *   engine still rejects a duplicate during insertion.
    */
   fun sourceExists(sourceId: String): Boolean?
 
   /**
-   * Adds an image source carrying its pixels, for engines whose source JSON can only name a URL.
+   * Adds an image source from pixel data when source JSON only supports a URL.
    *
    * @param coordinates the four corners in MapLibre's order: top left, top right, bottom right,
    *   bottom left.
    * @return false if the style has unloaded, in which case nothing was added.
-   * @throws StyleMutationException if MapLibre refuses the source.
+   * @throws StyleMutationException if the engine returns an error.
    */
   fun addImageSourceImage(
     sourceId: String,
@@ -198,18 +203,18 @@ internal interface StyleBinding {
   /** Replaces an image source's content with a URL. */
   fun setImageSourceUrl(sourceId: String, url: String)
 
-  /** Moves an image source's four corners, given in MapLibre's order. */
+  /** Sets an image source's four corners in MapLibre order. */
   fun setImageSourceCoordinates(sourceId: String, coordinates: List<Position>)
 
   /** @return null if the style has unloaded, or the source is not a live image source. */
   fun imageSourceCoordinates(sourceId: String): List<Position>?
 
   /**
-   * Adds a GeoJSON source from its data and options. The default writes the style-spec JSON; an
-   * engine with a typed adder overrides it.
+   * Adds a GeoJSON source from its data and options. The default implementation writes style-spec
+   * JSON. An engine can override this function to use a typed API.
    *
    * @return false if the style has unloaded, in which case nothing was added.
-   * @throws StyleMutationException if MapLibre refuses the source or the data.
+   * @throws StyleMutationException if the engine returns an error for the source or its data.
    */
   fun addGeoJsonSource(sourceId: String, data: GeoJsonData, options: GeoJsonOptions): Boolean =
     addSource(
@@ -222,8 +227,10 @@ internal interface StyleBinding {
     )
 
   /**
-   * Converts inline [data] into this engine's install form on the caller, so an expensive parse
-   * stays off the map's owner thread. A URL installs through [setGeoJsonSourceUrl] instead.
+   * Converts inline [data] to the engine-specific installation form on the calling thread.
+   *
+   * Callers can run this function outside the map owner thread. Use [setGeoJsonSourceUrl] for a
+   * URL.
    */
   fun prepareGeoJson(data: GeoJsonData, options: GeoJsonOptions): PreparedGeoJson
 
@@ -235,26 +242,25 @@ internal interface StyleBinding {
   ): PreparedGeoJson = prepareGeoJson(data, fallbackOptions)
 
   /**
-   * Installs [prepared] on a live GeoJSON source when [claim] answers true.
+   * Installs [prepared] on a live GeoJSON source if [claim] returns true.
    *
-   * [claim] runs where this engine serializes installs. Overlapping installs resolve their order in
-   * one place. It runs even when the style has unloaded or the install is dropped. The live handle
-   * records the applied data. This function returns after the install has run or been dropped. The
-   * caller may then close [prepared].
+   * The implementation invokes [claim] in the serialized installation context. It invokes [claim]
+   * even if the style has unloaded or the implementation discards the installation. This function
+   * returns after installation or disposal. The caller can then close [prepared].
    */
   fun setGeoJsonSourceData(sourceId: String, prepared: PreparedGeoJson, claim: () -> Boolean)
 
-  /** Points a live GeoJSON source at [url]; [claim] follows the [setGeoJsonSourceData] contract. */
+  /** Sets [url] on a live GeoJSON source. [claim] follows [setGeoJsonSourceData]. */
   fun setGeoJsonSourceUrl(sourceId: String, url: String, claim: () -> Boolean)
 
   /**
-   * Adds a custom geometry source whose feature tiles [provider] supplies. The engine owns the
-   * tile-serving machinery for the source and tears it down on remove or unload.
+   * Adds a custom geometry source that obtains feature tiles from [provider]. Removal or style
+   * unload stops the source and releases its resources.
    *
    * @return false if the style has unloaded, in which case nothing was added.
    * @throws UnsupportedOperationException on an engine with no custom geometry source (MapLibre GL
    *   JS).
-   * @throws StyleMutationException if MapLibre refuses the source.
+   * @throws StyleMutationException if the engine returns an error.
    */
   fun addCustomGeometrySource(
     sourceId: String,
@@ -269,11 +275,11 @@ internal interface StyleBinding {
   fun invalidateCustomGeometrySourceTile(sourceId: String, tile: TileCoordinate)
 
   /**
-   * Adds a custom vector source whose MVT tiles [provider] supplies. The engine owns the
-   * tile-serving machinery for the source and tears it down on remove or unload.
+   * Adds a custom vector source that obtains MVT tiles from [provider]. Removal or style unload
+   * stops the source and releases its resources.
    *
    * @return false if the style has unloaded, in which case nothing was added.
-   * @throws StyleMutationException if MapLibre refuses the source.
+   * @throws StyleMutationException if the engine returns an error.
    */
   fun addCustomVectorSource(
     sourceId: String,
@@ -290,18 +296,22 @@ internal interface StyleBinding {
   fun invalidateCustomVectorSourceTile(sourceId: String, tile: TileCoordinate)
 
   /**
-   * The zoom at which [feature]'s cluster breaks apart, or null when the feature carries no cluster
-   * id, no live source can answer, or the cluster is gone.
+   * Returns the cluster expansion zoom for [feature].
+   *
+   * @return null if the feature has no cluster ID, the source is unavailable, or the cluster no
+   *   longer exists.
    */
   suspend fun clusterExpansionZoom(sourceId: String, feature: Feature<*, JsonObject?>): Double?
 
-  /** The features one level down from [feature]'s cluster; null as [clusterExpansionZoom]. */
+  /**
+   * Returns the cluster children for [feature], or null under [clusterExpansionZoom] conditions.
+   */
   suspend fun clusterChildren(
     sourceId: String,
     feature: Feature<*, JsonObject?>,
   ): FeatureCollection<Geometry, JsonObject?>?
 
-  /** The original points under [feature]'s cluster; null as [clusterExpansionZoom]. */
+  /** Returns the cluster leaves for [feature], or null under [clusterExpansionZoom] conditions. */
   suspend fun clusterLeaves(
     sourceId: String,
     feature: Feature<*, JsonObject?>,
@@ -310,9 +320,9 @@ internal interface StyleBinding {
   ): FeatureCollection<Geometry, JsonObject?>?
 
   /**
-   * Reports that [sourceId] was added or removed, so the style state can refresh that source
-   * without waiting for idle. An engine that adds sources through its own hop calls this from
-   * inside that hop, after the add or remove.
+   * Reports the addition or removal of [sourceId] without waiting for an idle event.
+   *
+   * An asynchronous implementation calls this function after it completes the addition or removal.
    */
   fun reportSourceChanged(sourceId: String) {}
 
@@ -351,23 +361,23 @@ internal interface StyleBinding {
   ): List<Feature<Geometry, JsonObject?>>
 }
 
-/** An engine's install form of one GeoJSON payload. [close] releases what the engine holds. */
+/** Stores one GeoJSON payload in an engine-specific installation form. [close] releases it. */
 internal interface PreparedGeoJson : AutoCloseable
 
-/** The prepared form of an engine with nothing to prepare. */
+/** Represents a GeoJSON payload that requires no preparation. */
 internal object NoPreparedGeoJson : PreparedGeoJson {
   override fun close() = Unit
 }
 
-/** Which part of a layer object a property belongs to. */
+/** Identifies the section of a layer object that contains a property. */
 internal enum class LayerPropertyKind {
   LAYOUT,
   PAINT,
 
-  /** A key on the layer object itself, such as `minzoom`, rather than in `layout` or `paint`. */
+  /** Identifies a key on the layer object, such as `minzoom`, outside `layout` and `paint`. */
   ROOT,
 }
 
-/** A style mutation MapLibre refused. */
+/** Reports an engine error from a style mutation. */
 internal class StyleMutationException(message: String?, cause: Throwable?) :
   RuntimeException(message, cause)

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleDefinitions.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleDefinitions.kt
@@ -14,7 +14,7 @@ import org.maplibre.compose.util.ImageStretch
 import org.maplibre.compose.util.toImageBitmap
 import org.maplibre.spatialk.geojson.Position
 
-/** One immutable source definition that can be installed in any loaded style. */
+/** Defines an immutable source that can be installed in any loaded style. */
 internal sealed interface SourceDefinition {
   val id: String
 
@@ -54,7 +54,7 @@ internal sealed interface SourceDefinition {
   ) : SourceDefinition
 }
 
-/** One immutable layer definition. Layer placement belongs to the desired style revision. */
+/** Defines an immutable layer. The desired style revision specifies its placement. */
 internal data class LayerDefinition(
   val id: String,
   val type: String,
@@ -63,9 +63,7 @@ internal data class LayerDefinition(
   val unsupportedProperties: Map<String, String> = emptyMap(),
 )
 
-/**
- * One resolved image definition. It contains no painter, composition, or loaded-style reference.
- */
+/** Defines a resolved image without a painter, composition, or loaded-style reference. */
 internal data class StyleImageDefinition(
   val id: String,
   val image: ImageSnapshot,
@@ -73,7 +71,7 @@ internal data class StyleImageDefinition(
   val stretch: ImageStretch?,
 )
 
-/** An engine-neutral image value that stores an independent copy of its pixels. */
+/** Stores an independent pixel copy in an engine-neutral format. */
 internal class ImageSnapshot
 private constructor(
   val width: Int,

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapLifecycleBindingTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapLifecycleBindingTest.kt
@@ -330,6 +330,19 @@ class MapLifecycleBindingTest {
   }
 
   @Test
+  fun a_late_attach_start_is_inert_after_closure_begins() = runTest {
+    val adapter = FakeMapLifecycleAdapter().apply { allowResources = CompletableDeferred() }
+    val lifecycle = bindLifecycle(adapter)
+    lifecycle.close()
+
+    assertTrue(!lifecycle.beginAttachIfOpen())
+
+    adapter.allowResources.complete(Unit)
+    lifecycle.awaitClosed()
+    assertEquals(listOf("close resources"), adapter.commands)
+  }
+
+  @Test
   fun detach_during_failed_engine_creation_cleans_partial_engine_resources() = runTest {
     val adapter =
       FakeMapLifecycleAdapter().apply {

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
@@ -55,19 +55,6 @@ import org.maplibre.spatialk.geojson.dsl.buildFeatureCollection
 class MapPresentationTest {
 
   @Test
-  fun closure_updates_the_observable_runtime_and_map_flags_immediately() {
-    val runtime = mapRuntimeForTest()
-    val state = runtime.createMapState()
-
-    assertFalse(runtime.isClosed)
-    assertFalse(state.isClosed)
-    state.close()
-    assertTrue(state.isClosed)
-    runtime.close()
-    assertTrue(runtime.isClosed)
-  }
-
-  @Test
   fun closing_map_state_closes_a_bound_session_before_it_is_published() = runTest {
     val runtime = mapRuntimeForTest(physicalScope = backgroundScope)
     val state = runtime.createMapState()
@@ -86,6 +73,23 @@ class MapPresentationTest {
   }
 
   @Test
+  fun a_bound_but_unpublished_session_cannot_mutate_durable_style_state() = runTest {
+    val runtime = mapRuntimeForTest(physicalScope = backgroundScope)
+    val state = runtime.createMapState()
+    val session = BoundLifecycleSession()
+    session.lifecycle = state.lifecycle.bind(session)
+    session.lifecycle.attach()
+
+    assertFalse(state.updateLoadedStyle(session, RecordingStyleBinding()))
+    assertFalse(state.markStyleReady(session))
+    assertEquals(StyleLoadState.Pending, state.style.loadState)
+
+    state.close()
+    state.awaitClosed()
+    runtime.close()
+  }
+
+  @Test
   fun a_session_that_closes_itself_is_retired_and_its_failure_reaches_map_closure() = runTest {
     val runtime = mapRuntimeForTest(physicalScope = backgroundScope)
     val state = runtime.createMapState()
@@ -96,6 +100,7 @@ class MapPresentationTest {
     val token = state.reservePresentation()
     state.publishPresentation(token, session)
     assertSame(session, state.presentation?.adapter)
+    assertTrue(state.updateLoadedStyle(session, RecordingStyleBinding()))
     assertTrue(state.markStyleReady(session))
     assertEquals(StyleLoadState.Ready, state.style.loadState)
 
@@ -137,6 +142,7 @@ class MapPresentationTest {
     session.lifecycle.attach()
     val token = state.reservePresentation()
     state.publishPresentation(token, session)
+    assertTrue(state.updateLoadedStyle(session, RecordingStyleBinding()))
     assertTrue(state.markStyleReady(session))
 
     state.releasePresentation(token, session)
@@ -538,6 +544,24 @@ class MapPresentationTest {
   }
 
   @Test
+  fun publishing_a_replacement_style_makes_handles_unavailable_until_it_is_ready() {
+    val fixture = presentationFixture()
+    val first = RecordingStyleBinding()
+    assertTrue(fixture.state.updateLoadedStyle(fixture.adapter, first))
+    assertTrue(fixture.state.markStyleReady(fixture.adapter))
+    assertEquals(StyleLoadState.Ready, fixture.state.style.loadState)
+
+    val replacement = RecordingStyleBinding()
+    assertTrue(fixture.state.updateLoadedStyle(fixture.adapter, replacement))
+
+    assertEquals(StyleLoadState.Loading, fixture.state.style.loadState)
+    assertNull(fixture.state.style.layer("anything"))
+    assertTrue(fixture.state.markStyleReady(fixture.adapter))
+    assertEquals(StyleLoadState.Ready, fixture.state.style.loadState)
+    fixture.close()
+  }
+
+  @Test
   fun publication_happens_after_the_adapter_accepts_initial_map_state() {
     val runtime = mapRuntimeForTest()
     val initialCamera = CameraPosition(target = Position(12.0, 34.0), zoom = 8.0)
@@ -561,6 +585,35 @@ class MapPresentationTest {
     assertNull(fixture.presentation.getVisibleRegion())
     assertNull(fixture.presentation.getVisibleBoundingBox())
     assertNull(fixture.presentation.metersPerDpAtLatitude(0.0))
+    fixture.close()
+  }
+
+  @Test
+  fun a_new_presentation_does_not_inherit_the_adapters_previous_viewport() {
+    val runtime = mapRuntimeForTest()
+    val state = runtime.createMapState()
+    val token = state.reservePresentation()
+    val adapter = PresentationTestAdapter().apply { currentViewport = testViewport() }
+
+    state.publishPresentation(token, adapter)
+
+    assertNull(state.presentation?.viewport)
+    state.close()
+    runtime.close()
+  }
+
+  @Test
+  fun a_bounds_set_waits_for_this_presentations_viewport() = runTest {
+    val fixture = presentationFixture()
+    val operation = async {
+      fixture.presentation.setCameraPosition(BoundingBox(Position(-1.0, -1.0), Position(1.0, 1.0)))
+    }
+    testScheduler.runCurrent()
+
+    assertFalse(fixture.adapter.boundsSet.isCompleted)
+    fixture.presentation.updateViewport(testViewport())
+    operation.await()
+    assertTrue(fixture.adapter.boundsSet.isCompleted)
     fixture.close()
   }
 
@@ -738,6 +791,8 @@ internal open class PresentationTestAdapter(
   var lastCameraPosition = CameraPosition()
   var presentationWasVisibleWhileConfiguring = false
   var viewportReads = 0
+  var currentViewport: Viewport? = null
+  val boundsSet = CompletableDeferred<Unit>()
   val queryStarted = CompletableDeferred<Unit>()
   val animationStarted = CompletableDeferred<Unit>()
   val finishAnimation = CompletableDeferred<Unit>()
@@ -783,7 +838,9 @@ internal open class PresentationTestAdapter(
     bearing: Double,
     tilt: Double,
     padding: PaddingValues,
-  ) = Unit
+  ) {
+    boundsSet.complete(Unit)
+  }
 
   override fun setCameraConstraints(value: CameraConstraints) = Unit
 
@@ -800,7 +857,7 @@ internal open class PresentationTestAdapter(
 
   override fun getViewport(): Viewport? {
     viewportReads++
-    return null
+    return currentViewport
   }
 
   override fun setRenderSettings(value: RenderOptions) = Unit

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
@@ -255,6 +255,24 @@ class MapPresentationTest {
   }
 
   @Test
+  fun a_style_failure_during_presentation_configuration_is_published_after_admission() = runTest {
+    val runtime = mapRuntimeForTest()
+    val state = runtime.createMapState()
+    val callbacks = state.durableStyleCallbacks()
+    val token = state.reservePresentation()
+    val adapter = FailureDuringConfigurationAdapter { map ->
+      callbacks.onMapFailLoading(map, "style refused")
+    }
+
+    state.publishPresentation(token, adapter)
+
+    val failure = assertIs<StyleLoadState.Failed>(state.style.loadState)
+    assertEquals("style refused", failure.reason)
+    state.close()
+    runtime.close()
+  }
+
+  @Test
   fun an_accepted_camera_set_updates_the_durable_map_position() {
     val fixture = presentationFixture()
     val position = CameraPosition(target = Position(12.0, 34.0), zoom = 8.0)
@@ -782,6 +800,14 @@ private class ClosingDuringConfigurationAdapter(private val closeState: () -> Un
       closed = true
       closeState()
     }
+  }
+}
+
+private class FailureDuringConfigurationAdapter(private val reportFailure: (MapAdapter) -> Unit) :
+  PresentationTestAdapter() {
+  override fun setBaseStyle(style: BaseStyle) {
+    super.setBaseStyle(style)
+    reportFailure(this)
   }
 }
 

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
@@ -255,7 +255,7 @@ class MapPresentationTest {
   }
 
   @Test
-  fun a_style_failure_during_presentation_configuration_is_published_after_admission() = runTest {
+  fun a_style_failure_before_publication_remains_the_durable_load_state() = runTest {
     val runtime = mapRuntimeForTest()
     val state = runtime.createMapState()
     val callbacks = state.durableStyleCallbacks()
@@ -273,6 +273,42 @@ class MapPresentationTest {
   }
 
   @Test
+  fun a_configuration_error_publishes_the_presentation_with_failed_style_state() = runTest {
+    val runtime = mapRuntimeForTest()
+    val state = runtime.createMapState()
+    val token = state.reservePresentation()
+    val adapter = ConfigurationErrorAdapter()
+
+    state.publishPresentation(token, adapter)
+
+    assertSame(adapter, state.presentation?.adapter)
+    val failure = assertIs<StyleLoadState.Failed>(state.style.loadState)
+    assertEquals("style rejected", failure.reason)
+    state.close()
+    runtime.close()
+  }
+
+  @Test
+  fun style_events_before_publication_update_the_durable_style_state() = runTest {
+    val runtime = mapRuntimeForTest()
+    val state = runtime.createMapState()
+    val token = state.reservePresentation()
+    val adapter = PresentationTestAdapter()
+    val callbacks = state.durableStyleCallbacks()
+    val style = RecordingStyleBinding()
+
+    assertTrue(state.lifecycle.selectAdapterForPresentation(adapter))
+    callbacks.onStyleChanged(adapter, style)
+    callbacks.onMapFinishedLoading(adapter)
+    state.publishPresentation(token, adapter)
+
+    assertEquals(StyleLoadState.Ready, state.style.loadState)
+    assertSame(style, state.style.currentLoadedStyle())
+    state.close()
+    runtime.close()
+  }
+
+  @Test
   fun an_accepted_camera_set_updates_the_durable_map_position() {
     val fixture = presentationFixture()
     val position = CameraPosition(target = Position(12.0, 34.0), zoom = 8.0)
@@ -282,6 +318,28 @@ class MapPresentationTest {
     assertEquals(position, fixture.state.cameraPosition)
     assertEquals(position, fixture.adapter.lastCameraPosition)
     fixture.close()
+  }
+
+  @Test
+  fun camera_intent_accepted_before_detachment_remains_durable() {
+    val runtime = mapRuntimeForTest()
+    val state = runtime.createMapState()
+    val token = state.reservePresentation()
+    val adapter = ReleasingCameraAdapter { map ->
+      state.releasePresentation(token, map)
+    }
+    state.publishPresentation(token, adapter)
+    val presentation = requireNotNull(state.presentation)
+    val position = CameraPosition(target = Position(12.0, 34.0), zoom = 8.0)
+    adapter.releaseOnNextCameraSet = true
+
+    presentation.setCameraPosition(position)
+
+    assertEquals(position, state.cameraPosition)
+    assertFalse(presentation.isValid)
+    assertNull(state.presentation)
+    state.close()
+    runtime.close()
   }
 
   @Test
@@ -607,15 +665,16 @@ class MapPresentationTest {
   }
 
   @Test
-  fun a_new_presentation_does_not_inherit_the_adapters_previous_viewport() {
+  fun publication_uses_the_viewport_the_adapter_has_for_the_current_attachment() {
     val runtime = mapRuntimeForTest()
     val state = runtime.createMapState()
     val token = state.reservePresentation()
-    val adapter = PresentationTestAdapter().apply { currentViewport = testViewport() }
+    val viewport = testViewport()
+    val adapter = PresentationTestAdapter().apply { currentViewport = viewport }
 
     state.publishPresentation(token, adapter)
 
-    assertNull(state.presentation?.viewport)
+    assertEquals(viewport, state.presentation?.viewport)
     state.close()
     runtime.close()
   }
@@ -808,6 +867,25 @@ private class FailureDuringConfigurationAdapter(private val reportFailure: (MapA
   override fun setBaseStyle(style: BaseStyle) {
     super.setBaseStyle(style)
     reportFailure(this)
+  }
+}
+
+private class ConfigurationErrorAdapter : PresentationTestAdapter() {
+  override fun setBaseStyle(style: BaseStyle) {
+    error("style rejected")
+  }
+}
+
+private class ReleasingCameraAdapter(private val release: (MapAdapter) -> Unit) :
+  PresentationTestAdapter() {
+  var releaseOnNextCameraSet = false
+
+  override fun setCameraPosition(cameraPosition: CameraPosition) {
+    super.setCameraPosition(cameraPosition)
+    if (releaseOnNextCameraSet) {
+      releaseOnNextCameraSet = false
+      release(this)
+    }
   }
 }
 

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapRuntimeTestSupport.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapRuntimeTestSupport.kt
@@ -1,0 +1,16 @@
+package org.maplibre.compose.map
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+
+internal fun mapRuntimeForTest(
+  physicalScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
+  closeResources: suspend () -> Unit = {},
+): MapRuntime =
+  RuntimeImplementation(
+    platformOptions = null,
+    resources = MapRuntimeResources(closeResources),
+    logger = null,
+    physicalScope = physicalScope,
+  )

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsModule.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsModule.kt
@@ -133,6 +133,8 @@ internal external class MaplibreMap(options: MapOptions) {
 
   fun setFilter(layerId: String, filter: FilterSpecification?)
 
+  fun getFilter(layerId: String): FilterSpecification?
+
   fun setPaintProperty(layerId: String, name: String, value: Any?)
 
   fun getPaintProperty(layerId: String, name: String): Any?

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsTypes.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsTypes.kt
@@ -65,6 +65,8 @@ internal external interface FilterSpecification
 internal external interface StyleLayer {
   val id: String
   val type: String
+  val source: String?
+  val sourceLayer: String?
   val minzoom: Double?
   val maxzoom: Double?
 }

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
@@ -309,6 +309,7 @@ internal class GlJsMapSession(
       return it
     }
     if (!lifecycle.acceptsWork) return null
+    if (!lifecycleAuthority.selectAdapterForPresentation(this)) return null
 
     val host = document.createElement("div").unsafeCast<HTMLElement>()
     host.style.cssText = OFFSCREEN_CONTAINER_STYLE

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
@@ -98,8 +98,8 @@ internal class GlJsMapSession(
   }
 
   internal var callbacks: MapAdapter.Callbacks = callbacks
-  private val lifecycle = lifecycleAuthority.bind(this)
-  private val lifecycleCallbacks = MapLifecycleCallbacks(lifecycle) { this.callbacks }
+  private val lifecycle by lazy { lifecycleAuthority.bind(this) }
+  private val lifecycleCallbacks by lazy { MapLifecycleCallbacks(lifecycle) { this.callbacks } }
   private var lifecycleEngineIdentity: EngineMapIdentity? = null
   private var lifecycleRenderLease: RenderLease? = null
   private var lifecycleStyleRequestIdentity: StyleRequestIdentity? = null
@@ -267,11 +267,7 @@ internal class GlJsMapSession(
   }
 
   fun start() {
-    when (lifecycle.state) {
-      is MapLifecycleState.Attaching,
-      is MapLifecycleState.Attached -> return
-      else -> lifecycle.beginAttach()
-    }
+    lifecycle.beginAttachIfOpen()
   }
 
   override suspend fun createEngine(identity: EngineMapIdentity) {

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/style/GlJsStyleBinding.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/style/GlJsStyleBinding.kt
@@ -495,11 +495,10 @@ internal class GlJsStyleBinding(
     val number = (value as? JsonPrimitive)?.content?.toDoubleOrNull()
     val layer = map.getLayer(layerId)
     if (number == null || layer == null || (name != "minzoom" && name != "maxzoom")) {
-      logger?.w {
-        "Layer '$layerId' cannot change '$name' once it is in the style; MapLibre GL JS fixes it " +
-          "at construction."
-      }
-      return
+      throw StyleMutationException(
+        "Layer '$layerId' cannot change '$name' once it is in the style",
+        null,
+      )
     }
     val minZoom = if (name == "minzoom") number else layer.minzoom ?: 0.0
     val maxZoom = if (name == "maxzoom") number else layer.maxzoom ?: 24.0
@@ -519,7 +518,19 @@ internal class GlJsStyleBinding(
    */
   override fun layerProperty(layerId: String, name: String): JsonElement? {
     requireLoaded()
-    if (map.getLayer(layerId) == null) return null
+    val layer = map.getLayer(layerId) ?: return null
+    val root =
+      when (name) {
+        "id" -> JsonPrimitive(layer.id)
+        "type" -> JsonPrimitive(layer.type)
+        "source" -> layer.source?.let(::JsonPrimitive)
+        "source-layer" -> layer.sourceLayer?.let(::JsonPrimitive)
+        "minzoom" -> layer.minzoom?.let(::JsonPrimitive)
+        "maxzoom" -> layer.maxzoom?.let(::JsonPrimitive)
+        "filter" -> map.getFilter(layerId)?.toJsonElement()
+        else -> null
+      }
+    if (root != null) return root
     val value =
       runCatching { map.getPaintProperty(layerId, name) }.getOrNull()
         ?: runCatching { map.getLayoutProperty(layerId, name) }.getOrNull()

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/style/GlJsStyleBinding.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/style/GlJsStyleBinding.kt
@@ -492,7 +492,7 @@ internal class GlJsStyleBinding(
    * so the half that was not asked for is read back off the live layer.
    */
   private fun setRootProperty(layerId: String, name: String, value: JsonElement) {
-    val number = (value as? JsonPrimitive)?.content?.toDoubleOrNull()
+    val number = (value as? JsonPrimitive)?.takeUnless { it.isString }?.doubleOrNull
     val layer = map.getLayer(layerId)
     if (number == null || layer == null || (name != "minzoom" && name != "maxzoom")) {
       throw StyleMutationException(

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/LocalComposeMapPresentationHost.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/LocalComposeMapPresentationHost.kt
@@ -2,9 +2,11 @@ package org.maplibre.compose.desktop
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.NonSkippableComposable
 import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.referentialEqualityPolicy
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.staticCompositionLocalOf
 import java.awt.Window
 import org.maplibre.compose.desktop.skiko.AwtComposeMapPresentationHost
 import org.maplibre.compose.location.LocalXdgPortalWindow
@@ -16,10 +18,10 @@ import org.maplibre.compose.location.LocalXdgPortalWindow
  * from [rememberAwtComposeMapPresentationHost]. Prefer [ProvideMapPresentationHost] over setting
  * this directly.
  *
- * This is `static`: changing it rebuilds the map's GPU bridge rather than recomposing it.
+ * Replacing the host rebuilds the map's GPU bridge, even when the two host objects compare equal.
  */
 public val LocalComposeMapPresentationHost: ProvidableCompositionLocal<ComposeMapPresentationHost> =
-  staticCompositionLocalOf {
+  compositionLocalOf(referentialEqualityPolicy()) {
     error(
       "No ComposeMapPresentationHost is installed. Wrap this window's content in " +
         "ProvideMapPresentationHost(...)."
@@ -48,6 +50,7 @@ public fun rememberAwtComposeMapPresentationHost(window: Window): ComposeMapPres
  * ```
  */
 @Composable
+@NonSkippableComposable
 public fun ProvideMapPresentationHost(
   host: ComposeMapPresentationHost,
   content: @Composable () -> Unit,

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/map/DesktopMapView.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/map/DesktopMapView.kt
@@ -8,9 +8,16 @@ import org.maplibre.compose.desktop.LocalComposeMapPresentationHost
 import org.maplibre.compose.desktop.bridge.ComposeMapPresentationHostFactory
 import org.maplibre.compose.style.BaseStyle
 
+/** Gives Compose value-based keys reference-identity semantics for physical host resources. */
+internal class ReferenceIdentityKey(private val value: Any) {
+  override fun equals(other: Any?): Boolean = other is ReferenceIdentityKey && value === other.value
+
+  override fun hashCode(): Int = System.identityHashCode(value)
+}
+
 @Composable
 internal actual fun mapPresentationHostIdentity(): Any =
-  LocalMlnFfiMapHostFactory.current ?: LocalComposeMapPresentationHost.current
+  ReferenceIdentityKey(LocalMlnFfiMapHostFactory.current ?: LocalComposeMapPresentationHost.current)
 
 @Composable
 internal actual fun ComposableMapView(
@@ -26,7 +33,9 @@ internal actual fun ComposableMapView(
   val hostFactory =
     LocalMlnFfiMapHostFactory.current
       ?: LocalComposeMapPresentationHost.current.let { presentationHost ->
-        remember(presentationHost) { ComposeMapPresentationHostFactory(presentationHost) }
+        remember(ReferenceIdentityKey(presentationHost)) {
+          ComposeMapPresentationHostFactory(presentationHost)
+        }
       }
   MlnFfiMapView(
     hostFactory = hostFactory,

--- a/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/map/DesktopPresentationHostLifetimeTest.kt
+++ b/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/map/DesktopPresentationHostLifetimeTest.kt
@@ -1,8 +1,11 @@
 package org.maplibre.compose.map
 
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.referentialEqualityPolicy
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.test.ExperimentalTestApi
 import kotlin.test.AfterTest
 import kotlin.test.Test
@@ -38,7 +41,11 @@ class DesktopPresentationHostLifetimeTest {
       MlnFfiApplication.configure(runtimeOptions)
       val runtime = createNativeMapRuntime(runtimeOptions)
       val state = runtime.createMapState(initialBaseStyle = BaseStyle.Empty)
-      var host by mutableStateOf(ContextlessPresentationHost("first"))
+      var host by
+        mutableStateOf(
+          ContextlessPresentationHost("first", equalityKey = "same"),
+          referentialEqualityPolicy(),
+        )
 
       setContent {
         ProvideMapPresentationHost(host) {
@@ -49,7 +56,7 @@ class DesktopPresentationHostLifetimeTest {
       val firstPresentation = requireNotNull(state.presentation)
       val engine = firstPresentation.adapter
 
-      host = ContextlessPresentationHost("second")
+      runOnIdle { host = ContextlessPresentationHost("second", equalityKey = "same") }
       waitUntil(timeoutMillis = 10_000) {
         state.presentation != null && state.presentation !== firstPresentation
       }
@@ -65,7 +72,25 @@ class DesktopPresentationHostLifetimeTest {
       runtime.awaitClosed()
     }
 
-  private class ContextlessPresentationHost(private val name: String) : ComposeMapPresentationHost {
+  @Test
+  fun inspection_mode_does_not_require_a_presentation_host() = runFfiComposeUiTest {
+    val runtime = createNativeMapRuntime(runtimeOptions)
+    val state = runtime.createMapState(initialBaseStyle = BaseStyle.Empty)
+
+    setContent {
+      CompositionLocalProvider(LocalInspectionMode provides true) { MaplibreMap(state) }
+    }
+
+    waitForIdle()
+    assertTrue(state.presentation == null)
+    runtime.close()
+    runtime.awaitClosed()
+  }
+
+  private class ContextlessPresentationHost(
+    private val name: String,
+    private val equalityKey: String,
+  ) : ComposeMapPresentationHost {
     override val description: String = "$name contextless presentation host"
     override val backend: ComposeRenderBackend = packagedComposeBackend()
 
@@ -74,6 +99,11 @@ class DesktopPresentationHostLifetimeTest {
     override fun runOnGpuThread(action: Runnable) {
       action.run()
     }
+
+    override fun equals(other: Any?): Boolean =
+      other is ContextlessPresentationHost && equalityKey == other.equalityKey
+
+    override fun hashCode(): Int = equalityKey.hashCode()
   }
 
   private companion object {

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/layers/LayerHandlePropertyTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/layers/LayerHandlePropertyTest.kt
@@ -50,6 +50,9 @@ class LayerHandlePropertyTest {
       handle.setRootProperty("minzoom", JsonPrimitive(3.0))
       assertEquals(JsonPrimitive(3.0), handle.getProperty("minzoom"))
       assertFailsWith<StyleHandleException> {
+        handle.setRootProperty("minzoom", JsonPrimitive("4"))
+      }
+      assertFailsWith<StyleHandleException> {
         handle.setRootProperty("source-layer", JsonPrimitive("replacement"))
       }
     }

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/layers/LayerHandlePropertyTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/layers/LayerHandlePropertyTest.kt
@@ -36,10 +36,29 @@ class LayerHandlePropertyTest {
     }
   }
 
+  @Test
+  fun root_properties_are_readable_and_rejected_writes_throw(): MapTestResult = runMapTest {
+    createMapFixture().use { fixture ->
+      fixture.loadStyle(STYLE)
+      val handle = assertNotNull(fixture.state.style.layer("background"))
+      val circle = assertNotNull(fixture.state.style.layer("points"))
+
+      assertEquals(JsonPrimitive("background"), handle.getProperty("id"))
+      assertEquals(JsonPrimitive("background"), handle.getProperty("type"))
+      assertEquals(JsonPrimitive(2.0), handle.getProperty("minzoom"))
+      assertEquals(JsonPrimitive("points-source"), circle.getProperty("source"))
+      handle.setRootProperty("minzoom", JsonPrimitive(3.0))
+      assertEquals(JsonPrimitive(3.0), handle.getProperty("minzoom"))
+      assertFailsWith<StyleHandleException> {
+        handle.setRootProperty("source-layer", JsonPrimitive("replacement"))
+      }
+    }
+  }
+
   private companion object {
     val STYLE =
       BaseStyle.Json(
-        """{"version":8,"sources":{},"layers":[{"id":"background","type":"background"}]}"""
+        """{"version":8,"sources":{"points-source":{"type":"geojson","data":{"type":"FeatureCollection","features":[]}}},"layers":[{"id":"background","type":"background","minzoom":2},{"id":"points","type":"circle","source":"points-source"}]}"""
       )
   }
 }

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -162,8 +162,8 @@ internal class MlnFfiMapSession(
 
   @Volatile internal var callbacks: MapAdapter.Callbacks = callbacks
   @Volatile internal var durableCallbacks: MapAdapter.Callbacks = EmptyMapAdapterCallbacks
-  private val lifecycle = lifecycleAuthority.bind(this)
-  private val lifecycleCallbacks = MapLifecycleCallbacks(lifecycle) { this.callbacks }
+  private val lifecycle by lazy { lifecycleAuthority.bind(this) }
+  private val lifecycleCallbacks by lazy { MapLifecycleCallbacks(lifecycle) { this.callbacks } }
   @Volatile private var lifecycleEngineIdentity: EngineMapIdentity? = null
   @Volatile private var lifecycleRenderLease: RenderLease? = null
   /** Presentation producer installed and sampled only on the native map's owner thread. */
@@ -195,9 +195,6 @@ internal class MlnFfiMapSession(
   private class PendingMapAction(val run: (MapHandle) -> Unit, val abandon: () -> Unit)
 
   private val pendingMapActions = mutableListOf<PendingMapAction>()
-
-  /** Bounds fits accepted before the first real render target. Guarded by [stateLock]. */
-  private val pendingViewportActions = mutableListOf<PendingMapAction>()
 
   /** Guarded by [stateLock]; once true, the map has dimensions suitable for fitting bounds. */
   private var hasAttachedViewport = false
@@ -459,18 +456,7 @@ internal class MlnFfiMapSession(
     get() = presentationPublicationCount > 0
 
   /** Commits a render lease in the apply phase when no physical detachment must finish first. */
-  internal fun beginPresentationAttachment(): Boolean =
-    when (lifecycle.state) {
-      is MapLifecycleState.OpenDetached -> {
-        lifecycle.beginAttach()
-        true
-      }
-      is MapLifecycleState.Attaching,
-      is MapLifecycleState.Attached -> true
-      is MapLifecycleState.Detaching,
-      is MapLifecycleState.Closing,
-      MapLifecycleState.Closed -> false
-    }
+  internal fun beginPresentationAttachment(): Boolean = lifecycle.beginAttachIfOpen()
 
   internal fun markPresentationPublished() {
     presentationPublicationCount++
@@ -478,14 +464,13 @@ internal class MlnFfiMapSession(
 
   override suspend fun attachPresentation() {
     lifecycle.attachRetainedEngine()
+  }
+
+  internal fun publishRetainedStyle() {
     styleBinding?.let { callbacks.onStyleChanged(this, it) }
   }
 
   override suspend fun detachPresentation() {
-    val abandoned = stateLock.withLock {
-      pendingViewportActions.toList().also { pendingViewportActions.clear() }
-    }
-    abandoned.forEach { it.abandon() }
     lifecycle.detachCurrentPresentation()
   }
 
@@ -501,6 +486,7 @@ internal class MlnFfiMapSession(
   }
 
   override suspend fun detach(identity: EngineMapIdentity, lease: RenderLease) {
+    stateLock.withLock { hasAttachedViewport = false }
     callbacks = durableCallbacks
     if (lifecycleRenderLease == lease) lifecycleRenderLease = null
     // This must happen before the first suspension. A host may tear down its renderer thread as
@@ -524,12 +510,7 @@ internal class MlnFfiMapSession(
 
   override suspend fun closeResources() {
     val abandoned = stateLock.withLock {
-      buildList {
-        addAll(pendingMapActions)
-        pendingMapActions.clear()
-        addAll(pendingViewportActions)
-        pendingViewportActions.clear()
-      }
+      pendingMapActions.toList().also { pendingMapActions.clear() }
     }
     abandoned.forEach { it.abandon() }
     resumeStrandedTransitions()
@@ -546,11 +527,7 @@ internal class MlnFfiMapSession(
   }
 
   fun start() {
-    when (lifecycle.state) {
-      is MapLifecycleState.Attaching,
-      is MapLifecycleState.Attached -> return
-      else -> lifecycle.beginAttach()
-    }
+    lifecycle.beginAttachIfOpen()
   }
 
   private fun startEngine(identity: EngineMapIdentity) {
@@ -587,10 +564,9 @@ internal class MlnFfiMapSession(
     val stopping = stateLock.withLock {
       val current = loop
       loop = null
+      hasAttachedViewport = false
       abandoned += pendingMapActions
       pendingMapActions.clear()
-      abandoned += pendingViewportActions
-      pendingViewportActions.clear()
       current
     }
     abandoned.forEach { it.abandon() }
@@ -1107,28 +1083,10 @@ internal class MlnFfiMapSession(
     postWhenMapExists(action, abandon = {})
   }
 
-  /** Queues [action] until the first render target has supplied the map's real dimensions. */
-  private fun postWhenViewportExists(action: (MapHandle) -> Unit, abandon: () -> Unit): Boolean {
-    val current = stateLock.withLock {
-      if (!lifecycle.acceptsWork) return false
-      if (!hasAttachedViewport) {
-        pendingViewportActions += PendingMapAction(action, abandon)
-        return true
-      }
-      loop
-    }
-    return current?.post(action, abandon) ?: false
-  }
-
   private fun publishAttachedViewport() {
-    val (current, pending) =
-      stateLock.withLock {
-        if (!lifecycle.acceptsWork || hasAttachedViewport) return
-        hasAttachedViewport = true
-        loop to pendingViewportActions.toList().also { pendingViewportActions.clear() }
-      }
-    pending.forEach { action ->
-      if (current?.post(action.run, action.abandon) != true) action.abandon()
+    stateLock.withLock {
+      if (!lifecycle.acceptsWork) return
+      hasAttachedViewport = true
     }
   }
 
@@ -1407,15 +1365,12 @@ internal class MlnFfiMapSession(
       map.jumpTo(cameraForBounds(map, boundingBox, bearing, tilt, padding))
       snapshotViewport(map)
     }
-    // The fit reads the live map's dimensions, so before a viewport exists it can only queue.
-    // After one exists it runs as one round-trip instead, so a camera or viewport read made right
-    // after this call observes the fitted camera rather than the previous mirrored snapshot —
-    // the ordering the blocking getters on main provided.
+    // MapPresentation waits for the current lease's viewport before it calls this adapter.
     val hasViewport = stateLock.withLock {
       hasAttachedViewport && lifecycle.acceptsWork && loop != null
     }
-    if (hasViewport && runOnMap(fit) != null) return
-    postWhenViewportExists(fit, abandon = {})
+    check(hasViewport) { "A bounds fit requires the current presentation viewport" }
+    check(runOnMap(fit) != null) { "The map became unavailable during the bounds fit" }
   }
 
   private fun cameraForBounds(
@@ -1478,7 +1433,10 @@ internal class MlnFfiMapSession(
     padding: PaddingValues,
     duration: Duration,
   ) {
-    startTransitionAwaitingRelease(duration, requiresViewport = true) { map, animation ->
+    check(stateLock.withLock { hasAttachedViewport }) {
+      "A bounds animation requires the current presentation viewport"
+    }
+    startTransitionAwaitingRelease(duration) { map, animation ->
       map.flyTo(cameraForBounds(map, boundingBox, bearing, tilt, padding), animation)
     }
   }
@@ -1486,11 +1444,10 @@ internal class MlnFfiMapSession(
   /** Resumes normally however the transition ended. */
   private suspend fun startTransitionAwaitingRelease(
     duration: Duration,
-    requiresViewport: Boolean = false,
     start: (MapHandle, AnimationOptions) -> Unit,
   ): Unit = suspendCancellableCoroutine { continuation ->
     val queued =
-      (if (requiresViewport) ::postWhenViewportExists else ::postWhenMapExists)(
+      postWhenMapExists(
         { map -> startTransitionOnMap(map, duration, start, continuation) },
         { if (continuation.isActive) continuation.resume(Unit) },
       )

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -446,21 +446,14 @@ internal class MlnFfiMapSession(
 
   internal fun preparePresentation() {
     hasLoadedFirstStyle = false
-    presentationPublicationCount = 0
   }
-
-  internal var presentationPublicationCount: Int = 0
-    private set
 
   internal val isPresentationPublished: Boolean
-    get() = presentationPublicationCount > 0
+    get() = lifecycleAuthority.acceptsPresentation(this)
 
   /** Commits a render lease in the apply phase when no physical detachment must finish first. */
-  internal fun beginPresentationAttachment(): Boolean = lifecycle.beginAttachIfOpen()
-
-  internal fun markPresentationPublished() {
-    presentationPublicationCount++
-  }
+  internal fun beginPresentationAttachment(): Boolean =
+    lifecycleAuthority.selectAdapterForPresentation(this) && lifecycle.beginAttachIfOpen()
 
   override suspend fun attachPresentation() {
     lifecycle.attachRetainedEngine()

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapView.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapView.kt
@@ -124,19 +124,16 @@ internal fun MlnFfiMapView(
   // Must run in the apply phase, not from a coroutine: the unload has to precede the content
   // subcomposition inserting layers, or a style switch fails anchor validation (see #269).
   SideEffect { session.setBaseStyle(style) }
-  SideEffect {
-    if (session.beginPresentationAttachment()) {
-      update(session)
-      if (!session.isPresentationPublished) session.markPresentationPublished()
-    }
-  }
+  SideEffect { session.beginPresentationAttachment() }
   LaunchedEffect(session) {
     try {
       session.attachPresentation()
       if (!session.isPresentationPublished) {
         update(session)
+        if (state.presentation?.adapter !== session) return@LaunchedEffect
         session.markPresentationPublished()
       }
+      session.publishRetainedStyle()
     } catch (error: CancellationException) {
       throw error
     } catch (_: MapClosedException) {

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapView.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapView.kt
@@ -136,7 +136,6 @@ internal fun MlnFfiMapView(
       if (!session.isPresentationPublished) {
         currentUpdate.value(session)
         if (state.presentation?.adapter !== session) return@LaunchedEffect
-        session.markPresentationPublished()
       }
       session.publishRetainedStyle()
     } catch (error: CancellationException) {

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapView.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapView.kt
@@ -119,17 +119,22 @@ internal fun MlnFfiMapView(
   session.callbacks = callbacks
   session.logger = logger
   session.layoutDirection = layoutDirection
+  val currentUpdate = rememberUpdatedState(update)
   val currentOnReset = rememberUpdatedState(onReset)
 
   // Must run in the apply phase, not from a coroutine: the unload has to precede the content
   // subcomposition inserting layers, or a style switch fails anchor validation (see #269).
   SideEffect { session.setBaseStyle(style) }
-  SideEffect { session.beginPresentationAttachment() }
+  SideEffect {
+    if (session.beginPresentationAttachment() && session.isPresentationPublished) {
+      currentUpdate.value(session)
+    }
+  }
   LaunchedEffect(session) {
     try {
       session.attachPresentation()
       if (!session.isPresentationPublished) {
-        update(session)
+        currentUpdate.value(session)
         if (state.presentation?.adapter !== session) return@LaunchedEffect
         session.markPresentationPublished()
       }

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/style/MlnFfiStyleBinding.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/style/MlnFfiStyleBinding.kt
@@ -542,6 +542,8 @@ internal open class MlnFfiStyleBinding(
     data: GeoJsonData,
     options: GeoJsonSourceOptions,
   ): PreparedGeoJson =
+    // TODO: Run native GeoJSON preparation asynchronously by default and report failures that occur
+    // after submission through an asynchronous source-error API.
     try {
       MlnFfiPreparedGeoJson(GeoJsonSourceDataHandle.create(data.toInlineUtf8()!!, options))
     } catch (error: MaplibreException) {
@@ -560,9 +562,10 @@ internal open class MlnFfiStyleBinding(
     val source = sources?.get(sourceId) as? JsonObject ?: return null
     if ((source["type"] as? JsonPrimitive)?.content != "geojson") return null
     val defaults = GeoJsonOptions()
+    val minZoom = (source["minzoom"] as? JsonPrimitive)?.doubleOrNull ?: defaults.minZoom.toDouble()
     val maxZoom = (source["maxzoom"] as? JsonPrimitive)?.doubleOrNull ?: defaults.maxZoom.toDouble()
     return GeoJsonSourceOptions().also { options ->
-      options.minZoom = defaults.minZoom.toDouble()
+      options.minZoom = minZoom
       options.maxZoom = maxZoom
       options.tolerance =
         (source["tolerance"] as? JsonPrimitive)?.doubleOrNull ?: defaults.tolerance.toDouble()
@@ -769,7 +772,6 @@ internal open class MlnFfiStyleBinding(
     mutateMap { map -> map.moveStyleLayer(layerId, beforeLayerId) }
   }
 
-  /** [kind] is unused: mbgl's `Layer::setProperty` takes layout, paint, and root keys alike. */
   override fun setLayerProperty(
     layerId: String,
     name: String,
@@ -778,7 +780,15 @@ internal open class MlnFfiStyleBinding(
   ) {
     mutateMap { map ->
       try {
-        map.setLayerProperty(layerId, name, value.toJsonBytes())
+        when {
+          kind != LayerPropertyKind.ROOT -> map.setLayerProperty(layerId, name, value.toJsonBytes())
+          name == "source" -> map.setLayerSourceId(layerId, value.requireRootString(layerId, name))
+          name == "source-layer" ->
+            map.setLayerSourceLayer(layerId, value.requireRootString(layerId, name))
+          name == "minzoom" -> map.setLayerMinZoom(layerId, value.requireRootNumber(layerId, name))
+          name == "maxzoom" -> map.setLayerMaxZoom(layerId, value.requireRootNumber(layerId, name))
+          else -> map.setLayerProperty(layerId, name, value.toJsonBytes())
+        }
       } catch (error: MaplibreException) {
         throw StyleMutationException(error.message, error)
       }
@@ -796,7 +806,17 @@ internal open class MlnFfiStyleBinding(
   }
 
   override fun layerProperty(layerId: String, name: String): JsonElement? = readMap { map ->
-    map.layerProperty(layerId, name)?.toJsonElement()
+    when (name) {
+      "id" -> JsonPrimitive(layerId)
+      "type" -> map.styleLayerType(layerId)?.let(::JsonPrimitive)
+      "source" -> map.layerSourceId(layerId).takeIf(String::isNotEmpty)?.let(::JsonPrimitive)
+      "source-layer" ->
+        map.layerSourceLayer(layerId).takeIf(String::isNotEmpty)?.let(::JsonPrimitive)
+      "minzoom" -> map.layerMinZoom(layerId).takeIf(Double::isFinite)?.let(::JsonPrimitive)
+      "maxzoom" -> map.layerMaxZoom(layerId).takeIf(Double::isFinite)?.let(::JsonPrimitive)
+      "filter" -> map.layerFilter(layerId)?.toJsonElement()
+      else -> map.layerProperty(layerId, name)?.toJsonElement()
+    }
   }
 
   override fun layerExists(layerId: String): Boolean? = readMap { map ->
@@ -839,6 +859,14 @@ internal open class MlnFfiStyleBinding(
       )
   }
 }
+
+private fun JsonElement.requireRootString(layerId: String, name: String): String =
+  (this as? JsonPrimitive)?.takeIf { it.isString }?.contentOrNull
+    ?: throw StyleMutationException("Layer '$layerId' property '$name' requires a string", null)
+
+private fun JsonElement.requireRootNumber(layerId: String, name: String): Double =
+  (this as? JsonPrimitive)?.doubleOrNull
+    ?: throw StyleMutationException("Layer '$layerId' property '$name' requires a number", null)
 
 /** A parsed and indexed GeoJSON document, ready to install on the owner thread. */
 private class MlnFfiPreparedGeoJson(val handle: GeoJsonSourceDataHandle) : PreparedGeoJson {

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/style/MlnFfiStyleBinding.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/style/MlnFfiStyleBinding.kt
@@ -865,7 +865,7 @@ private fun JsonElement.requireRootString(layerId: String, name: String): String
     ?: throw StyleMutationException("Layer '$layerId' property '$name' requires a string", null)
 
 private fun JsonElement.requireRootNumber(layerId: String, name: String): Double =
-  (this as? JsonPrimitive)?.doubleOrNull
+  (this as? JsonPrimitive)?.takeUnless { it.isString }?.doubleOrNull
     ?: throw StyleMutationException("Layer '$layerId' property '$name' requires a number", null)
 
 /** A parsed and indexed GeoJSON document, ready to install on the owner thread. */

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/sources/GeoJsonSourceUpdateTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/sources/GeoJsonSourceUpdateTest.kt
@@ -85,6 +85,24 @@ class GeoJsonSourceUpdateTest {
     }
 
   @Test
+  fun a_base_style_update_preserves_the_loaded_sources_minimum_zoom(): MapTestResult = runMapTest {
+    createMapFixture().use { fixture ->
+      fixture.loadStyle(MIN_ZOOM_STYLE)
+      fixture.presentation.setCameraPosition(CameraPosition(target = ORIGIN, zoom = 6.0))
+      val handle = assertIs<GeoJsonSourceHandle>(fixture.state.style.source(SOURCE_ID))
+      fixture.pumpUntil("the source to stay hidden below its minimum zoom") {
+        fixture.readPixel(256, 256).isNear(BACKGROUND)
+      }
+
+      handle.setData(GeoJsonData.Features(pointAt(ORIGIN)))
+
+      fixture.settle()
+      assertTrue(fixture.readPixel(256, 256).isNear(BACKGROUND))
+      assertEquals(emptyList(), fixture.errors)
+    }
+  }
+
+  @Test
   fun a_cached_handle_uses_reconciled_options_after_a_same_id_replacement(): MapTestResult =
     runMapTest {
       createMapFixture().use { fixture ->
@@ -141,6 +159,18 @@ class GeoJsonSourceUpdateTest {
           "type":"FeatureCollection","features":[{"type":"Feature","geometry":{
             "type":"Point","coordinates":[0,0]},"properties":{}}]},
           "cluster":true,"clusterRadius":123,"clusterMaxZoom":10}},"layers":[
+          {"id":"background","type":"background","paint":{"background-color":"#336699"}},
+          {"id":"points-layer","type":"circle","source":"points","paint":{
+            "circle-radius":16,"circle-color":"#000000"}}]}
+        """
+          .trimIndent()
+      )
+    val MIN_ZOOM_STYLE =
+      BaseStyle.Json(
+        """
+        {"version":8,"sources":{"points":{"type":"geojson","minzoom":7,"data":{
+          "type":"FeatureCollection","features":[{"type":"Feature","geometry":{
+            "type":"Point","coordinates":[0,0]},"properties":{}}]}}},"layers":[
           {"id":"background","type":"background","paint":{"background-color":"#336699"}},
           {"id":"points-layer","type":"circle","source":"points","paint":{
             "circle-radius":16,"circle-color":"#000000"}}]}


### PR DESCRIPTION
## Description

Completes the pre-feature API redesign cleanup from #1149 by tightening map lifecycle and style-handle behavior, removing obsolete machinery and redundant tests, documenting GeoJSON submission semantics, and adding focused regression coverage.

## Validation

Passed mise run check, test:android, test:js, test:desktop, test:ios, style-spec:parity --check, and build:docs.

## AI assistance

Implemented and reviewed with OpenAI Codex using GPT-5.