### PR TITLE
Update gesture redesign sequencing for the landed ownership API

### DIFF
--- a/.agents/docs/GESTURE_REDESIGN.md
+++ b/.agents/docs/GESTURE_REDESIGN.md
@@ -311,26 +311,20 @@ extracted later without breaking the parameter form, so it waits for demand.
 
 ## Sequence
 
-All in 0.16. The phases are PR sequencing against the API redesign work, which
-is in flight on the `api-redesign-*` branches.
+All in 0.16. These phases land on the ownership API.
 
 1. **Value model.** Events, filters, bindings, actions, `MapGestures`, in
-   `commonMain`, referencing no map state type. Parallel with the redesign
-   branches; conflicts with nothing in flight.
+   `commonMain`, referencing no map state type.
 2. **Arena rewrite.** `MapPointerGesture` reads bindings instead of
    `GestureOptions` and inline conditionals. Behavior-identical at `Standard`,
    verified against the existing `commonTest` and `liveMapTest` suites,
    including the token-ordering tests. `GestureOptions` is deleted. Still
-   against the internal `GestureTarget` seam, so still parallel.
+   against the internal `GestureTarget` seam.
 3. **New events.** Hover, double tap, long press as events with user actions
    (#951, #952), minus the layer walk.
-4. **Wiring after the `MapState` split lands.** The dispatch chain moves the
-   layer walk out of `MaplibreMap.kt` into delivery against the state-owned
-   composition host; `state.gestureCamera` becomes public; `MaplibreMap` takes
-   `gestures`. This phase serializes behind the `api-redesign-mapstate-split`
-   merge, because those PRs are rewriting the files it touches. The conflicts
-   confined to the attach points (`MaplibreMap.kt`, `MlnFfiMapView.kt`,
-   `JsMapView.kt`) are mechanical.
+4. **Wiring.** The dispatch chain moves the layer walk out of `MaplibreMap.kt`
+   into delivery against the state-owned composition host; `state.gestureCamera`
+   becomes public; `MaplibreMap` takes `gestures`.
 5. **Device work.** Trackpad scroll-pan through the continuous-scroll heuristic,
    trackpad pinch through Ctrl-scroll on web and the `Scale` events where a
    platform emits them, tilt velocity, and Shift-drag box zoom, as recognizers
@@ -347,7 +341,7 @@ until the query answers. A prototype decides.
 
 **Naming.** `MapGestures`, binding and action class names, and
 `state.gestureCamera` are placeholders. The final names follow the `MapState`
-naming that step 4 of the API redesign settles.
+naming in the ownership API.
 
 **Chain latency bounds.** The double-tap fallthrough waits on one
 `queryRenderedFeatures`. If a style makes that query slow, the zoom lags. A


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Revise the 0.16 gesture plan so its phases land on the ownership API instead of waiting for finished `api-redesign-*` work.

## Validation

A markdown search finds no remaining `api-redesign` or in-flight redesign sequencing, and the pre-commit formatter accepted the file.

## AI assistance

Cursor Grok 4.6 cloud agent.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c7c668c0-3bab-4f15-9315-54f29f245e94?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c7c668c0-3bab-4f15-9315-54f29f245e94&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

