### PR TITLE
Add a common API for map resource request hooks

### DIFF
--- a/.agents/docs/COMMON_API_GAPS.md
+++ b/.agents/docs/COMMON_API_GAPS.md
@@ -97,18 +97,9 @@ per-map options.
 
 ## HTTP header transforms
 
-A hook to add or rewrite request headers for every resource the map fetches —
-the usual home for an `Authorization` header or an API key that does not belong
-in a URL.
-
-- FFI: `setHttpHeaderTransform`, `clearHttpHeaderTransform`
-  ([#509](https://github.com/maplibre/maplibre-native-ffi/pull/509))
-
-Related to the resource-transform entry below, and worth designing with it: one
-rewrites the URL, the other the headers, and an application adding credentials
-needs whichever the server expects. Note the FFI reports this as unsupported on
-OpenHarmony, whose HTTP client cannot intercept redirects, so a common API has
-to tolerate a platform declining it.
+Done: `MapRequestInterceptor` on `MapRuntime` / `MapRuntimeOptions`. Native
+installs `setHttpHeaderTransform`; web sets `transformRequest` headers. The
+install is skipped when the FFI reports the hook as unsupported.
 
 ## Missing style images
 
@@ -124,14 +115,10 @@ See the `MAP_STYLE_IMAGE_MISSING` branch in `MlnFfiMapSession.handleEvent`.
 
 ## Resource transform
 
-A hook to rewrite every resource URL before it is requested — how applications
-add API keys, route through a proxy, or redirect to a local mirror.
-
-- FFI: `setResourceTransform`, `clearResourceTransform`
-
-The FFI integration already has a broader mechanism in `MlnFfiResourceProvider`,
-which serves resources rather than only rewriting their URLs. The redesign
-should decide which of the two is the public API, rather than shipping both.
+Done: the same `MapRequestInterceptor` rewrites URLs. Native installs
+`setResourceTransform`. `MapResourceProvider` is the public serve-bytes API;
+`MlnFfiResourceProvider` remains the internal packaged-resource adapter and
+composes the user provider in front of `jar:file:` / `file:` reads.
 
 ## Offline database merge
 

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Requests.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Requests.kt
@@ -1,0 +1,49 @@
+@file:Suppress("unused")
+
+package org.maplibre.compose.docsnippets
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import org.maplibre.compose.map.MaplibreMap
+import org.maplibre.compose.map.rememberMapRuntime
+import org.maplibre.compose.map.rememberMapState
+import org.maplibre.compose.resource.MapRequestTransform
+import org.maplibre.compose.resource.MapResourceLoad
+import org.maplibre.compose.resource.MapResourceProvider
+
+@Composable
+fun InterceptorMap(token: String) {
+  val runtime = rememberMapRuntime()
+  // #region interceptor
+  LaunchedEffect(token) {
+    runtime.setRequestInterceptor { request ->
+      if (request.url.startsWith("https://tiles.example.com/")) {
+        MapRequestTransform(headers = mapOf("Authorization" to "Bearer $token"))
+      } else {
+        MapRequestTransform()
+      }
+    }
+  }
+  MaplibreMap(state = rememberMapState(runtime))
+  // #endregion interceptor
+}
+
+@Suppress("UNUSED_PARAMETER") suspend fun readAsset(url: String): ByteArray = ByteArray(0)
+
+fun assetProvider(): MapResourceProvider {
+  // #region provider
+  val provider = MapResourceProvider(scheme = "app") { request -> readAsset(request.url) }
+  // #endregion provider
+  return provider
+}
+
+fun filteredProvider(): MapResourceProvider {
+  // #region provider-accept
+  val provider =
+    MapResourceProvider(
+      accepts = { request -> request.url.startsWith("app://") },
+      load = { request -> MapResourceLoad.Bytes(readAsset(request.url)) },
+    )
+  // #endregion provider-accept
+  return provider
+}

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Requests.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Requests.kt
@@ -8,7 +8,6 @@ import org.maplibre.compose.map.MaplibreMap
 import org.maplibre.compose.map.rememberMapRuntime
 import org.maplibre.compose.map.rememberMapState
 import org.maplibre.compose.resource.MapRequestTransform
-import org.maplibre.compose.resource.MapResourceLoad
 import org.maplibre.compose.resource.MapResourceProvider
 
 @Composable
@@ -34,16 +33,5 @@ fun assetProvider(): MapResourceProvider {
   // #region provider
   val provider = MapResourceProvider(scheme = "app") { request -> readAsset(request.url) }
   // #endregion provider
-  return provider
-}
-
-fun filteredProvider(): MapResourceProvider {
-  // #region provider-accept
-  val provider =
-    MapResourceProvider(
-      accepts = { request -> request.url.startsWith("app://") },
-      load = { request -> MapResourceLoad.Bytes(readAsset(request.url)) },
-    )
-  // #endregion provider-accept
   return provider
 }

--- a/docs/astro.config.mts
+++ b/docs/astro.config.mts
@@ -60,7 +60,7 @@ export default defineConfig({
             { label: "Overlay Compose UI", slug: "controls" },
             { label: "Show the user's location", slug: "location" },
             { label: "Download maps for offline use", slug: "offline" },
-            { label: "Authenticate and serve map requests", slug: "requests" },
+            { label: "Rewrite or serve map requests", slug: "requests" },
           ],
         },
         {

--- a/docs/astro.config.mts
+++ b/docs/astro.config.mts
@@ -60,6 +60,7 @@ export default defineConfig({
             { label: "Overlay Compose UI", slug: "controls" },
             { label: "Show the user's location", slug: "location" },
             { label: "Download maps for offline use", slug: "offline" },
+            { label: "Authenticate and serve map requests", slug: "requests" },
           ],
         },
         {

--- a/docs/src/content/docs/requests.mdx
+++ b/docs/src/content/docs/requests.mdx
@@ -1,0 +1,64 @@
+---
+title: Authenticate and serve map requests
+description: Add headers or serve selected map resources from the application.
+---
+
+import { Aside, Code } from "@astrojs/starlight/components";
+import Api from "../../components/Api.astro";
+import { region } from "../../snippets";
+
+import requests from "../../../../demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Requests.kt?raw";
+
+MapLibre fetches styles, tiles, glyphs, and sprites as the camera moves. An
+application that must sign those requests, or serve some of them from its own
+storage, installs a hook on the <Api of="MapRuntime" />.
+
+A <Api of="MapRequestInterceptor" /> rewrites the URL or adds headers. The
+engine still fetches the resource, so its cache and retry stay in use. Use
+this for an `Authorization` header or an API key.
+
+A <Api of="MapResourceProvider" /> supplies the response bytes. The engine
+skips its HTTP client for every request the provider accepts. Use this for a
+custom URL scheme or an application archive.
+
+## Add headers or rewrite a URL
+
+<Api of="MapRuntime.setRequestInterceptor" /> replaces the interceptor on a
+live runtime. The change applies to requests that start after the call
+returns:
+
+<Code code={region(requests, "interceptor")} lang="kotlin" title="App.kt" />
+
+Compare the URL against the origins you control before you attach a
+credential. A style also names glyphs, sprites, and tiles on hosts you do not
+own.
+
+The interceptor may run on a network thread. It must return quickly, must be
+safe to call concurrently, and must not call map APIs.
+
+A URL rewrite runs before headers are applied. Header logic should key off the
+URL the client will send.
+
+Pass the same interceptor to <Api of="createMapRuntime" /> in
+`MapRuntimeOptions` when the runtime should start with it.
+
+## Serve bytes from the application
+
+A provider decides first, then loads. <Api of="MapResourceProvider.accepts" />
+runs on a network thread and must return quickly. Return true only for
+requests this provider will load. <Api of="MapResourceProvider.load" /> may
+suspend; cancellation means the map no longer needs that resource.
+
+The shortest form matches a URL scheme:
+
+<Code code={region(requests, "provider")} lang="kotlin" title="App.kt" />
+
+Pass the provider in `MapRuntimeOptions` when you call
+<Api of="createMapRuntime" />. A provider is fixed for the lifetime of the
+runtime.
+
+<Aside type="note">
+  On the web, a provider can serve any URL that `accepts` returns true for.
+  Accepted `https` URLs are rewritten to a Compose protocol and served on the
+  main thread.
+</Aside>

--- a/docs/src/content/docs/requests.mdx
+++ b/docs/src/content/docs/requests.mdx
@@ -1,64 +1,36 @@
 ---
-title: Authenticate and serve map requests
-description: Add headers or serve selected map resources from the application.
+title: Rewrite or serve map requests
+description: Rewrite map HTTP requests, or serve tiles and fonts from application code.
 ---
 
-import { Aside, Code } from "@astrojs/starlight/components";
+import { Code } from "@astrojs/starlight/components";
 import Api from "../../components/Api.astro";
 import { region } from "../../snippets";
 
 import requests from "../../../../demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Requests.kt?raw";
 
-MapLibre fetches styles, tiles, glyphs, and sprites as the camera moves. An
-application that must sign those requests, or serve some of them from its own
-storage, installs a hook on the <Api of="MapRuntime" />.
+Tiles, sprites, and fonts come from URLs in the style. Rewrite those requests,
+or serve the bytes from application code.
 
-A <Api of="MapRequestInterceptor" /> rewrites the URL or adds headers. The
-engine still fetches the resource, so its cache and retry stay in use. Use
-this for an `Authorization` header or an API key.
+<Api of="MapRequestInterceptor" /> changes the URL or headers and lets the
+engine fetch. <Api of="MapResourceProvider" /> serves the bytes. A provider
+that accepts a request skips the engine HTTP client. The interceptor can
+change after construction. The provider is fixed at construction.
 
-A <Api of="MapResourceProvider" /> supplies the response bytes. The engine
-skips its HTTP client for every request the provider accepts. Use this for a
-custom URL scheme or an application archive.
+## Rewrite a request
 
-## Add headers or rewrite a URL
-
-<Api of="MapRuntime.setRequestInterceptor" /> replaces the interceptor on a
-live runtime. The change applies to requests that start after the call
-returns:
+<Api of="MapRuntime.setRequestInterceptor" /> applies to every map and
+snapshotter on the runtime:
 
 <Code code={region(requests, "interceptor")} lang="kotlin" title="App.kt" />
 
-Compare the URL against the origins you control before you attach a
-credential. A style also names glyphs, sprites, and tiles on hosts you do not
-own.
+Attach credentials only to hosts you own. A style also names glyphs, sprites,
+and tiles on other hosts.
 
-The interceptor may run on a network thread. It must return quickly, must be
-safe to call concurrently, and must not call map APIs.
+## Serve the bytes
 
-A URL rewrite runs before headers are applied. Header logic should key off the
-URL the client will send.
-
-Pass the same interceptor to <Api of="createMapRuntime" /> in
-`MapRuntimeOptions` when the runtime should start with it.
-
-## Serve bytes from the application
-
-A provider decides first, then loads. <Api of="MapResourceProvider.accepts" />
-runs on a network thread and must return quickly. Return true only for
-requests this provider will load. <Api of="MapResourceProvider.load" /> may
-suspend; cancellation means the map no longer needs that resource.
-
-The shortest form matches a URL scheme:
+Pass a <Api of="MapResourceProvider" /> as `resourceProvider` on the runtime
+options when you call <Api of="createMapRuntime" />. The scheme factory
+accepts every URL with that scheme:
 
 <Code code={region(requests, "provider")} lang="kotlin" title="App.kt" />
-
-Pass the provider in `MapRuntimeOptions` when you call
-<Api of="createMapRuntime" />. A provider is fixed for the lifetime of the
-runtime.
-
-<Aside type="note">
-  On the web, a provider can serve any URL that `accepts` returns true for.
-  Accepted `https` URLs are rewritten to a Compose protocol and served on the
-  main thread.
-</Aside>

--- a/lib/maplibre-compose/src/androidJvmMain/kotlin/org/maplibre/compose/mlnffi/MlnFfiOwnerThread.kt
+++ b/lib/maplibre-compose/src/androidJvmMain/kotlin/org/maplibre/compose/mlnffi/MlnFfiOwnerThread.kt
@@ -25,3 +25,5 @@ internal actual class MlnFfiOwnerThread actual constructor(name: String, body: (
 }
 
 internal actual fun currentMlnFfiThreadName(): String = Thread.currentThread().name
+
+internal actual fun currentMlnFfiThreadKey(): Any = Thread.currentThread()

--- a/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/android/AndroidRuntimeOptions.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/android/AndroidRuntimeOptions.kt
@@ -6,6 +6,8 @@ import co.touchlab.kermit.Logger
 import java.io.File
 import kotlinx.io.files.Path
 import org.maplibre.compose.mlnffi.MlnFfiRuntimeOptions
+import org.maplibre.compose.resource.MapRequestInterceptor
+import org.maplibre.compose.resource.MapResourceProvider
 
 /** Configuration for one MapLibre Native runtime on Android. */
 @Immutable
@@ -21,6 +23,12 @@ public data class AndroidRuntimeOptions(
 
   /** Receives diagnostic messages from maps and shared runtime resources. */
   public val logger: Logger? = Logger.withTag("maplibre-compose"),
+
+  /** Rewrites URLs and headers for every resource this runtime fetches. */
+  public val requestInterceptor: MapRequestInterceptor? = null,
+
+  /** Serves bytes for resource URLs this provider accepts. */
+  public val resourceProvider: MapResourceProvider? = null,
 )
 
 /** Returns the default private cache database for this application. */
@@ -28,4 +36,10 @@ public fun androidCacheFile(context: Context): File =
   context.applicationContext.cacheDir.resolve("maplibre-cache.db")
 
 internal fun AndroidRuntimeOptions.toMlnFfiRuntimeOptions(): MlnFfiRuntimeOptions =
-  MlnFfiRuntimeOptions(Path(cacheFile.absolutePath), maximumCacheSizeBytes, logger)
+  MlnFfiRuntimeOptions(
+    Path(cacheFile.absolutePath),
+    maximumCacheSizeBytes,
+    logger,
+    requestInterceptor,
+    resourceProvider,
+  )

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
@@ -48,6 +48,8 @@ import org.maplibre.compose.layers.layerHandle
 import org.maplibre.compose.offline.CapabilityCheckedOfflineManager
 import org.maplibre.compose.offline.EmptyOfflineManager
 import org.maplibre.compose.offline.OfflineManager
+import org.maplibre.compose.resource.MapRequestInterceptor
+import org.maplibre.compose.resource.MapResourceConfig
 import org.maplibre.compose.sources.SourceHandle
 import org.maplibre.compose.sources.sourceHandle
 import org.maplibre.compose.style.BaseStyle
@@ -85,6 +87,14 @@ public interface MapRuntime {
 
   /** The offline packs and ambient cache managed by this runtime. */
   public val offlineManager: OfflineManager
+
+  /**
+   * Replaces the request interceptor for every map and snapshotter on this runtime.
+   *
+   * A null [interceptor] stops rewriting URLs and headers. The change applies to requests that
+   * start after this call returns.
+   */
+  public fun setRequestInterceptor(interceptor: MapRequestInterceptor?)
 
   /** Creates a logical map. The caller must close the result. */
   public fun createMapState(
@@ -914,6 +924,7 @@ internal class RuntimeImplementation(
   internal val snapshotterAdapterFactory: SnapshotterAdapterFactory =
     UnsupportedSnapshotterAdapterFactory,
   internal val styleEvaluator: StyleCompositionEvaluator = DefaultStyleCompositionEvaluator,
+  internal val resourceConfig: MapResourceConfig = MapResourceConfig(),
 ) : MapRuntime {
   override val offlineManager: OfflineManager =
     CapabilityCheckedOfflineManager(
@@ -942,6 +953,11 @@ internal class RuntimeImplementation(
   ): MapSnapshotter = lock.withLock {
     requireOpenLocked()
     MapSnapshotterImplementation(this, baseStyle, styleComposition).also(snapshotters::add)
+  }
+
+  final override fun setRequestInterceptor(interceptor: MapRequestInterceptor?) {
+    lock.withLock { requireOpenLocked() }
+    resourceConfig.setInterceptor(interceptor)
   }
 
   private fun requireOpen() {

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
@@ -956,8 +956,10 @@ internal class RuntimeImplementation(
   }
 
   final override fun setRequestInterceptor(interceptor: MapRequestInterceptor?) {
-    lock.withLock { requireOpenLocked() }
-    resourceConfig.setInterceptor(interceptor)
+    lock.withLock {
+      requireOpenLocked()
+      resourceConfig.setInterceptor(interceptor)
+    }
   }
 
   private fun requireOpen() {

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/resource/MapResourceConfig.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/resource/MapResourceConfig.kt
@@ -1,0 +1,28 @@
+package org.maplibre.compose.resource
+
+import kotlin.concurrent.atomics.AtomicReference
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+
+/**
+ * Live interceptor and construction-time provider for one [org.maplibre.compose.map.MapRuntime].
+ */
+@OptIn(ExperimentalAtomicApi::class)
+internal class MapResourceConfig(
+  interceptor: MapRequestInterceptor? = null,
+  val provider: MapResourceProvider? = null,
+) {
+  private val interceptorRef = AtomicReference(interceptor)
+
+  fun interceptor(): MapRequestInterceptor? = interceptorRef.load()
+
+  fun setInterceptor(interceptor: MapRequestInterceptor?) {
+    interceptorRef.store(interceptor)
+  }
+}
+
+internal fun MapRequestInterceptor?.transform(request: MapResourceRequest): MapRequestTransform =
+  try {
+    this?.intercept(request) ?: MapRequestTransform()
+  } catch (_: Throwable) {
+    MapRequestTransform()
+  }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/resource/MapResourceConfig.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/resource/MapResourceConfig.kt
@@ -23,7 +23,7 @@ internal class MapResourceConfig(
 internal fun MapRequestInterceptor?.transform(request: MapResourceRequest): MapRequestTransform =
   try {
     this?.intercept(request) ?: MapRequestTransform()
-  } catch (_: Throwable) {
+  } catch (_: Exception) {
     MapRequestTransform()
   }
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/resource/MapResourceConfig.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/resource/MapResourceConfig.kt
@@ -20,12 +20,15 @@ internal class MapResourceConfig(
   }
 }
 
-internal fun MapRequestInterceptor?.transform(request: MapResourceRequest): MapRequestTransform =
-  try {
-    this?.intercept(request) ?: MapRequestTransform()
-  } catch (_: Exception) {
-    MapRequestTransform()
-  }
+internal fun MapRequestInterceptor?.transform(request: MapResourceRequest): MapRequestTransform {
+  val result =
+    try {
+      this?.intercept(request) ?: MapRequestTransform()
+    } catch (_: Exception) {
+      MapRequestTransform()
+    }
+  return if (result.url != null && result.url.isEmpty()) result.copy(url = null) else result
+}
 
 /**
  * Returns false when [MapResourceProvider.accepts] throws, so an engine callback can still decide.

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/resource/MapResourceConfig.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/resource/MapResourceConfig.kt
@@ -33,6 +33,6 @@ internal fun MapRequestInterceptor?.transform(request: MapResourceRequest): MapR
 internal fun MapResourceProvider.acceptsOrDeclines(request: MapResourceRequest): Boolean =
   try {
     accepts(request)
-  } catch (_: Throwable) {
+  } catch (_: Exception) {
     false
   }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/resource/MapResourceConfig.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/resource/MapResourceConfig.kt
@@ -27,7 +27,7 @@ internal fun MapRequestInterceptor?.transform(request: MapResourceRequest): MapR
     } catch (_: Exception) {
       MapRequestTransform()
     }
-  return if (result.url != null && result.url.isEmpty()) result.copy(url = null) else result
+  return if (result.url != null && result.url.isBlank()) result.copy(url = null) else result
 }
 
 /**

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/resource/MapResourceConfig.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/resource/MapResourceConfig.kt
@@ -26,3 +26,13 @@ internal fun MapRequestInterceptor?.transform(request: MapResourceRequest): MapR
   } catch (_: Throwable) {
     MapRequestTransform()
   }
+
+/**
+ * Returns false when [MapResourceProvider.accepts] throws, so an engine callback can still decide.
+ */
+internal fun MapResourceProvider.acceptsOrDeclines(request: MapResourceRequest): Boolean =
+  try {
+    accepts(request)
+  } catch (_: Throwable) {
+    false
+  }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/resource/MapResourceRequests.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/resource/MapResourceRequests.kt
@@ -29,8 +29,8 @@ public data class MapResourceRequest(
 /**
  * Changes to apply to a resource request.
  *
- * A null [url] keeps the incoming URL. [headers] are added to the HTTP request that follows a URL
- * rewrite. Header logic should key off the URL the client will send.
+ * A null or blank [url] keeps the incoming URL. [headers] are added to the HTTP request that
+ * follows a URL rewrite. Header logic should key off the URL the client will send.
  */
 public data class MapRequestTransform(
   public val url: String? = null,

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/resource/MapResourceRequests.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/resource/MapResourceRequests.kt
@@ -19,8 +19,7 @@ public enum class MapResourceKind {
 /**
  * One resource MapLibre is about to fetch.
  *
- * [url] is the URL after the engine resolves tile-server aliases, when the platform supplies a
- * resolved URL.
+ * [url] is the URL after the engine resolves tile-server aliases.
  */
 public data class MapResourceRequest(
   public val url: String,

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/resource/MapResourceRequests.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/resource/MapResourceRequests.kt
@@ -1,0 +1,110 @@
+package org.maplibre.compose.resource
+
+/**
+ * The kind of resource MapLibre is about to fetch.
+ *
+ * A newer engine may report a kind that has no name here; that value becomes [Unknown].
+ */
+public enum class MapResourceKind {
+  Style,
+  Source,
+  Tile,
+  Glyphs,
+  SpriteJson,
+  SpriteImage,
+  Image,
+  Unknown,
+}
+
+/**
+ * One resource MapLibre is about to fetch.
+ *
+ * [url] is the URL after the engine resolves tile-server aliases, when the platform supplies a
+ * resolved URL.
+ */
+public data class MapResourceRequest(
+  public val url: String,
+  public val kind: MapResourceKind,
+)
+
+/**
+ * Changes to apply to a resource request.
+ *
+ * A null [url] keeps the incoming URL. [headers] are added to the HTTP request that follows a URL
+ * rewrite. Header logic should key off the URL the client will send.
+ */
+public data class MapRequestTransform(
+  public val url: String? = null,
+  public val headers: Map<String, String> = emptyMap(),
+)
+
+/**
+ * Rewrites the URL or headers of every resource the runtime fetches.
+ *
+ * The engine may invoke this from network threads. The implementation must return quickly, must be
+ * safe to call concurrently, and must not call map APIs.
+ */
+public fun interface MapRequestInterceptor {
+  public fun intercept(request: MapResourceRequest): MapRequestTransform
+}
+
+/** Bytes or a failure for a request that [MapResourceProvider.accepts] returned true for. */
+public sealed interface MapResourceLoad {
+  /**
+   * A successful body for the request.
+   *
+   * [etag] and [mustRevalidate] are optional cache validators. Native applies them to the ambient
+   * cache; the browser ignores them.
+   */
+  public class Bytes(
+    public val bytes: ByteArray,
+    public val etag: String? = null,
+    public val mustRevalidate: Boolean = false,
+  ) : MapResourceLoad
+
+  /** A failure that MapLibre should treat as a failed fetch. */
+  public data class Failed(public val message: String) : MapResourceLoad
+}
+
+/**
+ * Serves resource bytes for requests the application accepts.
+ *
+ * [accepts] runs on a network thread and must return quickly. Return true only for requests this
+ * provider will load. [load] may suspend; cancellation means the engine no longer needs the
+ * resource.
+ *
+ * A true [accepts] result skips the engine HTTP client for that request, including its cache and
+ * retry.
+ */
+public interface MapResourceProvider {
+  public fun accepts(request: MapResourceRequest): Boolean
+
+  public suspend fun load(request: MapResourceRequest): MapResourceLoad
+}
+
+/** Returns a provider that calls [accepts] and [load]. */
+public fun MapResourceProvider(
+  accepts: (MapResourceRequest) -> Boolean,
+  load: suspend (MapResourceRequest) -> MapResourceLoad,
+): MapResourceProvider =
+  object : MapResourceProvider {
+    override fun accepts(request: MapResourceRequest): Boolean = accepts(request)
+
+    override suspend fun load(request: MapResourceRequest): MapResourceLoad = load(request)
+  }
+
+/**
+ * Returns a provider that serves URLs whose scheme is [scheme].
+ *
+ * [scheme] is the scheme name without a trailing colon, such as `app`.
+ */
+public fun MapResourceProvider(
+  scheme: String,
+  load: suspend (MapResourceRequest) -> ByteArray,
+): MapResourceProvider {
+  val prefix = "${scheme.trimEnd(':')}:"
+  return MapResourceProvider(
+    accepts = { request -> request.url.startsWith(prefix, ignoreCase = true) },
+    load = { request -> MapResourceLoad.Bytes(load(request)) },
+  )
+}

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/resource/MapResourceUrlCodec.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/resource/MapResourceUrlCodec.kt
@@ -1,0 +1,42 @@
+package org.maplibre.compose.resource
+
+/** Percent-encodes a resource URL so it can sit in a custom-scheme path. */
+internal fun encodeResourceUrl(url: String): String {
+  val out = StringBuilder(url.length)
+  for (byte in url.encodeToByteArray()) {
+    val value = byte.toInt() and 0xFF
+    val char = value.toChar()
+    if (char.isUnreserved()) out.append(char)
+    else {
+      out.append('%')
+      out.append(value.toString(16).padStart(2, '0').uppercase())
+    }
+  }
+  return out.toString()
+}
+
+internal fun decodeResourceUrl(encoded: String): String {
+  val bytes = ArrayList<Byte>(encoded.length)
+  var index = 0
+  while (index < encoded.length) {
+    val char = encoded[index]
+    if (char == '%' && index + 2 < encoded.length) {
+      val hex = encoded.substring(index + 1, index + 3)
+      bytes += hex.toInt(16).toByte()
+      index += 3
+    } else {
+      bytes += char.code.toByte()
+      index += 1
+    }
+  }
+  return bytes.toByteArray().decodeToString()
+}
+
+private fun Char.isUnreserved(): Boolean =
+  this in 'a'..'z' ||
+    this in 'A'..'Z' ||
+    this in '0'..'9' ||
+    this == '-' ||
+    this == '_' ||
+    this == '.' ||
+    this == '~'

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/resource/MapRequestInterceptorTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/resource/MapRequestInterceptorTest.kt
@@ -13,7 +13,7 @@ class MapRequestInterceptorTest {
 
   @Test
   fun a_blank_url_rewrite_keeps_the_incoming_url() {
-    val interceptor = MapRequestInterceptor { MapRequestTransform(url = "") }
+    val interceptor = MapRequestInterceptor { MapRequestTransform(url = "   ") }
     val transform = interceptor.transform(REQUEST)
     assertEquals(null, transform.url)
   }

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/resource/MapRequestInterceptorTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/resource/MapRequestInterceptorTest.kt
@@ -53,6 +53,13 @@ class MapRequestInterceptorTest {
   }
 
   @Test
+  fun an_accepts_exception_declines_the_request() {
+    val provider =
+      MapResourceProvider(accepts = { error("classifier exploded") }, load = { error("unused") })
+    assertFalse(provider.acceptsOrDeclines(REQUEST))
+  }
+
+  @Test
   fun a_scheme_provider_accepts_only_that_scheme() = runTest {
     val provider = MapResourceProvider("app") { "body".encodeToByteArray() }
     assertTrue(provider.accepts(MapResourceRequest("app://style.json", MapResourceKind.Style)))

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/resource/MapRequestInterceptorTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/resource/MapRequestInterceptorTest.kt
@@ -35,11 +35,11 @@ class MapRequestInterceptorTest {
 
   @Test
   fun a_fatal_interceptor_error_propagates() {
-    val interceptor = MapRequestInterceptor { throw OutOfMemoryError("heap") }
+    val interceptor = MapRequestInterceptor { throw FatalTestError() }
     try {
       interceptor.transform(REQUEST)
-      error("expected OutOfMemoryError")
-    } catch (_: OutOfMemoryError) {}
+      error("expected FatalTestError")
+    } catch (_: FatalTestError) {}
   }
 
   @Test
@@ -78,11 +78,11 @@ class MapRequestInterceptorTest {
   @Test
   fun a_fatal_accepts_error_propagates() {
     val provider =
-      MapResourceProvider(accepts = { throw OutOfMemoryError("heap") }, load = { error("unused") })
+      MapResourceProvider(accepts = { throw FatalTestError() }, load = { error("unused") })
     try {
       provider.acceptsOrDeclines(REQUEST)
-      error("expected OutOfMemoryError")
-    } catch (_: OutOfMemoryError) {}
+      error("expected FatalTestError")
+    } catch (_: FatalTestError) {}
   }
 
   @Test
@@ -108,3 +108,5 @@ class MapRequestInterceptorTest {
     val REQUEST = MapResourceRequest("https://tiles.example.com/style.json", MapResourceKind.Style)
   }
 }
+
+private class FatalTestError : Error("heap")

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/resource/MapRequestInterceptorTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/resource/MapRequestInterceptorTest.kt
@@ -12,6 +12,13 @@ import org.maplibre.compose.map.mapRuntimeForTest
 class MapRequestInterceptorTest {
 
   @Test
+  fun a_blank_url_rewrite_keeps_the_incoming_url() {
+    val interceptor = MapRequestInterceptor { MapRequestTransform(url = "") }
+    val transform = interceptor.transform(REQUEST)
+    assertEquals(null, transform.url)
+  }
+
+  @Test
   fun a_null_interceptor_keeps_the_url_and_adds_no_headers() {
     val transform = (null as MapRequestInterceptor?).transform(REQUEST)
     assertEquals(null, transform.url)

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/resource/MapRequestInterceptorTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/resource/MapRequestInterceptorTest.kt
@@ -27,6 +27,15 @@ class MapRequestInterceptorTest {
   }
 
   @Test
+  fun a_fatal_interceptor_error_propagates() {
+    val interceptor = MapRequestInterceptor { throw OutOfMemoryError("heap") }
+    try {
+      interceptor.transform(REQUEST)
+      error("expected OutOfMemoryError")
+    } catch (_: OutOfMemoryError) {}
+  }
+
+  @Test
   fun set_request_interceptor_replaces_the_live_callback() {
     val runtime = mapRuntimeForTest()
     val first = MapRequestInterceptor { MapRequestTransform(url = "https://first.example/style") }

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/resource/MapRequestInterceptorTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/resource/MapRequestInterceptorTest.kt
@@ -60,6 +60,16 @@ class MapRequestInterceptorTest {
   }
 
   @Test
+  fun a_fatal_accepts_error_propagates() {
+    val provider =
+      MapResourceProvider(accepts = { throw OutOfMemoryError("heap") }, load = { error("unused") })
+    try {
+      provider.acceptsOrDeclines(REQUEST)
+      error("expected OutOfMemoryError")
+    } catch (_: OutOfMemoryError) {}
+  }
+
+  @Test
   fun a_scheme_provider_accepts_only_that_scheme() = runTest {
     val provider = MapResourceProvider("app") { "body".encodeToByteArray() }
     assertTrue(provider.accepts(MapResourceRequest("app://style.json", MapResourceKind.Style)))

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/resource/MapRequestInterceptorTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/resource/MapRequestInterceptorTest.kt
@@ -1,0 +1,77 @@
+package org.maplibre.compose.resource
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+import org.maplibre.compose.map.MapRuntimeClosedException
+import org.maplibre.compose.map.RuntimeImplementation
+import org.maplibre.compose.map.mapRuntimeForTest
+
+class MapRequestInterceptorTest {
+
+  @Test
+  fun a_null_interceptor_keeps_the_url_and_adds_no_headers() {
+    val transform = (null as MapRequestInterceptor?).transform(REQUEST)
+    assertEquals(null, transform.url)
+    assertEquals(emptyMap(), transform.headers)
+  }
+
+  @Test
+  fun an_interceptor_exception_keeps_the_original_request() {
+    val interceptor = MapRequestInterceptor { error("token store exploded") }
+    val transform = interceptor.transform(REQUEST)
+    assertEquals(null, transform.url)
+    assertEquals(emptyMap(), transform.headers)
+  }
+
+  @Test
+  fun set_request_interceptor_replaces_the_live_callback() {
+    val runtime = mapRuntimeForTest()
+    val first = MapRequestInterceptor { MapRequestTransform(url = "https://first.example/style") }
+    val second = MapRequestInterceptor { MapRequestTransform(url = "https://second.example/style") }
+    runtime.setRequestInterceptor(first)
+    val config = (runtime as RuntimeImplementation).resourceConfig
+    assertEquals("https://first.example/style", config.interceptor().transform(REQUEST).url)
+    runtime.setRequestInterceptor(second)
+    assertEquals("https://second.example/style", config.interceptor().transform(REQUEST).url)
+    runtime.setRequestInterceptor(null)
+    assertEquals(null, config.interceptor())
+    runtime.close()
+  }
+
+  @Test
+  fun set_request_interceptor_fails_after_the_runtime_closes() = runTest {
+    val runtime = mapRuntimeForTest()
+    runtime.close()
+    runtime.awaitClosed()
+    try {
+      runtime.setRequestInterceptor(MapRequestInterceptor { MapRequestTransform() })
+      error("expected MapRuntimeClosedException")
+    } catch (_: MapRuntimeClosedException) {}
+  }
+
+  @Test
+  fun a_scheme_provider_accepts_only_that_scheme() = runTest {
+    val provider = MapResourceProvider("app") { "body".encodeToByteArray() }
+    assertTrue(provider.accepts(MapResourceRequest("app://style.json", MapResourceKind.Style)))
+    assertTrue(provider.accepts(MapResourceRequest("APP://style.json", MapResourceKind.Style)))
+    assertFalse(
+      provider.accepts(MapResourceRequest("https://example.test/style.json", MapResourceKind.Style))
+    )
+    val load = provider.load(MapResourceRequest("app://style.json", MapResourceKind.Style))
+    val bytes = load as MapResourceLoad.Bytes
+    assertEquals("body", bytes.bytes.decodeToString())
+  }
+
+  @Test
+  fun encode_and_decode_preserve_a_url_with_punctuation() {
+    val url = "https://tiles.example.com/style.json?key=a+b&x=1"
+    assertEquals(url, decodeResourceUrl(encodeResourceUrl(url)))
+  }
+
+  private companion object {
+    val REQUEST = MapResourceRequest("https://tiles.example.com/style.json", MapResourceKind.Style)
+  }
+}

--- a/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/ios/IosRuntimeOptions.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/ios/IosRuntimeOptions.kt
@@ -4,6 +4,8 @@ import androidx.compose.runtime.Immutable
 import co.touchlab.kermit.Logger
 import kotlinx.io.files.Path
 import org.maplibre.compose.mlnffi.MlnFfiRuntimeOptions
+import org.maplibre.compose.resource.MapRequestInterceptor
+import org.maplibre.compose.resource.MapResourceProvider
 import platform.Foundation.NSCachesDirectory
 import platform.Foundation.NSSearchPathForDirectoriesInDomains
 import platform.Foundation.NSUserDomainMask
@@ -19,6 +21,12 @@ public data class IosRuntimeOptions(
 
   /** Receives diagnostic messages from maps and shared runtime resources. */
   public val logger: Logger? = Logger.withTag("maplibre-compose"),
+
+  /** Rewrites URLs and headers for every resource this runtime fetches. */
+  public val requestInterceptor: MapRequestInterceptor? = null,
+
+  /** Serves bytes for resource URLs this provider accepts. */
+  public val resourceProvider: MapResourceProvider? = null,
 )
 
 /** Returns the default private cache database for this application. */
@@ -30,4 +38,10 @@ public fun iosCacheFile(): String {
 }
 
 internal fun IosRuntimeOptions.toMlnFfiRuntimeOptions(): MlnFfiRuntimeOptions =
-  MlnFfiRuntimeOptions(Path(cacheFile), maximumCacheSizeBytes, logger)
+  MlnFfiRuntimeOptions(
+    Path(cacheFile),
+    maximumCacheSizeBytes,
+    logger,
+    requestInterceptor,
+    resourceProvider,
+  )

--- a/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/mlnffi/MlnFfiOwnerThread.ios.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/mlnffi/MlnFfiOwnerThread.ios.kt
@@ -124,3 +124,6 @@ internal actual fun currentMlnFfiThreadName(): String = memScoped {
   }
   name.toKString()
 }
+
+internal actual fun currentMlnFfiThreadKey(): Any =
+  checkNotNull(pthread_self()) { "pthread_self returned null" }

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsTypes.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsTypes.kt
@@ -32,6 +32,7 @@ internal external interface MapOptions {
   var canvasContextAttributes: CanvasContextAttributes?
   /** `[width, height]` in physical pixels, above which MapLibre lowers its own pixel ratio. */
   var maxCanvasSize: Array<Double>?
+  var transformRequest: ((url: String, resourceType: String?) -> Any?)?
 }
 
 internal external interface CanvasContextAttributes {
@@ -58,6 +59,7 @@ internal external interface SourceSpecification
 
 internal external interface RequestParameters {
   val url: String
+  val headers: Any?
 }
 
 internal external interface ProtocolResponse {

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
@@ -51,6 +51,7 @@ import org.maplibre.compose.gljs.queryPoint
 import org.maplibre.compose.gljs.styleJson
 import org.maplibre.compose.gljs.styleUrl
 import org.maplibre.compose.gljs.subscribe
+import org.maplibre.compose.resource.GlJsRequestController
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.compose.style.DesiredStyleRevision
 import org.maplibre.compose.style.GlJsStyleBinding
@@ -91,6 +92,7 @@ internal class GlJsMapSession(
   callbacks: MapAdapter.Callbacks,
   internal var logger: Logger?,
   internal var layoutDirection: LayoutDirection,
+  private val requests: GlJsRequestController? = null,
 ) : MapLifecycleSession, GlJsMapRenderer, GestureTarget {
 
   init {
@@ -335,6 +337,9 @@ internal class GlJsMapSession(
           // MapLibre otherwise clamps its pixel ratio to the drawing buffer of the canvas it
           // shares, which is Compose's whole viewport at the moment the map was built.
           maxCanvasSize = maxTextureSize(it.gl)
+        }
+        requests?.let { controller ->
+          transformRequest = { url, resourceType -> controller.transformRequest(url, resourceType) }
         }
       }
     GlJsRuntime.pointAtWorker(DEFAULT_WORKER_URL)

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsSnapshotterAdapter.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsSnapshotterAdapter.kt
@@ -19,6 +19,7 @@ import org.maplibre.compose.gljs.isTerminalStyleLoadFailure
 import org.maplibre.compose.gljs.styleJson
 import org.maplibre.compose.gljs.styleUrl
 import org.maplibre.compose.gljs.subscribe
+import org.maplibre.compose.resource.GlJsRequestController
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.compose.style.DesiredStyleRevision
 import org.maplibre.compose.style.GlJsStyleBinding
@@ -30,13 +31,18 @@ import web.dom.document
 import web.html.HTMLCanvasElement
 import web.html.HTMLElement
 
-internal class GlJsSnapshotterAdapterFactory(private val logger: Logger?) :
-  SnapshotterAdapterFactory {
-  override fun create(): SnapshotterAdapter = GlJsSnapshotterAdapter(logger)
+internal class GlJsSnapshotterAdapterFactory(
+  private val logger: Logger?,
+  private val requests: GlJsRequestController? = null,
+) : SnapshotterAdapterFactory {
+  override fun create(): SnapshotterAdapter = GlJsSnapshotterAdapter(logger, requests)
 }
 
 /** One private GL JS map and DOM target for a Web snapshotter. */
-private class GlJsSnapshotterAdapter(private val logger: Logger?) : SnapshotterAdapter {
+private class GlJsSnapshotterAdapter(
+  private val logger: Logger?,
+  private val requests: GlJsRequestController?,
+) : SnapshotterAdapter {
   private var open = true
   private var map: MaplibreMap? = null
   private var container: HTMLElement? = null
@@ -191,6 +197,9 @@ private class GlJsSnapshotterAdapter(private val logger: Logger?) : SnapshotterA
         maxCanvasSize = arrayOf(MAX_CANVAS_SIZE.toDouble(), MAX_CANVAS_SIZE.toDouble())
         canvasContextAttributes =
           unsafeJso<CanvasContextAttributes> { preserveDrawingBuffer = true }
+        requests?.let { controller ->
+          transformRequest = { url, resourceType -> controller.transformRequest(url, resourceType) }
+        }
       }
     GlJsRuntime.pointAtWorker(DEFAULT_WORKER_URL)
     return try {

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/JsMapView.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/JsMapView.kt
@@ -40,6 +40,7 @@ internal actual fun ComposableMapView(
         callbacks = callbacks,
         logger = logger,
         layoutDirection = layoutDirection,
+        requests = state.runtime.jsRequests,
       )
     }
 

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/MapRuntime.js.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/MapRuntime.js.kt
@@ -3,6 +3,10 @@ package org.maplibre.compose.map
 import androidx.compose.runtime.Composable
 import co.touchlab.kermit.Logger
 import org.maplibre.compose.offline.EmptyOfflineManager
+import org.maplibre.compose.resource.GlJsRequestController
+import org.maplibre.compose.resource.MapRequestInterceptor
+import org.maplibre.compose.resource.MapResourceConfig
+import org.maplibre.compose.resource.MapResourceProvider
 
 private val webMapRuntimeCapabilities =
   MapRuntimeCapabilities(
@@ -12,18 +16,34 @@ private val webMapRuntimeCapabilities =
 
 /** Browser runtime configuration. */
 public actual data class MapRuntimeOptions(
-  public val logger: Logger? = Logger.withTag("maplibre-compose")
+  public val logger: Logger? = Logger.withTag("maplibre-compose"),
+  /** Rewrites URLs and headers for every resource this runtime fetches. */
+  public val requestInterceptor: MapRequestInterceptor? = null,
+  /** Serves bytes for resource URLs this provider accepts. */
+  public val resourceProvider: MapResourceProvider? = null,
 )
 
-public actual fun createMapRuntime(options: MapRuntimeOptions): MapRuntime =
-  RuntimeImplementation(
-    platformOptions = options,
-    resources = MapRuntimeResources {},
+internal class JsRuntimePlatform(
+  val options: MapRuntimeOptions,
+  val requests: GlJsRequestController,
+)
+
+public actual fun createMapRuntime(options: MapRuntimeOptions): MapRuntime {
+  val resourceConfig = MapResourceConfig(options.requestInterceptor, options.resourceProvider)
+  val requests = GlJsRequestController(resourceConfig)
+  return RuntimeImplementation(
+    platformOptions = JsRuntimePlatform(options, requests),
+    resources = MapRuntimeResources { requests.close() },
     logger = options.logger,
     capabilities = webMapRuntimeCapabilities,
     offlineManagerBackend = EmptyOfflineManager,
-    snapshotterAdapterFactory = GlJsSnapshotterAdapterFactory(options.logger),
+    snapshotterAdapterFactory = GlJsSnapshotterAdapterFactory(options.logger, requests),
+    resourceConfig = resourceConfig,
   )
+}
+
+internal val RuntimeImplementation.jsRequests: GlJsRequestController?
+  get() = (platformOptions as? JsRuntimePlatform)?.requests
 
 private val processMapRuntime: MapRuntime = createMapRuntime(MapRuntimeOptions())
 

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/resource/GlJsRequestController.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/resource/GlJsRequestController.kt
@@ -17,7 +17,7 @@ import org.maplibre.compose.gljs.addProtocol
 import org.maplibre.compose.gljs.removeProtocol
 
 internal class GlJsRequestController(private val config: MapResourceConfig) : AutoCloseable {
-  val scheme = newResourceProtocolScheme()
+  val scheme: String by lazy { newResourceProtocolScheme() }
   private val scope =
     CoroutineScope(
       SupervisorJob() + Dispatchers.Default + CoroutineName("maplibre-compose-js-resource")
@@ -96,9 +96,23 @@ internal class GlJsRequestController(private val config: MapResourceConfig) : Au
   }
 }
 
-/** A per-runtime scheme that another map on the page cannot guess. */
+/**
+ * A per-runtime scheme that another map on the page cannot guess.
+ *
+ * Uses `crypto.getRandomValues`, which is present in non-secure HTTP contexts where
+ * `crypto.randomUUID` is not.
+ */
 private fun newResourceProtocolScheme(): String {
-  val token = js("crypto.randomUUID()").unsafeCast<String>().replace("-", "")
+  val bytes = Uint8Array<ArrayBuffer>(16)
+  js("crypto.getRandomValues")(bytes)
+  val token =
+    buildString(32) {
+      for (index in 0 until 16) {
+        val value = bytes.asDynamic()[index].unsafeCast<Int>()
+        append("0123456789abcdef"[value ushr 4])
+        append("0123456789abcdef"[value and 0x0f])
+      }
+    }
   return "mlc-res-$token"
 }
 

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/resource/GlJsRequestController.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/resource/GlJsRequestController.kt
@@ -48,7 +48,7 @@ internal class GlJsRequestController(private val config: MapResourceConfig) : Au
     request: RequestParameters,
     abortController: Any,
   ): Promise<ProtocolResponse> {
-    val parsed = parseProtocolUrl(request.url)
+    val parsed = requireAccepted(request.url)
     val work = scope.async {
       val provider =
         config.provider ?: throw IllegalStateException("No resource provider is installed")
@@ -67,6 +67,16 @@ internal class GlJsRequestController(private val config: MapResourceConfig) : Au
 
   fun protocolUrl(url: String, kind: MapResourceKind): String =
     "$scheme://${kind.name}/${encodeResourceUrl(url)}"
+
+  internal fun requireAccepted(protocolUrl: String): MapResourceRequest {
+    val parsed = parseProtocolUrl(protocolUrl)
+    val provider =
+      config.provider ?: throw IllegalStateException("No resource provider is installed")
+    if (!provider.acceptsOrDeclines(parsed)) {
+      throw IllegalStateException("Resource provider declined ${parsed.url}")
+    }
+    return parsed
+  }
 
   fun parseProtocolUrl(protocolUrl: String): MapResourceRequest {
     val remainder = protocolUrl.substringAfter("://")

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/resource/GlJsRequestController.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/resource/GlJsRequestController.kt
@@ -36,7 +36,7 @@ internal class GlJsRequestController(private val config: MapResourceConfig) : Au
     val incoming = MapResourceRequest(url, kind)
     val transform = config.interceptor().transform(incoming)
     val nextUrl = transform.url ?: url
-    val accepted = config.provider?.accepts(MapResourceRequest(nextUrl, kind)) == true
+    val accepted = config.provider?.acceptsOrDeclines(MapResourceRequest(nextUrl, kind)) == true
     if (!accepted && transform.url == null && transform.headers.isEmpty()) return undefined
     return requestParameters(
       url = if (accepted) protocolUrl(nextUrl, kind) else nextUrl,
@@ -72,10 +72,7 @@ internal class GlJsRequestController(private val config: MapResourceConfig) : Au
     val remainder = protocolUrl.substringAfter("://")
     val separator = remainder.indexOf('/')
     require(separator > 0) { "Invalid resource protocol URL: $protocolUrl" }
-    val kind =
-      remainder.substring(0, separator).toResourceKind().takeUnless {
-        it == MapResourceKind.Unknown
-      } ?: MapResourceKind.Unknown
+    val kind = remainder.substring(0, separator).toStoredResourceKind()
     return MapResourceRequest(decodeResourceUrl(remainder.substring(separator + 1)), kind)
   }
 
@@ -104,6 +101,10 @@ internal fun String?.toResourceKind(): MapResourceKind =
     "Image" -> MapResourceKind.Image
     else -> MapResourceKind.Unknown
   }
+
+/** Parses a kind that [GlJsRequestController.protocolUrl] stored as [MapResourceKind.name]. */
+internal fun String.toStoredResourceKind(): MapResourceKind =
+  MapResourceKind.entries.firstOrNull { it.name == this } ?: MapResourceKind.Unknown
 
 private fun requestParameters(url: String, headers: Map<String, String>): Any {
   val params = js("{}")

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/resource/GlJsRequestController.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/resource/GlJsRequestController.kt
@@ -1,0 +1,123 @@
+package org.maplibre.compose.resource
+
+import js.buffer.ArrayBuffer
+import js.objects.unsafeJso
+import js.typedarrays.Uint8Array
+import kotlin.js.Promise
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.asPromise
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
+import org.maplibre.compose.gljs.ProtocolResponse
+import org.maplibre.compose.gljs.RequestParameters
+import org.maplibre.compose.gljs.addProtocol
+import org.maplibre.compose.gljs.removeProtocol
+
+internal class GlJsRequestController(private val config: MapResourceConfig) : AutoCloseable {
+  val scheme = "mlc-res-${nextId++}"
+  private val scope =
+    CoroutineScope(
+      SupervisorJob() + Dispatchers.Default + CoroutineName("maplibre-compose-js-resource")
+    )
+  private val protocolInstalled = config.provider != null
+  private var open = true
+
+  init {
+    if (protocolInstalled) {
+      addProtocol(scheme) { request, abortController -> loadProtocol(request, abortController) }
+    }
+  }
+
+  fun transformRequest(url: String, resourceType: String?): Any? {
+    val kind = resourceType.toResourceKind()
+    val incoming = MapResourceRequest(url, kind)
+    val transform = config.interceptor().transform(incoming)
+    val nextUrl = transform.url ?: url
+    val accepted = config.provider?.accepts(MapResourceRequest(nextUrl, kind)) == true
+    if (!accepted && transform.url == null && transform.headers.isEmpty()) return undefined
+    return requestParameters(
+      url = if (accepted) protocolUrl(nextUrl, kind) else nextUrl,
+      headers = transform.headers,
+    )
+  }
+
+  private fun loadProtocol(
+    request: RequestParameters,
+    abortController: Any,
+  ): Promise<ProtocolResponse> {
+    val parsed = parseProtocolUrl(request.url)
+    val work = scope.async {
+      val provider =
+        config.provider ?: throw IllegalStateException("No resource provider is installed")
+      when (val result = provider.load(MapResourceRequest(parsed.url, parsed.kind))) {
+        is MapResourceLoad.Bytes -> result.bytes.toProtocolResponse()
+        is MapResourceLoad.Failed -> throw IllegalStateException(result.message)
+      }
+    }
+    val signal = abortController.asDynamic().signal
+    val abort: () -> Unit = { work.cancel() }
+    signal.addEventListener("abort", abort)
+    work.invokeOnCompletion { signal.removeEventListener("abort", abort) }
+    if (signal.aborted == true) work.cancel()
+    return work.asPromise()
+  }
+
+  fun protocolUrl(url: String, kind: MapResourceKind): String =
+    "$scheme://${kind.name}/${encodeResourceUrl(url)}"
+
+  fun parseProtocolUrl(protocolUrl: String): MapResourceRequest {
+    val remainder = protocolUrl.substringAfter("://")
+    val separator = remainder.indexOf('/')
+    require(separator > 0) { "Invalid resource protocol URL: $protocolUrl" }
+    val kind =
+      remainder.substring(0, separator).toResourceKind().takeUnless {
+        it == MapResourceKind.Unknown
+      } ?: MapResourceKind.Unknown
+    return MapResourceRequest(decodeResourceUrl(remainder.substring(separator + 1)), kind)
+  }
+
+  override fun close() {
+    if (!open) return
+    open = false
+    scope.cancel()
+    if (protocolInstalled) removeProtocol(scheme)
+  }
+
+  private companion object {
+    var nextId = 1L
+  }
+}
+
+private val undefined: Any? = js("undefined")
+
+internal fun String?.toResourceKind(): MapResourceKind =
+  when (this) {
+    "Style" -> MapResourceKind.Style
+    "Source" -> MapResourceKind.Source
+    "Tile" -> MapResourceKind.Tile
+    "Glyphs" -> MapResourceKind.Glyphs
+    "SpriteJSON" -> MapResourceKind.SpriteJson
+    "SpriteImage" -> MapResourceKind.SpriteImage
+    "Image" -> MapResourceKind.Image
+    else -> MapResourceKind.Unknown
+  }
+
+private fun requestParameters(url: String, headers: Map<String, String>): Any {
+  val params = js("{}")
+  params.url = url
+  if (headers.isNotEmpty()) {
+    val headerObject = js("{}")
+    headers.forEach { (name, value) -> headerObject[name] = value }
+    params.headers = headerObject
+  }
+  return params
+}
+
+private fun ByteArray.toProtocolResponse(): ProtocolResponse {
+  val bytes = Uint8Array<ArrayBuffer>(size)
+  forEachIndexed { index, byte -> bytes.asDynamic()[index] = byte.toInt() and 0xFF }
+  return unsafeJso { data = bytes.buffer }
+}

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/resource/GlJsRequestController.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/resource/GlJsRequestController.kt
@@ -17,7 +17,7 @@ import org.maplibre.compose.gljs.addProtocol
 import org.maplibre.compose.gljs.removeProtocol
 
 internal class GlJsRequestController(private val config: MapResourceConfig) : AutoCloseable {
-  val scheme = "mlc-res-${nextId++}"
+  val scheme = newResourceProtocolScheme()
   private val scope =
     CoroutineScope(
       SupervisorJob() + Dispatchers.Default + CoroutineName("maplibre-compose-js-resource")
@@ -79,7 +79,9 @@ internal class GlJsRequestController(private val config: MapResourceConfig) : Au
   }
 
   fun parseProtocolUrl(protocolUrl: String): MapResourceRequest {
-    val remainder = protocolUrl.substringAfter("://")
+    val prefix = "$scheme://"
+    require(protocolUrl.startsWith(prefix)) { "Invalid resource protocol URL: $protocolUrl" }
+    val remainder = protocolUrl.substring(prefix.length)
     val separator = remainder.indexOf('/')
     require(separator > 0) { "Invalid resource protocol URL: $protocolUrl" }
     val kind = remainder.substring(0, separator).toStoredResourceKind()
@@ -92,10 +94,12 @@ internal class GlJsRequestController(private val config: MapResourceConfig) : Au
     scope.cancel()
     if (protocolInstalled) removeProtocol(scheme)
   }
+}
 
-  private companion object {
-    var nextId = 1L
-  }
+/** A per-runtime scheme that another map on the page cannot guess. */
+private fun newResourceProtocolScheme(): String {
+  val token = js("crypto.randomUUID()").unsafeCast<String>().replace("-", "")
+  return "mlc-res-$token"
 }
 
 private val undefined: Any? = js("undefined")

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/resource/GlJsRequestControllerTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/resource/GlJsRequestControllerTest.kt
@@ -2,6 +2,8 @@ package org.maplibre.compose.resource
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFails
+import kotlin.test.assertNotEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -97,6 +99,25 @@ class GlJsRequestControllerTest {
   }
 
   @Test
+  fun each_runtime_registers_an_unguessable_protocol_scheme() {
+    val first =
+      GlJsRequestController(
+        MapResourceConfig(provider = MapResourceProvider("app") { ByteArray(0) })
+      )
+    val second =
+      GlJsRequestController(
+        MapResourceConfig(provider = MapResourceProvider("app") { ByteArray(0) })
+      )
+    assertTrue(SCHEME.matches(first.scheme))
+    assertTrue(SCHEME.matches(second.scheme))
+    assertNotEquals(first.scheme, second.scheme)
+    val foreign = first.protocolUrl("app://style.json", MapResourceKind.Style)
+    assertFails { second.requireAccepted(foreign) }
+    first.close()
+    second.close()
+  }
+
+  @Test
   fun a_rejected_https_url_is_not_rewritten_to_the_protocol() {
     val controller =
       GlJsRequestController(
@@ -104,5 +125,9 @@ class GlJsRequestControllerTest {
       )
     assertNull(controller.transformRequest("https://tiles.example.com/style.json", "Tile"))
     controller.close()
+  }
+
+  private companion object {
+    val SCHEME = Regex("^mlc-res-[0-9a-f]{32}$")
   }
 }

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/resource/GlJsRequestControllerTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/resource/GlJsRequestControllerTest.kt
@@ -1,0 +1,61 @@
+package org.maplibre.compose.resource
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class GlJsRequestControllerTest {
+
+  @Test
+  fun an_empty_config_leaves_the_request_unchanged() {
+    val controller = GlJsRequestController(MapResourceConfig())
+    assertNull(controller.transformRequest("https://tiles.example.com/style.json", "Style"))
+    controller.close()
+  }
+
+  @Test
+  fun an_interceptor_rewrites_the_url_and_adds_headers() {
+    val controller =
+      GlJsRequestController(
+        MapResourceConfig(
+          interceptor = { request ->
+            MapRequestTransform(
+              url = request.url.replace("http://", "https://"),
+              headers = mapOf("Authorization" to "Bearer x"),
+            )
+          }
+        )
+      )
+    val result = controller.transformRequest("http://tiles.example.com/style.json", "Style")
+    val dynamic = result.asDynamic()
+    assertEquals("https://tiles.example.com/style.json", dynamic.url as String)
+    assertEquals("Bearer x", dynamic.headers["Authorization"] as String)
+    controller.close()
+  }
+
+  @Test
+  fun an_accepted_provider_rewrites_to_the_runtime_protocol() {
+    val controller =
+      GlJsRequestController(
+        MapResourceConfig(provider = MapResourceProvider("app") { ByteArray(0) })
+      )
+    val result = controller.transformRequest("app://style.json", "Style")
+    val url = result.asDynamic().url as String
+    assertTrue(url.startsWith("${controller.scheme}://Style/"))
+    val parsed = controller.parseProtocolUrl(url)
+    assertEquals("app://style.json", parsed.url)
+    assertEquals(MapResourceKind.Style, parsed.kind)
+    controller.close()
+  }
+
+  @Test
+  fun a_rejected_https_url_is_not_rewritten_to_the_protocol() {
+    val controller =
+      GlJsRequestController(
+        MapResourceConfig(provider = MapResourceProvider("app") { ByteArray(0) })
+      )
+    assertNull(controller.transformRequest("https://tiles.example.com/style.json", "Tile"))
+    controller.close()
+  }
+}

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/resource/GlJsRequestControllerTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/resource/GlJsRequestControllerTest.kt
@@ -50,6 +50,37 @@ class GlJsRequestControllerTest {
   }
 
   @Test
+  fun a_protocol_url_round_trips_sprite_json() {
+    val controller =
+      GlJsRequestController(
+        MapResourceConfig(provider = MapResourceProvider("app") { ByteArray(0) })
+      )
+    val result = controller.transformRequest("app://sprite.json", "SpriteJSON")
+    val url = result.asDynamic().url as String
+    assertTrue(url.startsWith("${controller.scheme}://SpriteJson/"))
+    val parsed = controller.parseProtocolUrl(url)
+    assertEquals("app://sprite.json", parsed.url)
+    assertEquals(MapResourceKind.SpriteJson, parsed.kind)
+    controller.close()
+  }
+
+  @Test
+  fun an_accepts_exception_leaves_the_https_request_unchanged() {
+    val controller =
+      GlJsRequestController(
+        MapResourceConfig(
+          provider =
+            MapResourceProvider(
+              accepts = { error("classifier exploded") },
+              load = { error("unused") },
+            )
+        )
+      )
+    assertNull(controller.transformRequest("https://tiles.example.com/style.json", "Style"))
+    controller.close()
+  }
+
+  @Test
   fun a_rejected_https_url_is_not_rewritten_to_the_protocol() {
     val controller =
       GlJsRequestController(

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/resource/GlJsRequestControllerTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/resource/GlJsRequestControllerTest.kt
@@ -81,6 +81,22 @@ class GlJsRequestControllerTest {
   }
 
   @Test
+  fun a_forged_protocol_url_is_declined() {
+    val controller =
+      GlJsRequestController(
+        MapResourceConfig(provider = MapResourceProvider("app") { ByteArray(0) })
+      )
+    val forged = controller.protocolUrl("https://evil.example/style.json", MapResourceKind.Style)
+    try {
+      controller.requireAccepted(forged)
+      error("expected the provider to decline the forged URL")
+    } catch (error: IllegalStateException) {
+      assertTrue(error.message.orEmpty().contains("declined"))
+    }
+    controller.close()
+  }
+
+  @Test
   fun a_rejected_https_url_is_not_rewritten_to_the_protocol() {
     val controller =
       GlJsRequestController(

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/MapLibre.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/MapLibre.kt
@@ -5,6 +5,8 @@ import java.nio.file.Path
 import java.nio.file.Paths
 import org.maplibre.compose.mlnffi.MlnFfiApplication
 import org.maplibre.compose.mlnffi.MlnFfiRuntimeOptions
+import org.maplibre.compose.resource.MapRequestInterceptor
+import org.maplibre.compose.resource.MapResourceProvider
 
 /** Configuration for one desktop map runtime that the caller closes. */
 public data class DesktopRuntimeOptions(
@@ -15,10 +17,22 @@ public data class DesktopRuntimeOptions(
 
   /** Receives diagnostic messages from maps and shared runtime resources. */
   public val logger: Logger? = Logger.withTag("maplibre-compose"),
+
+  /** Rewrites URLs and headers for every resource this runtime fetches. */
+  public val requestInterceptor: MapRequestInterceptor? = null,
+
+  /** Serves bytes for resource URLs this provider accepts. */
+  public val resourceProvider: MapResourceProvider? = null,
 )
 
 internal fun DesktopRuntimeOptions.toMlnFfiRuntimeOptions(): MlnFfiRuntimeOptions =
-  desktopRuntimeOptions(applicationId, maximumCacheSizeBytes, logger)
+  desktopRuntimeOptions(
+    applicationId,
+    maximumCacheSizeBytes,
+    logger,
+    requestInterceptor,
+    resourceProvider,
+  )
 
 /** Desktop configuration for MapLibre Compose. */
 public object MapLibre {
@@ -36,8 +50,18 @@ public object MapLibre {
     applicationId: String = inferredApplicationId(),
     maximumCacheSizeBytes: Long? = null,
     logger: Logger? = Logger.withTag("maplibre-compose"),
+    requestInterceptor: MapRequestInterceptor? = null,
+    resourceProvider: MapResourceProvider? = null,
   ) {
-    MlnFfiApplication.configure(desktopRuntimeOptions(applicationId, maximumCacheSizeBytes, logger))
+    MlnFfiApplication.configure(
+      desktopRuntimeOptions(
+        applicationId,
+        maximumCacheSizeBytes,
+        logger,
+        requestInterceptor,
+        resourceProvider,
+      )
+    )
   }
 }
 
@@ -45,6 +69,8 @@ internal fun desktopRuntimeOptions(
   applicationId: String = inferredApplicationId(),
   maximumCacheSizeBytes: Long? = null,
   logger: Logger? = Logger.withTag("maplibre-compose"),
+  requestInterceptor: MapRequestInterceptor? = null,
+  resourceProvider: MapResourceProvider? = null,
 ): MlnFfiRuntimeOptions {
   require(APPLICATION_ID.matches(applicationId)) {
     "applicationId must contain only nonempty dot-separated letters, digits, underscores, or hyphens"
@@ -54,6 +80,8 @@ internal fun desktopRuntimeOptions(
     kotlinx.io.files.Path(cachePath.toString()),
     maximumCacheSizeBytes,
     logger,
+    requestInterceptor,
+    resourceProvider,
   )
 }
 

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapRuntimeLoop.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapRuntimeLoop.kt
@@ -7,6 +7,7 @@ import org.maplibre.compose.mlnffi.MlnFfiGate
 import org.maplibre.compose.mlnffi.MlnFfiOwnerLock
 import org.maplibre.compose.mlnffi.MlnFfiOwnerThread
 import org.maplibre.compose.mlnffi.withLock
+import org.maplibre.compose.resource.MapResourceConfig
 import org.maplibre.compose.resource.MlnFfiResourceProvider
 import org.maplibre.compose.resource.MlnFfiResourceProviderFactory
 import org.maplibre.compose.resource.MlnFfiRuntimeOwner
@@ -50,6 +51,7 @@ internal class MlnFfiMapRuntimeLoop(
   private val cacheFile: Path,
   private val getLogger: () -> Logger?,
   private val resourceProviderFactory: MlnFfiResourceProviderFactory = ::MlnFfiResourceProvider,
+  private val resourceConfig: MapResourceConfig = MapResourceConfig(),
   /** Runs on the owner thread once the map exists, before it is published. */
   private val onMapCreated: (MapHandle) -> Unit,
   /** Runs on the owner thread after [map] publishes the created map. */
@@ -210,6 +212,7 @@ internal class MlnFfiMapRuntimeLoop(
             getLogger,
             "MapLibre runtime",
             resourceProviderFactory,
+            resourceConfig,
           )
           .also { runtimeOwner = it }
       } catch (error: Throwable) {

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -56,6 +56,7 @@ import org.maplibre.compose.mlnffi.VulkanSurfaceTarget
 import org.maplibre.compose.mlnffi.WglContextHandles
 import org.maplibre.compose.mlnffi.currentMlnFfiThreadName
 import org.maplibre.compose.mlnffi.withLock
+import org.maplibre.compose.resource.MapResourceConfig
 import org.maplibre.compose.resource.MlnFfiResourceProvider
 import org.maplibre.compose.resource.MlnFfiResourceProviderFactory
 import org.maplibre.compose.style.BaseStyle
@@ -158,6 +159,7 @@ internal class MlnFfiMapSession(
   @Volatile internal var layoutDirection: LayoutDirection,
   private val cacheFile: Path,
   private val resourceProviderFactory: MlnFfiResourceProviderFactory = ::MlnFfiResourceProvider,
+  private val resourceConfig: MapResourceConfig = MapResourceConfig(),
 ) : MapLifecycleSession, MlnFfiMapRenderer, GestureTarget {
 
   @Volatile internal var callbacks: MapAdapter.Callbacks = callbacks
@@ -535,6 +537,7 @@ internal class MlnFfiMapSession(
           cacheFile = cacheFile,
           getLogger = { logger },
           resourceProviderFactory = resourceProviderFactory,
+          resourceConfig = resourceConfig,
           onMapCreated = ::onMapCreated,
           onEvent = { handleEvent(identity, it) },
           onEventsDrained = { onEventsDrained(identity, it) },

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapView.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapView.kt
@@ -111,6 +111,7 @@ internal fun MlnFfiMapView(
           layoutDirection = layoutDirection,
           cacheFile = applicationOptions.cacheFile,
           resourceProviderFactory = applicationOptions.resourceProviderFactory,
+          resourceConfig = state.runtime.resourceConfig,
         )
       }
   val session = remember(unpreparedSession) { unpreparedSession.apply { preparePresentation() } }

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/NativeMapRuntime.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/NativeMapRuntime.kt
@@ -5,6 +5,7 @@ import org.maplibre.compose.mlnffi.MlnFfiLock
 import org.maplibre.compose.mlnffi.MlnFfiRuntimeOptions
 import org.maplibre.compose.mlnffi.withLock
 import org.maplibre.compose.offline.MlnFfiOfflineManager
+import org.maplibre.compose.resource.MapResourceConfig
 
 private val nativeMapRuntimeCapabilities =
   MapRuntimeCapabilities(
@@ -45,6 +46,7 @@ private fun createNativeMapRuntimeImplementation(
   options: MlnFfiRuntimeOptions
 ): RuntimeImplementation {
   val offlineManager = MlnFfiOfflineManager(options)
+  val resourceConfig = MapResourceConfig(options.requestInterceptor, options.resourceProvider)
   return RuntimeImplementation(
     platformOptions = options,
     resources =
@@ -54,7 +56,8 @@ private fun createNativeMapRuntimeImplementation(
     logger = options.logger,
     capabilities = nativeMapRuntimeCapabilities,
     offlineManagerBackend = offlineManager,
-    snapshotterAdapterFactory = NativeSnapshotterAdapterFactory(options),
+    snapshotterAdapterFactory = NativeSnapshotterAdapterFactory(options, resourceConfig),
+    resourceConfig = resourceConfig,
   )
 }
 

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/NativeMapRuntime.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/NativeMapRuntime.kt
@@ -45,8 +45,8 @@ internal fun createNativeMapRuntime(options: MlnFfiRuntimeOptions): MapRuntime =
 private fun createNativeMapRuntimeImplementation(
   options: MlnFfiRuntimeOptions
 ): RuntimeImplementation {
-  val offlineManager = MlnFfiOfflineManager(options)
   val resourceConfig = MapResourceConfig(options.requestInterceptor, options.resourceProvider)
+  val offlineManager = MlnFfiOfflineManager(options, resourceConfig)
   return RuntimeImplementation(
     platformOptions = options,
     resources =

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/NativeSnapshotterAdapter.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/NativeSnapshotterAdapter.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.withContext
 import org.maplibre.compose.mlnffi.MapRenderBackend
 import org.maplibre.compose.mlnffi.MlnFfiRuntimeOptions
+import org.maplibre.compose.resource.MapResourceConfig
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.compose.style.DesiredStyleRevision
 import org.maplibre.compose.style.MlnFfiStyleBinding
@@ -36,14 +37,18 @@ private val SNAPSHOT_EVENTS =
     RuntimeEventMask.MAP_RENDER_ERROR +
     RuntimeEventMask.MAP_RENDER_UPDATE_AVAILABLE
 
-internal class NativeSnapshotterAdapterFactory(private val options: MlnFfiRuntimeOptions) :
-  SnapshotterAdapterFactory {
-  override fun create(): SnapshotterAdapter = NativeSnapshotterAdapter(options)
+internal class NativeSnapshotterAdapterFactory(
+  private val options: MlnFfiRuntimeOptions,
+  private val resourceConfig: MapResourceConfig,
+) : SnapshotterAdapterFactory {
+  override fun create(): SnapshotterAdapter = NativeSnapshotterAdapter(options, resourceConfig)
 }
 
 /** One private map, offscreen render session, and retained reconciler for a native snapshotter. */
-private class NativeSnapshotterAdapter(private val options: MlnFfiRuntimeOptions) :
-  SnapshotterAdapter {
+private class NativeSnapshotterAdapter(
+  private val options: MlnFfiRuntimeOptions,
+  private val resourceConfig: MapResourceConfig,
+) : SnapshotterAdapter {
   @Volatile private var open = true
   @Volatile private var engine: NativeSnapshotEngine? = null
   @Volatile private var styleBinding: MlnFfiStyleBinding? = null
@@ -168,6 +173,7 @@ private class NativeSnapshotterAdapter(private val options: MlnFfiRuntimeOptions
         cacheFile = options.cacheFile,
         getLogger = { options.logger },
         resourceProviderFactory = options.resourceProviderFactory,
+        resourceConfig = resourceConfig,
         onMapCreated = resources::attach,
         onMapPublished = { created.completion.complete(Result.success(Unit)) },
         onMapClosing = { resources.close() },

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/PlatformMapAccess.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/PlatformMapAccess.kt
@@ -21,6 +21,7 @@ public actual suspend fun <T> MapState.withPlatformMap(block: PlatformMapScope.(
           layoutDirection = LayoutDirection.Ltr,
           cacheFile = options.cacheFile,
           resourceProviderFactory = options.resourceProviderFactory,
+          resourceConfig = runtime.resourceConfig,
         )
         .also { session ->
           session.setCameraPosition(cameraPosition)

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/mlnffi/MlnFfiOwnerThread.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/mlnffi/MlnFfiOwnerThread.kt
@@ -44,3 +44,6 @@ internal expect class MlnFfiOwnerThread(name: String, body: () -> Unit) {
 
 /** The name of the calling thread, for diagnostics. */
 internal expect fun currentMlnFfiThreadName(): String
+
+/** Identity of the calling thread, unique among live threads. */
+internal expect fun currentMlnFfiThreadKey(): Any

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/mlnffi/MlnFfiRuntimeOptions.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/mlnffi/MlnFfiRuntimeOptions.kt
@@ -5,6 +5,8 @@ import co.touchlab.kermit.Logger
 import kotlin.concurrent.Volatile
 import kotlinx.io.files.Path
 import org.maplibre.compose.map.ProcessNativeMapRuntime
+import org.maplibre.compose.resource.MapRequestInterceptor
+import org.maplibre.compose.resource.MapResourceProvider
 import org.maplibre.compose.resource.MlnFfiResourceProvider
 import org.maplibre.compose.resource.MlnFfiResourceProviderFactory
 
@@ -14,6 +16,8 @@ internal data class MlnFfiRuntimeOptions(
   val cacheFile: Path,
   val maximumCacheSizeBytes: Long? = null,
   val logger: Logger? = Logger.withTag("maplibre-compose"),
+  val requestInterceptor: MapRequestInterceptor? = null,
+  val resourceProvider: MapResourceProvider? = null,
   internal val resourceProviderFactory: MlnFfiResourceProviderFactory = ::MlnFfiResourceProvider,
 )
 

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/offline/MlnFfiOfflineManager.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/offline/MlnFfiOfflineManager.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import org.maplibre.compose.mlnffi.MlnFfiGate
 import org.maplibre.compose.mlnffi.MlnFfiRuntimeOptions
+import org.maplibre.compose.resource.MapResourceConfig
 import org.maplibre.nativeffi.error.MaplibreException
 import org.maplibre.nativeffi.error.MaplibreStatus
 import org.maplibre.nativeffi.offline.OfflineRegionDownloadState
@@ -22,8 +23,11 @@ import org.maplibre.nativeffi.runtime.RuntimeEventType
 import org.maplibre.nativeffi.runtime.RuntimeHandle
 
 /** The MapLibre Native FFI offline manager that belongs to one map runtime. */
-internal class MlnFfiOfflineManager(private val options: MlnFfiRuntimeOptions) :
-  OfflineManager, OfflinePackOwner {
+internal class MlnFfiOfflineManager(
+  private val options: MlnFfiRuntimeOptions,
+  resourceConfig: MapResourceConfig =
+    MapResourceConfig(options.requestInterceptor, options.resourceProvider),
+) : OfflineManager, OfflinePackOwner {
 
   private val logger = options.logger
 
@@ -36,7 +40,8 @@ internal class MlnFfiOfflineManager(private val options: MlnFfiRuntimeOptions) :
   /** Owner-thread state: the packs this manager has seen, keyed by native region id. */
   private val packsById = mutableMapOf<Long, OfflinePack>()
 
-  private val runtime = MlnFfiOfflineRuntime(options.cacheFile, logger, ::handleEvent)
+  private val runtime =
+    MlnFfiOfflineRuntime(options.cacheFile, logger, ::handleEvent, resourceConfig)
 
   /** One manager applies one cache-budget change at a time. */
   private val cacheBudgetMutex = Mutex()

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/offline/MlnFfiOfflineRuntime.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/offline/MlnFfiOfflineRuntime.kt
@@ -8,6 +8,7 @@ import org.maplibre.compose.mlnffi.MlnFfiOwnerLock
 import org.maplibre.compose.mlnffi.MlnFfiOwnerThread
 import org.maplibre.compose.mlnffi.currentMlnFfiThreadName
 import org.maplibre.compose.mlnffi.withLock
+import org.maplibre.compose.resource.MapResourceConfig
 import org.maplibre.compose.resource.MlnFfiRuntimeOwner
 import org.maplibre.nativeffi.runtime.OfflineOperationHandle
 import org.maplibre.nativeffi.runtime.RuntimeEvent
@@ -39,6 +40,7 @@ internal class MlnFfiOfflineRuntime(
   private val cacheFile: Path,
   private val logger: Logger?,
   private val onEvent: (RuntimeEvent) -> Unit,
+  private val resourceConfig: MapResourceConfig = MapResourceConfig(),
 ) {
 
   /** Work for the owner thread, with the failure path it must take if it never gets to run. */
@@ -156,7 +158,12 @@ internal class MlnFfiOfflineRuntime(
   private fun runLoop() {
     val runtime =
       try {
-        MlnFfiRuntimeOwner.open(cacheFile, { logger }, "MapLibre offline runtime")
+        MlnFfiRuntimeOwner.open(
+            cacheFile,
+            { logger },
+            "MapLibre offline runtime",
+            resourceConfig = resourceConfig,
+          )
           .also { runtimeOwner = it }
           .runtime
       } catch (error: Throwable) {

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/resource/MlnFfiRequestHooks.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/resource/MlnFfiRequestHooks.kt
@@ -2,7 +2,7 @@ package org.maplibre.compose.resource
 
 import kotlinx.atomicfu.locks.reentrantLock
 import kotlinx.atomicfu.locks.withLock
-import org.maplibre.compose.mlnffi.currentMlnFfiThreadName
+import org.maplibre.compose.mlnffi.currentMlnFfiThreadKey
 import org.maplibre.compose.util.rethrowIfFatal
 import org.maplibre.nativeffi.resource.HttpHeader
 import org.maplibre.nativeffi.resource.HttpHeaderTransformCallback
@@ -38,19 +38,19 @@ internal fun RuntimeHandle.installRequestInterceptor(config: MapResourceConfig) 
  * Remembers the URL-callback interceptor result so the header callback can reuse it.
  *
  * Native asks for the URL and headers in separate callbacks on the same network thread. One slot
- * per thread is overwritten by the next URL callback, so a cache hit that never reaches HTTP cannot
- * leak a transform to a later request. A request the user provider or the packaged-resource loader
- * will handle is not recorded.
+ * per thread identity is overwritten by the next URL callback, so a cache hit that never reaches
+ * HTTP cannot leak a transform to a later request. A request the user provider or the
+ * packaged-resource loader will handle is not recorded.
  */
 internal class NativeRequestTransforms(private val config: MapResourceConfig) {
   private val lock = reentrantLock()
-  private val pending = mutableMapOf<String, MapRequestTransform>()
+  private val pending = mutableMapOf<Any, MapRequestTransform>()
 
   fun rewrittenUrl(request: MapResourceRequest): String {
     val transform = config.interceptor().transform(request)
     val nextUrl = transform.url ?: request.url
     if (shouldRecord(nextUrl, request.kind)) {
-      lock.withLock { pending[currentMlnFfiThreadName()] = transform }
+      lock.withLock { pending[currentMlnFfiThreadKey()] = transform }
     }
     return transform.url.orEmpty()
   }
@@ -59,7 +59,7 @@ internal class NativeRequestTransforms(private val config: MapResourceConfig) {
     take(request).headers.map { HttpHeader(it.key, it.value) }
 
   internal fun take(request: MapResourceRequest): MapRequestTransform {
-    val remembered = lock.withLock { pending.remove(currentMlnFfiThreadName()) }
+    val remembered = lock.withLock { pending.remove(currentMlnFfiThreadKey()) }
     return remembered ?: config.interceptor().transform(request)
   }
 

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/resource/MlnFfiRequestHooks.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/resource/MlnFfiRequestHooks.kt
@@ -1,0 +1,42 @@
+package org.maplibre.compose.resource
+
+import org.maplibre.nativeffi.resource.HttpHeader
+import org.maplibre.nativeffi.resource.HttpHeaderTransformCallback
+import org.maplibre.nativeffi.resource.ResourceKind
+import org.maplibre.nativeffi.resource.ResourceTransformCallback
+import org.maplibre.nativeffi.runtime.RuntimeHandle
+
+/** Installs live URL and header transforms that read [config] on every request. */
+internal fun RuntimeHandle.installRequestInterceptor(config: MapResourceConfig) {
+  setResourceTransform(
+    ResourceTransformCallback { request ->
+      config.interceptor().transform(MapResourceRequest(request.url, request.kind.toCommon())).url
+        ?: ""
+    }
+  )
+  try {
+    setHttpHeaderTransform(
+      HttpHeaderTransformCallback { request ->
+        config
+          .interceptor()
+          .transform(MapResourceRequest(request.url, request.kind.toCommon()))
+          .headers
+          .map { HttpHeader(it.key, it.value) }
+      }
+    )
+  } catch (_: Throwable) {
+    // OpenHarmony and the browser FFI decline header transforms.
+  }
+}
+
+internal fun ResourceKind.toCommon(): MapResourceKind =
+  when (this) {
+    ResourceKind.STYLE -> MapResourceKind.Style
+    ResourceKind.SOURCE -> MapResourceKind.Source
+    ResourceKind.TILE -> MapResourceKind.Tile
+    ResourceKind.GLYPHS -> MapResourceKind.Glyphs
+    ResourceKind.SPRITE_JSON -> MapResourceKind.SpriteJson
+    ResourceKind.SPRITE_IMAGE -> MapResourceKind.SpriteImage
+    ResourceKind.IMAGE -> MapResourceKind.Image
+    else -> MapResourceKind.Unknown
+  }

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/resource/MlnFfiRequestHooks.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/resource/MlnFfiRequestHooks.kt
@@ -32,10 +32,11 @@ internal fun RuntimeHandle.installRequestInterceptor(config: MapResourceConfig) 
 }
 
 /**
- * One interceptor invocation supplies both the rewritten URL and the headers for that request.
+ * Remembers the URL-callback interceptor result so the header callback can reuse it.
  *
- * Native asks for those fields in separate callbacks. This remembers the URL-callback result so the
- * header callback does not call the interceptor again.
+ * Native asks for the URL and headers in separate callbacks and identifies a request by URL and
+ * kind. Two in-flight requests that share that pair can overwrite the pending result; the displaced
+ * header callback calls the interceptor again.
  */
 internal class NativeRequestTransforms(private val config: MapResourceConfig) {
   private val lock = reentrantLock()

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/resource/MlnFfiRequestHooks.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/resource/MlnFfiRequestHooks.kt
@@ -34,17 +34,18 @@ internal fun RuntimeHandle.installRequestInterceptor(config: MapResourceConfig) 
 /**
  * Remembers the URL-callback interceptor result so the header callback can reuse it.
  *
- * Native asks for the URL and headers in separate callbacks and identifies a request by URL and
- * kind. Two in-flight requests that share that pair can overwrite the pending result; the displaced
- * header callback calls the interceptor again.
+ * Native asks for the URL and headers in separate callbacks. The pending map is keyed by the URL
+ * the client will send. Two in-flight requests that rewrite to the same URL can overwrite the
+ * pending result; the displaced header callback calls the interceptor again.
  */
 internal class NativeRequestTransforms(private val config: MapResourceConfig) {
   private val lock = reentrantLock()
-  private val pending = mutableMapOf<RequestKey, PendingTransform>()
+  private val pending = mutableMapOf<RequestKey, MapRequestTransform>()
 
   fun rewrittenUrl(request: MapResourceRequest): String {
     val transform = config.interceptor().transform(request)
-    remember(request, transform)
+    val nextUrl = transform.url ?: request.url
+    lock.withLock { pending[RequestKey(nextUrl, request.kind)] = transform }
     return transform.url.orEmpty()
   }
 
@@ -52,30 +53,11 @@ internal class NativeRequestTransforms(private val config: MapResourceConfig) {
     take(request).headers.map { HttpHeader(it.key, it.value) }
 
   internal fun take(request: MapResourceRequest): MapRequestTransform {
-    val remembered = lock.withLock {
-      val found = pending.remove(RequestKey(request.url, request.kind)) ?: return@withLock null
-      found.keys.forEach { pending.remove(it) }
-      found.transform
-    }
+    val remembered = lock.withLock { pending.remove(RequestKey(request.url, request.kind)) }
     return remembered ?: config.interceptor().transform(request)
   }
 
-  private fun remember(request: MapResourceRequest, transform: MapRequestTransform) {
-    val nextUrl = transform.url ?: request.url
-    val keys = buildList {
-      add(RequestKey(nextUrl, request.kind))
-      if (request.url != nextUrl) add(RequestKey(request.url, request.kind))
-    }
-    val pendingTransform = PendingTransform(transform, keys)
-    lock.withLock { keys.forEach { pending[it] = pendingTransform } }
-  }
-
   private data class RequestKey(val url: String, val kind: MapResourceKind)
-
-  private class PendingTransform(
-    val transform: MapRequestTransform,
-    val keys: List<RequestKey>,
-  )
 }
 
 internal fun ResourceKind.toCommon(): MapResourceKind =

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/resource/MlnFfiRequestHooks.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/resource/MlnFfiRequestHooks.kt
@@ -2,6 +2,7 @@ package org.maplibre.compose.resource
 
 import kotlinx.atomicfu.locks.reentrantLock
 import kotlinx.atomicfu.locks.withLock
+import org.maplibre.compose.mlnffi.currentMlnFfiThreadName
 import org.maplibre.compose.util.rethrowIfFatal
 import org.maplibre.nativeffi.resource.HttpHeader
 import org.maplibre.nativeffi.resource.HttpHeaderTransformCallback
@@ -36,22 +37,20 @@ internal fun RuntimeHandle.installRequestInterceptor(config: MapResourceConfig) 
 /**
  * Remembers the URL-callback interceptor result so the header callback can reuse it.
  *
- * Native asks for the URL and headers in separate callbacks. Pending results are queued by the URL
- * the client will send. A request the user provider or the packaged-resource loader will handle
- * never reaches the header callback, so it is not recorded. Header callbacks consume the queue in
- * URL-callback order.
+ * Native asks for the URL and headers in separate callbacks on the same network thread. One slot
+ * per thread is overwritten by the next URL callback, so a cache hit that never reaches HTTP cannot
+ * leak a transform to a later request. A request the user provider or the packaged-resource loader
+ * will handle is not recorded.
  */
 internal class NativeRequestTransforms(private val config: MapResourceConfig) {
   private val lock = reentrantLock()
-  private val pending = mutableMapOf<RequestKey, ArrayDeque<MapRequestTransform>>()
+  private val pending = mutableMapOf<String, MapRequestTransform>()
 
   fun rewrittenUrl(request: MapResourceRequest): String {
     val transform = config.interceptor().transform(request)
     val nextUrl = transform.url ?: request.url
     if (shouldRecord(nextUrl, request.kind)) {
-      lock.withLock {
-        pending.getOrPut(RequestKey(nextUrl, request.kind), ::ArrayDeque).addLast(transform)
-      }
+      lock.withLock { pending[currentMlnFfiThreadName()] = transform }
     }
     return transform.url.orEmpty()
   }
@@ -60,25 +59,17 @@ internal class NativeRequestTransforms(private val config: MapResourceConfig) {
     take(request).headers.map { HttpHeader(it.key, it.value) }
 
   internal fun take(request: MapResourceRequest): MapRequestTransform {
-    val remembered = lock.withLock {
-      val key = RequestKey(request.url, request.kind)
-      val queue = pending[key] ?: return@withLock null
-      val transform = queue.removeFirst()
-      if (queue.isEmpty()) pending.remove(key)
-      transform
-    }
+    val remembered = lock.withLock { pending.remove(currentMlnFfiThreadName()) }
     return remembered ?: config.interceptor().transform(request)
   }
 
-  internal fun pendingCount(): Int = lock.withLock { pending.values.sumOf { it.size } }
+  internal fun pendingCount(): Int = lock.withLock { pending.size }
 
   private fun shouldRecord(nextUrl: String, kind: MapResourceKind): Boolean {
     val nextRequest = MapResourceRequest(nextUrl, kind)
     if (config.provider?.acceptsOrDeclines(nextRequest) == true) return false
     return isMapLibresToFetch(nextUrl)
   }
-
-  private data class RequestKey(val url: String, val kind: MapResourceKind)
 }
 
 internal fun ResourceKind.toCommon(): MapResourceKind =

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/resource/MlnFfiRequestHooks.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/resource/MlnFfiRequestHooks.kt
@@ -34,18 +34,23 @@ internal fun RuntimeHandle.installRequestInterceptor(config: MapResourceConfig) 
 /**
  * Remembers the URL-callback interceptor result so the header callback can reuse it.
  *
- * Native asks for the URL and headers in separate callbacks. The pending map is keyed by the URL
- * the client will send. Two in-flight requests that rewrite to the same URL can overwrite the
- * pending result; the displaced header callback calls the interceptor again.
+ * Native asks for the URL and headers in separate callbacks. Pending results are queued by the URL
+ * the client will send. A provider-accepted request never reaches the header callback, so it is not
+ * recorded. Header callbacks consume the queue in URL-callback order.
  */
 internal class NativeRequestTransforms(private val config: MapResourceConfig) {
   private val lock = reentrantLock()
-  private val pending = mutableMapOf<RequestKey, MapRequestTransform>()
+  private val pending = mutableMapOf<RequestKey, ArrayDeque<MapRequestTransform>>()
 
   fun rewrittenUrl(request: MapResourceRequest): String {
     val transform = config.interceptor().transform(request)
     val nextUrl = transform.url ?: request.url
-    lock.withLock { pending[RequestKey(nextUrl, request.kind)] = transform }
+    val nextRequest = MapResourceRequest(nextUrl, request.kind)
+    if (config.provider?.acceptsOrDeclines(nextRequest) != true) {
+      lock.withLock {
+        pending.getOrPut(RequestKey(nextUrl, request.kind), ::ArrayDeque).addLast(transform)
+      }
+    }
     return transform.url.orEmpty()
   }
 
@@ -53,9 +58,17 @@ internal class NativeRequestTransforms(private val config: MapResourceConfig) {
     take(request).headers.map { HttpHeader(it.key, it.value) }
 
   internal fun take(request: MapResourceRequest): MapRequestTransform {
-    val remembered = lock.withLock { pending.remove(RequestKey(request.url, request.kind)) }
+    val remembered = lock.withLock {
+      val key = RequestKey(request.url, request.kind)
+      val queue = pending[key] ?: return@withLock null
+      val transform = queue.removeFirst()
+      if (queue.isEmpty()) pending.remove(key)
+      transform
+    }
     return remembered ?: config.interceptor().transform(request)
   }
+
+  internal fun pendingCount(): Int = lock.withLock { pending.values.sumOf { it.size } }
 
   private data class RequestKey(val url: String, val kind: MapResourceKind)
 }

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/resource/MlnFfiRequestHooks.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/resource/MlnFfiRequestHooks.kt
@@ -2,6 +2,7 @@ package org.maplibre.compose.resource
 
 import kotlinx.atomicfu.locks.reentrantLock
 import kotlinx.atomicfu.locks.withLock
+import org.maplibre.compose.util.rethrowIfFatal
 import org.maplibre.nativeffi.resource.HttpHeader
 import org.maplibre.nativeffi.resource.HttpHeaderTransformCallback
 import org.maplibre.nativeffi.resource.ResourceKind
@@ -19,7 +20,8 @@ internal fun RuntimeHandle.installRequestInterceptor(config: MapResourceConfig) 
       }
     )
     headersInstalled = true
-  } catch (_: Throwable) {
+  } catch (error: Throwable) {
+    rethrowIfFatal(error)
     // OpenHarmony and the browser FFI decline header transforms.
   }
   setResourceTransform(
@@ -35,8 +37,9 @@ internal fun RuntimeHandle.installRequestInterceptor(config: MapResourceConfig) 
  * Remembers the URL-callback interceptor result so the header callback can reuse it.
  *
  * Native asks for the URL and headers in separate callbacks. Pending results are queued by the URL
- * the client will send. A provider-accepted request never reaches the header callback, so it is not
- * recorded. Header callbacks consume the queue in URL-callback order.
+ * the client will send. A request the user provider or the packaged-resource loader will handle
+ * never reaches the header callback, so it is not recorded. Header callbacks consume the queue in
+ * URL-callback order.
  */
 internal class NativeRequestTransforms(private val config: MapResourceConfig) {
   private val lock = reentrantLock()
@@ -45,8 +48,7 @@ internal class NativeRequestTransforms(private val config: MapResourceConfig) {
   fun rewrittenUrl(request: MapResourceRequest): String {
     val transform = config.interceptor().transform(request)
     val nextUrl = transform.url ?: request.url
-    val nextRequest = MapResourceRequest(nextUrl, request.kind)
-    if (config.provider?.acceptsOrDeclines(nextRequest) != true) {
+    if (shouldRecord(nextUrl, request.kind)) {
       lock.withLock {
         pending.getOrPut(RequestKey(nextUrl, request.kind), ::ArrayDeque).addLast(transform)
       }
@@ -69,6 +71,12 @@ internal class NativeRequestTransforms(private val config: MapResourceConfig) {
   }
 
   internal fun pendingCount(): Int = lock.withLock { pending.values.sumOf { it.size } }
+
+  private fun shouldRecord(nextUrl: String, kind: MapResourceKind): Boolean {
+    val nextRequest = MapResourceRequest(nextUrl, kind)
+    if (config.provider?.acceptsOrDeclines(nextRequest) == true) return false
+    return isMapLibresToFetch(nextUrl)
+  }
 
   private data class RequestKey(val url: String, val kind: MapResourceKind)
 }

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/resource/MlnFfiRequestHooks.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/resource/MlnFfiRequestHooks.kt
@@ -1,5 +1,7 @@
 package org.maplibre.compose.resource
 
+import kotlinx.atomicfu.locks.reentrantLock
+import kotlinx.atomicfu.locks.withLock
 import org.maplibre.nativeffi.resource.HttpHeader
 import org.maplibre.nativeffi.resource.HttpHeaderTransformCallback
 import org.maplibre.nativeffi.resource.ResourceKind
@@ -8,25 +10,71 @@ import org.maplibre.nativeffi.runtime.RuntimeHandle
 
 /** Installs live URL and header transforms that read [config] on every request. */
 internal fun RuntimeHandle.installRequestInterceptor(config: MapResourceConfig) {
-  setResourceTransform(
-    ResourceTransformCallback { request ->
-      config.interceptor().transform(MapResourceRequest(request.url, request.kind.toCommon())).url
-        ?: ""
-    }
-  )
+  val transforms = NativeRequestTransforms(config)
+  var headersInstalled = false
   try {
     setHttpHeaderTransform(
       HttpHeaderTransformCallback { request ->
-        config
-          .interceptor()
-          .transform(MapResourceRequest(request.url, request.kind.toCommon()))
-          .headers
-          .map { HttpHeader(it.key, it.value) }
+        transforms.headers(MapResourceRequest(request.url, request.kind.toCommon()))
       }
     )
+    headersInstalled = true
   } catch (_: Throwable) {
     // OpenHarmony and the browser FFI decline header transforms.
   }
+  setResourceTransform(
+    ResourceTransformCallback { request ->
+      val mapRequest = MapResourceRequest(request.url, request.kind.toCommon())
+      if (headersInstalled) transforms.rewrittenUrl(mapRequest)
+      else config.interceptor().transform(mapRequest).url.orEmpty()
+    }
+  )
+}
+
+/**
+ * One interceptor invocation supplies both the rewritten URL and the headers for that request.
+ *
+ * Native asks for those fields in separate callbacks. This remembers the URL-callback result so the
+ * header callback does not call the interceptor again.
+ */
+internal class NativeRequestTransforms(private val config: MapResourceConfig) {
+  private val lock = reentrantLock()
+  private val pending = mutableMapOf<RequestKey, PendingTransform>()
+
+  fun rewrittenUrl(request: MapResourceRequest): String {
+    val transform = config.interceptor().transform(request)
+    remember(request, transform)
+    return transform.url.orEmpty()
+  }
+
+  fun headers(request: MapResourceRequest): List<HttpHeader> =
+    take(request).headers.map { HttpHeader(it.key, it.value) }
+
+  internal fun take(request: MapResourceRequest): MapRequestTransform {
+    val remembered = lock.withLock {
+      val found = pending.remove(RequestKey(request.url, request.kind)) ?: return@withLock null
+      found.keys.forEach { pending.remove(it) }
+      found.transform
+    }
+    return remembered ?: config.interceptor().transform(request)
+  }
+
+  private fun remember(request: MapResourceRequest, transform: MapRequestTransform) {
+    val nextUrl = transform.url ?: request.url
+    val keys = buildList {
+      add(RequestKey(nextUrl, request.kind))
+      if (request.url != nextUrl) add(RequestKey(request.url, request.kind))
+    }
+    val pendingTransform = PendingTransform(transform, keys)
+    lock.withLock { keys.forEach { pending[it] = pendingTransform } }
+  }
+
+  private data class RequestKey(val url: String, val kind: MapResourceKind)
+
+  private class PendingTransform(
+    val transform: MapRequestTransform,
+    val keys: List<RequestKey>,
+  )
 }
 
 internal fun ResourceKind.toCommon(): MapResourceKind =

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/resource/MlnFfiResourceProvider.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/resource/MlnFfiResourceProvider.kt
@@ -9,6 +9,9 @@ import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.maplibre.compose.util.rethrowIfFatal
 import org.maplibre.nativeffi.resource.ResourceErrorReason
@@ -24,6 +27,8 @@ import org.maplibre.nativeffi.resource.ResourceResponseStatus
  * non-HTTP URI with `invalid authority`.
  */
 private val NETWORK_SCHEMES = setOf("http", "https")
+
+private const val REQUEST_CANCEL_POLL_MILLIS = 16L
 
 internal typealias MlnFfiResourceProviderFactory =
   (getLogger: () -> Logger?) -> MlnFfiResourceProvider
@@ -66,7 +71,7 @@ internal class MlnFfiResourceProvider(
     val url = request.resolvedUrl
     val mapRequest = MapResourceRequest(url, request.kind.toCommon())
     val user = userProvider
-    if (user != null && user.accepts(mapRequest)) {
+    if (user != null && user.acceptsOrDeclines(mapRequest)) {
       takeUser(FfiResourceRequest(handle), mapRequest, url, request.requestedUrl)
       return ResourceProviderDecision.HANDLE
     }
@@ -80,7 +85,7 @@ internal class MlnFfiResourceProvider(
     return ResourceProviderDecision.HANDLE
   }
 
-  private fun takeUser(
+  internal fun takeUser(
     request: TakenResourceRequest,
     mapRequest: MapResourceRequest,
     url: String,
@@ -112,7 +117,7 @@ internal class MlnFfiResourceProvider(
         if (open.isCancelled()) return
         val response =
           try {
-            provider.load(mapRequest).toResourceResponse()
+            loadWhileRequestOpen(open, provider, mapRequest)
           } catch (error: CancellationException) {
             return
           } catch (error: Throwable) {
@@ -195,9 +200,31 @@ internal class MlnFfiResourceProvider(
     }
   }
 
-  /** Stops taking new reads. Accepted reads own their handles and finish independently. */
+  /**
+   * Stops taking new reads and cancels application [MapResourceProvider] loads. Packaged-resource
+   * reads own their handles and finish independently.
+   */
   override fun close() {
     accepting.store(false)
+    userScope.cancel()
+  }
+
+  private suspend fun loadWhileRequestOpen(
+    request: TakenResourceRequest,
+    provider: MapResourceProvider,
+    mapRequest: MapResourceRequest,
+  ): ResourceResponse = coroutineScope {
+    val watch = launch {
+      while (true) {
+        if (request.isCancelled()) throw CancellationException("The resource request was cancelled")
+        delay(REQUEST_CANCEL_POLL_MILLIS)
+      }
+    }
+    try {
+      provider.load(mapRequest).toResourceResponse()
+    } finally {
+      watch.cancel()
+    }
   }
 }
 

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/resource/MlnFfiResourceProvider.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/resource/MlnFfiResourceProvider.kt
@@ -7,6 +7,7 @@ import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
@@ -53,6 +54,8 @@ internal class MlnFfiResourceProvider(
   private val passThroughNetwork: Boolean = true,
   /** Test seam: observes when a native completion call finishes and whether it failed. */
   private val onResponseCompletionFinished: ((url: String, error: Throwable?) -> Unit)? = null,
+  /** Test seam: a cancelled scope reproduces a close that races [takeUser]. */
+  userCoroutineScope: CoroutineScope? = null,
   @Volatile var userProvider: MapResourceProvider? = null,
 ) : ResourceProviderCallback, AutoCloseable {
 
@@ -61,9 +64,10 @@ internal class MlnFfiResourceProvider(
 
   private val accepting = AtomicBoolean(true)
   private val userScope =
-    CoroutineScope(
-      SupervisorJob() + Dispatchers.Default + CoroutineName("maplibre-compose-resource-provider")
-    )
+    userCoroutineScope
+      ?: CoroutineScope(
+        SupervisorJob() + Dispatchers.Default + CoroutineName("maplibre-compose-resource-provider")
+      )
 
   override fun handle(
     request: ResourceRequest,
@@ -101,9 +105,12 @@ internal class MlnFfiResourceProvider(
       refuse(request, url, requestedUrl)
       return
     }
-    userScope.launch {
+    var started = false
+    userScope.launch(start = CoroutineStart.UNDISPATCHED) {
+      started = true
       serveUser(request, provider, mapRequest, url, requestedUrl)
     }
+    if (!started) refuse(request, url, requestedUrl)
   }
 
   private suspend fun serveUser(

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/resource/MlnFfiResourceProvider.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/resource/MlnFfiResourceProvider.kt
@@ -120,7 +120,15 @@ internal class MlnFfiResourceProvider(
           try {
             loadWhileRequestOpen(open, provider, mapRequest)
           } catch (error: CancellationException) {
-            return
+            if (open.isCancelled()) return
+            failure(
+              url,
+              requestedUrl,
+              ResourceErrorReason.OTHER,
+              "was cancelled",
+              error,
+              logger,
+            )
           } catch (error: Throwable) {
             rethrowIfFatal(error)
             failure(url, requestedUrl, ResourceErrorReason.OTHER, "failed to load", error, logger)

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/resource/MlnFfiResourceProvider.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/resource/MlnFfiResourceProvider.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
@@ -214,14 +215,18 @@ internal class MlnFfiResourceProvider(
     provider: MapResourceProvider,
     mapRequest: MapResourceRequest,
   ): ResourceResponse = coroutineScope {
+    val load = async { provider.load(mapRequest).toResourceResponse() }
     val watch = launch {
-      while (true) {
-        if (request.isCancelled()) throw CancellationException("The resource request was cancelled")
+      while (load.isActive) {
+        if (request.isCancelled()) {
+          load.cancel()
+          return@launch
+        }
         delay(REQUEST_CANCEL_POLL_MILLIS)
       }
     }
     try {
-      provider.load(mapRequest).toResourceResponse()
+      load.await()
     } finally {
       watch.cancel()
     }

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/resource/MlnFfiResourceProvider.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/resource/MlnFfiResourceProvider.kt
@@ -1,8 +1,15 @@
 package org.maplibre.compose.resource
 
 import co.touchlab.kermit.Logger
+import kotlin.concurrent.Volatile
 import kotlin.concurrent.atomics.AtomicBoolean
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import org.maplibre.compose.util.rethrowIfFatal
 import org.maplibre.nativeffi.resource.ResourceErrorReason
 import org.maplibre.nativeffi.resource.ResourceProviderCallback
@@ -40,18 +47,29 @@ internal class MlnFfiResourceProvider(
   private val passThroughNetwork: Boolean = true,
   /** Test seam: observes when a native completion call finishes and whether it failed. */
   private val onResponseCompletionFinished: ((url: String, error: Throwable?) -> Unit)? = null,
+  @Volatile var userProvider: MapResourceProvider? = null,
 ) : ResourceProviderCallback, AutoCloseable {
 
   private val logger: Logger?
     get() = getLogger()
 
   private val accepting = AtomicBoolean(true)
+  private val userScope =
+    CoroutineScope(
+      SupervisorJob() + Dispatchers.Default + CoroutineName("maplibre-compose-resource-provider")
+    )
 
   override fun handle(
     request: ResourceRequest,
     handle: ResourceRequestHandle,
   ): ResourceProviderDecision {
     val url = request.resolvedUrl
+    val mapRequest = MapResourceRequest(url, request.kind.toCommon())
+    val user = userProvider
+    if (user != null && user.accepts(mapRequest)) {
+      takeUser(FfiResourceRequest(handle), mapRequest, url, request.requestedUrl)
+      return ResourceProviderDecision.HANDLE
+    }
     if (passThroughNetwork && isMapLibresToFetch(url)) {
       return ResourceProviderDecision.PASS_THROUGH
     }
@@ -60,6 +78,62 @@ internal class MlnFfiResourceProvider(
     // affinity, so the answer need not happen before this returns.
     take(FfiResourceRequest(handle), url, request.requestedUrl)
     return ResourceProviderDecision.HANDLE
+  }
+
+  private fun takeUser(
+    request: TakenResourceRequest,
+    mapRequest: MapResourceRequest,
+    url: String,
+    requestedUrl: String,
+  ) {
+    if (!accepting.load()) {
+      refuse(request, url, requestedUrl)
+      return
+    }
+    val provider = userProvider
+    if (provider == null) {
+      refuse(request, url, requestedUrl)
+      return
+    }
+    userScope.launch {
+      serveUser(request, provider, mapRequest, url, requestedUrl)
+    }
+  }
+
+  private suspend fun serveUser(
+    request: TakenResourceRequest,
+    provider: MapResourceProvider,
+    mapRequest: MapResourceRequest,
+    url: String,
+    requestedUrl: String,
+  ) {
+    try {
+      request.use { open ->
+        if (open.isCancelled()) return
+        val response =
+          try {
+            provider.load(mapRequest).toResourceResponse()
+          } catch (error: CancellationException) {
+            return
+          } catch (error: Throwable) {
+            rethrowIfFatal(error)
+            failure(url, requestedUrl, ResourceErrorReason.OTHER, "failed to load", error, logger)
+          }
+        if (open.isCancelled()) return
+        var completionError: Throwable? = null
+        try {
+          open.complete(response)
+        } catch (error: Throwable) {
+          completionError = error
+          throw error
+        } finally {
+          onResponseCompletionFinished?.invoke(url, completionError)
+        }
+      }
+    } catch (error: Throwable) {
+      rethrowIfFatal(error)
+      logger?.w(error) { "Failed to answer the resource request for $url" }
+    }
   }
 
   /** Queues [request] for the reader, or refuses it if this provider is shutting down. */
@@ -237,3 +311,18 @@ internal fun schemeOf(url: String): String? {
 private fun Char.isAsciiLetter(): Boolean = this in 'a'..'z' || this in 'A'..'Z'
 
 private fun Char.isAsciiDigit(): Boolean = this in '0'..'9'
+
+private fun MapResourceLoad.toResourceResponse(): ResourceResponse =
+  when (this) {
+    is MapResourceLoad.Bytes ->
+      ResourceResponse(ResourceResponseStatus.OK).also {
+        it.bytes = bytes
+        it.etag = etag
+        it.mustRevalidate = mustRevalidate
+      }
+    is MapResourceLoad.Failed ->
+      ResourceResponse(ResourceResponseStatus.ERROR).also {
+        it.errorReason = ResourceErrorReason.OTHER
+        it.errorMessage = message
+      }
+  }

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/resource/MlnFfiRuntimeOwner.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/resource/MlnFfiRuntimeOwner.kt
@@ -47,6 +47,7 @@ private constructor(
       getLogger: () -> Logger?,
       what: String,
       resourceProviderFactory: MlnFfiResourceProviderFactory = ::MlnFfiResourceProvider,
+      resourceConfig: MapResourceConfig = MapResourceConfig(),
     ): MlnFfiRuntimeOwner {
       val cacheFile = normalizeMlnFfiPath(rawCacheFile)
       // MapLibre opens the database as the runtime is created, and fails if the directory is
@@ -62,7 +63,7 @@ private constructor(
         }
       val provider =
         try {
-          resourceProviderFactory(getLogger)
+          resourceProviderFactory(getLogger).also { it.userProvider = resourceConfig.provider }
         } catch (error: Throwable) {
           runCatching { runtime.close() }
           throw error
@@ -72,6 +73,7 @@ private constructor(
         // Installed with the runtime rather than with the map, so nothing can request a resource
         // before the provider that serves it exists.
         runtime.setResourceProvider(provider)
+        runtime.installRequestInterceptor(resourceConfig)
         getLogger()?.i { "Created the $what on ${currentMlnFfiThreadName()}" }
         owner
       } catch (error: Throwable) {

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/resource/MlnFfiRequestHooksTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/resource/MlnFfiRequestHooksTest.kt
@@ -1,0 +1,21 @@
+package org.maplibre.compose.resource
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import org.maplibre.nativeffi.resource.ResourceKind
+
+class MlnFfiRequestHooksTest {
+
+  @Test
+  fun every_named_kind_maps_to_the_common_kind() {
+    assertEquals(MapResourceKind.Style, ResourceKind.STYLE.toCommon())
+    assertEquals(MapResourceKind.Source, ResourceKind.SOURCE.toCommon())
+    assertEquals(MapResourceKind.Tile, ResourceKind.TILE.toCommon())
+    assertEquals(MapResourceKind.Glyphs, ResourceKind.GLYPHS.toCommon())
+    assertEquals(MapResourceKind.SpriteJson, ResourceKind.SPRITE_JSON.toCommon())
+    assertEquals(MapResourceKind.SpriteImage, ResourceKind.SPRITE_IMAGE.toCommon())
+    assertEquals(MapResourceKind.Image, ResourceKind.IMAGE.toCommon())
+    assertEquals(MapResourceKind.Unknown, ResourceKind.UNKNOWN.toCommon())
+    assertEquals(MapResourceKind.Unknown, ResourceKind(nativeValue = 99).toCommon())
+  }
+}

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/resource/MlnFfiRequestHooksTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/resource/MlnFfiRequestHooksTest.kt
@@ -37,6 +37,38 @@ class MlnFfiRequestHooksTest {
   }
 
   @Test
+  fun a_rewrite_alias_does_not_steal_another_request_headers() {
+    val transforms =
+      NativeRequestTransforms(
+        MapResourceConfig(
+          interceptor = { request ->
+            when (request.url) {
+              "https://origin.example/a" ->
+                MapRequestTransform(
+                  url = "https://cdn.example/a",
+                  headers = mapOf("Authorization" to "Bearer a"),
+                )
+              "https://cdn.example/a" ->
+                MapRequestTransform(
+                  url = "https://other.example/a",
+                  headers = mapOf("Authorization" to "Bearer b"),
+                )
+              else -> MapRequestTransform()
+            }
+          }
+        )
+      )
+    transforms.rewrittenUrl(MapResourceRequest("https://origin.example/a", MapResourceKind.Style))
+    transforms.rewrittenUrl(MapResourceRequest("https://cdn.example/a", MapResourceKind.Style))
+    val first =
+      transforms.headers(MapResourceRequest("https://cdn.example/a", MapResourceKind.Style))
+    val second =
+      transforms.headers(MapResourceRequest("https://other.example/a", MapResourceKind.Style))
+    assertEquals("Bearer a", first.single().value)
+    assertEquals("Bearer b", second.single().value)
+  }
+
+  @Test
   fun every_named_kind_maps_to_the_common_kind() {
     assertEquals(MapResourceKind.Style, ResourceKind.STYLE.toCommon())
     assertEquals(MapResourceKind.Source, ResourceKind.SOURCE.toCommon())

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/resource/MlnFfiRequestHooksTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/resource/MlnFfiRequestHooksTest.kt
@@ -59,9 +59,9 @@ class MlnFfiRequestHooksTest {
         )
       )
     transforms.rewrittenUrl(MapResourceRequest("https://origin.example/a", MapResourceKind.Style))
-    transforms.rewrittenUrl(MapResourceRequest("https://cdn.example/a", MapResourceKind.Style))
     val first =
       transforms.headers(MapResourceRequest("https://cdn.example/a", MapResourceKind.Style))
+    transforms.rewrittenUrl(MapResourceRequest("https://cdn.example/a", MapResourceKind.Style))
     val second =
       transforms.headers(MapResourceRequest("https://other.example/a", MapResourceKind.Style))
     assertEquals("Bearer a", first.single().value)
@@ -69,26 +69,23 @@ class MlnFfiRequestHooksTest {
   }
 
   @Test
-  fun colliding_rewrites_keep_both_header_sets() {
+  fun a_later_url_callback_replaces_an_unconsumed_transform() {
+    val calls = AtomicInt(0)
     val transforms =
       NativeRequestTransforms(
         MapResourceConfig(
-          interceptor = { request ->
-            MapRequestTransform(
-              url = "https://cdn.example/tile",
-              headers = mapOf("Authorization" to request.url.substringAfterLast('/')),
-            )
+          interceptor = {
+            calls.incrementAndFetch()
+            MapRequestTransform(headers = mapOf("Authorization" to "Bearer ${calls.load()}"))
           }
         )
       )
-    transforms.rewrittenUrl(MapResourceRequest("https://a.example/one", MapResourceKind.Tile))
-    transforms.rewrittenUrl(MapResourceRequest("https://b.example/two", MapResourceKind.Tile))
-    val first =
-      transforms.headers(MapResourceRequest("https://cdn.example/tile", MapResourceKind.Tile))
-    val second =
-      transforms.headers(MapResourceRequest("https://cdn.example/tile", MapResourceKind.Tile))
-    assertEquals("one", first.single().value)
-    assertEquals("two", second.single().value)
+    transforms.rewrittenUrl(MapResourceRequest("https://tiles.example.com/a", MapResourceKind.Tile))
+    transforms.rewrittenUrl(MapResourceRequest("https://tiles.example.com/a", MapResourceKind.Tile))
+    val headers =
+      transforms.headers(MapResourceRequest("https://tiles.example.com/a", MapResourceKind.Tile))
+    assertEquals("Bearer 2", headers.single().value)
+    assertEquals(0, transforms.pendingCount())
   }
 
   @Test

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/resource/MlnFfiRequestHooksTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/resource/MlnFfiRequestHooksTest.kt
@@ -69,6 +69,49 @@ class MlnFfiRequestHooksTest {
   }
 
   @Test
+  fun colliding_rewrites_keep_both_header_sets() {
+    val transforms =
+      NativeRequestTransforms(
+        MapResourceConfig(
+          interceptor = { request ->
+            MapRequestTransform(
+              url = "https://cdn.example/tile",
+              headers = mapOf("Authorization" to request.url.substringAfterLast('/')),
+            )
+          }
+        )
+      )
+    transforms.rewrittenUrl(MapResourceRequest("https://a.example/one", MapResourceKind.Tile))
+    transforms.rewrittenUrl(MapResourceRequest("https://b.example/two", MapResourceKind.Tile))
+    val first =
+      transforms.headers(MapResourceRequest("https://cdn.example/tile", MapResourceKind.Tile))
+    val second =
+      transforms.headers(MapResourceRequest("https://cdn.example/tile", MapResourceKind.Tile))
+    assertEquals("one", first.single().value)
+    assertEquals("two", second.single().value)
+  }
+
+  @Test
+  fun a_provider_accepted_request_is_not_recorded() {
+    val transforms =
+      NativeRequestTransforms(
+        MapResourceConfig(
+          interceptor = {
+            MapRequestTransform(
+              url = "app://style.json",
+              headers = mapOf("Authorization" to "Bearer a"),
+            )
+          },
+          provider = MapResourceProvider("app") { ByteArray(0) },
+        )
+      )
+    transforms.rewrittenUrl(
+      MapResourceRequest("https://tiles.example.com/style.json", MapResourceKind.Style)
+    )
+    assertEquals(0, transforms.pendingCount())
+  }
+
+  @Test
   fun every_named_kind_maps_to_the_common_kind() {
     assertEquals(MapResourceKind.Style, ResourceKind.STYLE.toCommon())
     assertEquals(MapResourceKind.Source, ResourceKind.SOURCE.toCommon())

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/resource/MlnFfiRequestHooksTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/resource/MlnFfiRequestHooksTest.kt
@@ -5,6 +5,9 @@ import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.concurrent.atomics.incrementAndFetch
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.maplibre.compose.mlnffi.MlnFfiOwnerThread
+import org.maplibre.compose.mlnffi.TestLatch
 import org.maplibre.nativeffi.resource.ResourceKind
 
 @OptIn(ExperimentalAtomicApi::class)
@@ -85,6 +88,48 @@ class MlnFfiRequestHooksTest {
     val headers =
       transforms.headers(MapResourceRequest("https://tiles.example.com/a", MapResourceKind.Tile))
     assertEquals("Bearer 2", headers.single().value)
+    assertEquals(0, transforms.pendingCount())
+  }
+
+  @Test
+  fun two_threads_with_the_same_name_keep_separate_transforms() {
+    val transforms =
+      NativeRequestTransforms(
+        MapResourceConfig(
+          interceptor = {
+            MapRequestTransform(headers = mapOf("Authorization" to "Bearer ${it.url}"))
+          }
+        )
+      )
+    val firstStored = TestLatch(1)
+    val secondStored = TestLatch(1)
+    var firstHeader: String? = null
+    val first =
+      MlnFfiOwnerThread("http-worker") {
+        transforms.rewrittenUrl(
+          MapResourceRequest("https://a.example/style.json", MapResourceKind.Style)
+        )
+        firstStored.countDown()
+        check(secondStored.await(10_000)) { "the second thread never stored a transform" }
+        firstHeader =
+          transforms
+            .headers(MapResourceRequest("https://a.example/style.json", MapResourceKind.Style))
+            .single()
+            .value
+      }
+    val second =
+      MlnFfiOwnerThread("http-worker") {
+        check(firstStored.await(10_000)) { "the first thread never stored a transform" }
+        transforms.rewrittenUrl(
+          MapResourceRequest("https://b.example/style.json", MapResourceKind.Style)
+        )
+        secondStored.countDown()
+      }
+    first.start()
+    second.start()
+    assertTrue(first.join(10_000), "the first worker never finished")
+    assertTrue(second.join(10_000), "the second worker never finished")
+    assertEquals("Bearer https://a.example/style.json", firstHeader)
     assertEquals(0, transforms.pendingCount())
   }
 

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/resource/MlnFfiRequestHooksTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/resource/MlnFfiRequestHooksTest.kt
@@ -92,6 +92,25 @@ class MlnFfiRequestHooksTest {
   }
 
   @Test
+  fun a_packaged_resource_request_is_not_recorded() {
+    val transforms =
+      NativeRequestTransforms(
+        MapResourceConfig(
+          interceptor = {
+            MapRequestTransform(
+              url = "jar:file:/app.jar!/style.json",
+              headers = mapOf("Authorization" to "Bearer a"),
+            )
+          }
+        )
+      )
+    transforms.rewrittenUrl(
+      MapResourceRequest("https://tiles.example.com/style.json", MapResourceKind.Style)
+    )
+    assertEquals(0, transforms.pendingCount())
+  }
+
+  @Test
   fun a_provider_accepted_request_is_not_recorded() {
     val transforms =
       NativeRequestTransforms(

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/resource/MlnFfiRequestHooksTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/resource/MlnFfiRequestHooksTest.kt
@@ -104,6 +104,7 @@ class MlnFfiRequestHooksTest {
     val firstStored = TestLatch(1)
     val secondStored = TestLatch(1)
     var firstHeader: String? = null
+    var secondHeader: String? = null
     val first =
       MlnFfiOwnerThread("http-worker") {
         transforms.rewrittenUrl(
@@ -124,12 +125,18 @@ class MlnFfiRequestHooksTest {
           MapResourceRequest("https://b.example/style.json", MapResourceKind.Style)
         )
         secondStored.countDown()
+        secondHeader =
+          transforms
+            .headers(MapResourceRequest("https://b.example/style.json", MapResourceKind.Style))
+            .single()
+            .value
       }
     first.start()
     second.start()
     assertTrue(first.join(10_000), "the first worker never finished")
     assertTrue(second.join(10_000), "the second worker never finished")
     assertEquals("Bearer https://a.example/style.json", firstHeader)
+    assertEquals("Bearer https://b.example/style.json", secondHeader)
     assertEquals(0, transforms.pendingCount())
   }
 

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/resource/MlnFfiRequestHooksTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/resource/MlnFfiRequestHooksTest.kt
@@ -1,10 +1,40 @@
 package org.maplibre.compose.resource
 
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+import kotlin.concurrent.atomics.incrementAndFetch
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import org.maplibre.nativeffi.resource.ResourceKind
 
+@OptIn(ExperimentalAtomicApi::class)
 class MlnFfiRequestHooksTest {
+
+  @Test
+  fun url_and_header_callbacks_share_one_interceptor_result() {
+    val calls = AtomicInt(0)
+    val transforms =
+      NativeRequestTransforms(
+        MapResourceConfig(
+          interceptor = { request ->
+            calls.incrementAndFetch()
+            MapRequestTransform(
+              url = request.url.replace("http://", "https://"),
+              headers = mapOf("Authorization" to "Bearer ${calls.load()}"),
+            )
+          }
+        )
+      )
+    val incoming = MapResourceRequest("http://tiles.example.com/style.json", MapResourceKind.Style)
+    assertEquals("https://tiles.example.com/style.json", transforms.rewrittenUrl(incoming))
+    val headers =
+      transforms.headers(
+        MapResourceRequest("https://tiles.example.com/style.json", MapResourceKind.Style)
+      )
+    assertEquals(1, calls.load())
+    assertEquals("Authorization", headers.single().name)
+    assertEquals("Bearer 1", headers.single().value)
+  }
 
   @Test
   fun every_named_kind_maps_to_the_common_kind() {

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/resource/MlnFfiResourceRequestTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/resource/MlnFfiResourceRequestTest.kt
@@ -13,6 +13,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.TimeSource
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.suspendCancellableCoroutine
 import org.maplibre.compose.mlnffi.TestLatch
 import org.maplibre.compose.mlnffi.launchTestTask
@@ -101,6 +102,25 @@ class MlnFfiResourceRequestTest {
 
     assertTrue(cancelled.load(), "an abandoned request must cancel provider.load")
     assertEquals(0, request.completions)
+  }
+
+  @Test
+  fun a_provider_timeout_completes_an_active_request() {
+    val provider =
+      MlnFfiResourceProvider(getLogger = { null }, passThroughNetwork = true).also {
+        providers += it
+      }
+    provider.userProvider =
+      MapResourceProvider(
+        accepts = { true },
+        load = { throw CancellationException("timeout") },
+      )
+    val request = RecordedRequest()
+    provider.takeUser(request, MapResourceRequest(URL, MapResourceKind.Style), URL, URL)
+    request.awaitAnswer()
+    assertEquals(ResourceResponseStatus.ERROR, request.response.status)
+    assertContains(request.response.errorMessage.orEmpty(), "cancelled")
+    request.awaitClose()
   }
 
   @Test

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/resource/MlnFfiResourceRequestTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/resource/MlnFfiResourceRequestTest.kt
@@ -1,5 +1,8 @@
+@file:OptIn(ExperimentalAtomicApi::class)
+
 package org.maplibre.compose.resource
 
+import kotlin.concurrent.atomics.AtomicBoolean
 import kotlin.concurrent.atomics.AtomicInt
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.concurrent.atomics.incrementAndFetch
@@ -10,6 +13,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.TimeSource
+import kotlinx.coroutines.suspendCancellableCoroutine
 import org.maplibre.compose.mlnffi.TestLatch
 import org.maplibre.compose.mlnffi.launchTestTask
 import org.maplibre.compose.mlnffi.parkForTest
@@ -68,6 +72,35 @@ class MlnFfiResourceRequestTest {
     request.awaitAnswer()
     assertEquals("late", request.response.bytes.decodeToString())
     request.awaitClose()
+  }
+
+  @Test
+  fun a_cancelled_user_load_is_cancelled_and_closed() {
+    val loading = TestLatch(1)
+    val cancelled = AtomicBoolean(false)
+    val provider =
+      MlnFfiResourceProvider(getLogger = { null }, passThroughNetwork = true).also {
+        providers += it
+      }
+    provider.userProvider =
+      MapResourceProvider(
+        accepts = { true },
+        load = {
+          suspendCancellableCoroutine { continuation ->
+            continuation.invokeOnCancellation { cancelled.store(true) }
+            loading.countDown()
+          }
+        },
+      )
+    val request = RecordedRequest()
+    provider.takeUser(request, MapResourceRequest(URL, MapResourceKind.Style), URL, URL)
+    assertTrue(loading.await(WAIT_SECONDS * 1_000), "the user load never started")
+
+    request.cancel()
+    request.awaitClose()
+
+    assertTrue(cancelled.load(), "an abandoned request must cancel provider.load")
+    assertEquals(0, request.completions)
   }
 
   @Test
@@ -168,12 +201,17 @@ class MlnFfiResourceRequestTest {
 
   /** A request the provider can take, recording what it did with it. */
   @OptIn(ExperimentalAtomicApi::class)
-  private class RecordedRequest(private val cancelled: Boolean = false) : TakenResourceRequest {
+  private class RecordedRequest(cancelled: Boolean = false) : TakenResourceRequest {
     private val responses = RecordingList<ResourceResponse>()
     private val answered = TestLatch(1)
     private val closeCount = AtomicInt(0)
+    private val cancelledState = AtomicBoolean(cancelled)
 
-    override fun isCancelled(): Boolean = cancelled
+    override fun isCancelled(): Boolean = cancelledState.load()
+
+    fun cancel() {
+      cancelledState.store(true)
+    }
 
     override fun complete(response: ResourceResponse) {
       responses += response

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/resource/MlnFfiResourceRequestTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/resource/MlnFfiResourceRequestTest.kt
@@ -14,6 +14,8 @@ import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.TimeSource
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.suspendCancellableCoroutine
 import org.maplibre.compose.mlnffi.TestLatch
 import org.maplibre.compose.mlnffi.launchTestTask
@@ -73,6 +75,42 @@ class MlnFfiResourceRequestTest {
     request.awaitAnswer()
     assertEquals("late", request.response.bytes.decodeToString())
     request.awaitClose()
+  }
+
+  @Test
+  fun a_user_scope_cancelled_before_dispatch_still_closes_the_handle() {
+    val provider =
+      MlnFfiResourceProvider(
+          getLogger = { null },
+          passThroughNetwork = true,
+          userCoroutineScope = CoroutineScope(SupervisorJob().apply { cancel() }),
+        )
+        .also { providers += it }
+    provider.userProvider =
+      MapResourceProvider(accepts = { true }, load = { MapResourceLoad.Bytes(ByteArray(0)) })
+    val request = RecordedRequest()
+    provider.takeUser(request, MapResourceRequest(URL, MapResourceKind.Style), URL, URL)
+    request.awaitClose()
+    assertEquals(1, request.closes)
+    assertEquals(1, request.completions)
+    assertEquals(ResourceResponseStatus.ERROR, request.response.status)
+  }
+
+  @Test
+  fun take_user_after_shutdown_is_refused() {
+    val provider =
+      MlnFfiResourceProvider(getLogger = { null }, passThroughNetwork = true).also {
+        providers += it
+      }
+    provider.userProvider =
+      MapResourceProvider(accepts = { true }, load = { MapResourceLoad.Bytes(ByteArray(0)) })
+    provider.close()
+    val request = RecordedRequest()
+    provider.takeUser(request, MapResourceRequest(URL, MapResourceKind.Style), URL, URL)
+    assertEquals(1, request.completions)
+    assertEquals(ResourceResponseStatus.ERROR, request.response.status)
+    assertContains(request.response.errorMessage.orEmpty(), "shut down")
+    assertEquals(1, request.closes)
   }
 
   @Test


### PR DESCRIPTION
Resolve #466

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Adds `MapRequestInterceptor` and `MapResourceProvider` so applications can rewrite URLs, add headers, or serve selected map resources on every platform.

## Validation

Ran JVM resource tests and `:lib:maplibre-compose:jsBrowserTest --tests org.maplibre.compose.resource.GlJsRequestControllerTest` after the review fixes (both BUILD SUCCESSFUL).

## AI assistance

Cursor Grok 4.6 cloud agent.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f4ebd377-f598-4a37-81d7-d518b8d4f7c6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f4ebd377-f598-4a37-81d7-d518b8d4f7c6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

