### PR TITLE
Stop pinning a host-specific Compose Desktop artifact in published JVM metadata

### DIFF
--- a/demo-app/common/build.gradle.kts
+++ b/demo-app/common/build.gradle.kts
@@ -102,7 +102,10 @@ kotlin {
     }
 
     jvmMain.dependencies {
-      implementation(compose.desktop.currentOs)
+      // Host-neutral desktop APIs. currentOs belongs on the AWT application module; this
+      // source set is also compiled into the GLFW and Nucleus hosts, which stay off that
+      // artifact.
+      implementation(compose.desktop.common)
       implementation(libs.kotlinx.coroutines.swing)
       implementation(libs.ktor.client.okhttp)
     }

--- a/demo-app/common/build.gradle.kts
+++ b/demo-app/common/build.gradle.kts
@@ -102,9 +102,6 @@ kotlin {
     }
 
     jvmMain.dependencies {
-      // Host-neutral desktop APIs. currentOs belongs on the AWT application module; this
-      // source set is also compiled into the GLFW and Nucleus hosts, which stay off that
-      // artifact.
       implementation(compose.desktop.common)
       implementation(libs.kotlinx.coroutines.swing)
       implementation(libs.ktor.client.okhttp)

--- a/lib/maplibre-compose/build.gradle.kts
+++ b/lib/maplibre-compose/build.gradle.kts
@@ -106,9 +106,6 @@ kotlin {
 
     jvmMain.apply {
       dependencies {
-        // Host-neutral desktop APIs. currentOs names a host-specific native artifact in the
-        // published JVM metadata, so every consumer receives the publishing host's Skiko
-        // runtime beside the one their own currentOs already selected.
         implementation(compose.desktop.common)
 
         // The Compose host needs direct Vulkan/OpenGL access; the natives come from the runtime
@@ -172,8 +169,6 @@ kotlin {
     // a CI matrix adds processes for additional applicable backends.
     val jvmTest by getting
     jvmTest.dependencies {
-      // Host Skiko natives for the live-map tests. jvmMain stays on compose.desktop.common so
-      // published metadata does not name a host-specific artifact.
       implementation(compose.desktop.currentOs)
       // Only the EGL interop tests bind EGL directly; nothing in the library does.
       implementation(libs.lwjgl.egl)

--- a/lib/maplibre-compose/build.gradle.kts
+++ b/lib/maplibre-compose/build.gradle.kts
@@ -106,7 +106,10 @@ kotlin {
 
     jvmMain.apply {
       dependencies {
-        implementation(compose.desktop.currentOs)
+        // Host-neutral desktop APIs. currentOs names a host-specific native artifact in the
+        // published JVM metadata, so every consumer receives the publishing host's Skiko
+        // runtime beside the one their own currentOs already selected.
+        implementation(compose.desktop.common)
 
         // The Compose host needs direct Vulkan/OpenGL access; the natives come from the runtime
         // artifact the application picks.
@@ -169,6 +172,9 @@ kotlin {
     // a CI matrix adds processes for additional applicable backends.
     val jvmTest by getting
     jvmTest.dependencies {
+      // Host Skiko natives for the live-map tests. jvmMain stays on compose.desktop.common so
+      // published metadata does not name a host-specific artifact.
+      implementation(compose.desktop.currentOs)
       // Only the EGL interop tests bind EGL directly; nothing in the library does.
       implementation(libs.lwjgl.egl)
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Published `maplibre-compose-jvm` metadata now names host-neutral `compose.desktop.common` instead of the publishing host's `compose.desktop.currentOs` artifact, so Linux and Windows consumers no longer receive macOS Skiko natives. Fixes #1183.

## Validation

Generated the JVM POM and Gradle module metadata on Linux, compiled the library plus the AWT, GLFW, and Nucleus desktop hosts, and ran `MapLibreConfigurationTest`.

## AI assistance

Cursor Grok 4.6 cloud agent.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4aedf59a-1a2a-49ef-8fda-f3f453196ee3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4aedf59a-1a2a-49ef-8fda-f3f453196ee3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

