### PR TITLE
Wait for a presented frame before sampling surface-loss pixels

### DIFF
--- a/lib/maplibre-compose/src/androidDeviceTest/kotlin/org/maplibre/compose/mlnffi/AndroidEglTestRenderDriver.kt
+++ b/lib/maplibre-compose/src/androidDeviceTest/kotlin/org/maplibre/compose/mlnffi/AndroidEglTestRenderDriver.kt
@@ -70,6 +70,14 @@ private constructor(private val display: EGLDisplay, private val config: EGLConf
   /** The producer renders directly into this EGL pbuffer, so there is no consumer-side bridge. */
   override fun present(target: MlnFfiRenderTarget): Boolean = true
 
+  override fun discardPresentedFrame() {
+    if (surface == EGL14.EGL_NO_SURFACE) return
+    // The session that just lost this surface may still name it while it closes.
+    retiredSurfaces += surface
+    surface = EGL14.EGL_NO_SURFACE
+    extent = MapExtent.Empty
+  }
+
   override fun readPixel(x: Int, y: Int): RgbaPixel {
     check(surface != EGL14.EGL_NO_SURFACE) { "No Android test frame has been rendered" }
     // A dedicated session keeps its context current on this thread after render. Symbol passes

--- a/lib/maplibre-compose/src/iosTest/kotlin/org/maplibre/compose/mlnffi/IosMetalTestRenderDriver.kt
+++ b/lib/maplibre-compose/src/iosTest/kotlin/org/maplibre/compose/mlnffi/IosMetalTestRenderDriver.kt
@@ -83,6 +83,12 @@ internal class IosMetalTestRenderDriver private constructor(private val device: 
   /** The producer renders directly into the test texture, so there is nothing to present. */
   override fun present(target: MlnFfiRenderTarget): Boolean = true
 
+  override fun discardPresentedFrame() {
+    texture?.let(retiredTextures::add)
+    texture = null
+    extent = MapExtent.Empty
+  }
+
   override fun readPixel(x: Int, y: Int): RgbaPixel = autoreleasepool {
     val texture = checkNotNull(texture) { "No iOS test frame has been rendered" }
     memScoped {

--- a/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/mlnffi/ProductionBridgeTestRenderDriver.kt
+++ b/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/mlnffi/ProductionBridgeTestRenderDriver.kt
@@ -205,7 +205,15 @@ private abstract class DesktopTestGpuEnvironment : AutoCloseable {
     }
   }
 
-  fun discardPresentedFrame() = closeDestination()
+  /**
+   * Forgets the last presented consumer frame so a later readback cannot use the previous session's
+   * GPU objects.
+   *
+   * Direct3D 12 keeps one Skiko window for the suite. Closing that destination mid-suite stalls the
+   * GPU thread on Windows ARM, so that environment leaves the surface in place. The fixture still
+   * rejects reads until the next present.
+   */
+  open fun discardPresentedFrame() = closeDestination()
 
   protected fun closeDestination() {
     if (destination == null) return
@@ -392,6 +400,8 @@ private class Direct3D12TestGpuEnvironment private constructor(private val windo
   override fun <T> withContext(action: (ComposeGpuContext) -> T): T = presentationHost.onGpuThread {
     action(presentationHost.requireContext<Direct3D12ComposeGpuContext>())
   }
+
+  override fun discardPresentedFrame() {}
 
   override fun close() {
     closeDestination()

--- a/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/mlnffi/ProductionBridgeTestRenderDriver.kt
+++ b/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/mlnffi/ProductionBridgeTestRenderDriver.kt
@@ -107,6 +107,10 @@ private constructor(
 
   override fun readPixel(x: Int, y: Int): RgbaPixel = environment.readPixel(x, y)
 
+  override fun discardPresentedFrame() {
+    environment.discardPresentedFrame()
+  }
+
   override fun close() {
     try {
       bridge.close()
@@ -200,6 +204,8 @@ private abstract class DesktopTestGpuEnvironment : AutoCloseable {
       )
     }
   }
+
+  fun discardPresentedFrame() = closeDestination()
 
   protected fun closeDestination() {
     if (destination == null) return

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/MlnFfiSurfaceLossTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/MlnFfiSurfaceLossTest.kt
@@ -143,24 +143,29 @@ class MlnFfiSurfaceLossTest {
       style.install(layer)
 
       style.setFeatureState(source.id, null, "1", state("before-surface"))
-      it.frame()
       it.pumpUntil("the incomplete feature state to render blue") {
-        it.readPixel(CENTER, CENTER).isNear(BLUE)
+        it.tryReadPixel(CENTER, CENTER)?.isNear(BLUE) == true
       }
       it.loseSurface()
       style.setFeatureState(source.id, null, "1", state("without-surface"))
+      assertEquals(
+        state("before-surface", "without-surface"),
+        style.featureState(source.id, null, "1"),
+      )
       it.restoreSurface()
-      it.frame()
       it.pumpUntil("feature state to replay into the replacement renderer") {
-        it.readPixel(CENTER, CENTER).isNear(RED)
+        it.tryReadPixel(CENTER, CENTER)?.isNear(RED) == true
       }
 
       it.loseSurface()
       style.resetFeatureStates(source.id, null)
+      assertEquals(
+        JsonObject(emptyMap()),
+        style.featureState(source.id, null, "1"),
+      )
       it.restoreSurface()
-      it.frame()
       it.pumpUntil("the reset feature state to replay") {
-        it.readPixel(CENTER, CENTER).isNear(BLUE)
+        it.tryReadPixel(CENTER, CENTER)?.isNear(BLUE) == true
       }
     }
   }
@@ -195,7 +200,9 @@ class MlnFfiSurfaceLossTest {
     /** Camera round trips lose a little precision through the projection. */
     const val TOLERANCE = 1e-3
 
-    fun state(key: String): JsonObject = buildJsonObject { put(key, true) }
+    fun state(vararg keys: String): JsonObject = buildJsonObject {
+      keys.forEach { key -> put(key, true) }
+    }
 
     fun assertNear(expected: Double, actual: Double, message: String) {
       assertTrue(abs(expected - actual) < TOLERANCE, "$message (expected $expected, got $actual)")

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/MlnFfiSurfaceLossTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/MlnFfiSurfaceLossTest.kt
@@ -147,23 +147,27 @@ class MlnFfiSurfaceLossTest {
         it.tryReadPixel(CENTER, CENTER)?.isNear(BLUE) == true
       }
       it.loseSurface()
+      assertEquals(null, it.tryReadPixel(CENTER, CENTER))
       style.setFeatureState(source.id, null, "1", state("without-surface"))
       assertEquals(
         state("before-surface", "without-surface"),
         style.featureState(source.id, null, "1"),
       )
       it.restoreSurface()
+      assertEquals(null, it.tryReadPixel(CENTER, CENTER))
       it.pumpUntil("feature state to replay into the replacement renderer") {
         it.tryReadPixel(CENTER, CENTER)?.isNear(RED) == true
       }
 
       it.loseSurface()
+      assertEquals(null, it.tryReadPixel(CENTER, CENTER))
       style.resetFeatureStates(source.id, null)
       assertEquals(
         JsonObject(emptyMap()),
         style.featureState(source.id, null, "1"),
       )
       it.restoreSurface()
+      assertEquals(null, it.tryReadPixel(CENTER, CENTER))
       it.pumpUntil("the reset feature state to replay") {
         it.tryReadPixel(CENTER, CENTER)?.isNear(BLUE) == true
       }

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/mlnffi/BridgeMapFixture.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/mlnffi/BridgeMapFixture.kt
@@ -94,12 +94,18 @@ private constructor(
    */
   fun loseSurface() {
     session.onSurfaceLost()
+    forgetPresentedFrame()
   }
 
   /** Hands the surface back, and forgets that anything was ever rendered into the old one. */
   fun restoreSurface() {
-    hasRendered = false
+    forgetPresentedFrame()
     session.onSurfaceAvailable(hostSession)
+  }
+
+  private fun forgetPresentedFrame() {
+    hasRendered = false
+    driver.discardPresentedFrame()
   }
 
   val attachCount: Int

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/mlnffi/BridgeMapFixture.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/mlnffi/BridgeMapFixture.kt
@@ -139,7 +139,16 @@ private constructor(
   }
 
   /** Reads one rendered RGBA pixel back from the platform/backend target. */
-  fun readPixel(x: Int, y: Int): RgbaPixel = driver.readPixel(x, y)
+  fun readPixel(x: Int, y: Int): RgbaPixel =
+    checkNotNull(tryReadPixel(x, y)) { "No production bridge frame has been presented" }
+
+  /**
+   * One rendered pixel after the current surface has presented a frame, or null.
+   *
+   * [readPixel] requires that presentation. A [pumpUntil] condition uses this so a skipped frame
+   * waits for the next one.
+   */
+  fun tryReadPixel(x: Int, y: Int): RgbaPixel? = if (hasRendered) driver.readPixel(x, y) else null
 
   /** Renders frames until MapLibre has drawn once, so the map is known to exist. */
   fun pumpUntilRendered(extent: MapExtent = initialExtent, timeout: Duration = 30.seconds) {

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/mlnffi/FfiTestPlatform.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/mlnffi/FfiTestPlatform.kt
@@ -58,4 +58,12 @@ internal interface FfiTestRenderDriver : MlnFfiMapHost {
 
   /** Reads one pixel after presentation. */
   fun readPixel(x: Int, y: Int): RgbaPixel
+
+  /**
+   * Forgets the last presented consumer frame.
+   *
+   * A replaced surface has a new producer. The previous destination still names the old session's
+   * GPU objects, and a readback through that destination can stall the test thread.
+   */
+  fun discardPresentedFrame() {}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Wait for a presented frame before sampling surface-loss pixels, discard the previous OpenGL or Metal destination when the surface is replaced, and leave the shared D3D12 destination in place so Windows ARM does not stall the GPU thread.

## Validation

CI on `03e7a0e0` passed macOS, Linux ARM, Windows ARM, Android 36, and the other desktop jobs; Android 24 failed the still-present live-map input class (fixed on the input-test branch), and iOS failed an unrelated `IosHeadingProviderTest` coroutine timeout.

## AI assistance

Cursor Grok 4.6 diagnosed the macOS flake, the Linux ARM stall, and the Windows ARM hang after destination close.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-99588bea-cb77-45b7-8111-9321421bf49c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-99588bea-cb77-45b7-8111-9321421bf49c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

