### PR TITLE
Seed the first presentation viewport when its camera callback is dropped

### DIFF
--- a/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MlnFfiMapInputTest.kt
+++ b/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MlnFfiMapInputTest.kt
@@ -1008,7 +1008,15 @@ class MlnFfiMapInputTest {
 
     // The map thread reports the first viewport, and a suspended test body pumps no snapshot apply
     // notifications; waitUntil polls with frame pumps, so that report can't strand it.
-    waitUntil(timeoutMillis = TIMEOUT) { mapState.presentation?.viewport != null }
+    try {
+      waitUntil(timeoutMillis = TIMEOUT) { mapState.presentation?.viewport != null }
+    } catch (timeout: ComposeTimeoutException) {
+      throw AssertionError(
+        "the map never published a viewport within ${TIMEOUT}ms " +
+          "(presentation=${mapState.presentation != null})",
+        timeout,
+      )
+    }
     val camera = PresentationCamera(mapState)
     camera.position = initialPosition
     waitUntil(timeoutMillis = TIMEOUT) { frames.load() > 0 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleAuthority.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleAuthority.kt
@@ -277,6 +277,19 @@ internal class MapLifecycleAuthority(
     }
   }
 
+  /**
+   * Seeds the published presentation from [adapter] after that adapter first has a viewport.
+   *
+   * Publication also seeds, but the first frame snapshot can arrive while the lease is still
+   * attaching. [acceptPresentationEvent] then rejects the camera callback, and an idle empty style
+   * may never emit another one.
+   */
+  fun seedCurrentPresentationViewport(adapter: MapAdapter) {
+    val token =
+      serialized { attachment?.takeIf { it.adapter === adapter && !it.releasing }?.token } ?: return
+    owner.seedPresentationViewport(token, adapter)
+  }
+
   fun selectAdapterForPresentation(adapter: MapAdapter): Boolean = serialized {
     if (closed) return@serialized false
     val current = attachment ?: return@serialized false

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleAuthority.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleAuthority.kt
@@ -281,8 +281,8 @@ internal class MapLifecycleAuthority(
    * Seeds the published presentation from [adapter] after that adapter first has a viewport.
    *
    * Publication also seeds, but the first frame snapshot can arrive while the lease is still
-   * attaching. [acceptPresentationEvent] then rejects the camera callback, and an idle empty style
-   * may never emit another one.
+   * attaching. The attach-gated camera callback is then rejected, and an idle empty style may never
+   * emit another one.
    */
   fun seedCurrentPresentationViewport(adapter: MapAdapter) {
     val token =

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
@@ -680,6 +680,25 @@ class MapPresentationTest {
   }
 
   @Test
+  fun a_viewport_that_arrives_after_publication_still_seeds_the_presentation() {
+    val runtime = mapRuntimeForTest()
+    val state = runtime.createMapState()
+    val token = state.reservePresentation()
+    val adapter = PresentationTestAdapter()
+
+    state.publishPresentation(token, adapter)
+    assertNull(state.presentation?.viewport)
+
+    val viewport = testViewport()
+    adapter.currentViewport = viewport
+    state.lifecycle.seedCurrentPresentationViewport(adapter)
+
+    assertEquals(viewport, state.presentation?.viewport)
+    state.close()
+    runtime.close()
+  }
+
+  @Test
   fun a_bounds_set_waits_for_this_presentations_viewport() = runTest {
     val fixture = presentationFixture()
     val operation = async {

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
@@ -412,7 +412,9 @@ internal class GlJsMapSession(
     map.resize()
     hasUsableViewport = true
     // resize() may also fire `move`; a second onCameraMoved is how overlays learn the viewport
-    // changed when the camera position did not.
+    // changed when the camera position did not. Seed here too: the first resize can land before
+    // the lease is Attached, and acceptPresentationEvent then drops that callback.
+    lifecycleAuthority.seedCurrentPresentationViewport(this)
     withLifecyclePresentation { engine, lease ->
       lifecycleCallbacks.onCameraMoved(engine, lease, this)
     }

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -1264,6 +1264,9 @@ internal class MlnFfiMapSession(
    */
   private fun snapshotViewportAndNotify(map: MapHandle) {
     snapshotViewport(map)
+    // The first attach snapshot can land before the lease is Attached. Seed from the snapshot
+    // itself so a dropped camera callback cannot leave MapPresentation.viewport null.
+    lifecycleAuthority.seedCurrentPresentationViewport(this)
     withLifecyclePresentation { engine, lease ->
       lifecycleCallbacks.onCameraMoved(engine, lease, this)
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Seeds the published presentation viewport from the first attach snapshot so a dropped Attaching-state camera callback cannot leave input tests waiting 30s for a null viewport.

## Validation

Passed `:lib:maplibre-compose:jvmTest --tests MapPresentationTest --tests MlnFfiMapInputTest` (33 + 46, 0 failures) on Linux; the first CI docs failure was a Dokka KDoc link, now removed.

## AI assistance

Cursor Grok 4.6 investigated issue 1033 and implemented the viewport seed.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-99588bea-cb77-45b7-8111-9321421bf49c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-99588bea-cb77-45b7-8111-9321421bf49c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

