### PR TITLE
Use the runtime logger for offline and the Web process default

### DIFF
--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/MapRuntime.js.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/MapRuntime.js.kt
@@ -25,14 +25,6 @@ public actual fun createMapRuntime(options: MapRuntimeOptions): MapRuntime =
     snapshotterAdapterFactory = GlJsSnapshotterAdapterFactory(options.logger),
   )
 
-private val processMapRuntime: MapRuntime =
-  RuntimeImplementation(
-    platformOptions = null,
-    resources = MapRuntimeResources {},
-    logger = Logger.withTag("maplibre-compose"),
-    capabilities = webMapRuntimeCapabilities,
-    offlineManagerBackend = EmptyOfflineManager,
-    snapshotterAdapterFactory = GlJsSnapshotterAdapterFactory(Logger.withTag("maplibre-compose")),
-  )
+private val processMapRuntime: MapRuntime = createMapRuntime(MapRuntimeOptions())
 
 @Composable public actual fun rememberMapRuntime(): MapRuntime = processMapRuntime

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/offline/MlnFfiOfflineManager.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/offline/MlnFfiOfflineManager.kt
@@ -1,7 +1,6 @@
 package org.maplibre.compose.offline
 
 import androidx.compose.runtime.mutableStateOf
-import co.touchlab.kermit.Logger
 import kotlin.concurrent.atomics.AtomicBoolean
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.coroutines.cancellation.CancellationException
@@ -26,7 +25,7 @@ import org.maplibre.nativeffi.runtime.RuntimeHandle
 internal class MlnFfiOfflineManager(private val options: MlnFfiRuntimeOptions) :
   OfflineManager, OfflinePackOwner {
 
-  private val logger = Logger.withTag("maplibre-compose")
+  private val logger = options.logger
 
   /**
    * Compose state, written inline on the owner thread — never hopped to a dispatcher, which would
@@ -55,7 +54,7 @@ internal class MlnFfiOfflineManager(private val options: MlnFfiRuntimeOptions) :
         nativeRuntime.takeOfflineRegionsResult(handle).forEach { info ->
           // One unrepresentable region must not cost the user the rest of their packs.
           runCatching { registerRegion(info) }
-            .onFailure { logger.w(it) { "Ignoring offline region ${info.id}" } }
+            .onFailure { logger?.w(it) { "Ignoring offline region ${info.id}" } }
         }
       },
     )
@@ -104,7 +103,7 @@ internal class MlnFfiOfflineManager(private val options: MlnFfiRuntimeOptions) :
         )
     val failure = settledOutcome.exceptionOrNull()
     if (failure != null) failStartup("Could not configure MapLibre's offline runtime", failure)
-    if (initialSize != null) logger.d { "Ambient cache size set to $initialSize bytes" }
+    if (initialSize != null) logger?.d { "Ambient cache size set to $initialSize bytes" }
   }
 
   private fun failStartup(message: String, cause: Throwable): Nothing {
@@ -234,7 +233,7 @@ internal class MlnFfiOfflineManager(private val options: MlnFfiRuntimeOptions) :
         finish = { _, _ -> refreshStatus(pack.regionId) },
       )
     if (!accepted) {
-      logger.w { "Cannot change the download state of pack ${pack.regionId}: manager disposed" }
+      logger?.w { "Cannot change the download state of pack ${pack.regionId}: manager disposed" }
     }
   }
 
@@ -284,7 +283,7 @@ internal class MlnFfiOfflineManager(private val options: MlnFfiRuntimeOptions) :
 
       RuntimeEventType.OFFLINE_REGION_TILE_COUNT_LIMIT_EXCEEDED -> {
         val payload = event.payload as? RuntimeEventPayload.OfflineRegionTileCountLimit ?: return
-        logger.w { "Offline pack ${payload.regionId} hit the tile limit of ${payload.limit}" }
+        logger?.w { "Offline pack ${payload.regionId} hit the tile limit of ${payload.limit}" }
         publishProgress(payload.regionId, DownloadProgress.TileLimitExceeded(payload.limit))
       }
 
@@ -292,21 +291,21 @@ internal class MlnFfiOfflineManager(private val options: MlnFfiRuntimeOptions) :
         val payload = event.payload as? RuntimeEventPayload.OfflineRegionResponseError ?: return
         val reason = payload.reason.toDownloadErrorReason()
         val message = event.message.ifBlank { "MapLibre could not download an offline resource" }
-        logger.e { "Offline pack ${payload.regionId} failed ($reason): $message" }
+        logger?.e { "Offline pack ${payload.regionId} failed ($reason): $message" }
         publishProgress(payload.regionId, DownloadProgress.Error(reason, message))
       }
 
       else ->
         // Event types are value classes over Int, so an FFI upgrade can deliver a type this build
         // has never seen.
-        logger.v { "Ignoring MapLibre event ${event.type} on the offline runtime" }
+        logger?.v { "Ignoring MapLibre event ${event.type} on the offline runtime" }
     }
   }
 
   private fun publishProgress(regionId: Long, progress: DownloadProgress) {
     val pack = packsById[regionId]
     if (pack == null) {
-      logger.v { "Ignoring progress for offline region $regionId, which has no pack" }
+      logger?.v { "Ignoring progress for offline region $regionId, which has no pack" }
       return
     }
     pack.progressState.value = progress
@@ -335,7 +334,7 @@ internal class MlnFfiOfflineManager(private val options: MlnFfiRuntimeOptions) :
     isCancelled: () -> Boolean = { false },
     onStarted: (OfflineOperationHandle<T>) -> Unit = {},
     onResult: (Result<R>) -> Unit = { result ->
-      result.onFailure { logger.e(it) { "Failed to $description" } }
+      result.onFailure { logger?.e(it) { "Failed to $description" } }
     },
   ): Boolean {
     return runtime.post(
@@ -405,12 +404,12 @@ internal class MlnFfiOfflineManager(private val options: MlnFfiRuntimeOptions) :
       is MaplibreException -> {
         // OfflineManagerException carries no cause, so the native detail is logged before it is
         // flattened into the message.
-        logger.d(this) { "Native failure while trying to $description" }
+        logger?.d(this) { "Native failure while trying to $description" }
         val detail = diagnostic.ifBlank { message.orEmpty() }
         OfflineManagerException("Failed to $description: $detail")
       }
       else -> {
-        logger.d(this) { "Failure while trying to $description" }
+        logger?.d(this) { "Failure while trying to $description" }
         OfflineManagerException(
           "Failed to $description: ${message ?: this::class.simpleName.orEmpty()}"
         )

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/offline/MlnFfiOfflineRuntime.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/offline/MlnFfiOfflineRuntime.kt
@@ -37,7 +37,7 @@ private const val OWNER_THREAD_NAME = "maplibre-compose-offline"
  */
 internal class MlnFfiOfflineRuntime(
   private val cacheFile: Path,
-  private val logger: Logger,
+  private val logger: Logger?,
   private val onEvent: (RuntimeEvent) -> Unit,
 ) {
 
@@ -149,7 +149,7 @@ internal class MlnFfiOfflineRuntime(
         reject = {},
       )
     if (!posted) {
-      logger.v { "Offline operation ${handle.id} was cancelled after its runtime closed" }
+      logger?.v { "Offline operation ${handle.id} was cancelled after its runtime closed" }
     }
   }
 
@@ -160,7 +160,7 @@ internal class MlnFfiOfflineRuntime(
           .also { runtimeOwner = it }
           .runtime
       } catch (error: Throwable) {
-        logger.e(error) { "Could not create the MapLibre runtime for offline management" }
+        logger?.e(error) { "Could not create the MapLibre runtime for offline management" }
         rejectQueuedTasks(
           OfflineManagerException(
             "The MapLibre offline runtime could not be created: " +
@@ -175,7 +175,7 @@ internal class MlnFfiOfflineRuntime(
         // Owner-thread affine (validated natively), so this cannot be hoisted into start().
         runtime.acquireWakeSource()
       } catch (error: Throwable) {
-        logger.e(error) { "Could not acquire a wake source for the MapLibre offline runtime" }
+        logger?.e(error) { "Could not acquire a wake source for the MapLibre offline runtime" }
         teardown(runtime)
         return
       }
@@ -194,7 +194,7 @@ internal class MlnFfiOfflineRuntime(
         drainEvents(runtime)
       }
     } catch (error: Throwable) {
-      logger.e(error) { "The MapLibre offline runtime loop failed" }
+      logger?.e(error) { "The MapLibre offline runtime loop failed" }
     } finally {
       teardown(runtime)
     }
@@ -206,7 +206,7 @@ internal class MlnFfiOfflineRuntime(
       try {
         runtime.drainEvents().events
       } catch (error: Throwable) {
-        logger.e(error) { "Failed to drain MapLibre offline runtime events" }
+        logger?.e(error) { "Failed to drain MapLibre offline runtime events" }
         return
       }
     for (event in events) {
@@ -214,7 +214,7 @@ internal class MlnFfiOfflineRuntime(
         completeOperation(runtime, event)
       } else {
         runCatching { onEvent(event) }
-          .onFailure { logger.e(it) { "Failed to handle offline event ${event.type}" } }
+          .onFailure { logger?.e(it) { "Failed to handle offline event ${event.type}" } }
       }
     }
   }
@@ -222,21 +222,21 @@ internal class MlnFfiOfflineRuntime(
   private fun completeOperation(runtime: RuntimeHandle, event: RuntimeEvent) {
     val payload = event.payload as? RuntimeEventPayload.OfflineOperationCompleted
     if (payload == null) {
-      logger.w { "An offline operation completed without a payload naming it" }
+      logger?.w { "An offline operation completed without a payload naming it" }
       return
     }
 
     val operation = pending.remove(payload.operationId)
     if (operation == null) {
       // Expected after a cancellation: the caller discarded the operation before native finished.
-      logger.v { "Ignoring the completion of unknown offline operation ${payload.operationId}" }
+      logger?.v { "Ignoring the completion of unknown offline operation ${payload.operationId}" }
       return
     }
 
     try {
       operation.complete(runtime, event)
     } catch (error: Throwable) {
-      logger.e(error) { "Failed to complete the offline operation to ${operation.description}" }
+      logger?.e(error) { "Failed to complete the offline operation to ${operation.description}" }
     } finally {
       closeQuietly(operation.handle, "the operation to ${operation.description}")
     }
@@ -259,7 +259,7 @@ internal class MlnFfiOfflineRuntime(
       }
       task.run(runtime)
     } catch (error: Throwable) {
-      logger.e(error) { "An offline runtime task failed" }
+      logger?.e(error) { "An offline runtime task failed" }
       // The task may have failed before reporting anything; a caller that already heard ignores
       // this.
       runCatching { task.reject(error) }
@@ -281,7 +281,9 @@ internal class MlnFfiOfflineRuntime(
       // Handles close on the thread that owns them, which is this one.
       closeQuietly(operation.handle, "the operation to ${operation.description}")
       runCatching { operation.discard(disposed) }
-        .onFailure { logger.e(it) { "Failed to cancel the operation to ${operation.description}" } }
+        .onFailure {
+          logger?.e(it) { "Failed to cancel the operation to ${operation.description}" }
+        }
     }
 
     // Last, and only after its children: the provider retires before the runtime.
@@ -303,12 +305,12 @@ internal class MlnFfiOfflineRuntime(
     // A wake source is its own native handle: closing the runtime does not release it.
     source?.let { closing ->
       runCatching { closing.close() }
-        .onFailure { logger.w(it) { "Failed to close the offline runtime's wake source" } }
+        .onFailure { logger?.w(it) { "Failed to close the offline runtime's wake source" } }
     }
   }
 
   private fun closeQuietly(handle: OfflineOperationHandle<*>, what: String) {
-    runCatching { handle.close() }.onFailure { logger.w(it) { "Failed to close $what" } }
+    runCatching { handle.close() }.onFailure { logger?.w(it) { "Failed to close $what" } }
   }
 
   private fun assertOwnerThread(operation: String) {

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/offline/util.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/offline/util.kt
@@ -47,7 +47,7 @@ internal fun OfflinePackDefinition.toFfiRegionDefinition(): FfiRegionDefinition 
  * reports it as `Unknown`, which carries no style URL and so cannot become an
  * [OfflinePackDefinition].
  */
-internal fun FfiRegionDefinition.toOfflinePackDefinition(logger: Logger): OfflinePackDefinition? =
+internal fun FfiRegionDefinition.toOfflinePackDefinition(logger: Logger?): OfflinePackDefinition? =
   when (this) {
     is FfiRegionDefinition.TilePyramid ->
       OfflinePackDefinition.TilePyramid(
@@ -67,12 +67,12 @@ internal fun FfiRegionDefinition.toOfflinePackDefinition(logger: Logger): Offlin
         maxZoom = maxZoom.takeIf { it.isFinite() }?.toInt(),
       )
     else -> {
-      logger.w { "Ignoring an offline region with an unrecognized definition: $this" }
+      logger?.w { "Ignoring an offline region with an unrecognized definition: $this" }
       null
     }
   }
 
-internal fun OfflineRegionStatus.toDownloadProgress(logger: Logger): DownloadProgress =
+internal fun OfflineRegionStatus.toDownloadProgress(logger: Logger?): DownloadProgress =
   DownloadProgress.Healthy(
     completedResourceCount = completedResourceCount,
     completedResourceBytes = completedResourceSize,
@@ -86,7 +86,7 @@ internal fun OfflineRegionStatus.toDownloadProgress(logger: Logger): DownloadPro
         else -> {
           // Download states are value classes over Int rather than enums, so a newer native runtime
           // can report one this build has never seen.
-          logger.w { "Unrecognized offline download state $downloadState; reporting it as paused" }
+          logger?.w { "Unrecognized offline download state $downloadState; reporting it as paused" }
           DownloadStatus.Paused
         }
       },
@@ -108,12 +108,12 @@ internal fun ResourceErrorReason.toDownloadErrorReason(): String =
     else -> "REASON_OTHER"
   }
 
-private fun ByteArray.toGeoJsonGeometry(logger: Logger): Geometry = runCatching {
+private fun ByteArray.toGeoJsonGeometry(logger: Logger?): Geometry = runCatching {
   Geometry.fromJson(decodeToString())
 }
   .getOrElse {
     // An unreadable shape has no GeoJSON spelling; an empty collection keeps the pack listed and
     // deletable.
-    logger.w(it) { "Offline region shape has no readable GeoJSON; reporting it as empty" }
+    logger?.w(it) { "Offline region shape has no readable GeoJSON; reporting it as empty" }
     GeometryCollection<Geometry>(emptyList())
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

The offline manager and the Web process-default runtime now use `MapRuntimeOptions.logger` instead of constructing a tagged default of their own.

## Validation

Compiled the changed JVM and JS sources and ran the existing `OfflineProgressMappingTest` suite on desktop.

## AI assistance

Cursor Grok 4.6 cloud agent.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7c7b1a53-97fb-4dbd-bf4f-3210b382730e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7c7b1a53-97fb-4dbd-bf4f-3210b382730e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

