### PR TITLE
Avoid reusing Android surfaces across renderer sessions

### DIFF
--- a/lib/maplibre-compose/src/androidDeviceTest/AndroidManifest.xml
+++ b/lib/maplibre-compose/src/androidDeviceTest/AndroidManifest.xml
@@ -11,5 +11,10 @@
       android:exported="false"
       android:theme="@android:style/Theme.Material.Light.NoActionBar"
     />
+    <activity
+      android:name="org.maplibre.compose.mlnffi.ReusableSurfaceActivity"
+      android:exported="false"
+      android:theme="@android:style/Theme.Material.Light.NoActionBar"
+    />
   </application>
 </manifest>

--- a/lib/maplibre-compose/src/androidDeviceTest/kotlin/org/maplibre/compose/mlnffi/AndroidSurfaceReplacementTest.kt
+++ b/lib/maplibre-compose/src/androidDeviceTest/kotlin/org/maplibre/compose/mlnffi/AndroidSurfaceReplacementTest.kt
@@ -5,8 +5,11 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.ReusableContentHost
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.test.core.app.ActivityScenario
@@ -52,9 +55,89 @@ class AndroidSurfaceReplacementTest {
     }
   }
 
+  @Test
+  fun a_surface_host_receives_its_surface_after_reusable_content_is_reactivated() {
+    ActivityScenario.launch(ReusableSurfaceActivity::class.java).use { scenario ->
+      lateinit var activity: ReusableSurfaceActivity
+      scenario.onActivity { activity = it }
+      assertTrue(
+        activity.initialSurface.await(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS),
+        "the initial surface host did not receive its surface",
+      )
+
+      scenario.onActivity { it.deactivateSurface() }
+      assertTrue(
+        activity.surfaceDisposed.await(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS),
+        "the reusable surface content was not disposed",
+      )
+
+      scenario.onActivity { it.reactivateSurface() }
+      assertTrue(
+        activity.reactivatedSurface.await(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS),
+        "the reactivated surface host did not receive its surface",
+      )
+    }
+  }
+
   private companion object {
     const val TIMEOUT_MILLIS = 10_000L
   }
+}
+
+class ReusableSurfaceActivity : ComponentActivity() {
+  private var surfaceActive by mutableStateOf(true)
+  private var reactivationRequested = false
+
+  val initialSurface = CountDownLatch(1)
+  val surfaceDisposed = CountDownLatch(1)
+  val reactivatedSurface = CountDownLatch(1)
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    setContent {
+      ReusableContentHost(active = surfaceActive) {
+        val renderer = remember { ReusableTestRenderer(::onSurfaceAvailable) }
+        DisposableEffect(Unit) { onDispose { surfaceDisposed.countDown() } }
+        AndroidMlnFfiSurface(
+          renderer = renderer,
+          runtimeBackends = setOf(MapRenderBackend.OPENGL),
+          backend = MapRenderBackend.OPENGL,
+          kind = AndroidMapSurfaceKind.Surface,
+          modifier = Modifier.fillMaxSize(),
+          logger = null,
+        )
+      }
+    }
+  }
+
+  fun deactivateSurface() {
+    surfaceActive = false
+  }
+
+  fun reactivateSurface() {
+    reactivationRequested = true
+    surfaceActive = true
+  }
+
+  private fun onSurfaceAvailable() {
+    if (reactivationRequested) {
+      reactivatedSurface.countDown()
+    } else {
+      initialSurface.countDown()
+    }
+  }
+}
+
+private class ReusableTestRenderer(private val onSurfaceAvailable: () -> Unit) : MlnFfiMapRenderer {
+  override val backend = MapRenderBackend.OPENGL
+
+  override fun onSurfaceAvailable(session: MlnFfiMapHostSession) {
+    onSurfaceAvailable()
+  }
+
+  override fun render(frame: MlnFfiMapFrame) = MlnFfiFrameResult.SKIPPED
+
+  override fun close() {}
 }
 
 class SurfaceReplacementActivity : ComponentActivity() {

--- a/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/mlnffi/AndroidMlnFfiSurface.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/mlnffi/AndroidMlnFfiSurface.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
@@ -92,21 +93,26 @@ internal fun AndroidMlnFfiSurface(
         }
       }
     AndroidMapSurfaceKind.Surface ->
-      AndroidExternalSurface(
-        // Work around #1150: Compose can delay a replacement SurfaceView until another window
-        // invalidation. The graphics layer forces that traversal when the map has no overlay.
-        modifier = modifier.graphicsLayer(),
-        // Never opaque: before its first swap the hole would otherwise read as black.
-        isOpaque = false,
-        // Behind the window, matching MapLibre's MapView: Compose overlays draw on top of the map.
-        zOrder = AndroidExternalSurfaceZOrder.Behind,
-      ) {
-        onSurface { surface, width, height ->
-          controller.surfaceCreated(surface, width, height, density)
-          surface.onChanged { changedWidth, changedHeight ->
-            controller.surfaceChanged(changedWidth, changedHeight, density)
+      // Do not reuse a SurfaceView whose callback belongs to a disposed renderer session.
+      // https://issuetracker.google.com/issues/554586999
+      key(controller) {
+        AndroidExternalSurface(
+          // Force a traversal for a replacement SurfaceView that would otherwise wait for another
+          // window invalidation. https://issuetracker.google.com/issues/554732248
+          modifier = modifier.graphicsLayer(),
+          // Never opaque: before its first swap the hole would otherwise read as black.
+          isOpaque = false,
+          // Behind the window, matching MapLibre's MapView: Compose overlays draw on top of the
+          // map.
+          zOrder = AndroidExternalSurfaceZOrder.Behind,
+        ) {
+          onSurface { surface, width, height ->
+            controller.surfaceCreated(surface, width, height, density)
+            surface.onChanged { changedWidth, changedHeight ->
+              controller.surfaceChanged(changedWidth, changedHeight, density)
+            }
+            surface.onDestroyed { controller.surfaceDestroyed() }
           }
-          surface.onDestroyed { controller.surfaceDestroyed() }
         }
       }
   }


### PR DESCRIPTION
## Description

Key each SurfaceView-backed external surface to its renderer-session controller so Compose cannot reuse a view whose callback targets disposed state ([AndroidX bug 554586999](https://issuetracker.google.com/issues/554586999)); retain and document the traversal workaround for [AndroidX bug 554732248](https://issuetracker.google.com/issues/554732248).

## Validation

`mise run check`, `mise run test:android`, `mise run lint:android`, and both `AndroidSurfaceReplacementTest` cases on an API 36 arm64 emulator pass; removing only `key(controller)` makes the reuse regression fail.

## AI assistance

GPT 5.6 Sol in Codex assisted with diagnosis, implementation, and test validation.