### PR TITLE
Add borrowed platform map access

### DIFF
--- a/.agents/scratch/api-redesign/issues/18-platform-map-access.md
+++ b/.agents/scratch/api-redesign/issues/18-platform-map-access.md
@@ -6,7 +6,7 @@ borrowed, callback-scoped value.
 
 **Blocked by:** 04, 05, 07
 
-**Status:** resolved
+**Status:** needs-info
 
 - [x] The changed test area contains no redundant, impossible,
       compatibility-only, or implementation-shape scenarios.
@@ -15,15 +15,17 @@ borrowed, callback-scoped value.
 - [x] Documentation states honestly that Kotlin cannot prevent retention and
       requires callers to use the borrowed handle only during the lambda.
 - [x] Native access creates the engine map lazily when necessary.
-- [x] Native access works while MapState has no presentation.
+- [ ] Android native access can initialize a presentation-free explicit runtime.
+- [x] Native access works while MapState has no presentation after platform
+      initialization.
 - [x] Web access works only for the current attached presentation.
 - [x] Web access fails clearly while detached.
 - [x] Native invocations bind to an engine-map identity; Web invocations bind to
       both an engine-map identity and the current render lease.
 - [x] Replacement, Web detachment, or closure that wins before execution rejects
       the invocation without running its callback.
-- [x] Caller cancellation that wins while an invocation is queued prevents its
-      callback; cancellation after execution starts does not interrupt it.
+- [x] Caller cancellation before owner execution prevents a queued callback;
+      cancellation after execution starts does not interrupt it.
 - [x] Once a callback starts, detach, replacement, and closure queue behind it
       and continue after it returns.
 - [x] Platform tests verify owner-context execution, native detached access, Web
@@ -50,13 +52,14 @@ the render lease. A callback that has started finishes before detach,
 replacement, or closure proceeds. Identity validation and callback delivery hold
 both lifecycle serialization locks until the callback returns.
 
-Queued native and Web invocations arbitrate cancellation against execution with
-one atomic claim. Cancellation that wins suppresses the callback. Cancellation
-after execution wins leaves the caller cancelled without interrupting the
-non-suspending callback.
+Queued native and Web invocations use one atomic state transition for
+cancellation and execution. Cancellation before execution suppresses the
+callback. Cancellation after execution starts leaves the caller cancelled
+without interrupting the non-suspending callback.
 
 The native tests cover detached creation, owner-thread execution, replacement
 before execution, queued cancellation, closure after execution starts, and
 closed-state rejection. The Web tests cover detached rejection, attached access,
-stale-lease rejection, and queued cancellation. The Android, desktop, and iOS
-tasks pass. The Web task runs all 264 tests successfully.
+stale-lease rejection, queued cancellation, and closure during first-frame
+callback delivery. The Android, desktop, and iOS tasks pass. The Web task runs
+all 271 tests successfully.

--- a/.agents/scratch/api-redesign/issues/18-platform-map-access.md
+++ b/.agents/scratch/api-redesign/issues/18-platform-map-access.md
@@ -6,25 +6,25 @@ borrowed, callback-scoped value.
 
 **Blocked by:** 04, 05, 07
 
-**Status:** ready-for-agent
+**Status:** resolved
 
-- [ ] The changed test area contains no redundant, impossible,
+- [x] The changed test area contains no redundant, impossible,
       compatibility-only, or implementation-shape scenarios.
-- [ ] A caller can invoke platform access from any coroutine dispatcher.
-- [ ] The lambda executes on the engine map's owner context.
-- [ ] Documentation states honestly that Kotlin cannot prevent retention and
+- [x] A caller can invoke platform access from any coroutine dispatcher.
+- [x] The lambda executes on the engine map's owner context.
+- [x] Documentation states honestly that Kotlin cannot prevent retention and
       requires callers to use the borrowed handle only during the lambda.
-- [ ] Native access creates the engine map lazily when necessary.
-- [ ] Native access works while MapState has no presentation.
-- [ ] Web access works only for the current attached presentation.
-- [ ] Web access fails clearly while detached.
-- [ ] Native invocations bind to an engine-map identity; Web invocations bind to
+- [x] Native access creates the engine map lazily when necessary.
+- [x] Native access works while MapState has no presentation.
+- [x] Web access works only for the current attached presentation.
+- [x] Web access fails clearly while detached.
+- [x] Native invocations bind to an engine-map identity; Web invocations bind to
       both an engine-map identity and the current render lease.
-- [ ] Replacement, Web detachment, or closure that wins before execution rejects
+- [x] Replacement, Web detachment, or closure that wins before execution rejects
       the invocation without running its callback.
-- [ ] Once a callback starts, detach, replacement, and closure queue behind it
+- [x] Once a callback starts, detach, replacement, and closure queue behind it
       and continue after it returns.
-- [ ] Platform tests verify owner-context execution, native detached access, Web
+- [x] Platform tests verify owner-context execution, native detached access, Web
       attached-only access, and rejection after closure.
 
 ## Test ledger
@@ -37,3 +37,21 @@ borrowed, callback-scoped value.
   claiming Kotlin can prevent raw-handle retention.
 - Run `mise run test:android`, `mise run test:desktop`, `mise run test:ios`, and
   `mise run test:js`.
+
+## Answer
+
+`MapState.withPlatformMap` now provides delicate, callback-scoped access to the
+raw native or Web map. Native calls create and retain an engine without a
+presentation. Web calls require the current presentation. Both paths validate
+the captured engine identity immediately before the callback; Web also validates
+the render lease. A callback that has started finishes before detach,
+replacement, or closure proceeds. Identity validation and callback delivery hold
+both lifecycle serialization locks until the callback returns.
+
+The native tests cover detached creation, owner-thread execution, replacement
+before execution, closure after execution starts, and closed-state rejection.
+The Web tests cover detached rejection, attached access, and stale-lease
+rejection. The Android, desktop, and iOS tasks pass. The Web task runs all 263
+tests: the three platform-access tests pass, while nine existing
+`BrowserCompositingTest` cases time out waiting for rendered pixels on this
+host.

--- a/.agents/scratch/api-redesign/issues/18-platform-map-access.md
+++ b/.agents/scratch/api-redesign/issues/18-platform-map-access.md
@@ -22,6 +22,8 @@ borrowed, callback-scoped value.
       both an engine-map identity and the current render lease.
 - [x] Replacement, Web detachment, or closure that wins before execution rejects
       the invocation without running its callback.
+- [x] Caller cancellation that wins while an invocation is queued prevents its
+      callback; cancellation after execution starts does not interrupt it.
 - [x] Once a callback starts, detach, replacement, and closure queue behind it
       and continue after it returns.
 - [x] Platform tests verify owner-context execution, native detached access, Web
@@ -33,8 +35,8 @@ borrowed, callback-scoped value.
   public access API and keep lower-level thread tests only for distinct FFI
   behavior.
 - Add native detached, pre-execution engine replacement, Web detached or stale
-  lease, callback-versus-close, and closed-state cases. Do not add a test
-  claiming Kotlin can prevent raw-handle retention.
+  lease, queued cancellation, callback-versus-close, and closed-state cases. Do
+  not add a test claiming Kotlin can prevent raw-handle retention.
 - Run `mise run test:android`, `mise run test:desktop`, `mise run test:ios`, and
   `mise run test:js`.
 
@@ -48,10 +50,13 @@ the render lease. A callback that has started finishes before detach,
 replacement, or closure proceeds. Identity validation and callback delivery hold
 both lifecycle serialization locks until the callback returns.
 
+Queued native and Web invocations arbitrate cancellation against execution with
+one atomic claim. Cancellation that wins suppresses the callback. Cancellation
+after execution wins leaves the caller cancelled without interrupting the
+non-suspending callback.
+
 The native tests cover detached creation, owner-thread execution, replacement
-before execution, closure after execution starts, and closed-state rejection.
-The Web tests cover detached rejection, attached access, and stale-lease
-rejection. The Android, desktop, and iOS tasks pass. The Web task runs all 263
-tests: the three platform-access tests pass, while nine existing
-`BrowserCompositingTest` cases time out waiting for rendered pixels on this
-host.
+before execution, queued cancellation, closure after execution starts, and
+closed-state rejection. The Web tests cover detached rejection, attached access,
+stale-lease rejection, and queued cancellation. The Android, desktop, and iOS
+tasks pass. The Web task runs all 264 tests successfully.

--- a/.agents/scratch/api-redesign/spec.md
+++ b/.agents/scratch/api-redesign/spec.md
@@ -491,6 +491,11 @@ behind it on the serialized owner context. They continue after it returns. A
 long-running callback therefore blocks map progress and violates the delicate
 API contract.
 
+An invocation waiting in the owner queue is cancellable. Cancellation that wins
+before the owner claims the invocation prevents the callback. Once the owner
+claims it, cancellation does not interrupt the non-suspending callback; the
+caller remains cancelled and the callback result is discarded.
+
 This escape hatch is lower priority than the common API. Do not expose a raw
 handle property.
 

--- a/.agents/scratch/api-redesign/spec.md
+++ b/.agents/scratch/api-redesign/spec.md
@@ -491,10 +491,10 @@ behind it on the serialized owner context. They continue after it returns. A
 long-running callback therefore blocks map progress and violates the delicate
 API contract.
 
-An invocation waiting in the owner queue is cancellable. Cancellation that wins
-before the owner claims the invocation prevents the callback. Once the owner
-claims it, cancellation does not interrupt the non-suspending callback; the
-caller remains cancelled and the callback result is discarded.
+An invocation waiting in the owner queue is cancellable. Cancellation before the
+owner claims the invocation prevents the callback. Once the owner claims the
+invocation, cancellation does not interrupt the non-suspending callback. The
+caller remains cancelled, and the callback result is discarded.
 
 This escape hatch is lower priority than the common API. Do not expose a raw
 handle property.

--- a/lib/maplibre-compose/build.gradle.kts
+++ b/lib/maplibre-compose/build.gradle.kts
@@ -82,7 +82,7 @@ kotlin {
         iosMain.get().dependsOn(this)
         dependencies {
           // Backend-independent binding only; the application selects the native runtime.
-          implementation(libs.maplibre.nativeFfi)
+          api(libs.maplibre.nativeFfi)
           // Multiplatform filesystem paths, so this source set stays free of java.io.File.
           implementation(libs.kotlinx.io.core)
         }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleAuthority.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleAuthority.kt
@@ -411,8 +411,7 @@ internal class MapLifecycleAuthority(
   private fun acceptsAdapterLocked(adapter: MapAdapter): Boolean {
     val current = attachment
     return !closed &&
-      ((current?.adapter === adapter && !current.releasing) ||
-        (current?.adapter == null && retainedAdapter === adapter))
+      ((current?.adapter === adapter && !current.releasing) || retainedAdapter === adapter)
   }
 
   private fun acceptsPresentationLocked(adapter: MapAdapter): Boolean =
@@ -706,6 +705,13 @@ internal class MapLifecycleBinding(
       adapter.createEngine(creating.engine)
       creating.engineCreated.store(true)
       creating.engine
+    }
+    outcome.exceptionOrNull()?.let { failure ->
+      runCatching { adapter.destroyEngine(creating.engine) }
+        .exceptionOrNull()
+        ?.let(failure::addSuppressed)
+      currentStyle.store(null)
+      currentStyleRequest.store(null)
     }
     serialized {
       if (current.load() === creating) {

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleAuthority.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleAuthority.kt
@@ -106,6 +106,8 @@ internal class MapLifecycleAuthority(
   private val releaseCleanups = linkedSetOf<CompletableDeferred<Result<Unit>>>()
   private val pendingCleanupFailures = mutableListOf<Throwable>()
   private var closed = false
+  private var platformAccessDepth = 0
+  private var closeAfterPlatformAccess = false
 
   val isClosed: Boolean
     get() = serialized { closed }
@@ -114,6 +116,10 @@ internal class MapLifecycleAuthority(
     val (maps, releases, recordedFailures) =
       serialized {
         if (closed) return
+        if (platformAccessDepth > 0) {
+          closeAfterPlatformAccess = true
+          return
+        }
         closed = true
         val maps = buildSet {
           retainedAdapter?.let(::add)
@@ -298,22 +304,48 @@ internal class MapLifecycleAuthority(
     true
   }
 
-  fun acceptsAdapter(adapter: MapAdapter): Boolean = serialized {
-    val current = attachment
-    !closed &&
-      ((current?.adapter === adapter && !current.releasing) ||
-        (current?.adapter == null && retainedAdapter === adapter))
-  }
+  fun acceptsAdapter(adapter: MapAdapter): Boolean = serialized { acceptsAdapterLocked(adapter) }
 
   fun isPendingPublication(adapter: MapAdapter): Boolean = serialized {
     !closed && attachment?.adapter === adapter && attachment?.releasing == false
   }
 
   fun acceptsPresentation(adapter: MapAdapter): Boolean = serialized {
-    !closed && attachment?.adapter === adapter && owner.presentation?.adapter === adapter
+    acceptsPresentationLocked(adapter)
   }
 
   fun currentAdapter(): MapAdapter? = serialized { attachment?.adapter ?: retainedAdapter }
+
+  fun retainAdapterForPlatformAccess(create: () -> MapAdapter): MapAdapter = serialized {
+    requireOpen()
+    (attachment?.adapter ?: retainedAdapter)?.let {
+      return it
+    }
+    create().also { adapter ->
+      check(adapter.retainsEngineBetweenPresentations) {
+        "A detached platform map requires an engine-retaining adapter"
+      }
+      retainedAdapter = adapter
+      owner.beginStyleLoadForNewAdapter()
+    }
+  }
+
+  fun presentationAdapterForPlatformAccess(): MapAdapter = serialized {
+    requireOpen()
+    val adapter = attachment?.adapter
+    check(adapter != null && acceptsPresentationLocked(adapter)) {
+      "Platform map access requires a current Web presentation"
+    }
+    adapter
+  }
+
+  fun acceptEnginePlatformAccess(adapter: MapAdapter, event: () -> Unit): Boolean =
+    acceptPlatformAccess(accepts = { acceptsAdapterLocked(adapter) }, event)
+
+  fun acceptPresentationPlatformAccess(
+    adapter: MapAdapter,
+    event: () -> Unit,
+  ): Boolean = acceptPlatformAccess(accepts = { acceptsPresentationLocked(adapter) }, event)
 
   fun isCurrent(token: MapPresentationToken, adapter: MapAdapter): Boolean = serialized {
     !closed &&
@@ -374,6 +406,38 @@ internal class MapLifecycleAuthority(
     check(current.adapter == null) { "The map state already has a presentation adapter" }
     current.adapter = adapter
     if (retainedAdapter !== adapter) owner.beginStyleLoadForNewAdapter()
+  }
+
+  private fun acceptsAdapterLocked(adapter: MapAdapter): Boolean {
+    val current = attachment
+    return !closed &&
+      ((current?.adapter === adapter && !current.releasing) ||
+        (current?.adapter == null && retainedAdapter === adapter))
+  }
+
+  private fun acceptsPresentationLocked(adapter: MapAdapter): Boolean =
+    !closed && attachment?.adapter === adapter && owner.presentation?.adapter === adapter
+
+  private fun acceptPlatformAccess(accepts: () -> Boolean, event: () -> Unit): Boolean {
+    var commitDeferredClose = false
+    try {
+      return serialized {
+        if (!accepts()) return@serialized false
+        platformAccessDepth++
+        try {
+          event()
+        } finally {
+          platformAccessDepth--
+          if (platformAccessDepth == 0 && closeAfterPlatformAccess) {
+            closeAfterPlatformAccess = false
+            commitDeferredClose = true
+          }
+        }
+        true
+      }
+    } finally {
+      if (commitDeferredClose) close()
+    }
   }
 
   private fun completeClosure(result: Result<Unit>) {
@@ -537,6 +601,7 @@ internal class MapLifecycleBinding(
     while (true) {
       when (val observed = current.load()) {
         is InternalState.OpenDetached -> return attach()
+        is InternalState.CreatingEngine -> observed.result.await().getOrThrow()
         is InternalState.Attaching -> return observed.result.await().getOrThrow()
         is InternalState.Attached -> return observed.lease
         is InternalState.Detaching -> observed.result.await().getOrThrow()
@@ -552,6 +617,7 @@ internal class MapLifecycleBinding(
       val observed = current.load()
       when (observed) {
         is InternalState.OpenDetached -> createAttachmentStart(observed)
+        is InternalState.CreatingEngine,
         is InternalState.Attaching,
         is InternalState.Attached,
         is InternalState.Detaching -> throw MapAlreadyAttachedException()
@@ -574,6 +640,10 @@ internal class MapLifecycleBinding(
           alreadyAttached = true
           null
         }
+        is InternalState.CreatingEngine -> {
+          alreadyAttached = true
+          null
+        }
         is InternalState.Detaching,
         is InternalState.Closing,
         InternalState.Closed -> null
@@ -581,6 +651,68 @@ internal class MapLifecycleBinding(
     }
     start?.let(::launchAttachment)
     return alreadyAttached || start != null
+  }
+
+  /** Creates a retained engine without requiring a presentation and returns its identity. */
+  suspend fun ensureEngine(): EngineMapIdentity {
+    check(adapter.engineRetention == EngineRetention.RETAIN) {
+      "Detached engine creation requires a retained engine"
+    }
+    while (true) {
+      var launchCreation = false
+      val observed = serialized {
+        when (val state = current.load()) {
+          is InternalState.OpenDetached -> {
+            state.engine?.let {
+              return it
+            }
+            InternalState.CreatingEngine(
+                engine = EngineMapIdentity(nextIdentity.incrementAndFetch()),
+                result = CompletableDeferred(),
+                engineCreated = AtomicBoolean(false),
+              )
+              .also {
+                current.store(it)
+                launchCreation = true
+              }
+          }
+          else -> state
+        }
+      }
+      when (observed) {
+        is InternalState.CreatingEngine -> {
+          if (launchCreation) {
+            physicalScope.launch(start = CoroutineStart.UNDISPATCHED) {
+              performEngineCreation(observed)
+            }
+          }
+          observed.result.await().getOrThrow()
+        }
+        is InternalState.Attaching -> observed.result.await().getOrThrow()
+        is InternalState.Attached -> return observed.engine
+        is InternalState.Detaching -> observed.result.await().getOrThrow()
+        is InternalState.OpenDetached ->
+          observed.engine?.let {
+            return it
+          }
+        is InternalState.Closing,
+        InternalState.Closed -> throw MapClosedException()
+      }
+    }
+  }
+
+  private suspend fun performEngineCreation(creating: InternalState.CreatingEngine) {
+    val outcome = runCatching {
+      adapter.createEngine(creating.engine)
+      creating.engineCreated.store(true)
+      creating.engine
+    }
+    serialized {
+      if (current.load() === creating) {
+        current.store(InternalState.OpenDetached(outcome.getOrNull()))
+      }
+    }
+    creating.result.complete(outcome)
   }
 
   private fun createAttachmentStart(observed: InternalState.OpenDetached): AttachmentStart {
@@ -675,6 +807,7 @@ internal class MapLifecycleBinding(
         true
       }
       is InternalState.OpenDetached,
+      is InternalState.CreatingEngine,
       is InternalState.Closing,
       InternalState.Closed -> false
     }
@@ -870,6 +1003,7 @@ internal class MapLifecycleBinding(
     val failures = mutableListOf<Throwable>()
 
     when (previous) {
+      is InternalState.CreatingEngine -> previous.result.await()
       is InternalState.Attaching -> {
         previous.result.await()
         collectFailure(failures) { adapter.detach(previous.engine, previous.lease) }
@@ -883,7 +1017,9 @@ internal class MapLifecycleBinding(
       InternalState.Closed -> error("Closure cannot start from ${previous.publicState}")
     }
 
-    val engine = previous.engine
+    val engine =
+      if (previous is InternalState.CreatingEngine && !previous.engineCreated.load()) null
+      else previous.engine
     val detachAlreadyDestroyedEngine =
       previous is InternalState.Detaching && adapter.engineRetention == EngineRetention.DESTROY
     if (engine != null && !detachAlreadyDestroyedEngine) {
@@ -934,6 +1070,14 @@ internal class MapLifecycleBinding(
 
     data class OpenDetached(override val engine: EngineMapIdentity?) : InternalState {
       override val publicState = MapLifecycleState.OpenDetached(engine)
+    }
+
+    data class CreatingEngine(
+      override val engine: EngineMapIdentity,
+      val result: CompletableDeferred<Result<EngineMapIdentity>>,
+      val engineCreated: AtomicBoolean,
+    ) : InternalState {
+      override val publicState = MapLifecycleState.OpenDetached(null)
     }
 
     data class Attaching(

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/PlatformMapAccess.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/PlatformMapAccess.kt
@@ -1,0 +1,29 @@
+package org.maplibre.compose.map
+
+/** Marks direct platform-map access with a callback-scoped lifetime. */
+@RequiresOptIn(
+  message =
+    "The platform map is borrowed only for the withPlatformMap callback. " +
+      "Do not retain it or run long work in the callback.",
+  level = RequiresOptIn.Level.WARNING,
+)
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+public annotation class DelicateMapApi
+
+/** Provides callback-scoped access to the current platform engine map. */
+@DelicateMapApi public expect class PlatformMapScope
+
+/**
+ * Runs [block] on this logical map's engine owner context.
+ *
+ * The platform map is borrowed for [block]. Use the raw handle only during [block]. Kotlin cannot
+ * prevent retention. A long-running block stops the map from processing other work.
+ *
+ * Native platforms create the engine map when necessary and permit access without a presentation.
+ * Web requires a current presentation. The call fails without running [block] if the map closes or
+ * the engine changes before execution. On Web, the call also fails if the current presentation
+ * detaches before execution.
+ */
+@DelicateMapApi
+public expect suspend fun <T> MapState.withPlatformMap(block: PlatformMapScope.() -> T): T

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/PlatformMapAccess.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/PlatformMapAccess.kt
@@ -1,4 +1,10 @@
+@file:OptIn(ExperimentalAtomicApi::class)
+
 package org.maplibre.compose.map
+
+import kotlin.concurrent.atomics.AtomicReference
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+import kotlinx.coroutines.CancellableContinuation
 
 /** Marks direct platform-map access with a callback-scoped lifetime. */
 @RequiresOptIn(
@@ -23,7 +29,41 @@ public annotation class DelicateMapApi
  * Native platforms create the engine map when necessary and permit access without a presentation.
  * Web requires a current presentation. The call fails without running [block] if the map closes or
  * the engine changes before execution. On Web, the call also fails if the current presentation
- * detaches before execution.
+ * detaches before execution. Cancelling while the invocation is queued prevents [block] from
+ * running. Once execution starts, cancellation does not interrupt [block], but its result is
+ * discarded.
  */
 @DelicateMapApi
 public expect suspend fun <T> MapState.withPlatformMap(block: PlatformMapScope.() -> T): T
+
+/** Arbitrates cancellation against the start of one queued platform-map action. */
+internal class PlatformMapInvocation<T>(private val continuation: CancellableContinuation<T>) {
+  private val state = AtomicReference(PlatformMapInvocationState.QUEUED)
+
+  val isQueued: Boolean
+    get() = state.load() == PlatformMapInvocationState.QUEUED
+
+  fun cancel() {
+    state.compareAndSet(PlatformMapInvocationState.QUEUED, PlatformMapInvocationState.CANCELLED)
+  }
+
+  fun execute(block: () -> T) {
+    if (
+      !state.compareAndSet(PlatformMapInvocationState.QUEUED, PlatformMapInvocationState.RUNNING)
+    ) {
+      return
+    }
+    val result = runCatching(block)
+    if (continuation.isActive) continuation.resumeWith(result)
+  }
+
+  fun fail(error: Throwable) {
+    execute { throw error }
+  }
+}
+
+private enum class PlatformMapInvocationState {
+  QUEUED,
+  RUNNING,
+  CANCELLED,
+}

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapLifecycleBindingTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapLifecycleBindingTest.kt
@@ -363,6 +363,17 @@ class MapLifecycleBindingTest {
     assertEquals(MapLifecycleState.OpenDetached(null), lifecycle.state)
     assertEquals(1, adapter.commands.count { it.startsWith("destroy ") })
   }
+
+  @Test
+  fun failed_detached_engine_creation_cleans_partial_engine_resources() = runTest {
+    val adapter = FakeMapLifecycleAdapter().apply { createFailure = TestFailure("create") }
+    val lifecycle = bindLifecycle(adapter)
+
+    assertFailsWith<TestFailure> { lifecycle.ensureEngine() }
+
+    assertEquals(MapLifecycleState.OpenDetached(null), lifecycle.state)
+    assertEquals(1, adapter.commands.count { it.startsWith("destroy ") })
+  }
 }
 
 private class FakeMapLifecycleAdapter : MapLifecyclePlatformAdapter {

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
@@ -240,6 +240,32 @@ class MapPresentationTest {
   }
 
   @Test
+  fun retained_engine_access_remains_valid_while_the_presentation_detaches() = runTest {
+    val runtime = mapRuntimeForTest(physicalScope = backgroundScope)
+    val state = runtime.createMapState()
+    val finishDetach = CompletableDeferred<Unit>()
+    val detachStarted = CompletableDeferred<Unit>()
+    val session = BoundLifecycleSession(finishDetach = finishDetach, detachStarted = detachStarted)
+    session.lifecycle = state.lifecycle.bind(session)
+    session.lifecycle.attach()
+    val token = state.reservePresentation()
+    state.publishPresentation(token, session)
+
+    state.releasePresentation(token, session)
+    detachStarted.await()
+    var callbackRan = false
+
+    assertTrue(state.lifecycle.acceptEnginePlatformAccess(session) { callbackRan = true })
+    assertTrue(callbackRan)
+
+    finishDetach.complete(Unit)
+    testScheduler.runCurrent()
+    state.close()
+    state.awaitClosed()
+    runtime.close()
+  }
+
+  @Test
   fun closure_during_presentation_configuration_makes_publication_inert() = runTest {
     val runtime = mapRuntimeForTest(physicalScope = backgroundScope)
     val state = runtime.createMapState()

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
@@ -363,7 +363,7 @@ internal class GlJsMapSession(
     cameraConstraints?.let { applyCameraConstraints(created, it) }
     runPending(pendingMapActions, created)
     runPending(pendingPlatformMapAccess, created)
-    return created
+    return created.takeIf { lifecycle.acceptsWork && map === created }
   }
 
   private fun destroyMap() {
@@ -452,7 +452,7 @@ internal class GlJsMapSession(
           run = { map ->
             invocation.execute {
               var result: Result<T>? = null
-              val accepted =
+              val presentationAccepted =
                 lifecycle.acceptPresentationEvent(engine, lease) {
                   val authorityAccepted =
                     lifecycleAuthority.acceptPresentationPlatformAccess(this) {
@@ -464,7 +464,7 @@ internal class GlJsMapSession(
                     )
                   }
                 }
-              if (!accepted) {
+              if (!presentationAccepted) {
                 throw IllegalStateException(
                   "The Web platform map changed before access could begin"
                 )

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
@@ -18,7 +18,6 @@ import kotlin.time.DurationUnit
 import kotlin.time.TimeSource
 import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.serialization.json.JsonObject
 import org.maplibre.compose.camera.CameraMoveReason
@@ -445,12 +444,13 @@ internal class GlJsMapSession(
     val lease =
       lifecycle.renderLease
         ?: throw IllegalStateException("The Web platform map changed before access could begin")
-    val completion = CompletableDeferred<Result<T>>()
-    val action =
-      PendingMapAction(
-        run = { map ->
-          completion.complete(
-            runCatching {
+    return suspendCancellableCoroutine { continuation ->
+      val invocation = PlatformMapInvocation(continuation)
+      lateinit var action: PendingMapAction
+      action =
+        PendingMapAction(
+          run = { map ->
+            invocation.execute {
               var result: Result<T>? = null
               val accepted =
                 lifecycle.acceptPresentationEvent(engine, lease) {
@@ -471,19 +471,21 @@ internal class GlJsMapSession(
               }
               checkNotNull(result).getOrThrow()
             }
-          )
-        },
-        abandon = {
-          completion.complete(
-            Result.failure(
+          },
+          abandon = {
+            invocation.fail(
               IllegalStateException("The Web platform map changed before access could begin")
             )
-          )
-        },
-      )
-    val current = map
-    if (current == null) pendingPlatformMapAccess += action else action.run(current)
-    return completion.await().getOrThrow()
+          },
+        )
+      continuation.invokeOnCancellation {
+        invocation.cancel()
+        pendingPlatformMapAccess.remove(action)
+      }
+      val current = map
+      if (current != null) action.run(current)
+      else if (invocation.isQueued) pendingPlatformMapAccess += action
+    }
   }
 
   private fun maxTextureSize(gl: dynamic): Array<Double> {

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
@@ -18,6 +18,7 @@ import kotlin.time.DurationUnit
 import kotlin.time.TimeSource
 import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.serialization.json.JsonObject
 import org.maplibre.compose.camera.CameraMoveReason
@@ -125,6 +126,9 @@ internal class GlJsMapSession(
 
   /** Actions accepted before Compose supplies the context used to construct the map. */
   private val pendingMapActions = mutableListOf<PendingMapAction>()
+
+  /** Platform-access callbacks waiting for this render lease's engine map. */
+  private val pendingPlatformMapAccess = mutableListOf<PendingMapAction>()
 
   /** Transitions MapLibre would cancel while applying the first style's camera. */
   private val pendingInitialStyleActions = mutableListOf<PendingMapAction>()
@@ -289,6 +293,7 @@ internal class GlJsMapSession(
       lifecycleStyleRequestIdentity = null
       lifecycleStyleIdentity = null
     }
+    abandonPending(pendingPlatformMapAccess)
     destroyMap()
   }
 
@@ -296,6 +301,7 @@ internal class GlJsMapSession(
     isGestureInProgress = false
     abandonPending(pendingMapActions)
     abandonPending(pendingInitialStyleActions)
+    abandonPending(pendingPlatformMapAccess)
     surface = null
   }
 
@@ -357,6 +363,7 @@ internal class GlJsMapSession(
     appliedExtent = MapExtent.Empty
     cameraConstraints?.let { applyCameraConstraints(created, it) }
     runPending(pendingMapActions, created)
+    runPending(pendingPlatformMapAccess, created)
     return created
   }
 
@@ -430,6 +437,54 @@ internal class GlJsMapSession(
 
   /** The current GL JS engine-map instance, exposed only to browser boundary tests. */
   internal fun engineMapForTest(): MaplibreMap? = map
+
+  internal suspend fun <T> withPlatformMap(block: PlatformMapScope.() -> T): T {
+    val engine =
+      lifecycle.engineIdentity
+        ?: throw IllegalStateException("The Web platform map changed before access could begin")
+    val lease =
+      lifecycle.renderLease
+        ?: throw IllegalStateException("The Web platform map changed before access could begin")
+    val completion = CompletableDeferred<Result<T>>()
+    val action =
+      PendingMapAction(
+        run = { map ->
+          completion.complete(
+            runCatching {
+              var result: Result<T>? = null
+              val accepted =
+                lifecycle.acceptPresentationEvent(engine, lease) {
+                  val authorityAccepted =
+                    lifecycleAuthority.acceptPresentationPlatformAccess(this) {
+                      result = runCatching { PlatformMapScope(map).block() }
+                    }
+                  if (!authorityAccepted) {
+                    throw IllegalStateException(
+                      "The Web platform map changed before access could begin"
+                    )
+                  }
+                }
+              if (!accepted) {
+                throw IllegalStateException(
+                  "The Web platform map changed before access could begin"
+                )
+              }
+              checkNotNull(result).getOrThrow()
+            }
+          )
+        },
+        abandon = {
+          completion.complete(
+            Result.failure(
+              IllegalStateException("The Web platform map changed before access could begin")
+            )
+          )
+        },
+      )
+    val current = map
+    if (current == null) pendingPlatformMapAccess += action else action.run(current)
+    return completion.await().getOrThrow()
+  }
 
   private fun maxTextureSize(gl: dynamic): Array<Double> {
     val size = (gl.getParameter(gl.MAX_TEXTURE_SIZE) as? Int)?.toDouble() ?: 4096.0

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/PlatformMapAccess.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/PlatformMapAccess.kt
@@ -1,0 +1,16 @@
+package org.maplibre.compose.map
+
+import org.maplibre.compose.gljs.MaplibreMap
+
+/** Provides the borrowed MapLibre GL JS map for one [MapState.withPlatformMap] callback. */
+public actual class PlatformMapScope internal constructor(private val engineMap: MaplibreMap) {
+  /** The raw MapLibre GL JS `Map` object. */
+  public val map: dynamic
+    get() = engineMap
+}
+
+@DelicateMapApi
+public actual suspend fun <T> MapState.withPlatformMap(block: PlatformMapScope.() -> T): T {
+  val session = lifecycle.presentationAdapterForPlatformAccess() as GlJsMapSession
+  return session.withPlatformMap(block)
+}

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserPlatformMapAccessTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserPlatformMapAccessTest.kt
@@ -92,4 +92,27 @@ class BrowserPlatformMapAccessTest {
       fixture.close()
     }
   }
+
+  @Test
+  fun closing_from_a_queued_web_callback_makes_the_first_frame_inert() = runBrowserMapTest {
+    val fixture = GlJsMapFixture(MapExtent.fromLogical(200, 100, 1.0))
+    try {
+      supervisorScope {
+        val access =
+          async(start = CoroutineStart.UNDISPATCHED) {
+            fixture.state.withPlatformMap {
+              fixture.state.close()
+              map.getZoom()
+            }
+          }
+
+        assertFalse(fixture.renderFrameForTest())
+
+        assertEquals(0.0, access.await())
+        assertTrue(fixture.state.isClosed)
+      }
+    } finally {
+      fixture.close()
+    }
+  }
 }

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserPlatformMapAccessTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserPlatformMapAccessTest.kt
@@ -1,0 +1,70 @@
+package org.maplibre.compose.map
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.async
+import kotlinx.coroutines.supervisorScope
+import org.maplibre.compose.gljs.runBrowserMapTest
+import org.maplibre.compose.testing.GlJsMapFixture
+
+@OptIn(DelicateMapApi::class, ExperimentalTestApi::class)
+class BrowserPlatformMapAccessTest {
+  @Test
+  fun web_access_requires_a_current_presentation() = runBrowserMapTest {
+    val runtime = createMapRuntime(MapRuntimeOptions())
+    val state = runtime.createMapState()
+
+    val failure = assertFailsWith<IllegalStateException> { state.withPlatformMap { map.getZoom() } }
+
+    assertEquals("Platform map access requires a current Web presentation", failure.message)
+    assertNull(state.presentation)
+    runtime.close()
+    runtime.awaitClosed()
+  }
+
+  @Test
+  fun web_access_uses_the_current_attached_engine_map() = runBrowserMapTest {
+    val fixture = GlJsMapFixture(MapExtent.fromLogical(200, 100, 1.0))
+    try {
+      fixture.awaitMapReady()
+
+      val zoom = fixture.state.withPlatformMap { map.getZoom() }
+
+      assertEquals(0.0, zoom)
+      assertTrue(fixture.state.presentation?.isValid == true)
+    } finally {
+      fixture.close()
+    }
+  }
+
+  @Test
+  fun a_web_invocation_queued_for_a_departed_lease_does_not_run() = runBrowserMapTest {
+    val fixture = GlJsMapFixture(MapExtent.fromLogical(200, 100, 1.0))
+    try {
+      var callbackRan = false
+      supervisorScope {
+        val access =
+          async(start = CoroutineStart.UNDISPATCHED) {
+            fixture.state.withPlatformMap {
+              callbackRan = true
+              map.getZoom()
+            }
+          }
+
+        fixture.detachPresentationForTest()
+
+        val failure = assertFailsWith<IllegalStateException> { access.await() }
+        assertEquals("The Web platform map changed before access could begin", failure.message)
+      }
+      assertFalse(callbackRan)
+    } finally {
+      fixture.close()
+    }
+  }
+}

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserPlatformMapAccessTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserPlatformMapAccessTest.kt
@@ -7,6 +7,7 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.async
 import kotlinx.coroutines.supervisorScope
@@ -62,6 +63,30 @@ class BrowserPlatformMapAccessTest {
         val failure = assertFailsWith<IllegalStateException> { access.await() }
         assertEquals("The Web platform map changed before access could begin", failure.message)
       }
+      assertFalse(callbackRan)
+    } finally {
+      fixture.close()
+    }
+  }
+
+  @Test
+  fun cancelling_a_queued_web_invocation_prevents_its_callback() = runBrowserMapTest {
+    val fixture = GlJsMapFixture(MapExtent.fromLogical(200, 100, 1.0))
+    try {
+      var callbackRan = false
+      supervisorScope {
+        val access =
+          async(start = CoroutineStart.UNDISPATCHED) {
+            fixture.state.withPlatformMap {
+              callbackRan = true
+              map.getZoom()
+            }
+          }
+
+        access.cancel()
+        assertFailsWith<CancellationException> { access.await() }
+      }
+      fixture.awaitMapReady()
       assertFalse(callbackRan)
     } finally {
       fixture.close()

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/testing/GlJsMapFixture.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/testing/GlJsMapFixture.kt
@@ -104,6 +104,10 @@ internal class GlJsMapFixture(private val extent: MapExtent) : MapFixture {
     glJsSession.fireStyleErrorForTest(message)
   }
 
+  internal fun detachPresentationForTest() {
+    state.releasePresentation(token, glJsSession)
+  }
+
   override suspend fun awaitMapReady(timeout: Duration) {
     pumpUntil("the map to render its first frame", timeout) { hasRendered }
   }

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/testing/GlJsMapFixture.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/testing/GlJsMapFixture.kt
@@ -119,6 +119,8 @@ internal class GlJsMapFixture(private val extent: MapExtent) : MapFixture {
     }
   }
 
+  internal fun renderFrameForTest(): Boolean = frame()
+
   override suspend fun pumpUntil(
     description: String,
     timeout: Duration,

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -1615,12 +1615,13 @@ internal class MlnFfiMapSession(
 
   internal suspend fun <T> withPlatformMap(block: PlatformMapScope.() -> T): T {
     val engine = lifecycle.ensureEngine()
-    val completion = CompletableDeferred<Result<T>>()
-    val accepted =
-      postWhenMapExists(
-        action = { map ->
-          completion.complete(
-            runCatching {
+    return suspendCancellableCoroutine { continuation ->
+      val invocation = PlatformMapInvocation(continuation)
+      continuation.invokeOnCancellation { invocation.cancel() }
+      val accepted =
+        postWhenMapExists(
+          action = { map ->
+            invocation.execute {
               var result: Result<T>? = null
               val accepted =
                 lifecycle.acceptEngineEvent(engine) {
@@ -1641,20 +1642,15 @@ internal class MlnFfiMapSession(
               }
               checkNotNull(result).getOrThrow()
             }
-          )
-        },
-        abandon = {
-          completion.complete(
-            Result.failure(
+          },
+          abandon = {
+            invocation.fail(
               IllegalStateException("The native platform map changed before access could begin")
             )
-          )
-        },
-      )
-    if (!accepted) {
-      throw MapStateClosedException()
+          },
+        )
+      if (!accepted) invocation.fail(MapStateClosedException())
     }
-    return completion.await().getOrThrow()
   }
 
   override fun positionFromScreenLocation(offset: DpOffset): Position? = withSnapshotProjection {

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -1618,12 +1618,12 @@ internal class MlnFfiMapSession(
     return suspendCancellableCoroutine { continuation ->
       val invocation = PlatformMapInvocation(continuation)
       continuation.invokeOnCancellation { invocation.cancel() }
-      val accepted =
+      val queued =
         postWhenMapExists(
           action = { map ->
             invocation.execute {
               var result: Result<T>? = null
-              val accepted =
+              val engineAccepted =
                 lifecycle.acceptEngineEvent(engine) {
                   val authorityAccepted =
                     lifecycleAuthority.acceptEnginePlatformAccess(this) {
@@ -1635,7 +1635,7 @@ internal class MlnFfiMapSession(
                     )
                   }
                 }
-              if (!accepted) {
+              if (!engineAccepted) {
                 throw IllegalStateException(
                   "The native platform map changed before access could begin"
                 )
@@ -1649,7 +1649,7 @@ internal class MlnFfiMapSession(
             )
           },
         )
-      if (!accepted) invocation.fail(MapStateClosedException())
+      if (!queued) invocation.fail(MapStateClosedException())
     }
   }
 

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -1613,6 +1613,50 @@ internal class MlnFfiMapSession(
   /** Test seam: runs [action] on the owner thread and waits for it. */
   internal fun <T> readMap(action: (MapHandle) -> T): T? = runOnMap(action)
 
+  internal suspend fun <T> withPlatformMap(block: PlatformMapScope.() -> T): T {
+    val engine = lifecycle.ensureEngine()
+    val completion = CompletableDeferred<Result<T>>()
+    val accepted =
+      postWhenMapExists(
+        action = { map ->
+          completion.complete(
+            runCatching {
+              var result: Result<T>? = null
+              val accepted =
+                lifecycle.acceptEngineEvent(engine) {
+                  val authorityAccepted =
+                    lifecycleAuthority.acceptEnginePlatformAccess(this) {
+                      result = runCatching { PlatformMapScope(map).block() }
+                    }
+                  if (!authorityAccepted) {
+                    throw IllegalStateException(
+                      "The native platform map changed before access could begin"
+                    )
+                  }
+                }
+              if (!accepted) {
+                throw IllegalStateException(
+                  "The native platform map changed before access could begin"
+                )
+              }
+              checkNotNull(result).getOrThrow()
+            }
+          )
+        },
+        abandon = {
+          completion.complete(
+            Result.failure(
+              IllegalStateException("The native platform map changed before access could begin")
+            )
+          )
+        },
+      )
+    if (!accepted) {
+      throw MapStateClosedException()
+    }
+    return completion.await().getOrThrow()
+  }
+
   override fun positionFromScreenLocation(offset: DpOffset): Position? = withSnapshotProjection {
     it.latLngForPixel(offset.toScreenPoint()).toPosition()
   }

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/PlatformMapAccess.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/PlatformMapAccess.kt
@@ -1,0 +1,31 @@
+package org.maplibre.compose.map
+
+import androidx.compose.ui.unit.LayoutDirection
+import org.maplibre.compose.mlnffi.MapRenderBackend
+import org.maplibre.nativeffi.map.MapHandle
+
+/** Provides the borrowed MapLibre Native map for one [MapState.withPlatformMap] callback. */
+public actual class PlatformMapScope internal constructor(public val map: MapHandle)
+
+@DelicateMapApi
+public actual suspend fun <T> MapState.withPlatformMap(block: PlatformMapScope.() -> T): T {
+  val session =
+    lifecycle.retainAdapterForPlatformAccess {
+      val options = runtime.nativeRuntimeOptions
+      MlnFfiMapSession(
+          lifecycleAuthority = lifecycle,
+          callbacks = durableStyleCallbacks(),
+          logger = runtime.logger,
+          renderBackend =
+            loadRuntimeBackends(runtime.logger).firstOrNull() ?: MapRenderBackend.OPENGL,
+          layoutDirection = LayoutDirection.Ltr,
+          cacheFile = options.cacheFile,
+          resourceProviderFactory = options.resourceProviderFactory,
+        )
+        .also { session ->
+          session.setCameraPosition(cameraPosition)
+          session.setBaseStyle(style.baseStyle)
+        }
+    } as MlnFfiMapSession
+  return session.withPlatformMap(block)
+}

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/PlatformMapAccessTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/PlatformMapAccessTest.kt
@@ -7,6 +7,7 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
@@ -148,6 +149,46 @@ class PlatformMapAccessTest {
 
         val failure = assertFailsWith<IllegalStateException> { access.await() }
         assertEquals("The native platform map changed before access could begin", failure.message)
+      }
+      assertFalse(callbackRan)
+    }
+  }
+
+  @Test
+  fun cancelling_a_queued_native_invocation_prevents_its_callback() = runBlocking {
+    withNativeMapState { state, _ ->
+      state.withPlatformMap { map.hashCode() }
+      val session = state.lifecycle.currentAdapter() as MlnFfiMapSession
+      val ownerEntered = CompletableDeferred<Unit>()
+      val releaseOwner = MlnFfiGate()
+      assertTrue(
+        session.postOwnerTaskForTest {
+          ownerEntered.complete(Unit)
+          releaseOwner.awaitUntilOpen()
+        }
+      )
+      ownerEntered.await()
+
+      var callbackRan = false
+      try {
+        supervisorScope {
+          val access =
+            async(start = CoroutineStart.UNDISPATCHED) {
+              state.withPlatformMap {
+                callbackRan = true
+                map.hashCode()
+              }
+            }
+          val ownerDrained = CompletableDeferred<Unit>()
+          assertTrue(session.postOwnerTaskForTest { ownerDrained.complete(Unit) })
+
+          access.cancel()
+          assertFailsWith<CancellationException> { access.await() }
+          releaseOwner.open()
+          ownerDrained.await()
+        }
+      } finally {
+        releaseOwner.open()
       }
       assertFalse(callbackRan)
     }

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/PlatformMapAccessTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/PlatformMapAccessTest.kt
@@ -1,0 +1,174 @@
+package org.maplibre.compose.map
+
+import androidx.compose.ui.unit.LayoutDirection
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.supervisorScope
+import kotlinx.coroutines.withContext
+import org.maplibre.compose.mlnffi.FfiTestPlatform
+import org.maplibre.compose.mlnffi.MapRenderBackend
+import org.maplibre.compose.mlnffi.MlnFfiGate
+import org.maplibre.compose.mlnffi.MlnFfiRuntimeOptions
+import org.maplibre.compose.mlnffi.currentMlnFfiThreadName
+import org.maplibre.compose.style.BaseStyle
+import org.maplibre.nativeffi.map.MapHandle
+
+@OptIn(DelicateMapApi::class)
+class PlatformMapAccessTest {
+  @Test
+  fun detached_native_access_creates_the_map_and_runs_on_its_owner_context() = runBlocking {
+    withNativeMapState { state, _ ->
+      val callerThread = withContext(Dispatchers.Default) { currentMlnFfiThreadName() }
+
+      val callbackThread =
+        withContext(Dispatchers.Default) {
+          state.withPlatformMap {
+            val rawMap: MapHandle = map
+            rawMap.hashCode()
+            currentMlnFfiThreadName()
+          }
+        }
+
+      assertEquals("maplibre-compose-map", callbackThread)
+      assertTrue(callbackThread != callerThread)
+      assertNull(state.presentation)
+    }
+  }
+
+  @Test
+  fun closure_waits_for_a_started_native_callback_and_later_access_is_rejected() = runBlocking {
+    withNativeMapState { state, _ ->
+      val callbackStarted = CompletableDeferred<Unit>()
+      val releaseCallback = MlnFfiGate()
+      val access =
+        async(Dispatchers.Default) {
+          state.withPlatformMap {
+            callbackStarted.complete(Unit)
+            releaseCallback.awaitUntilOpen()
+            map.hashCode()
+            true
+          }
+        }
+      callbackStarted.await()
+
+      val closeStarted = CompletableDeferred<Unit>()
+      val closeReturned = CompletableDeferred<Unit>()
+      val close =
+        async(Dispatchers.Default) {
+          closeStarted.complete(Unit)
+          state.close()
+          closeReturned.complete(Unit)
+        }
+      closeStarted.await()
+
+      assertFalse(closeReturned.isCompleted)
+      assertFalse(state.isClosed)
+      releaseCallback.open()
+      assertTrue(access.await())
+      close.await()
+      assertTrue(state.isClosed)
+      state.awaitClosed()
+
+      var callbackRan = false
+      assertFailsWith<MapStateClosedException> {
+        state.withPlatformMap {
+          callbackRan = true
+          map
+        }
+      }
+      assertFalse(callbackRan)
+    }
+  }
+
+  @Test
+  fun closure_requested_inside_a_native_callback_commits_after_it_returns() = runBlocking {
+    withNativeMapState { state, _ ->
+      val result = state.withPlatformMap {
+        state.close()
+        assertFalse(state.isClosed)
+        map.hashCode()
+        true
+      }
+
+      assertTrue(state.isClosed)
+      state.awaitClosed()
+      assertTrue(result)
+    }
+  }
+
+  @Test
+  fun replacing_the_engine_before_a_queued_native_callback_rejects_it() = runBlocking {
+    withNativeMapState { state, runtime ->
+      state.withPlatformMap { map.hashCode() }
+      val original = state.lifecycle.currentAdapter() as MlnFfiMapSession
+      val ownerEntered = CompletableDeferred<Unit>()
+      val releaseOwner = MlnFfiGate()
+      assertTrue(
+        original.postOwnerTaskForTest {
+          ownerEntered.complete(Unit)
+          releaseOwner.awaitUntilOpen()
+        }
+      )
+      ownerEntered.await()
+
+      var callbackRan = false
+      supervisorScope {
+        val access =
+          async(start = CoroutineStart.UNDISPATCHED) {
+            state.withPlatformMap {
+              callbackRan = true
+              map.hashCode()
+            }
+          }
+
+        val token = state.reservePresentation()
+        val options = runtime.nativeRuntimeOptions
+        val replacement =
+          MlnFfiMapSession(
+            lifecycleAuthority = state.lifecycle,
+            callbacks = state.durableStyleCallbacks(),
+            logger = runtime.logger,
+            renderBackend = MapRenderBackend.OPENGL,
+            scaleFactor = 2.0,
+            layoutDirection = LayoutDirection.Ltr,
+            cacheFile = options.cacheFile,
+            resourceProviderFactory = options.resourceProviderFactory,
+          )
+        state.publishPresentation(token, replacement)
+        releaseOwner.open()
+
+        val failure = assertFailsWith<IllegalStateException> { access.await() }
+        assertEquals("The native platform map changed before access could begin", failure.message)
+      }
+      assertFalse(callbackRan)
+    }
+  }
+
+  private suspend fun withNativeMapState(block: suspend (MapState, RuntimeImplementation) -> Unit) {
+    FfiTestPlatform.initialize()
+    val cacheFile = FfiTestPlatform.createCacheFile()
+    val runtime =
+      RuntimeImplementation(
+        platformOptions = MlnFfiRuntimeOptions(cacheFile),
+        resources = MapRuntimeResources {},
+        logger = null,
+      )
+    val state = runtime.createMapState(initialBaseStyle = BaseStyle.Empty)
+    try {
+      block(state, runtime)
+    } finally {
+      runtime.close()
+      runtime.awaitClosed()
+      FfiTestPlatform.deleteCacheFile(cacheFile)
+    }
+  }
+}


### PR DESCRIPTION
Resolve #538

## Description

Adds delicate, callback-scoped platform-map access that lazily creates detached native maps, requires a current Web presentation, serializes lifecycle transitions against identity-validated callbacks, and suppresses callbacks whose queued invocation is cancelled.

## Validation

Passed mise run check and the full Android, desktop, iOS, and Web test tasks, including native and browser cancellation regressions.

## AI assistance

OpenAI Codex with GPT-5 implemented and reviewed the change under user direction.