### PR TITLE
Fix map lifecycle lock inversion

### DIFF
--- a/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MapLifecycleCallbackRaceTest.kt
+++ b/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MapLifecycleCallbackRaceTest.kt
@@ -11,10 +11,57 @@ import kotlin.test.assertTrue
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.JsonObject
 import org.maplibre.compose.camera.CameraPosition
+import org.maplibre.compose.sources.Source
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.compose.style.RecordingStyleBinding
+import org.maplibre.compose.style.StyleBinding
 
 class MapLifecycleCallbackRaceTest {
+  @Test
+  fun an_accepted_owner_callback_completes_while_style_sources_are_read() = runBlocking {
+    val runtime = mapRuntimeForTest()
+    val state = runtime.createMapState()
+    val adapter = PresentationTestAdapter()
+    val token = state.reservePresentation()
+    state.publishPresentation(token, adapter)
+    val style = OwnerThreadSourceReadStyleBinding()
+    assertTrue(state.updateLoadedStyle(adapter, style))
+    val binding = state.lifecycle.bind(CallbackRacePlatformAdapter())
+    val lease = binding.attach()
+    val engine = requireNotNull(binding.engineIdentity)
+    val styleReadyFailure = AtomicReference<Throwable?>()
+    val callbackFailure = AtomicReference<Throwable?>()
+
+    val styleReadyThread = thread {
+      styleReadyFailure.set(runCatching { state.markStyleReady(adapter) }.exceptionOrNull())
+    }
+    assertTrue(style.sourceReadStarted.await(5, TimeUnit.SECONDS))
+    val callbackThread = thread {
+      callbackFailure.set(
+        runCatching {
+          assertTrue(
+            binding.acceptPresentationEvent(engine, lease) {
+              state.synchronizeCamera(adapter)
+            }
+          )
+        }
+          .onSuccess { style.ownerReadCompleted.countDown() }
+          .exceptionOrNull()
+      )
+    }
+
+    styleReadyThread.join()
+    callbackThread.join()
+
+    binding.close()
+    binding.awaitClosed()
+    state.close()
+    state.awaitClosed()
+    runtime.close()
+    assertEquals(null, styleReadyFailure.get())
+    assertEquals(null, callbackFailure.get())
+  }
+
   @Test
   fun accepted_callback_delivery_completes_before_closure_commits() = runBlocking {
     val runtime = mapRuntimeForTest()
@@ -266,4 +313,18 @@ private class CallbackRacePlatformAdapter : MapLifecyclePlatformAdapter {
   override suspend fun destroyEngine(identity: EngineMapIdentity) = Unit
 
   override suspend fun closeResources() = Unit
+}
+
+private class OwnerThreadSourceReadStyleBinding : StyleBinding by RecordingStyleBinding() {
+  val sourceReadStarted = CountDownLatch(1)
+  val ownerReadCompleted = CountDownLatch(1)
+
+  override fun getSources(): List<Source> {
+    sourceReadStarted.countDown()
+    assertTrue(
+      ownerReadCompleted.await(5, TimeUnit.SECONDS),
+      "The accepted owner callback could not run while style sources were being read",
+    )
+    return emptyList()
+  }
 }

--- a/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MlnFfiMapCompositionTest.kt
+++ b/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MlnFfiMapCompositionTest.kt
@@ -537,28 +537,13 @@ class MlnFfiMapCompositionTest {
           requireNotNull(mapState.presentation?.adapter as? MlnFfiMapSession) {
             "no native session"
           }
-        waitUntil(
-          conditionDescription = "the initial layer to reach the native style",
-          timeoutMillis = RENDER_TIMEOUT_MILLIS,
-        ) {
-          "toggled" in session.currentStyleLayerIds()
-        }
+        waitUntil { "toggled" in session.currentStyleLayerIds() }
 
         visible = false
-        waitUntil(
-          conditionDescription = "the removed layer to leave the native style",
-          timeoutMillis = RENDER_TIMEOUT_MILLIS,
-        ) {
-          "toggled" !in session.currentStyleLayerIds()
-        }
+        waitUntil { "toggled" !in session.currentStyleLayerIds() }
 
         visible = true
-        waitUntil(
-          conditionDescription = "the re-added layer to return to the native style",
-          timeoutMillis = RENDER_TIMEOUT_MILLIS,
-        ) {
-          "toggled" in session.currentStyleLayerIds()
-        }
+        waitUntil { "toggled" in session.currentStyleLayerIds() }
       }
     ) { errors, onFrame ->
       mapState =

--- a/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MlnFfiMapCompositionTest.kt
+++ b/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MlnFfiMapCompositionTest.kt
@@ -537,13 +537,19 @@ class MlnFfiMapCompositionTest {
           requireNotNull(mapState.presentation?.adapter as? MlnFfiMapSession) {
             "no native session"
           }
-        waitUntil { "toggled" in session.currentStyleLayerIds() }
+        waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) {
+          "toggled" in session.currentStyleLayerIds()
+        }
 
         visible = false
-        waitUntil { "toggled" !in session.currentStyleLayerIds() }
+        waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) {
+          "toggled" !in session.currentStyleLayerIds()
+        }
 
         visible = true
-        waitUntil { "toggled" in session.currentStyleLayerIds() }
+        waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) {
+          "toggled" in session.currentStyleLayerIds()
+        }
       }
     ) { errors, onFrame ->
       mapState =

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapAdapter.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapAdapter.kt
@@ -167,7 +167,7 @@ internal class DurableStyleCallbacks(private val owner: MapState) : MapAdapter.C
   }
 
   override fun onSourceChanged(map: MapAdapter, sourceId: String?) {
-    owner.refreshStyleSources(map, sourceId)
+    owner.refreshStyleSources(map)
   }
 
   override fun onMapFailLoading(map: MapAdapter, reason: String?) {

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
@@ -196,22 +196,20 @@ public class MapStyleState internal constructor(initialBaseStyle: BaseStyle) {
 
   internal fun currentLoadedStyle(): StyleBinding? = loadedStyle.load()
 
-  internal fun refreshSource(id: String) {
-    val refreshed = source(id)
-    sourcesState = if (refreshed == null) sourcesState - id else sourcesState + (id to refreshed)
-  }
-
   internal fun refreshSources() {
     val current = loadedStyle.load()
     sourcesState =
-      if (loadState != StyleLoadState.Ready || current == null) emptyMap()
-      else
-        current
-          .getSources()
-          .mapNotNull { source ->
-            sourceHandle(current, source.id)?.let { source.id to it }
-          }
-          .toMap()
+      if (loadState != StyleLoadState.Ready || current == null) emptyMap() else readSources(current)
+  }
+
+  internal fun readSources(current: StyleBinding): Map<String, SourceHandle> =
+    current
+      .getSources()
+      .mapNotNull { source -> sourceHandle(current, source.id)?.let { source.id to it } }
+      .toMap()
+
+  internal fun updateSources(sources: Map<String, SourceHandle>) {
+    sourcesState = sources
   }
 
   private fun operationGuard(style: StyleBinding): StyleHandleOperationGuard =
@@ -416,6 +414,7 @@ internal constructor(
   private var baseStyleCommandRevision = 0L
   private var cameraCommandRevision = 0L
   private var styleHandleEpoch = 0L
+  private var styleSourceChangeRevision = 0L
   private var closedState: Boolean by mutableStateOf(false)
   private var cameraPositionState: CameraPosition by
     mutableStateOf(initialCameraPosition, structuralEqualityPolicy())
@@ -482,23 +481,63 @@ internal constructor(
 
   internal fun durableStyleCallbacks(): MapAdapter.Callbacks = DurableStyleCallbacks(this)
 
-  internal fun markStyleReady(adapter: MapAdapter): Boolean = lifecycle.serialized {
-    if (!lifecycle.acceptsAdapter(adapter)) return false
-    if (style.currentLoadedStyle() == null) return false
-    style.loadState = StyleLoadState.Ready
-    style.refreshSources()
-    true
+  internal fun markStyleReady(adapter: MapAdapter): Boolean {
+    while (true) {
+      val read = lifecycle.serialized {
+        if (!lifecycle.acceptsAdapter(adapter)) return false
+        val binding = style.currentLoadedStyle() ?: return false
+        StyleSourceRead(binding, styleHandleEpoch, styleSourceChangeRevision)
+      }
+      val sources = runCatching { style.readSources(read.binding) }
+      if (sources.isFailure) {
+        val stillCurrent = lifecycle.serialized { isCurrentStyleSourceRead(adapter, read) }
+        if (!stillCurrent) return false
+        throw requireNotNull(sources.exceptionOrNull())
+      }
+      val committed = lifecycle.serialized {
+        if (!isCurrentStyleSourceRead(adapter, read)) return false
+        if (style.loadState is StyleLoadState.Failed) return false
+        if (styleSourceChangeRevision != read.sourceChangeRevision) return@serialized false
+        style.updateSources(sources.getOrThrow())
+        style.loadState = StyleLoadState.Ready
+        true
+      }
+      if (committed) return true
+    }
   }
 
   internal fun acceptsPresentationEvent(adapter: MapAdapter): Boolean =
     lifecycle.acceptsPresentation(adapter)
 
-  internal fun refreshStyleSources(adapter: MapAdapter, sourceId: String?): Boolean =
-    lifecycle.serialized {
+  internal fun refreshStyleSources(adapter: MapAdapter): Boolean {
+    val read = lifecycle.serialized {
       if (!lifecycle.acceptsAdapter(adapter)) return false
-      if (sourceId == null) style.refreshSources() else style.refreshSource(sourceId)
+      val sourceChangeRevision = ++styleSourceChangeRevision
+      if (style.loadState != StyleLoadState.Ready) return true
+      val binding = style.currentLoadedStyle() ?: return true
+      StyleSourceRead(binding, styleHandleEpoch, sourceChangeRevision)
+    }
+    val sources = runCatching { style.readSources(read.binding) }
+    if (sources.isFailure) {
+      val stillCurrent = lifecycle.serialized { isCurrentStyleSourceRead(adapter, read) }
+      if (!stillCurrent) return false
+      throw requireNotNull(sources.exceptionOrNull())
+    }
+    return lifecycle.serialized {
+      if (!isCurrentStyleSourceRead(adapter, read)) return false
+      if (style.loadState != StyleLoadState.Ready) return false
+      // A later callback performs its own complete read, preserving source order without allowing
+      // this older result to overwrite it.
+      if (styleSourceChangeRevision != read.sourceChangeRevision) return true
+      style.updateSources(sources.getOrThrow())
       true
     }
+  }
+
+  private fun isCurrentStyleSourceRead(adapter: MapAdapter, read: StyleSourceRead): Boolean =
+    lifecycle.acceptsAdapter(adapter) &&
+      styleHandleEpoch == read.styleHandleEpoch &&
+      style.currentLoadedStyle() === read.binding
 
   internal fun updateLoadedStyle(adapter: MapAdapter, loadedStyle: StyleBinding?): Boolean =
     lifecycle.serialized {
@@ -754,6 +793,12 @@ internal constructor(
     val adapter: MapAdapter,
     val value: BaseStyle,
     val revision: Long,
+  )
+
+  private data class StyleSourceRead(
+    val binding: StyleBinding,
+    val styleHandleEpoch: Long,
+    val sourceChangeRevision: Long,
   )
 }
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MaplibreMap.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MaplibreMap.kt
@@ -207,7 +207,7 @@ private fun MaplibreMapPresentation(
         }
 
         override fun onSourceChanged(map: MapAdapter, sourceId: String?) {
-          state.refreshStyleSources(map, sourceId)
+          state.refreshStyleSources(map)
         }
 
         override fun onCameraMoveStarted(map: MapAdapter, reason: CameraMoveReason) {


### PR DESCRIPTION
## Description

Moves loaded-style source reads outside MapState lifecycle serialization, validates their generation before commit, adds deterministic two-thread regression coverage, and removes the layer test deadlock-workaround scaffolding.

## Validation

Passed `mise run check`, `mise run test:android`, the full JVM test suite, ten repeated focused JVM runs, and focused Android API 34 device coverage; the full local device suite was inconclusive because the emulator went offline after 29 of 447 reported tests.

## AI assistance

Implemented and validated with OpenAI Codex using GPT-5 in the Codex desktop app.