### PR TITLE
Read the system measurement system on Apple platforms

### DIFF
--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/ScaleBarMeasures.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/ScaleBarMeasures.kt
@@ -16,6 +16,16 @@ public data class ScaleBarMeasures(
 /** use system locale APIs for the primary scale bar measure */
 @Composable internal expect fun systemDefaultPrimaryMeasure(): ScaleBarMeasure?
 
+internal fun scaleBarMeasureForAppleMeasurementSystem(
+  measurementSystem: String?
+): ScaleBarMeasure? =
+  when (measurementSystem) {
+    "Metric" -> Metric
+    "U.S." -> FeetAndMiles
+    "U.K." -> YardsAndMiles
+    else -> null
+  }
+
 /** if the system APIs don't provide a primary measure, fall back to our hardcoded lists */
 internal fun fallbackDefaultPrimaryMeasure(region: String?): ScaleBarMeasure =
   when (region) {

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/overlay/ScaleBarMeasuresTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/overlay/ScaleBarMeasuresTest.kt
@@ -1,0 +1,29 @@
+package org.maplibre.compose.overlay
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class ScaleBarMeasuresTest {
+  @Test
+  fun appleMeasurementSystemsMapToScaleBarMeasures() {
+    assertEquals(
+      ScaleBarMeasure.Metric,
+      scaleBarMeasureForAppleMeasurementSystem("Metric"),
+    )
+    assertEquals(
+      ScaleBarMeasure.FeetAndMiles,
+      scaleBarMeasureForAppleMeasurementSystem("U.S."),
+    )
+    assertEquals(
+      ScaleBarMeasure.YardsAndMiles,
+      scaleBarMeasureForAppleMeasurementSystem("U.K."),
+    )
+  }
+
+  @Test
+  fun unknownAppleMeasurementSystemFallsBackToTheLocale() {
+    assertNull(scaleBarMeasureForAppleMeasurementSystem(null))
+    assertNull(scaleBarMeasureForAppleMeasurementSystem("Nautical"))
+  }
+}

--- a/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/overlay/ScaleBarMeasure.ios.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/overlay/ScaleBarMeasure.ios.kt
@@ -1,18 +1,12 @@
 package org.maplibre.compose.overlay
 
 import androidx.compose.runtime.Composable
+import platform.Foundation.NSLocale
+import platform.Foundation.NSLocaleMeasurementSystem
+import platform.Foundation.currentLocale
 
-@Composable internal actual fun systemDefaultPrimaryMeasure(): ScaleBarMeasure? = null
-
-/*
-TODO iOS developer: needs to be implemented in Swift with #available
-internal actual fun scaleBareMeasurePreference(): ScaleBarMeasure? {
-  val system = NSLocale.currentLocale.measurementSystem
-  return when (userlocale.measurementSystem) {
-    Locale.MeasurementSystem.metric -> ScaleBarMeasure.Metric
-    Locale.MeasurementSystem.uk -> ScaleBarMeasure.YardsAndMiles
-    Locale.MeasurementSystem.us -> ScaleBarMeasure.FeetAndMiles
-    else -> null
-  }
+@Composable
+internal actual fun systemDefaultPrimaryMeasure(): ScaleBarMeasure? {
+  val measurementSystem = NSLocale.currentLocale.objectForKey(NSLocaleMeasurementSystem) as? String
+  return scaleBarMeasureForAppleMeasurementSystem(measurementSystem)
 }
-*/

--- a/lib/maplibre-compose/src/iosTest/kotlin/org/maplibre/compose/overlay/ScaleBarMeasureTest.kt
+++ b/lib/maplibre-compose/src/iosTest/kotlin/org/maplibre/compose/overlay/ScaleBarMeasureTest.kt
@@ -1,0 +1,24 @@
+@file:OptIn(ExperimentalForeignApi::class)
+
+package org.maplibre.compose.overlay
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.Foundation.NSLocale
+import platform.Foundation.NSLocaleMeasurementSystem
+
+class ScaleBarMeasureTest {
+  @Test
+  fun localeMeasurementSystemOverridesAreVisibleThroughFoundation() {
+    assertEquals(ScaleBarMeasure.Metric, measureFor("en-US-u-ms-metric"))
+    assertEquals(ScaleBarMeasure.FeetAndMiles, measureFor("de-DE-u-ms-ussystem"))
+    assertEquals(ScaleBarMeasure.YardsAndMiles, measureFor("en-US-u-ms-uksystem"))
+  }
+
+  private fun measureFor(localeIdentifier: String): ScaleBarMeasure? {
+    val locale = NSLocale(localeIdentifier)
+    val measurementSystem = locale.objectForKey(NSLocaleMeasurementSystem) as? String
+    return scaleBarMeasureForAppleMeasurementSystem(measurementSystem)
+  }
+}

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/bridge/ObjectiveC.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/bridge/ObjectiveC.kt
@@ -1,6 +1,8 @@
 package org.maplibre.compose.desktop.bridge
 
 import org.lwjgl.system.JNI
+import org.lwjgl.system.MemoryStack
+import org.lwjgl.system.MemoryUtil
 import org.lwjgl.system.MemoryUtil.NULL
 import org.lwjgl.system.macosx.DynamicLinkLoader.RTLD_LOCAL
 import org.lwjgl.system.macosx.DynamicLinkLoader.RTLD_NOW
@@ -52,6 +54,9 @@ internal object ObjectiveC {
     return JNI.invokePPPP(receiver, selector, argument, implementation(receiver, selector))
   }
 
+  fun sendClassPointer(className: String, selectorName: String): Long =
+    sendPointer(cls(className), selectorName)
+
   /** Sends a message returning `NSUInteger`, which comes back through the pointer register. */
   fun sendLong(receiver: Long, selectorName: String): Long = sendPointer(receiver, selectorName)
 
@@ -63,6 +68,21 @@ internal object ObjectiveC {
   fun sendVoid(receiver: Long, selectorName: String, argument: Long) {
     val selector = selector(selectorName)
     JNI.invokePPPV(receiver, selector, argument, implementation(receiver, selector))
+  }
+
+  fun nsString(value: String): Long =
+    MemoryStack.stackPush().use { stack ->
+      sendPointer(
+        cls("NSString"),
+        "stringWithUTF8String:",
+        MemoryUtil.memAddress(stack.UTF8(value)),
+      )
+    }
+
+  fun utf8String(nsString: Long): String? {
+    if (nsString == NULL) return null
+    val utf8 = sendPointer(nsString, "UTF8String")
+    return if (utf8 == NULL) null else MemoryUtil.memUTF8(utf8)
   }
 
   @Synchronized

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/overlay/ScaleBarMeasure.desktop.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/overlay/ScaleBarMeasure.desktop.kt
@@ -1,6 +1,21 @@
 package org.maplibre.compose.overlay
 
 import androidx.compose.runtime.Composable
+import org.maplibre.compose.desktop.bridge.ObjectiveC
 
-@Composable internal actual fun systemDefaultPrimaryMeasure(): ScaleBarMeasure? = null
-// TODO on macOS, there should be an API for this
+@Composable
+internal actual fun systemDefaultPrimaryMeasure(): ScaleBarMeasure? =
+  macosSystemDefaultPrimaryMeasure()
+
+internal fun macosSystemDefaultPrimaryMeasure(): ScaleBarMeasure? {
+  if (!System.getProperty("os.name").orEmpty().startsWith("Mac", ignoreCase = true)) return null
+  return runCatching {
+    ObjectiveC.runInAutoreleasePool {
+      val locale = ObjectiveC.sendClassPointer("NSLocale", "currentLocale")
+      val key = ObjectiveC.nsString("kCFLocaleMeasurementSystemKey")
+      val value = ObjectiveC.sendPointer(locale, "objectForKey:", key)
+      scaleBarMeasureForAppleMeasurementSystem(ObjectiveC.utf8String(value))
+    }
+  }
+    .getOrNull()
+}

--- a/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/overlay/ScaleBarMeasureTest.kt
+++ b/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/overlay/ScaleBarMeasureTest.kt
@@ -1,0 +1,12 @@
+package org.maplibre.compose.overlay
+
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+
+class ScaleBarMeasureTest {
+  @Test
+  fun macosReadsTheCurrentFoundationMeasurementSystem() {
+    if (!System.getProperty("os.name").orEmpty().startsWith("Mac", ignoreCase = true)) return
+    assertNotNull(macosSystemDefaultPrimaryMeasure())
+  }
+}


### PR DESCRIPTION
## Description

Read the user-selected measurement system from Foundation on iOS and macOS so default scale bars follow metric, US, or UK preferences, closing #1180.

## Validation

Validated with mise run check, mise run test:desktop, mise run test:ios, and mise run build:ios:device.

## AI assistance

OpenAI Codex using GPT-5 in the Codex desktop app assisted with implementation, testing, and PR preparation.