### PR TITLE
Add Web map snapshotter

### DIFF
--- a/.agents/scratch/api-redesign/issues/16-web-snapshotter.md
+++ b/.agents/scratch/api-redesign/issues/16-web-snapshotter.md
@@ -6,22 +6,22 @@ MapState.
 
 **Blocked by:** 15
 
-**Status:** ready-for-agent
+**Status:** resolved
 
-- [ ] The changed test area contains no redundant, impossible,
+- [x] The changed test area contains no redundant, impossible,
       compatibility-only, or implementation-shape scenarios.
-- [ ] Web capture uses a dedicated GL JS map and private rendering target.
-- [ ] The rendering target is non-visible, owned by the snapshotter engine, and
+- [x] Web capture uses a dedicated GL JS map and private rendering target.
+- [x] The rendering target is non-visible, owned by the snapshotter engine, and
       removed from the DOM during cleanup.
-- [ ] The snapshotter never attaches to MaplibreMap.
-- [ ] Capture does not attach, detach, pause, or retarget an interactive map.
-- [ ] Immutable request values control each output.
-- [ ] StyleComposition evaluation remains independent from interactive maps.
-- [ ] FIFO execution, desired-style claiming, cancellation, timeout, and closure
+- [x] The snapshotter never attaches to MaplibreMap.
+- [x] Capture does not attach, detach, pause, or retarget an interactive map.
+- [x] Immutable request values control each output.
+- [x] StyleComposition evaluation remains independent from interactive maps.
+- [x] FIFO execution, desired-style claiming, cancellation, timeout, and closure
       follow the common snapshotter contract.
-- [ ] Cancellation and closure release the GL JS map, DOM target, and rendering
+- [x] Cancellation and closure release the GL JS map, DOM target, and rendering
       resources.
-- [ ] Browser tests verify representative composed output and interactive-map
+- [x] Browser tests verify representative composed output and interactive-map
       independence.
 
 ## Test ledger
@@ -31,3 +31,24 @@ MapState.
 - Add focused browser cases for representative pixels, private DOM ownership,
   cleanup, and independence from an attached interactive map.
 - Run `mise run test:js` under `caffeinate -dimsu` on macOS.
+
+## Answer
+
+The Web adapter owns a non-interactive MapLibre GL JS map in a private hidden
+DOM target. It keeps that engine across compatible captures, applies every
+request's physical extent, density, camera, and transparency, and copies the
+preserved drawing buffer into the returned bitmap. Closing the snapshotter
+removes both the map and its target.
+
+Active Web cancellation removes the private engine because GL JS cannot cancel
+every in-flight style and render operation independently. The common adapter
+contract now reports whether cancellation retained or released the engine. A
+release invalidates the old style binding and returns the snapshotter style to
+pending before queued work recreates the engine. Native cancellation reports
+that its engine was retained.
+
+Browser tests cover composed pixels, private target ownership and cleanup,
+successive request extents, camera, density, and transparency, engine recreation
+after cancellation, and independence from an attached interactive map.
+Validation passed with `mise run check`, `caffeinate -dimsu mise run test:js`,
+`mise run test:android`, `mise run test:desktop`, and `mise run test:ios`.

--- a/.agents/scratch/api-redesign/issues/16-web-snapshotter.md
+++ b/.agents/scratch/api-redesign/issues/16-web-snapshotter.md
@@ -36,8 +36,8 @@ MapState.
 
 The Web adapter owns a non-interactive MapLibre GL JS map in a private hidden
 DOM target. It keeps that engine across compatible captures, applies every
-request's physical extent, density, camera, and transparency, and copies the
-preserved drawing buffer into the returned bitmap. Closing the snapshotter
+request's logical extent, density, camera, and transparency, and copies the
+physical drawing buffer into the returned bitmap. Closing the snapshotter
 removes both the map and its target.
 
 Active Web cancellation removes the private engine because GL JS cannot cancel

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsEvents.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsEvents.kt
@@ -8,3 +8,9 @@ internal fun MaplibreMap.subscribe(event: String, listener: (MapEvent) -> Unit):
   val subscription = on(event, listener)
   return GlJsSubscription { subscription.unsubscribe() }
 }
+
+/** Whether an error event ended a base-style request rather than one source or tile request. */
+internal fun MapEvent.isTerminalStyleLoadFailure(): Boolean {
+  val style = asDynamic().style ?: return false
+  return style._loaded != true && style._loadStyleRequest == null && style._frameRequest == null
+}

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsTypes.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsTypes.kt
@@ -29,8 +29,13 @@ internal external interface MapOptions {
   var attributionControl: Boolean?
   var maplibreLogo: Boolean?
   var pixelRatio: Double?
+  var canvasContextAttributes: CanvasContextAttributes?
   /** `[width, height]` in physical pixels, above which MapLibre lowers its own pixel ratio. */
   var maxCanvasSize: Array<Double>?
+}
+
+internal external interface CanvasContextAttributes {
+  var preserveDrawingBuffer: Boolean?
 }
 
 internal external interface SetStyleOptions {

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
@@ -37,7 +37,6 @@ import org.maplibre.compose.gljs.GlJsRuntime
 import org.maplibre.compose.gljs.GlJsSubscription
 import org.maplibre.compose.gljs.GlJsSurfaceSession
 import org.maplibre.compose.gljs.JumpToOptions
-import org.maplibre.compose.gljs.MapEvent
 import org.maplibre.compose.gljs.MapOptions
 import org.maplibre.compose.gljs.MaplibreMap
 import org.maplibre.compose.gljs.PaddingOptions
@@ -46,6 +45,7 @@ import org.maplibre.compose.gljs.QueryGeometry
 import org.maplibre.compose.gljs.QueryRenderedFeaturesOptions
 import org.maplibre.compose.gljs.SetStyleOptions
 import org.maplibre.compose.gljs.isCameraEasing
+import org.maplibre.compose.gljs.isTerminalStyleLoadFailure
 import org.maplibre.compose.gljs.queryBox
 import org.maplibre.compose.gljs.queryPoint
 import org.maplibre.compose.gljs.styleJson
@@ -808,16 +808,6 @@ internal class GlJsMapSession(
       }
       if (!hasLoadedInitialStyle) abandonPending(pendingInitialStyleActions)
     }
-  }
-
-  /**
-   * MapLibre sends style-request, source, sprite, tile, and API errors through one event. A
-   * terminal style-request error has no active request and occurs before MapLibre marks the style
-   * as loaded. The pinned MapLibre version exposes these fields on its internal `Style` object.
-   */
-  private fun MapEvent.isTerminalStyleLoadFailure(): Boolean {
-    val style = asDynamic().style ?: return false
-    return style._loaded != true && style._loadStyleRequest == null && style._frameRequest == null
   }
 
   internal fun fireStyleErrorForTest(message: String) {

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
@@ -1297,7 +1297,8 @@ internal class GlJsMapSession(
 
   internal companion object {
     const val OFFSCREEN_CONTAINER_STYLE =
-      "position:absolute;left:-10000px;top:0;visibility:hidden;pointer-events:none;"
+      "all:initial;position:absolute;display:block;left:-10000px;top:0;" +
+        "visibility:hidden;pointer-events:none;"
 
     var createdCount: Int = 0
       private set

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsSnapshotterAdapter.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsSnapshotterAdapter.kt
@@ -3,8 +3,10 @@ package org.maplibre.compose.map
 import androidx.compose.ui.graphics.ImageBitmap
 import co.touchlab.kermit.Logger
 import js.objects.unsafeJso
+import kotlin.coroutines.resume
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.suspendCancellableCoroutine
 import org.maplibre.compose.gljs.CanvasContextAttributes
 import org.maplibre.compose.gljs.DEFAULT_WORKER_URL
 import org.maplibre.compose.gljs.GlJsRuntime
@@ -39,7 +41,7 @@ private class GlJsSnapshotterAdapter(private val logger: Logger?) : SnapshotterA
   private var map: MaplibreMap? = null
   private var container: HTMLElement? = null
   private var styleBinding: GlJsStyleBinding? = null
-  private var loadedBaseStyle: BaseStyle? = null
+  private var loadedBaseStyleRevision: Long? = null
   private var loadedDensity: Float? = null
   private var currentDensity = 1f
   private var styleLoadSubscription: GlJsSubscription? = null
@@ -51,6 +53,7 @@ private class GlJsSnapshotterAdapter(private val logger: Logger?) : SnapshotterA
 
   override suspend fun prepare(
     baseStyle: BaseStyle,
+    baseStyleRevision: Long,
     request: MapSnapshotRequest,
   ): StyleBinding {
     check(open) { "The Web snapshotter is closed" }
@@ -58,14 +61,16 @@ private class GlJsSnapshotterAdapter(private val logger: Logger?) : SnapshotterA
     configure(currentMap, request)
     val current = styleBinding
     if (
-      loadedBaseStyle == baseStyle && loadedDensity == request.density && current?.isLoaded == true
+      loadedBaseStyleRevision == baseStyleRevision &&
+        loadedDensity == request.density &&
+        current?.isLoaded == true
     ) {
       return current
     }
 
     current?.invalidate()
     styleBinding = null
-    loadedBaseStyle = null
+    loadedBaseStyleRevision = null
     loadedDensity = null
     cancelStyleSubscriptions()
     val loading = CompletableDeferred<Result<Unit>>()
@@ -81,7 +86,7 @@ private class GlJsSnapshotterAdapter(private val logger: Logger?) : SnapshotterA
         val binding = GlJsStyleBinding(currentMap, logger) { currentDensity }
         styleBinding?.invalidate()
         styleBinding = binding
-        loadedBaseStyle = baseStyle
+        loadedBaseStyleRevision = baseStyleRevision
         loadedDensity = request.density
         loading.complete(Result.success(Unit))
       }
@@ -164,7 +169,7 @@ private class GlJsSnapshotterAdapter(private val logger: Logger?) : SnapshotterA
     }
   }
 
-  private fun ensureMap(request: MapSnapshotRequest): MaplibreMap {
+  private suspend fun ensureMap(request: MapSnapshotRequest): MaplibreMap {
     map?.let {
       return it
     }
@@ -173,7 +178,7 @@ private class GlJsSnapshotterAdapter(private val logger: Logger?) : SnapshotterA
     host.style.cssText = GlJsMapSession.OFFSCREEN_CONTAINER_STYLE
     host.setAttribute(SNAPSHOTTER_TARGET_ATTRIBUTE, "")
     size(host, request)
-    document.body.appendChild(host)
+    awaitDocumentBody().appendChild(host)
     container = host
 
     val options =
@@ -228,8 +233,11 @@ private class GlJsSnapshotterAdapter(private val logger: Logger?) : SnapshotterA
     val extent = request.extent()
     val width = extent.physicalWidth
     val height = extent.physicalHeight
-    check(source.width == width && source.height == height) {
-      "MapLibre rendered a ${source.width}x${source.height} snapshot canvas, expected ${width}x$height"
+    val renderedWidth = (extent.width * extent.scaleFactor).toInt().coerceAtLeast(1)
+    val renderedHeight = (extent.height * extent.scaleFactor).toInt().coerceAtLeast(1)
+    check(source.width == renderedWidth && source.height == renderedHeight) {
+      "MapLibre rendered a ${source.width}x${source.height} snapshot canvas, expected " +
+        "${renderedWidth}x$renderedHeight before fractional-density rounding"
     }
     val output = document.createElement("canvas").unsafeCast<HTMLCanvasElement>()
     output.width = width
@@ -263,7 +271,7 @@ private class GlJsSnapshotterAdapter(private val logger: Logger?) : SnapshotterA
     renderSubscription = null
     runCatching { styleBinding?.invalidate() }.exceptionOrNull()?.let(cleanupFailures::add)
     styleBinding = null
-    loadedBaseStyle = null
+    loadedBaseStyleRevision = null
     loadedDensity = null
     val currentMap = map
     map = null
@@ -278,6 +286,33 @@ private class GlJsSnapshotterAdapter(private val logger: Logger?) : SnapshotterA
     styleLoadSubscription = null
     styleErrorSubscription?.cancel()
     styleErrorSubscription = null
+  }
+
+  private suspend fun awaitDocumentBody(): HTMLElement {
+    documentBodyOrNull()?.let {
+      return it
+    }
+    return suspendCancellableCoroutine { continuation ->
+      val dynamicDocument = document.asDynamic()
+      lateinit var listener: (dynamic) -> Unit
+      listener = {
+        val body = documentBodyOrNull()
+        if (body != null) {
+          dynamicDocument.removeEventListener("DOMContentLoaded", listener)
+          if (continuation.isActive) continuation.resume(body)
+        }
+      }
+      dynamicDocument.addEventListener("DOMContentLoaded", listener)
+      continuation.invokeOnCancellation {
+        dynamicDocument.removeEventListener("DOMContentLoaded", listener)
+      }
+      listener(null)
+    }
+  }
+
+  private fun documentBodyOrNull(): HTMLElement? {
+    val body = document.asDynamic().body
+    return if (body == null) null else body.unsafeCast<HTMLElement>()
   }
 
   private fun MapSnapshotRequest.extent(): MapExtent =

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsSnapshotterAdapter.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsSnapshotterAdapter.kt
@@ -214,12 +214,9 @@ private class GlJsSnapshotterAdapter(private val logger: Logger?) : SnapshotterA
   }
 
   private fun size(container: HTMLElement, request: MapSnapshotRequest) {
-    val extent = MapExtent.fromPhysical(request.width, request.height, request.density.toDouble())
-    val rendered = MapExtent.fromLogical(extent.width, extent.height, extent.scaleFactor)
-    require(
-      rendered.physicalWidth <= MAX_CANVAS_SIZE && rendered.physicalHeight <= MAX_CANVAS_SIZE
-    ) {
-      "The Web snapshot needs a ${rendered.physicalWidth}x${rendered.physicalHeight} canvas, " +
+    val extent = request.extent()
+    require(extent.physicalWidth <= MAX_CANVAS_SIZE && extent.physicalHeight <= MAX_CANVAS_SIZE) {
+      "The Web snapshot needs a ${extent.physicalWidth}x${extent.physicalHeight} canvas, " +
         "which exceeds MapLibre GL JS's ${MAX_CANVAS_SIZE}px canvas limit"
     }
     container.style.width = "${extent.width}px"
@@ -228,29 +225,34 @@ private class GlJsSnapshotterAdapter(private val logger: Logger?) : SnapshotterA
 
   private fun readImage(map: MaplibreMap, request: MapSnapshotRequest): ImageBitmap {
     val source = map.getCanvas()
-    check(source.width > 0 && source.height > 0) { "MapLibre rendered an empty snapshot canvas" }
+    val extent = request.extent()
+    val width = extent.physicalWidth
+    val height = extent.physicalHeight
+    check(source.width == width && source.height == height) {
+      "MapLibre rendered a ${source.width}x${source.height} snapshot canvas, expected ${width}x$height"
+    }
     val output = document.createElement("canvas").unsafeCast<HTMLCanvasElement>()
-    output.width = request.width
-    output.height = request.height
+    output.width = width
+    output.height = height
     val context = output.asDynamic().getContext("2d")
     check(context != null && context != undefined) {
-      "The browser would not give a 2D context for a ${request.width}x${request.height} snapshot"
+      "The browser would not give a 2D context for a ${width}x$height snapshot"
     }
     if (!request.outputOptions.transparent) {
       context.fillStyle = "#ffffff"
-      context.fillRect(0, 0, request.width, request.height)
+      context.fillRect(0, 0, width, height)
     }
-    context.drawImage(source, 0, 0, request.width, request.height)
-    val data = context.getImageData(0, 0, request.width, request.height).data
+    context.drawImage(source, 0, 0, width, height)
+    val data = context.getImageData(0, 0, width, height).data
     val pixels =
-      IntArray(request.width * request.height) { index ->
+      IntArray(width * height) { index ->
         val offset = index * 4
         (data[offset].unsafeCast<Int>() shl 16) or
           (data[offset + 1].unsafeCast<Int>() shl 8) or
           data[offset + 2].unsafeCast<Int>() or
           (data[offset + 3].unsafeCast<Int>() shl 24)
       }
-    return pixels.toImageBitmap(request.width, request.height)
+    return pixels.toImageBitmap(width, height)
   }
 
   private fun releaseEngine(reason: Throwable) {
@@ -277,6 +279,9 @@ private class GlJsSnapshotterAdapter(private val logger: Logger?) : SnapshotterA
     styleErrorSubscription?.cancel()
     styleErrorSubscription = null
   }
+
+  private fun MapSnapshotRequest.extent(): MapExtent =
+    MapExtent.fromLogical(width, height, density.toDouble())
 
   private companion object {
     const val MAX_CANVAS_SIZE = 4_096

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsSnapshotterAdapter.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsSnapshotterAdapter.kt
@@ -187,7 +187,7 @@ private class GlJsSnapshotterAdapter(private val logger: Logger?) : SnapshotterA
         interactive = false
         attributionControl = false
         maplibreLogo = false
-        pixelRatio = request.density.toDouble()
+        pixelRatio = renderPixelRatio(request)
         maxCanvasSize = arrayOf(MAX_CANVAS_SIZE.toDouble(), MAX_CANVAS_SIZE.toDouble())
         canvasContextAttributes =
           unsafeJso<CanvasContextAttributes> { preserveDrawingBuffer = true }
@@ -205,7 +205,7 @@ private class GlJsSnapshotterAdapter(private val logger: Logger?) : SnapshotterA
   private fun configure(map: MaplibreMap, request: MapSnapshotRequest) {
     currentDensity = request.density
     container?.let { size(it, request) }
-    map.setPixelRatio(request.density.toDouble())
+    map.setPixelRatio(renderPixelRatio(request))
     map.resize()
     val camera = request.cameraPosition
     map.jumpTo(
@@ -220,8 +220,11 @@ private class GlJsSnapshotterAdapter(private val logger: Logger?) : SnapshotterA
 
   private fun size(container: HTMLElement, request: MapSnapshotRequest) {
     val extent = request.extent()
-    require(extent.physicalWidth <= MAX_CANVAS_SIZE && extent.physicalHeight <= MAX_CANVAS_SIZE) {
-      "The Web snapshot needs a ${extent.physicalWidth}x${extent.physicalHeight} canvas, " +
+    val pixelRatio = renderPixelRatio(request)
+    val renderedWidth = (extent.width * pixelRatio).toInt()
+    val renderedHeight = (extent.height * pixelRatio).toInt()
+    require(renderedWidth <= MAX_CANVAS_SIZE && renderedHeight <= MAX_CANVAS_SIZE) {
+      "The Web snapshot needs a ${renderedWidth}x$renderedHeight render canvas, " +
         "which exceeds MapLibre GL JS's ${MAX_CANVAS_SIZE}px canvas limit"
     }
     container.style.width = "${extent.width}px"
@@ -233,8 +236,9 @@ private class GlJsSnapshotterAdapter(private val logger: Logger?) : SnapshotterA
     val extent = request.extent()
     val width = extent.physicalWidth
     val height = extent.physicalHeight
-    val renderedWidth = (extent.width * extent.scaleFactor).toInt().coerceAtLeast(1)
-    val renderedHeight = (extent.height * extent.scaleFactor).toInt().coerceAtLeast(1)
+    val pixelRatio = renderPixelRatio(request)
+    val renderedWidth = (extent.width * pixelRatio).toInt()
+    val renderedHeight = (extent.height * pixelRatio).toInt()
     check(source.width == renderedWidth && source.height == renderedHeight) {
       "MapLibre rendered a ${source.width}x${source.height} snapshot canvas, expected " +
         "${renderedWidth}x$renderedHeight before fractional-density rounding"
@@ -261,6 +265,11 @@ private class GlJsSnapshotterAdapter(private val logger: Logger?) : SnapshotterA
           (data[offset + 3].unsafeCast<Int>() shl 24)
       }
     return pixels.toImageBitmap(width, height)
+  }
+
+  private fun renderPixelRatio(request: MapSnapshotRequest): Double {
+    val minimumRatio = 1.0 / minOf(request.width, request.height)
+    return maxOf(request.density.toDouble(), minimumRatio)
   }
 
   private fun releaseEngine(reason: Throwable) {

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsSnapshotterAdapter.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsSnapshotterAdapter.kt
@@ -1,0 +1,276 @@
+package org.maplibre.compose.map
+
+import androidx.compose.ui.graphics.ImageBitmap
+import co.touchlab.kermit.Logger
+import js.objects.unsafeJso
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import org.maplibre.compose.gljs.CanvasContextAttributes
+import org.maplibre.compose.gljs.DEFAULT_WORKER_URL
+import org.maplibre.compose.gljs.GlJsRuntime
+import org.maplibre.compose.gljs.GlJsSubscription
+import org.maplibre.compose.gljs.JumpToOptions
+import org.maplibre.compose.gljs.MapOptions
+import org.maplibre.compose.gljs.MaplibreMap
+import org.maplibre.compose.gljs.SetStyleOptions
+import org.maplibre.compose.gljs.isTerminalStyleLoadFailure
+import org.maplibre.compose.gljs.styleJson
+import org.maplibre.compose.gljs.styleUrl
+import org.maplibre.compose.gljs.subscribe
+import org.maplibre.compose.style.BaseStyle
+import org.maplibre.compose.style.DesiredStyleRevision
+import org.maplibre.compose.style.GlJsStyleBinding
+import org.maplibre.compose.style.StyleBinding
+import org.maplibre.compose.style.StyleReconciler
+import org.maplibre.compose.util.toImageBitmap
+import org.maplibre.compose.util.toLngLat
+import web.dom.document
+import web.html.HTMLCanvasElement
+import web.html.HTMLElement
+
+internal class GlJsSnapshotterAdapterFactory(private val logger: Logger?) :
+  SnapshotterAdapterFactory {
+  override fun create(): SnapshotterAdapter = GlJsSnapshotterAdapter(logger)
+}
+
+/** One private GL JS map and DOM target for a Web snapshotter. */
+private class GlJsSnapshotterAdapter(private val logger: Logger?) : SnapshotterAdapter {
+  private var open = true
+  private var map: MaplibreMap? = null
+  private var container: HTMLElement? = null
+  private var styleBinding: GlJsStyleBinding? = null
+  private var loadedBaseStyle: BaseStyle? = null
+  private var loadedDensity: Float? = null
+  private var currentDensity = 1f
+  private var styleLoadSubscription: GlJsSubscription? = null
+  private var styleErrorSubscription: GlJsSubscription? = null
+  private var renderSubscription: GlJsSubscription? = null
+  private var terminalOperation: CompletableDeferred<Result<Unit>>? = null
+  private val reconciler = StyleReconciler()
+  private val cleanupFailures = mutableListOf<Throwable>()
+
+  override suspend fun prepare(
+    baseStyle: BaseStyle,
+    request: MapSnapshotRequest,
+  ): StyleBinding {
+    check(open) { "The Web snapshotter is closed" }
+    val currentMap = ensureMap(request)
+    configure(currentMap, request)
+    val current = styleBinding
+    if (
+      loadedBaseStyle == baseStyle && loadedDensity == request.density && current?.isLoaded == true
+    ) {
+      return current
+    }
+
+    current?.invalidate()
+    styleBinding = null
+    loadedBaseStyle = null
+    loadedDensity = null
+    cancelStyleSubscriptions()
+    val loading = CompletableDeferred<Result<Unit>>()
+    terminalOperation = loading
+    lateinit var loadSubscription: GlJsSubscription
+    lateinit var errorSubscription: GlJsSubscription
+    loadSubscription =
+      currentMap.subscribe("style.load") {
+        loadSubscription.cancel()
+        errorSubscription.cancel()
+        if (styleLoadSubscription === loadSubscription) styleLoadSubscription = null
+        if (styleErrorSubscription === errorSubscription) styleErrorSubscription = null
+        val binding = GlJsStyleBinding(currentMap, logger) { currentDensity }
+        styleBinding?.invalidate()
+        styleBinding = binding
+        loadedBaseStyle = baseStyle
+        loadedDensity = request.density
+        loading.complete(Result.success(Unit))
+      }
+    errorSubscription =
+      currentMap.subscribe("error") { event ->
+        if (!event.isTerminalStyleLoadFailure()) return@subscribe
+        loadSubscription.cancel()
+        errorSubscription.cancel()
+        if (styleLoadSubscription === loadSubscription) styleLoadSubscription = null
+        if (styleErrorSubscription === errorSubscription) styleErrorSubscription = null
+        val reason = event.error?.message ?: "MapLibre failed to load the snapshot style"
+        loading.complete(Result.failure(IllegalStateException(reason)))
+      }
+    styleLoadSubscription = loadSubscription
+    styleErrorSubscription = errorSubscription
+    val options = unsafeJso<SetStyleOptions> { diff = false }
+    try {
+      when (baseStyle) {
+        is BaseStyle.Uri -> currentMap.setStyle(styleUrl(baseStyle.uri), options)
+        is BaseStyle.Json -> currentMap.setStyle(styleJson(baseStyle.json), options)
+      }
+    } catch (error: Throwable) {
+      cancelStyleSubscriptions()
+      loading.complete(Result.failure(error))
+    }
+    try {
+      loading.await().getOrThrow()
+    } finally {
+      if (terminalOperation === loading) terminalOperation = null
+    }
+    return checkNotNull(styleBinding) { "MapLibre loaded a snapshot style without a binding" }
+  }
+
+  override suspend fun capture(
+    request: MapSnapshotRequest,
+    revision: DesiredStyleRevision,
+  ): ImageBitmap {
+    check(open) { "The Web snapshotter is closed" }
+    val currentMap = checkNotNull(map) { "The Web snapshotter engine has not been created" }
+    val binding = checkNotNull(styleBinding) { "The Web snapshotter style has not loaded" }
+    reconciler.apply(binding, revision)
+    configure(currentMap, request)
+
+    val rendering = CompletableDeferred<Result<Unit>>()
+    terminalOperation = rendering
+    lateinit var idleSubscription: GlJsSubscription
+    idleSubscription =
+      currentMap.subscribe("idle") {
+        idleSubscription.cancel()
+        if (renderSubscription === idleSubscription) renderSubscription = null
+        rendering.complete(Result.success(Unit))
+      }
+    renderSubscription = idleSubscription
+    currentMap.redraw()
+    try {
+      rendering.await().getOrThrow()
+      currentMap.redraw()
+      return readImage(currentMap, request)
+    } finally {
+      idleSubscription.cancel()
+      if (renderSubscription === idleSubscription) renderSubscription = null
+      if (terminalOperation === rendering) terminalOperation = null
+    }
+  }
+
+  override suspend fun cancelActiveCapture(): SnapshotterEngineDisposition {
+    releaseEngine(CancellationException("The Web snapshot capture was cancelled"))
+    return SnapshotterEngineDisposition.RELEASED
+  }
+
+  override suspend fun close() {
+    if (!open) return
+    open = false
+    releaseEngine(MapSnapshotterClosedException())
+    if (cleanupFailures.isNotEmpty()) {
+      throw AggregateCleanupException(
+        "Web snapshotter cleanup failed in ${cleanupFailures.size} resource(s)",
+        cleanupFailures.toList(),
+      )
+    }
+  }
+
+  private fun ensureMap(request: MapSnapshotRequest): MaplibreMap {
+    map?.let {
+      return it
+    }
+    check(open) { "The Web snapshotter is closed" }
+    val host = document.createElement("div").unsafeCast<HTMLElement>()
+    host.style.cssText = GlJsMapSession.OFFSCREEN_CONTAINER_STYLE
+    host.setAttribute(SNAPSHOTTER_TARGET_ATTRIBUTE, "")
+    size(host, request)
+    document.body.appendChild(host)
+    container = host
+
+    val options =
+      unsafeJso<MapOptions> {
+        container = host
+        interactive = false
+        attributionControl = false
+        maplibreLogo = false
+        pixelRatio = request.density.toDouble()
+        canvasContextAttributes =
+          unsafeJso<CanvasContextAttributes> { preserveDrawingBuffer = true }
+      }
+    GlJsRuntime.pointAtWorker(DEFAULT_WORKER_URL)
+    return try {
+      MaplibreMap(options).also { map = it }
+    } catch (error: Throwable) {
+      container = null
+      runCatching { host.remove() }.exceptionOrNull()?.let(error::addSuppressed)
+      throw error
+    }
+  }
+
+  private fun configure(map: MaplibreMap, request: MapSnapshotRequest) {
+    currentDensity = request.density
+    container?.let { size(it, request) }
+    map.setPixelRatio(request.density.toDouble())
+    map.resize()
+    val camera = request.cameraPosition
+    map.jumpTo(
+      unsafeJso<JumpToOptions> {
+        center = camera.target.toLngLat()
+        zoom = camera.zoom
+        bearing = camera.bearing
+        pitch = camera.tilt
+      }
+    )
+  }
+
+  private fun size(container: HTMLElement, request: MapSnapshotRequest) {
+    val extent = MapExtent.fromPhysical(request.width, request.height, request.density.toDouble())
+    container.style.width = "${extent.width}px"
+    container.style.height = "${extent.height}px"
+  }
+
+  private fun readImage(map: MaplibreMap, request: MapSnapshotRequest): ImageBitmap {
+    val source = map.getCanvas()
+    check(source.width > 0 && source.height > 0) { "MapLibre rendered an empty snapshot canvas" }
+    val output = document.createElement("canvas").unsafeCast<HTMLCanvasElement>()
+    output.width = request.width
+    output.height = request.height
+    val context = output.asDynamic().getContext("2d")
+    check(context != null && context != undefined) {
+      "The browser would not give a 2D context for a ${request.width}x${request.height} snapshot"
+    }
+    if (!request.outputOptions.transparent) {
+      context.fillStyle = "#ffffff"
+      context.fillRect(0, 0, request.width, request.height)
+    }
+    context.drawImage(source, 0, 0, request.width, request.height)
+    val data = context.getImageData(0, 0, request.width, request.height).data
+    val pixels =
+      IntArray(request.width * request.height) { index ->
+        val offset = index * 4
+        (data[offset].unsafeCast<Int>() shl 16) or
+          (data[offset + 1].unsafeCast<Int>() shl 8) or
+          data[offset + 2].unsafeCast<Int>() or
+          (data[offset + 3].unsafeCast<Int>() shl 24)
+      }
+    return pixels.toImageBitmap(request.width, request.height)
+  }
+
+  private fun releaseEngine(reason: Throwable) {
+    terminalOperation?.complete(Result.failure(reason))
+    terminalOperation = null
+    cancelStyleSubscriptions()
+    renderSubscription?.cancel()
+    renderSubscription = null
+    runCatching { styleBinding?.invalidate() }.exceptionOrNull()?.let(cleanupFailures::add)
+    styleBinding = null
+    loadedBaseStyle = null
+    loadedDensity = null
+    val currentMap = map
+    map = null
+    runCatching { currentMap?.remove() }.exceptionOrNull()?.let(cleanupFailures::add)
+    val currentContainer = container
+    container = null
+    runCatching { currentContainer?.remove() }.exceptionOrNull()?.let(cleanupFailures::add)
+  }
+
+  private fun cancelStyleSubscriptions() {
+    styleLoadSubscription?.cancel()
+    styleLoadSubscription = null
+    styleErrorSubscription?.cancel()
+    styleErrorSubscription = null
+  }
+
+  private companion object {
+    const val SNAPSHOTTER_TARGET_ATTRIBUTE = "data-maplibre-compose-snapshotter"
+  }
+}

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsSnapshotterAdapter.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsSnapshotterAdapter.kt
@@ -183,6 +183,7 @@ private class GlJsSnapshotterAdapter(private val logger: Logger?) : SnapshotterA
         attributionControl = false
         maplibreLogo = false
         pixelRatio = request.density.toDouble()
+        maxCanvasSize = arrayOf(MAX_CANVAS_SIZE.toDouble(), MAX_CANVAS_SIZE.toDouble())
         canvasContextAttributes =
           unsafeJso<CanvasContextAttributes> { preserveDrawingBuffer = true }
       }
@@ -214,6 +215,13 @@ private class GlJsSnapshotterAdapter(private val logger: Logger?) : SnapshotterA
 
   private fun size(container: HTMLElement, request: MapSnapshotRequest) {
     val extent = MapExtent.fromPhysical(request.width, request.height, request.density.toDouble())
+    val rendered = MapExtent.fromLogical(extent.width, extent.height, extent.scaleFactor)
+    require(
+      rendered.physicalWidth <= MAX_CANVAS_SIZE && rendered.physicalHeight <= MAX_CANVAS_SIZE
+    ) {
+      "The Web snapshot needs a ${rendered.physicalWidth}x${rendered.physicalHeight} canvas, " +
+        "which exceeds MapLibre GL JS's ${MAX_CANVAS_SIZE}px canvas limit"
+    }
     container.style.width = "${extent.width}px"
     container.style.height = "${extent.height}px"
   }
@@ -271,6 +279,7 @@ private class GlJsSnapshotterAdapter(private val logger: Logger?) : SnapshotterA
   }
 
   private companion object {
+    const val MAX_CANVAS_SIZE = 4_096
     const val SNAPSHOTTER_TARGET_ATTRIBUTE = "data-maplibre-compose-snapshotter"
   }
 }

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/MapRuntime.js.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/MapRuntime.js.kt
@@ -13,6 +13,7 @@ public actual fun createMapRuntime(options: MapRuntimeOptions): MapRuntime =
     platformOptions = options,
     resources = MapRuntimeResources {},
     logger = options.logger,
+    snapshotterAdapterFactory = GlJsSnapshotterAdapterFactory(options.logger),
   )
 
 private val processMapRuntime: MapRuntime =
@@ -20,6 +21,7 @@ private val processMapRuntime: MapRuntime =
     platformOptions = null,
     resources = MapRuntimeResources {},
     logger = Logger.withTag("maplibre-compose"),
+    snapshotterAdapterFactory = GlJsSnapshotterAdapterFactory(Logger.withTag("maplibre-compose")),
   )
 
 @Composable public actual fun rememberMapRuntime(): MapRuntime = processMapRuntime

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserMapSnapshotterTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserMapSnapshotterTest.kt
@@ -225,6 +225,32 @@ class BrowserMapSnapshotterTest {
     }
 
   @Test
+  fun fractional_density_rounds_the_output_up_from_the_gl_js_canvas(): Promise<*> =
+    runBrowserMapTest {
+      val runtime = createMapRuntime(MapRuntimeOptions())
+      val snapshotter = runtime.createSnapshotter(BASE_STYLE, StyleComposition {})
+      try {
+        val captured =
+          snapshotter.capture(MapSnapshotRequest(width = 31, height = 23, density = 1.25f))
+        val target = assertNotNull(snapshotTargets().singleOrNull())
+        val canvas = assertNotNull(target.querySelector("canvas")).unsafeCast<HTMLCanvasElement>()
+
+        assertEquals(39, captured.width)
+        assertEquals(29, captured.height)
+        assertEquals(31, target.clientWidth)
+        assertEquals(23, target.clientHeight)
+        assertEquals(38, canvas.width)
+        assertEquals(28, canvas.height)
+        assertEquals(BACKGROUND, captured.readPixel(38, 28))
+      } finally {
+        snapshotter.close()
+        snapshotter.awaitClosed()
+        runtime.close()
+        runtime.awaitClosed()
+      }
+    }
+
+  @Test
   fun page_css_does_not_change_the_private_viewport(): Promise<*> = runBrowserMapTest {
     val pageStyle = document.createElement("style").unsafeCast<HTMLElement>()
     pageStyle.textContent =

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserMapSnapshotterTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserMapSnapshotterTest.kt
@@ -251,6 +251,29 @@ class BrowserMapSnapshotterTest {
     }
 
   @Test
+  fun subpixel_density_keeps_the_gl_js_canvas_nonzero(): Promise<*> = runBrowserMapTest {
+    val runtime = createMapRuntime(MapRuntimeOptions())
+    val snapshotter = runtime.createSnapshotter(BASE_STYLE, StyleComposition {})
+    try {
+      val captured = snapshotter.capture(MapSnapshotRequest(width = 1, height = 1, density = 0.5f))
+      val target = assertNotNull(snapshotTargets().singleOrNull())
+      val canvas = assertNotNull(target.querySelector("canvas")).unsafeCast<HTMLCanvasElement>()
+
+      assertEquals(1, captured.width)
+      assertEquals(1, captured.height)
+      assertEquals(1, target.clientWidth)
+      assertEquals(1, target.clientHeight)
+      assertEquals(1, canvas.width)
+      assertEquals(1, canvas.height)
+    } finally {
+      snapshotter.close()
+      snapshotter.awaitClosed()
+      runtime.close()
+      runtime.awaitClosed()
+    }
+  }
+
+  @Test
   fun page_css_does_not_change_the_private_viewport(): Promise<*> = runBrowserMapTest {
     val pageStyle = document.createElement("style").unsafeCast<HTMLElement>()
     pageStyle.textContent =

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserMapSnapshotterTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserMapSnapshotterTest.kt
@@ -152,10 +152,10 @@ class BrowserMapSnapshotterTest {
         val second = snapshotter.capture(MapSnapshotRequest(width = 96, height = 64, density = 2f))
 
         assertSame(target, snapshotTargets().singleOrNull())
-        assertEquals(96, second.width)
-        assertEquals(64, second.height)
-        assertEquals(96, canvas.width)
-        assertEquals(64, canvas.height)
+        assertEquals(192, second.width)
+        assertEquals(128, second.height)
+        assertEquals(192, canvas.width)
+        assertEquals(128, canvas.height)
       } finally {
         snapshotter.close()
         snapshotter.awaitClosed()
@@ -201,27 +201,28 @@ class BrowserMapSnapshotterTest {
   }
 
   @Test
-  fun a_sub_density_request_keeps_a_nonzero_logical_viewport(): Promise<*> = runBrowserMapTest {
-    val runtime = createMapRuntime(MapRuntimeOptions())
-    val snapshotter = runtime.createSnapshotter(BASE_STYLE, StyleComposition {})
-    try {
-      val captured = snapshotter.capture(MapSnapshotRequest(width = 1, height = 1, density = 3f))
-      val target = assertNotNull(snapshotTargets().singleOrNull())
-      val canvas = assertNotNull(target.querySelector("canvas")).unsafeCast<HTMLCanvasElement>()
+  fun density_scales_the_bitmap_without_changing_the_logical_viewport(): Promise<*> =
+    runBrowserMapTest {
+      val runtime = createMapRuntime(MapRuntimeOptions())
+      val snapshotter = runtime.createSnapshotter(BASE_STYLE, StyleComposition {})
+      try {
+        val captured = snapshotter.capture(MapSnapshotRequest(width = 1, height = 1, density = 3f))
+        val target = assertNotNull(snapshotTargets().singleOrNull())
+        val canvas = assertNotNull(target.querySelector("canvas")).unsafeCast<HTMLCanvasElement>()
 
-      assertEquals(1, captured.width)
-      assertEquals(1, captured.height)
-      assertEquals(1, target.clientWidth)
-      assertEquals(1, target.clientHeight)
-      assertEquals(3, canvas.width)
-      assertEquals(3, canvas.height)
-    } finally {
-      snapshotter.close()
-      snapshotter.awaitClosed()
-      runtime.close()
-      runtime.awaitClosed()
+        assertEquals(3, captured.width)
+        assertEquals(3, captured.height)
+        assertEquals(1, target.clientWidth)
+        assertEquals(1, target.clientHeight)
+        assertEquals(3, canvas.width)
+        assertEquals(3, canvas.height)
+      } finally {
+        snapshotter.close()
+        snapshotter.awaitClosed()
+        runtime.close()
+        runtime.awaitClosed()
+      }
     }
-  }
 
   @Test
   fun page_css_does_not_change_the_private_viewport(): Promise<*> = runBrowserMapTest {
@@ -257,7 +258,7 @@ class BrowserMapSnapshotterTest {
       try {
         val error =
           assertFailsWith<IllegalArgumentException> {
-            snapshotter.capture(MapSnapshotRequest(width = 4_097, height = 1))
+            snapshotter.capture(MapSnapshotRequest(width = 2_049, height = 1, density = 2f))
           }
 
         assertTrue(error.message.orEmpty().contains("4096px canvas limit"))
@@ -285,10 +286,14 @@ class BrowserMapSnapshotterTest {
       val first = snapshotter.capture(request)
       val second = snapshotter.capture(request.copy(density = 2f))
 
+      assertEquals(SIZE, first.width)
+      assertEquals(SIZE, first.height)
+      assertEquals(SIZE * 2, second.width)
+      assertEquals(SIZE * 2, second.height)
       assertEquals(GREEN, first.readPixel(SIZE / 2, SIZE / 2))
       assertEquals(BACKGROUND, first.readPixel(SIZE / 2 + 6, SIZE / 2))
-      assertEquals(GREEN, second.readPixel(SIZE / 2, SIZE / 2))
-      assertEquals(BACKGROUND, second.readPixel(SIZE / 2 + 6, SIZE / 2))
+      assertEquals(GREEN, second.readPixel(SIZE, SIZE))
+      assertEquals(BACKGROUND, second.readPixel(SIZE + 12, SIZE))
     } finally {
       snapshotter.close()
       snapshotter.awaitClosed()

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserMapSnapshotterTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserMapSnapshotterTest.kt
@@ -1,0 +1,404 @@
+package org.maplibre.compose.map
+
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.unit.dp
+import kotlin.js.Promise
+import kotlin.js.js
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+import kotlinx.browser.document
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.coroutineScope
+import kotlinx.serialization.json.JsonObject
+import org.maplibre.compose.camera.CameraPosition
+import org.maplibre.compose.expressions.dsl.const
+import org.maplibre.compose.expressions.dsl.image
+import org.maplibre.compose.gljs.runBrowserMapTest
+import org.maplibre.compose.gljs.setBrowserMapContent
+import org.maplibre.compose.gljs.waitUntilMap
+import org.maplibre.compose.layers.CircleLayer
+import org.maplibre.compose.layers.SymbolLayer
+import org.maplibre.compose.sources.GeoJsonData
+import org.maplibre.compose.sources.GeoJsonOptions
+import org.maplibre.compose.sources.GeoJsonSource
+import org.maplibre.compose.style.BaseStyle
+import org.maplibre.compose.style.StyleComposition
+import org.maplibre.compose.testing.RgbaPixel
+import org.maplibre.compose.util.toImageBitmap
+import org.maplibre.spatialk.geojson.Geometry
+import org.maplibre.spatialk.geojson.Point
+import org.maplibre.spatialk.geojson.Position
+import org.maplibre.spatialk.geojson.dsl.addFeature
+import org.maplibre.spatialk.geojson.dsl.buildFeatureCollection
+import web.html.HTMLCanvasElement
+import web.html.HTMLElement
+
+@OptIn(ExperimentalTestApi::class)
+class BrowserMapSnapshotterTest {
+
+  @Test
+  fun composed_content_renders_in_a_private_target_that_cleanup_removes(): Promise<*> =
+    runBrowserMapTest {
+      val runtime = createMapRuntime(MapRuntimeOptions())
+      val snapshotter = runtime.createSnapshotter(BASE_STYLE, POINT_STYLE)
+      try {
+        assertEquals(0, snapshotTargets().size)
+
+        val image =
+          snapshotter.capture(
+            MapSnapshotRequest(
+              width = SIZE,
+              height = SIZE,
+              cameraPosition =
+                CameraPosition(target = Position(longitude = 0.0, latitude = 0.0), zoom = 2.0),
+            )
+          )
+
+        assertEquals(SIZE, image.width)
+        assertEquals(SIZE, image.height)
+        assertEquals(GREEN, image.readPixel(SIZE / 2, SIZE / 2))
+        assertEquals(BACKGROUND, image.readPixel(0, 0))
+        val target = assertNotNull(snapshotTargets().singleOrNull())
+        assertTrue(target.style.visibility == "hidden")
+        assertTrue(target.parentElement === document.body)
+      } finally {
+        snapshotter.close()
+        snapshotter.awaitClosed()
+        assertEquals(0, snapshotTargets().size)
+        runtime.close()
+        runtime.awaitClosed()
+      }
+    }
+
+  @Test
+  fun capture_keeps_an_interactive_map_attached_and_evaluates_style_independently(): Promise<*> =
+    runBrowserMapTest {
+      val evaluatorIdentities = mutableSetOf<Any>()
+      val composition = StyleComposition {
+        val identity = remember { Any() }
+        DisposableEffect(identity) {
+          evaluatorIdentities += identity
+          onDispose {}
+        }
+        POINT_STYLE.content()
+      }
+      val runtime = createMapRuntime(MapRuntimeOptions())
+      val state = runtime.createMapState(initialBaseStyle = BASE_STYLE)
+      val snapshotter = runtime.createSnapshotter(BASE_STYLE, composition)
+      try {
+        setBrowserMapContent(size = SIZE) {
+          MaplibreMap(state = state, styleComposition = composition)
+        }
+        waitUntilMap("the interactive map to become ready") {
+          state.presentation != null && state.style.loadState == StyleLoadState.Ready
+        }
+        val presentation = assertNotNull(state.presentation)
+        val session = presentation.adapter as GlJsMapSession
+        val interactiveEngine = assertNotNull(session.engineMapForTest())
+
+        val image =
+          snapshotter.capture(
+            MapSnapshotRequest(
+              width = SIZE,
+              height = SIZE,
+              cameraPosition =
+                CameraPosition(target = Position(longitude = 0.0, latitude = 0.0), zoom = 2.0),
+            )
+          )
+
+        assertEquals(GREEN, image.readPixel(SIZE / 2, SIZE / 2))
+        assertEquals(2, evaluatorIdentities.size)
+        assertSame(presentation, state.presentation)
+        assertSame(interactiveEngine, session.engineMapForTest())
+        snapshotter.close()
+        snapshotter.awaitClosed()
+        assertSame(presentation, state.presentation)
+        assertSame(interactiveEngine, session.engineMapForTest())
+        assertEquals(StyleLoadState.Ready, state.style.loadState)
+      } finally {
+        snapshotter.close()
+        snapshotter.awaitClosed()
+        state.close()
+        state.awaitClosed()
+        runtime.close()
+        runtime.awaitClosed()
+      }
+    }
+
+  @Test
+  fun consecutive_requests_reuse_the_private_map_at_each_requested_extent(): Promise<*> =
+    runBrowserMapTest {
+      val runtime = createMapRuntime(MapRuntimeOptions())
+      val snapshotter = runtime.createSnapshotter(BASE_STYLE, POINT_STYLE)
+      try {
+        val first = snapshotter.capture(MapSnapshotRequest(width = 32, height = 24))
+        val target = assertNotNull(snapshotTargets().singleOrNull())
+        val canvas = assertNotNull(target.querySelector("canvas")).unsafeCast<HTMLCanvasElement>()
+
+        assertEquals(32, first.width)
+        assertEquals(24, first.height)
+        assertEquals(32, canvas.width)
+        assertEquals(24, canvas.height)
+
+        val second = snapshotter.capture(MapSnapshotRequest(width = 96, height = 64, density = 2f))
+
+        assertSame(target, snapshotTargets().singleOrNull())
+        assertEquals(96, second.width)
+        assertEquals(64, second.height)
+        assertEquals(96, canvas.width)
+        assertEquals(64, canvas.height)
+      } finally {
+        snapshotter.close()
+        snapshotter.awaitClosed()
+        runtime.close()
+        runtime.awaitClosed()
+      }
+    }
+
+  @Test
+  fun camera_position_is_a_per_capture_value(): Promise<*> = runBrowserMapTest {
+    val runtime = createMapRuntime(MapRuntimeOptions())
+    val snapshotter = runtime.createSnapshotter(BASE_STYLE, POINT_STYLE)
+    try {
+      val centered =
+        snapshotter.capture(
+          MapSnapshotRequest(
+            width = SIZE,
+            height = SIZE,
+            cameraPosition = CameraPosition(zoom = 2.0),
+          )
+        )
+      val shifted =
+        snapshotter.capture(
+          MapSnapshotRequest(
+            width = SIZE,
+            height = SIZE,
+            cameraPosition =
+              CameraPosition(
+                target = Position(longitude = 90.0, latitude = 0.0),
+                zoom = 2.0,
+              ),
+          )
+        )
+
+      assertEquals(GREEN, centered.readPixel(SIZE / 2, SIZE / 2))
+      assertEquals(BACKGROUND, shifted.readPixel(SIZE / 2, SIZE / 2))
+    } finally {
+      snapshotter.close()
+      snapshotter.awaitClosed()
+      runtime.close()
+      runtime.awaitClosed()
+    }
+  }
+
+  @Test
+  fun a_sub_density_request_keeps_a_nonzero_logical_viewport(): Promise<*> = runBrowserMapTest {
+    val runtime = createMapRuntime(MapRuntimeOptions())
+    val snapshotter = runtime.createSnapshotter(BASE_STYLE, StyleComposition {})
+    try {
+      val captured = snapshotter.capture(MapSnapshotRequest(width = 1, height = 1, density = 3f))
+      val target = assertNotNull(snapshotTargets().singleOrNull())
+      val canvas = assertNotNull(target.querySelector("canvas")).unsafeCast<HTMLCanvasElement>()
+
+      assertEquals(1, captured.width)
+      assertEquals(1, captured.height)
+      assertEquals(1, target.clientWidth)
+      assertEquals(1, target.clientHeight)
+      assertEquals(3, canvas.width)
+      assertEquals(3, canvas.height)
+    } finally {
+      snapshotter.close()
+      snapshotter.awaitClosed()
+      runtime.close()
+      runtime.awaitClosed()
+    }
+  }
+
+  @Test
+  fun a_density_change_reapplies_an_unchanged_style_image(): Promise<*> = runBrowserMapTest {
+    val icon = IntArray(8 * 8) { 0xff00ff00.toInt() }.toImageBitmap(8, 8)
+    val runtime = createMapRuntime(MapRuntimeOptions())
+    val snapshotter = runtime.createSnapshotter(BASE_STYLE, pointIconStyle(icon))
+    val request =
+      MapSnapshotRequest(
+        width = SIZE,
+        height = SIZE,
+        cameraPosition = CameraPosition(zoom = 2.0),
+      )
+    try {
+      val first = snapshotter.capture(request)
+      val second = snapshotter.capture(request.copy(density = 2f))
+
+      assertEquals(GREEN, first.readPixel(SIZE / 2, SIZE / 2))
+      assertEquals(BACKGROUND, first.readPixel(SIZE / 2 + 6, SIZE / 2))
+      assertEquals(GREEN, second.readPixel(SIZE / 2, SIZE / 2))
+      assertEquals(BACKGROUND, second.readPixel(SIZE / 2 + 6, SIZE / 2))
+    } finally {
+      snapshotter.close()
+      snapshotter.awaitClosed()
+      runtime.close()
+      runtime.awaitClosed()
+    }
+  }
+
+  @Test
+  fun output_transparency_is_a_per_capture_value(): Promise<*> = runBrowserMapTest {
+    val runtime = createMapRuntime(MapRuntimeOptions())
+    val snapshotter = runtime.createSnapshotter(EMPTY_STYLE, StyleComposition {})
+    try {
+      val opaque = snapshotter.capture(MapSnapshotRequest(width = 8, height = 8))
+      val transparent =
+        snapshotter.capture(
+          MapSnapshotRequest(
+            width = 8,
+            height = 8,
+            outputOptions = MapSnapshotOutputOptions(transparent = true),
+          )
+        )
+
+      assertEquals(WHITE, opaque.readPixel(0, 0))
+      assertEquals(TRANSPARENT, transparent.readPixel(0, 0))
+    } finally {
+      snapshotter.close()
+      snapshotter.awaitClosed()
+      runtime.close()
+      runtime.awaitClosed()
+    }
+  }
+
+  @Test
+  fun cancelling_an_active_capture_releases_and_recreates_its_private_engine(): Promise<*> =
+    runBrowserMapTest {
+      val global = js("window")
+      val originalFetch = global.fetch
+      var styleRequested = false
+      global.fetch = { input: dynamic, init: dynamic ->
+        val url = if (jsTypeOf(input) == "string") input as String else input.url as String
+        if (url == BLOCKED_STYLE_URI) {
+          styleRequested = true
+          Promise<dynamic> { _, _ -> }
+        } else {
+          originalFetch.call(global, input, init)
+        }
+      }
+      val runtime = createMapRuntime(MapRuntimeOptions())
+      val snapshotter = runtime.createSnapshotter(BaseStyle.Uri(BLOCKED_STYLE_URI), POINT_STYLE)
+      try {
+        coroutineScope {
+          val capture = async { snapshotter.capture(MapSnapshotRequest(SIZE, SIZE)) }
+          waitUntilMap("the snapshot style request to start") {
+            styleRequested && snapshotTargets().size == 1
+          }
+
+          capture.cancelAndJoin()
+
+          waitUntilMap("capture cancellation to release the private engine") {
+            snapshotTargets().isEmpty() && snapshotter.style.loadState == StyleLoadState.Pending
+          }
+        }
+        snapshotter.style.baseStyle = BASE_STYLE
+        val image =
+          snapshotter.capture(
+            MapSnapshotRequest(
+              width = SIZE,
+              height = SIZE,
+              cameraPosition = CameraPosition(zoom = 2.0),
+            )
+          )
+        assertEquals(GREEN, image.readPixel(SIZE / 2, SIZE / 2))
+        assertEquals(1, snapshotTargets().size)
+      } finally {
+        global.fetch = originalFetch
+        snapshotter.close()
+        snapshotter.awaitClosed()
+        runtime.close()
+        runtime.awaitClosed()
+      }
+    }
+
+  private fun snapshotTargets(): List<HTMLElement> {
+    val targets = document.querySelectorAll("[data-maplibre-compose-snapshotter]")
+    return List(targets.length) { index -> targets.item(index).unsafeCast<HTMLElement>() }
+  }
+
+  private fun pointIconStyle(icon: ImageBitmap) = StyleComposition {
+    val points =
+      GeoJsonSource(
+        id = "icon-points",
+        data =
+          GeoJsonData.Features(
+            buildFeatureCollection<Geometry, JsonObject?> {
+              addFeature(geometry = Point(Position(longitude = 0.0, latitude = 0.0)))
+            }
+          ),
+        options = GeoJsonOptions(),
+      )
+    SymbolLayer(
+      id = "composed-icon",
+      source = points,
+      iconImage = image(icon),
+      iconAllowOverlap = const(true),
+      iconIgnorePlacement = const(true),
+    )
+  }
+
+  private fun ImageBitmap.readPixel(x: Int, y: Int): RgbaPixel {
+    val pixel = IntArray(1)
+    readPixels(pixel, startX = x, startY = y, width = 1, height = 1)
+    return pixel.single().toRgbaPixel()
+  }
+
+  private fun Int.toRgbaPixel() =
+    RgbaPixel(
+      red = this ushr 16 and 0xff,
+      green = this ushr 8 and 0xff,
+      blue = this and 0xff,
+      alpha = this ushr 24 and 0xff,
+    )
+
+  private companion object {
+    const val SIZE = 64
+    const val BLOCKED_STYLE_URI = "https://snapshot-style.test/style.json"
+    val BACKGROUND = RgbaPixel(red = 51, green = 102, blue = 153, alpha = 255)
+    val GREEN = RgbaPixel(red = 0, green = 255, blue = 0, alpha = 255)
+    val WHITE = RgbaPixel(red = 255, green = 255, blue = 255, alpha = 255)
+    val TRANSPARENT = RgbaPixel(red = 0, green = 0, blue = 0, alpha = 0)
+    val EMPTY_STYLE = BaseStyle.Json("""{"version":8,"sources":{},"layers":[]}""")
+    val BASE_STYLE =
+      BaseStyle.Json(
+        """
+        {"version":8,"sources":{},"layers":[
+          {"id":"base-background","type":"background","paint":{"background-color":"#336699"}}
+        ]}
+        """
+          .trimIndent()
+      )
+    val POINT_STYLE = StyleComposition {
+      val points =
+        GeoJsonSource(
+          id = "points",
+          data =
+            GeoJsonData.Features(
+              buildFeatureCollection<Geometry, JsonObject?> {
+                addFeature(geometry = Point(Position(longitude = 0.0, latitude = 0.0)))
+              }
+            ),
+          options = GeoJsonOptions(),
+        )
+      CircleLayer(
+        id = "composed-circle",
+        source = points,
+        color = const(Color.Green),
+        radius = const(20.dp),
+      )
+    }
+  }
+}

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserMapSnapshotterTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserMapSnapshotterTest.kt
@@ -10,6 +10,7 @@ import kotlin.js.Promise
 import kotlin.js.js
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
@@ -221,6 +222,53 @@ class BrowserMapSnapshotterTest {
       runtime.awaitClosed()
     }
   }
+
+  @Test
+  fun page_css_does_not_change_the_private_viewport(): Promise<*> = runBrowserMapTest {
+    val pageStyle = document.createElement("style").unsafeCast<HTMLElement>()
+    pageStyle.textContent =
+      "[data-maplibre-compose-snapshotter] { " +
+        "box-sizing: border-box; border: 7px solid; padding: 11px; }"
+    document.body?.appendChild(pageStyle.asDynamic())
+    val runtime = createMapRuntime(MapRuntimeOptions())
+    val snapshotter = runtime.createSnapshotter(BASE_STYLE, StyleComposition {})
+    try {
+      val captured = snapshotter.capture(MapSnapshotRequest(width = 31, height = 23))
+      val target = assertNotNull(snapshotTargets().singleOrNull())
+
+      assertEquals(31, captured.width)
+      assertEquals(23, captured.height)
+      assertEquals(31, target.clientWidth)
+      assertEquals(23, target.clientHeight)
+    } finally {
+      snapshotter.close()
+      snapshotter.awaitClosed()
+      runtime.close()
+      runtime.awaitClosed()
+      pageStyle.remove()
+    }
+  }
+
+  @Test
+  fun a_request_above_the_web_canvas_limit_fails_before_map_creation(): Promise<*> =
+    runBrowserMapTest {
+      val runtime = createMapRuntime(MapRuntimeOptions())
+      val snapshotter = runtime.createSnapshotter(BASE_STYLE, StyleComposition {})
+      try {
+        val error =
+          assertFailsWith<IllegalArgumentException> {
+            snapshotter.capture(MapSnapshotRequest(width = 4_097, height = 1))
+          }
+
+        assertTrue(error.message.orEmpty().contains("4096px canvas limit"))
+        assertEquals(0, snapshotTargets().size)
+      } finally {
+        snapshotter.close()
+        snapshotter.awaitClosed()
+        runtime.close()
+        runtime.awaitClosed()
+      }
+    }
 
   @Test
   fun a_density_change_reapplies_an_unchanged_style_image(): Promise<*> = runBrowserMapTest {


### PR DESCRIPTION
## Description

Stacked on #1185, this adds a dedicated Web `MapSnapshotter` GL JS engine and private DOM target while preserving the shared FIFO, evaluation, cancellation, and lifecycle contract.

## Validation

Passed `mise run check`, `caffeinate -dimsu mise run test:js`, `mise run test:android`, `mise run test:desktop`, and `mise run test:ios`.

## AI assistance

Implemented and reviewed with OpenAI Codex in the Codex desktop app.