### PR TITLE
Fix JS compositing tests after presentation ownership

### DIFF
--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/CompositedMap.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/CompositedMap.kt
@@ -34,6 +34,7 @@ internal class CompositedMap(style: BaseStyle, private val scaleFactor: Double =
 
   private val session =
     GlJsMapSession(state.lifecycle, Callbacks(), logger = null, LayoutDirection.Ltr)
+  private val token = state.reservePresentation()
 
   init {
     session.start()
@@ -44,6 +45,8 @@ internal class CompositedMap(style: BaseStyle, private val scaleFactor: Double =
         }
       }
     )
+    // ensureMap constructs the MapLibre map only after this session is the reserved adapter.
+    state.publishPresentation(token, session)
     session.setBaseStyle(style)
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

`CompositedMap` now reserves and publishes a presentation so `GlJsMapSession.ensureMap` can construct the MapLibre map after #1172.

## Validation

Reproducing `BrowserCompositingTest` locally and on this PR's JS CI job.

## AI assistance

Cursor Grok 4.6 cloud agent investigated main CI and implemented the harness fix.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-99588bea-cb77-45b7-8111-9321421bf49c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-99588bea-cb77-45b7-8111-9321421bf49c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

