### PR TITLE
Remove the nested case workaround from switch

### DIFF
--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/dsl/decision.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/dsl/decision.kt
@@ -44,24 +44,20 @@ import org.maplibre.compose.expressions.value.StringValue
 public fun <T : ExpressionValue> switch(
   vararg conditions: Condition<T>,
   fallback: Expression<T>,
-): Expression<T> {
-  // HACK: See https://github.com/maplibre/maplibre-compose/issues/310
-  // The `case` expr supports multiple conditions, but on iOS it crashes when used with iconImage.
-  // So we split multiple conditions into cascaded `case` calls, each with a single condition.
-  // Can remove this hack when https://github.com/maplibre/maplibre-native/issues/3477 is resolved.
-  return when (conditions.size) {
+): Expression<T> =
+  when (conditions.size) {
     0 -> fallback
-    1 -> FunctionCall.of("case", conditions[0].test, conditions[0].output, fallback).cast()
     else ->
       FunctionCall.of(
           "case",
-          conditions[0].test,
-          conditions[0].output,
-          switch(*conditions.sliceArray(1 until conditions.size), fallback = fallback),
+          *conditions.foldToArgs { (test, output) ->
+            add(test)
+            add(output)
+          },
+          fallback,
         )
         .cast()
   }
-}
 
 /** See [case] */
 public data class Condition<T : ExpressionValue>

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/util/ExpressionSwitchTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/util/ExpressionSwitchTest.kt
@@ -1,0 +1,54 @@
+package org.maplibre.compose.util
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import org.maplibre.compose.expressions.ast.CompiledExpression
+import org.maplibre.compose.expressions.ast.Expression
+import org.maplibre.compose.expressions.ast.ExpressionContext
+import org.maplibre.compose.expressions.dsl.asString
+import org.maplibre.compose.expressions.dsl.condition
+import org.maplibre.compose.expressions.dsl.const
+import org.maplibre.compose.expressions.dsl.eq
+import org.maplibre.compose.expressions.dsl.feature
+import org.maplibre.compose.expressions.dsl.image
+import org.maplibre.compose.expressions.dsl.switch
+
+/** Compiles condition `switch` to the style-spec `case` operator. */
+class ExpressionSwitchTest {
+
+  private fun json(expression: CompiledExpression<*>): String = expression.toStyleJson().toString()
+
+  private fun compiled(expression: Expression<*>) = expression.compile(ExpressionContext.None)
+
+  @Test
+  fun switch_with_no_conditions_is_the_fallback() {
+    assertEquals("\"fallback\"", json(compiled(switch(fallback = const("fallback")))))
+  }
+
+  @Test
+  fun switch_with_one_condition_is_a_single_case() {
+    assertEquals(
+      """["case",true,"yes","no"]""",
+      json(compiled(switch(condition(const(true), const("yes")), fallback = const("no")))),
+    )
+  }
+
+  @Test
+  fun switch_with_several_conditions_nests_single_condition_cases() {
+    assertEquals(
+      """["case",["==",["string",["get","icon"]],"1"],["image","one"],""" +
+        """["case",["==",["string",["get","icon"]],"2"],["image","two"],""" +
+        """["case",["==",["string",["get","icon"]],"3"],["image","three"],""" +
+        """["image","fallback"]]]]""",
+      json(compiled(iconSwitch())),
+    )
+  }
+
+  private fun iconSwitch() =
+    switch(
+      condition(feature["icon"].asString() eq const("1"), image("one")),
+      condition(feature["icon"].asString() eq const("2"), image("two")),
+      condition(feature["icon"].asString() eq const("3"), image("three")),
+      fallback = image("fallback"),
+    )
+}

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/util/ExpressionSwitchTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/util/ExpressionSwitchTest.kt
@@ -34,12 +34,12 @@ class ExpressionSwitchTest {
   }
 
   @Test
-  fun switch_with_several_conditions_nests_single_condition_cases() {
+  fun switch_with_several_conditions_is_one_case() {
     assertEquals(
       """["case",["==",["string",["get","icon"]],"1"],["image","one"],""" +
-        """["case",["==",["string",["get","icon"]],"2"],["image","two"],""" +
-        """["case",["==",["string",["get","icon"]],"3"],["image","three"],""" +
-        """["image","fallback"]]]]""",
+        """["==",["string",["get","icon"]],"2"],["image","two"],""" +
+        """["==",["string",["get","icon"]],"3"],["image","three"],""" +
+        """["image","fallback"]]""",
       json(compiled(iconSwitch())),
     )
   }

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/util/ExpressionSwitchEngineTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/util/ExpressionSwitchEngineTest.kt
@@ -1,0 +1,62 @@
+package org.maplibre.compose.util
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlinx.serialization.json.JsonObject
+import org.maplibre.compose.expressions.ast.ExpressionContext
+import org.maplibre.compose.expressions.dsl.asString
+import org.maplibre.compose.expressions.dsl.condition
+import org.maplibre.compose.expressions.dsl.const
+import org.maplibre.compose.expressions.dsl.eq
+import org.maplibre.compose.expressions.dsl.feature
+import org.maplibre.compose.expressions.dsl.image
+import org.maplibre.compose.expressions.dsl.switch
+import org.maplibre.compose.layers.SymbolLayer
+import org.maplibre.compose.sources.GeoJsonData
+import org.maplibre.compose.sources.GeoJsonOptions
+import org.maplibre.compose.sources.GeoJsonSource
+import org.maplibre.compose.style.BaseStyle
+import org.maplibre.compose.style.install
+import org.maplibre.compose.testing.MapTestResult
+import org.maplibre.compose.testing.createMapFixture
+import org.maplibre.compose.testing.runMapTest
+import org.maplibre.spatialk.geojson.FeatureCollection
+import org.maplibre.spatialk.geojson.Geometry
+
+/**
+ * Applies a multi-condition `switch` of `image` expressions to `iconImage`. The old iOS SDK crashed
+ * on that shape ([#310](https://github.com/maplibre/maplibre-compose/issues/310)).
+ */
+class ExpressionSwitchEngineTest {
+
+  @Test
+  fun maplibre_accepts_a_multi_condition_image_switch_as_icon_image(): MapTestResult = runMapTest {
+    createMapFixture().use {
+      it.loadStyle(BaseStyle.Empty)
+      val style = assertNotNull(it.style, "Errors: ${it.errors}")
+      val source =
+        GeoJsonSource(
+          id = "features",
+          data = GeoJsonData.Features(FeatureCollection<Geometry, JsonObject?>()),
+          options = GeoJsonOptions(),
+        )
+      style.install(source)
+
+      val layer = SymbolLayer("markers", source)
+      layer.setIconImage(
+        switch(
+            condition(feature["icon"].asString() eq const("1"), image("one")),
+            condition(feature["icon"].asString() eq const("2"), image("two")),
+            condition(feature["icon"].asString() eq const("3"), image("three")),
+            fallback = image("fallback"),
+          )
+          .compile(ExpressionContext.None)
+      )
+      style.install(layer)
+
+      assertNotNull(style.getLayer("markers"))
+      assertEquals(emptyList(), it.errors, "the map should report nothing")
+    }
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Compile condition `switch` to one style-spec `case` now that the iOS `iconImage` crash is gone on the shared native FFI path.

## Validation

Desktop Vulkan and headless Chrome both accepted a three-condition `image` `switch` on `iconImage`. The compile suite pins the flat `case` JSON.

## AI assistance

Cursor Grok 4.6 in Cursor Cloud, following poteto-mode.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3c9b9bbc-48af-4e85-9409-2b9be8029cbb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3c9b9bbc-48af-4e85-9409-2b9be8029cbb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

