### PR TITLE
Initialize explicit Android runtimes

### DIFF
--- a/.agents/scratch/api-redesign/issues/18-platform-map-access.md
+++ b/.agents/scratch/api-redesign/issues/18-platform-map-access.md
@@ -6,7 +6,7 @@ borrowed, callback-scoped value.
 
 **Blocked by:** 04, 05, 07
 
-**Status:** needs-info
+**Status:** resolved
 
 - [x] The changed test area contains no redundant, impossible,
       compatibility-only, or implementation-shape scenarios.
@@ -15,7 +15,7 @@ borrowed, callback-scoped value.
 - [x] Documentation states honestly that Kotlin cannot prevent retention and
       requires callers to use the borrowed handle only during the lambda.
 - [x] Native access creates the engine map lazily when necessary.
-- [ ] Android native access can initialize a presentation-free explicit runtime.
+- [x] Android native access can initialize a presentation-free explicit runtime.
 - [x] Native access works while MapState has no presentation after platform
       initialization.
 - [x] Web access works only for the current attached presentation.

--- a/lib/maplibre-compose/src/androidDeviceTest/kotlin/org/maplibre/compose/map/AndroidExplicitRuntimeTest.kt
+++ b/lib/maplibre-compose/src/androidDeviceTest/kotlin/org/maplibre/compose/map/AndroidExplicitRuntimeTest.kt
@@ -1,0 +1,48 @@
+package org.maplibre.compose.map
+
+import androidx.test.platform.app.InstrumentationRegistry
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+import org.maplibre.compose.android.AndroidRuntimeOptions
+import org.maplibre.compose.mlnffi.AndroidMlnFfiPlatform
+import org.maplibre.compose.mlnffi.MlnFfiApplication
+import org.maplibre.compose.style.BaseStyle
+
+@OptIn(DelicateMapApi::class)
+class AndroidExplicitRuntimeTest {
+  @Test
+  fun explicit_runtime_initializes_android_without_configuring_the_process_runtime() = runBlocking {
+    val context = InstrumentationRegistry.getInstrumentation().targetContext
+    val cacheDirectory = context.cacheDir.resolve("explicit-runtime-${System.nanoTime()}")
+    check(cacheDirectory.mkdirs()) { "Could not create test directory $cacheDirectory" }
+    check(MlnFfiApplication.resetForTest()) { "Could not reset the process runtime" }
+    AndroidMlnFfiPlatform.resetForTest()
+    val runtime =
+      createMapRuntime(
+        AndroidRuntimeOptions(
+          context = context,
+          cacheFile = cacheDirectory.resolve("cache.db"),
+          logger = null,
+        )
+      )
+    val state = runtime.createMapState(initialBaseStyle = BaseStyle.Empty)
+
+    try {
+      assertSame(context.applicationContext, AndroidMlnFfiPlatform.applicationContext)
+      assertFalse(MlnFfiApplication.isConfigured)
+      assertTrue(
+        state.withPlatformMap {
+          map.hashCode()
+          true
+        }
+      )
+    } finally {
+      runtime.close()
+      runtime.awaitClosed()
+      cacheDirectory.deleteRecursively()
+    }
+  }
+}

--- a/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/android/AndroidRuntimeOptions.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/android/AndroidRuntimeOptions.kt
@@ -10,8 +10,11 @@ import org.maplibre.compose.mlnffi.MlnFfiRuntimeOptions
 /** Configuration for one MapLibre Native runtime on Android. */
 @Immutable
 public data class AndroidRuntimeOptions(
+  /** Context used to initialize Android platform services; only its application is retained. */
+  public val context: Context,
+
   /** Where the ambient resource cache and offline-region database live. */
-  public val cacheFile: File,
+  public val cacheFile: File = androidCacheFile(context),
 
   /** Maximum ambient cache size in bytes, or null for MapLibre's own default. */
   public val maximumCacheSizeBytes: Long? = null,

--- a/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/android/MapLibre.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/android/MapLibre.kt
@@ -7,17 +7,18 @@ import org.maplibre.compose.mlnffi.MlnFfiApplication
 /** Android configuration for MapLibre Compose. */
 public object MapLibre {
   /**
-   * Sets the cache file and ambient cache budget for every map and offline operation in this
-   * process.
-   *
-   * Defaults to [androidCacheFile] and MapLibre's cache budget. A conflicting call throws
-   * `IllegalStateException`.
+   * Configures the process-default runtime with [androidCacheFile] and the default cache budget.
    */
-  public fun configure(
-    context: Context,
-    options: AndroidRuntimeOptions = AndroidRuntimeOptions(androidCacheFile(context)),
-  ) {
-    AndroidMlnFfiPlatform.initialize(context)
+  public fun configure(context: Context) {
+    configure(AndroidRuntimeOptions(context))
+  }
+
+  /**
+   * Configures the process-default runtime and its offline operations with [options]. A conflicting
+   * call throws `IllegalStateException`.
+   */
+  public fun configure(options: AndroidRuntimeOptions) {
+    AndroidMlnFfiPlatform.initialize(options.context)
     MlnFfiApplication.configure(options.toMlnFfiRuntimeOptions())
   }
 }

--- a/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/map/MapRuntime.android.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/map/MapRuntime.android.kt
@@ -3,13 +3,16 @@ package org.maplibre.compose.map
 import androidx.compose.runtime.Composable
 import org.maplibre.compose.android.AndroidRuntimeOptions
 import org.maplibre.compose.android.toMlnFfiRuntimeOptions
+import org.maplibre.compose.mlnffi.AndroidMlnFfiPlatform
 import org.maplibre.compose.mlnffi.EnsureMlnFfiConfigured
 import org.maplibre.compose.mlnffi.MlnFfiApplication
 
 public actual typealias MapRuntimeOptions = AndroidRuntimeOptions
 
-public actual fun createMapRuntime(options: MapRuntimeOptions): MapRuntime =
-  createNativeMapRuntime(options.toMlnFfiRuntimeOptions())
+public actual fun createMapRuntime(options: MapRuntimeOptions): MapRuntime {
+  AndroidMlnFfiPlatform.initialize(options.context)
+  return createNativeMapRuntime(options.toMlnFfiRuntimeOptions())
+}
 
 @Composable
 public actual fun rememberMapRuntime(): MapRuntime {

--- a/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/mlnffi/AndroidMlnFfiPlatform.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/mlnffi/AndroidMlnFfiPlatform.kt
@@ -23,4 +23,9 @@ internal object AndroidMlnFfiPlatform {
       this.application = application
     }
   }
+
+  /** Clears the Compose-side initialization guard. Tests only. */
+  internal fun resetForTest() {
+    synchronized(this) { application = null }
+  }
 }

--- a/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/mlnffi/EnsureMlnFfiConfigured.android.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/mlnffi/EnsureMlnFfiConfigured.android.kt
@@ -3,7 +3,6 @@ package org.maplibre.compose.mlnffi
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
 import org.maplibre.compose.android.AndroidRuntimeOptions
-import org.maplibre.compose.android.androidCacheFile
 import org.maplibre.compose.android.toMlnFfiRuntimeOptions
 
 @Composable
@@ -11,6 +10,6 @@ internal actual fun EnsureMlnFfiConfigured() {
   val context = LocalContext.current
   AndroidMlnFfiPlatform.initialize(context)
   MlnFfiApplication.ensureConfigured {
-    AndroidRuntimeOptions(androidCacheFile(context)).toMlnFfiRuntimeOptions()
+    AndroidRuntimeOptions(context).toMlnFfiRuntimeOptions()
   }
 }


### PR DESCRIPTION
## Description

Requires an Android context in AndroidRuntimeOptions so explicit runtime creation initializes Android platform services without configuring the process-default runtime, and adds an isolated device regression.

## Validation

Passed mise run check, mise run test:android, mise run test:android:device with 445 tests on API 36, and mise run lint:android; the focused regression failed when the bootstrap call was removed and passed when it was restored.

## AI assistance

OpenAI Codex with GPT-5 implemented and validated the change under user direction.