### PR TITLE
Delete the viewport-vs-query lockstep live-map test

### DIFF
--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/MapVisibleAreaTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/MapVisibleAreaTest.kt
@@ -94,31 +94,6 @@ class MapVisibleAreaTest {
     }
   }
 
-  @Test
-  fun the_viewport_matches_the_session(): MapTestResult = runMapTest {
-    createMapFixture().use {
-      it.loadStyle(BaseStyle.Empty)
-      it.awaitMapReady()
-      it.presentation.setCameraPosition(ROTATED_CAMERA)
-      it.pumpUntil("the camera to rotate") { it.session.hasNativeCamera(ROTATED_CAMERA) }
-
-      it.pumpUntil("the public viewport to match the session") {
-        val publicBox = it.presentation.viewport?.visibleBoundingBox ?: return@pumpUntil false
-        boxesAreNear(it.presentation.getVisibleBoundingBox(), publicBox)
-      }
-
-      val viewport = assertNotNull(it.presentation.viewport)
-      assertNear(
-        assertNotNull(it.presentation.getVisibleBoundingBox()),
-        viewport.visibleBoundingBox,
-      )
-      assertTrue(
-        viewport.size.width.value > 0f && viewport.size.height.value > 0f,
-        "the viewport should carry the map's size, was ${viewport.size}",
-      )
-    }
-  }
-
   private companion object {
     val CAMERA = CameraPosition(target = Position(11.0, 47.0), zoom = 5.0)
     val ANTIMERIDIAN_CAMERA = CameraPosition(target = Position(179.9, 47.0), zoom = 5.0)
@@ -151,25 +126,6 @@ class MapVisibleAreaTest {
             (box.southwest.latitude - TOLERANCE)..(box.northeast.latitude + TOLERANCE),
         "the bounding box should contain $what: $position was outside $box",
       )
-    }
-
-    fun assertNear(expected: BoundingBox, actual: BoundingBox) {
-      assertTrue(
-        boxesAreNear(expected, actual),
-        "the queried box should match the session's: $actual was not $expected",
-      )
-    }
-
-    fun boxesAreNear(expected: BoundingBox?, actual: BoundingBox): Boolean {
-      if (expected == null) return false
-      val corners =
-        listOf(
-          expected.southwest.longitude to actual.southwest.longitude,
-          expected.southwest.latitude to actual.southwest.latitude,
-          expected.northeast.longitude to actual.northeast.longitude,
-          expected.northeast.latitude to actual.northeast.latitude,
-        )
-      return corners.all { (e, a) -> abs(e - a) < TOLERANCE }
     }
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Remove `the_viewport_matches_the_session` because `MapPresentation.viewport` is a Compose snapshot that may lag the live `getVisibleBoundingBox()` query.

## Validation

Ran `:lib:maplibre-compose:jvmTest --tests org.maplibre.compose.map.MapVisibleAreaTest` on Linux desktop Vulkan; the four remaining geometry tests passed.

## AI assistance

Cursor Grok 4.6 as a Cursor Cloud Agent.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-99588bea-cb77-45b7-8111-9321421bf49c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-99588bea-cb77-45b7-8111-9321421bf49c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

