### PR TITLE
Add swipe-to-delete for offline packs

### DIFF
--- a/lib/maplibre-compose-material3/build.gradle.kts
+++ b/lib/maplibre-compose-material3/build.gradle.kts
@@ -63,6 +63,8 @@ kotlin {
       implementation(libs.jetbrains.compose.ui.test)
     }
 
+    jvmTest.dependencies { implementation(compose.desktop.currentOs) }
+
     androidHostTest.dependencies { implementation(compose.desktop.currentOs) }
 
     androidDeviceTest.dependencies {

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values-en/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values-en/strings.xml
@@ -1,3 +1,10 @@
 <resources>
   <string name="library_name">MapLibre Compose</string>
+  <string name="offline_pack_delete">Delete</string>
+  <string name="offline_pack_delete_title">Delete offline map?</string>
+  <string name="offline_pack_delete_message">Downloaded map data will be removed from this device.</string>
+  <string name="offline_pack_delete_confirm">Delete</string>
+  <string name="offline_pack_delete_cancel">Cancel</string>
+  <string name="offline_pack_delete_error">Deletion failed: %1$s</string>
+  <string name="offline_pack_delete_unknown_error">Unknown error</string>
 </resources>

--- a/lib/maplibre-compose-material3/src/commonMain/composeResources/values/strings.xml
+++ b/lib/maplibre-compose-material3/src/commonMain/composeResources/values/strings.xml
@@ -1,3 +1,10 @@
 <resources>
   <string name="library_name">MapLibre Compose</string>
+  <string name="offline_pack_delete">Delete</string>
+  <string name="offline_pack_delete_title">Delete offline map?</string>
+  <string name="offline_pack_delete_message">Downloaded map data will be removed from this device.</string>
+  <string name="offline_pack_delete_confirm">Delete</string>
+  <string name="offline_pack_delete_cancel">Cancel</string>
+  <string name="offline_pack_delete_error">Deletion failed: %1$s</string>
+  <string name="offline_pack_delete_unknown_error">Unknown error</string>
 </resources>

--- a/lib/maplibre-compose-material3/src/jvmTest/kotlin/org/maplibre/compose/material3/OfflinePackListItemTest.kt
+++ b/lib/maplibre-compose-material3/src/jvmTest/kotlin/org/maplibre/compose/material3/OfflinePackListItemTest.kt
@@ -1,0 +1,80 @@
+package org.maplibre.compose.material3
+
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.swipe
+import androidx.compose.ui.test.v2.runComposeUiTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalTestApi::class)
+class OfflinePackListItemTest {
+  @Test
+  fun swipeRequiresConfirmationBeforeDeleting() = runComposeUiTest {
+    var deleteCount = 0
+    setContent {
+      MaterialTheme {
+        ConfirmedOfflinePackSwipeToDelete(
+          deleteKey = Unit,
+          onDelete = { deleteCount++ },
+          modifier = Modifier.testTag("offline pack"),
+        ) {
+          ListItem(headlineContent = { Text("Offline pack") })
+        }
+      }
+    }
+
+    swipeOfflinePack()
+    onNodeWithText("Delete offline map?").assertIsDisplayed()
+    runOnIdle { assertEquals(0, deleteCount) }
+
+    onNodeWithText("Cancel").performClick()
+    waitForIdle()
+    onAllNodesWithText("Delete offline map?").assertCountEquals(0)
+
+    swipeOfflinePack()
+    onNodeWithText("Delete").performClick()
+    waitForIdle()
+    runOnIdle { assertEquals(1, deleteCount) }
+  }
+
+  @Test
+  fun failedDeletionKeepsConfirmationOpen() = runComposeUiTest {
+    setContent {
+      MaterialTheme {
+        ConfirmedOfflinePackSwipeToDelete(
+          deleteKey = Unit,
+          onDelete = { error("Offline database rejected deletion") },
+          modifier = Modifier.testTag("offline pack"),
+        ) {
+          ListItem(headlineContent = { Text("Offline pack") })
+        }
+      }
+    }
+
+    swipeOfflinePack()
+    onNodeWithText("Delete").performClick()
+    waitForIdle()
+
+    onNodeWithText("Deletion failed: Offline database rejected deletion").assertIsDisplayed()
+    onNodeWithText("Delete offline map?").assertIsDisplayed()
+  }
+
+  private fun androidx.compose.ui.test.ComposeUiTest.swipeOfflinePack() {
+    onNodeWithTag("offline pack").performTouchInput {
+      swipe(start = centerRight, end = centerLeft, durationMillis = 200)
+    }
+    waitForIdle()
+  }
+}

--- a/lib/maplibre-compose-material3/src/maplibreNativeMain/kotlin/org/maplibre/compose/material3/OfflinePackListItem.kt
+++ b/lib/maplibre-compose-material3/src/maplibreNativeMain/kotlin/org/maplibre/compose/material3/OfflinePackListItem.kt
@@ -2,30 +2,56 @@ package org.maplibre.compose.material3
 
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ProgressIndicatorDefaults
+import androidx.compose.material3.SwipeToDismissBox
+import androidx.compose.material3.SwipeToDismissBoxState
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import me.saket.bytesize.binaryBytes
+import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.resources.vectorResource
 import org.maplibre.compose.material3.generated.Res
 import org.maplibre.compose.material3.generated.check_circle_filled
 import org.maplibre.compose.material3.generated.delete
 import org.maplibre.compose.material3.generated.error_filled
+import org.maplibre.compose.material3.generated.offline_pack_delete
+import org.maplibre.compose.material3.generated.offline_pack_delete_cancel
+import org.maplibre.compose.material3.generated.offline_pack_delete_confirm
+import org.maplibre.compose.material3.generated.offline_pack_delete_error
+import org.maplibre.compose.material3.generated.offline_pack_delete_message
+import org.maplibre.compose.material3.generated.offline_pack_delete_title
+import org.maplibre.compose.material3.generated.offline_pack_delete_unknown_error
 import org.maplibre.compose.material3.generated.pause
 import org.maplibre.compose.material3.generated.pause_circle_filled
 import org.maplibre.compose.material3.generated.resume
@@ -46,6 +72,9 @@ import org.maplibre.compose.offline.rememberOfflineManager
  * You must supply a [headlineContent] for the list item. Typically, this will be a suitable name
  * for the pack, parsed from [OfflinePack.metadata].
  *
+ * Swipe the item from end to start to request deletion. The default trailing delete button and the
+ * swipe gesture both require confirmation before deleting the pack.
+ *
  * You can customize each part of the [ListItem] by supplying alternate [leadingContent],
  * [supportingContent], and [trailingContent].
  */
@@ -65,14 +94,62 @@ public fun OfflinePackListItem(
   },
   headlineContent: @Composable () -> Unit,
 ) {
-  // TODO swipe to delete? confirmation to delete?
-  ListItem(
+  ConfirmedOfflinePackSwipeToDelete(
+    deleteKey = pack,
+    onDelete = { offlineManager.delete(pack) },
     modifier = modifier,
-    leadingContent = leadingContent,
-    headlineContent = headlineContent,
-    supportingContent = supportingContent,
-    trailingContent = trailingContent,
-  )
+  ) { requestDelete ->
+    CompositionLocalProvider(LocalDeleteRequest provides requestDelete) {
+      ListItem(
+        leadingContent = leadingContent,
+        headlineContent = headlineContent,
+        supportingContent = supportingContent,
+        trailingContent = trailingContent,
+      )
+    }
+  }
+}
+
+@Composable
+internal fun ConfirmedOfflinePackSwipeToDelete(
+  deleteKey: Any?,
+  onDelete: suspend () -> Unit,
+  modifier: Modifier = Modifier,
+  content: @Composable (requestDelete: () -> Unit) -> Unit,
+) {
+  key(deleteKey) {
+    val dismissState = rememberSwipeToDismissBoxState()
+    OfflinePackDeleteConfirmation(deleteKey, onDelete, dismissState) {
+      requestDelete,
+      deleting,
+      confirmationVisible ->
+      SwipeToDismissBox(
+        state = dismissState,
+        modifier = modifier.clipToBounds(),
+        enableDismissFromStartToEnd = false,
+        enableDismissFromEndToStart = true,
+        gesturesEnabled = !deleting && !confirmationVisible,
+        onDismiss = { requestDelete() },
+        backgroundContent = {
+          Box(
+            modifier =
+              Modifier.fillMaxSize()
+                .background(MaterialTheme.colorScheme.errorContainer)
+                .padding(horizontal = 24.dp),
+            contentAlignment = Alignment.CenterEnd,
+          ) {
+            Icon(
+              imageVector = vectorResource(Res.drawable.delete),
+              contentDescription = null,
+              tint = MaterialTheme.colorScheme.onErrorContainer,
+            )
+          }
+        },
+      ) {
+        content(requestDelete)
+      }
+    }
+  }
 }
 
 public object OfflinePackListItemDefaults {
@@ -186,16 +263,124 @@ public object OfflinePackListItemDefaults {
 
 @Composable
 private fun DeleteButton(pack: OfflinePack, offlineManager: OfflineManager) {
-  val coroutineScope = rememberCoroutineScope()
-  var deleting by remember { mutableStateOf(false) }
-
-  fun onDelete() {
-    deleting = true
-    coroutineScope.launch { offlineManager.delete(pack) }.invokeOnCompletion { deleting = false }
+  val sharedDeleteRequest = LocalDeleteRequest.current
+  if (sharedDeleteRequest != null) {
+    DeleteIconButton(onClick = sharedDeleteRequest)
+  } else {
+    OfflinePackDeleteConfirmation(
+      deleteKey = pack,
+      onDelete = { offlineManager.delete(pack) },
+    ) { requestDelete, deleting, _ ->
+      DeleteIconButton(requestDelete, enabled = !deleting)
+    }
   }
+}
 
-  IconButton(onClick = ::onDelete, enabled = !deleting) {
-    Icon(vectorResource(Res.drawable.delete), "Delete", tint = MaterialTheme.colorScheme.error)
+@Composable
+private fun DeleteIconButton(onClick: () -> Unit, enabled: Boolean = true) {
+  IconButton(onClick = onClick, enabled = enabled) {
+    Icon(
+      imageVector = vectorResource(Res.drawable.delete),
+      contentDescription = stringResource(Res.string.offline_pack_delete),
+      tint = MaterialTheme.colorScheme.error,
+    )
+  }
+}
+
+private val LocalDeleteRequest = compositionLocalOf<(() -> Unit)?> { null }
+
+@Composable
+private fun OfflinePackDeleteConfirmation(
+  deleteKey: Any?,
+  onDelete: suspend () -> Unit,
+  dismissState: SwipeToDismissBoxState? = null,
+  content:
+    @Composable
+    (
+      requestDelete: () -> Unit,
+      deleting: Boolean,
+      confirmationVisible: Boolean,
+    ) -> Unit,
+) {
+  val coroutineScope = rememberCoroutineScope()
+  val currentOnDelete by rememberUpdatedState(onDelete)
+  val unknownDeleteError = stringResource(Res.string.offline_pack_delete_unknown_error)
+  var confirmationVisible by remember(deleteKey) { mutableStateOf(false) }
+  var deleting by remember(deleteKey) { mutableStateOf(false) }
+  var deleteError by remember(deleteKey) { mutableStateOf<String?>(null) }
+
+  val requestDelete =
+    remember(deleteKey) {
+      {
+        if (!deleting) {
+          deleteError = null
+          confirmationVisible = true
+        }
+      }
+    }
+  val cancelDelete =
+    remember(deleteKey, dismissState, coroutineScope) {
+      {
+        if (!deleting) {
+          coroutineScope.launch {
+            dismissState?.reset()
+            deleteError = null
+            confirmationVisible = false
+          }
+        }
+      }
+    }
+  val confirmDelete =
+    remember(deleteKey, coroutineScope, unknownDeleteError) {
+      {
+        if (!deleting) {
+          deleting = true
+          deleteError = null
+          coroutineScope.launch {
+            try {
+              currentOnDelete()
+              confirmationVisible = false
+            } catch (e: CancellationException) {
+              throw e
+            } catch (e: Exception) {
+              deleteError = e.message ?: unknownDeleteError
+            } finally {
+              deleting = false
+            }
+          }
+        }
+      }
+    }
+
+  content(requestDelete, deleting, confirmationVisible)
+
+  if (confirmationVisible) {
+    AlertDialog(
+      onDismissRequest = cancelDelete,
+      title = { Text(stringResource(Res.string.offline_pack_delete_title)) },
+      text = {
+        Column {
+          Text(stringResource(Res.string.offline_pack_delete_message))
+          deleteError?.let {
+            Text(
+              text = stringResource(Res.string.offline_pack_delete_error, it),
+              color = MaterialTheme.colorScheme.error,
+              modifier = Modifier.padding(top = 16.dp),
+            )
+          }
+        }
+      },
+      confirmButton = {
+        TextButton(onClick = confirmDelete, enabled = !deleting) {
+          Text(stringResource(Res.string.offline_pack_delete_confirm))
+        }
+      },
+      dismissButton = {
+        TextButton(onClick = cancelDelete, enabled = !deleting) {
+          Text(stringResource(Res.string.offline_pack_delete_cancel))
+        }
+      },
+    )
   }
 }
 


### PR DESCRIPTION
## Description

Adds an end-to-start swipe gesture and a shared confirmation flow for deleting offline packs while retaining the explicit delete button, and closes #1181.

## Validation

Validated with `:lib:maplibre-compose-material3:jvmTest`, Android host compilation, iOS simulator compilation, `mise run check`, and a manual desktop demo check.

## AI assistance

Implemented and validated with OpenAI Codex using GPT-5.