### PR TITLE
Clear the request interceptor when leaving composition

### DIFF
--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Requests.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Requests.kt
@@ -3,7 +3,7 @@
 package org.maplibre.compose.docsnippets
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.DisposableEffect
 import org.maplibre.compose.map.MaplibreMap
 import org.maplibre.compose.map.rememberMapRuntime
 import org.maplibre.compose.map.rememberMapState
@@ -14,7 +14,7 @@ import org.maplibre.compose.resource.MapResourceProvider
 fun InterceptorMap(token: String) {
   val runtime = rememberMapRuntime()
   // #region interceptor
-  LaunchedEffect(token) {
+  DisposableEffect(token) {
     runtime.setRequestInterceptor { request ->
       if (request.url.startsWith("https://tiles.example.com/")) {
         MapRequestTransform(headers = mapOf("Authorization" to "Bearer $token"))
@@ -22,6 +22,7 @@ fun InterceptorMap(token: String) {
         MapRequestTransform()
       }
     }
+    onDispose { runtime.setRequestInterceptor(null) }
   }
   MaplibreMap(state = rememberMapState(runtime))
   // #endregion interceptor

--- a/docs/src/content/docs/requests.mdx
+++ b/docs/src/content/docs/requests.mdx
@@ -20,7 +20,8 @@ change after construction. The provider is fixed at construction.
 ## Rewrite a request
 
 <Api of="MapRuntime.setRequestInterceptor" /> applies to every map and
-snapshotter on the runtime:
+snapshotter on the runtime. Install it in a `DisposableEffect` so it lasts
+for this composition:
 
 <Code code={region(requests, "interceptor")} lang="kotlin" title="App.kt" />
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

The request-interceptor docs snippet now uses `DisposableEffect` and clears the interceptor when the composition leaves.

## Validation

Compiled `:demo-app:common:compileKotlinJvm` so the snippet still type-checks.

## AI assistance

Cursor Grok 4.6 cloud agent.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f4ebd377-f598-4a37-81d7-d518b8d4f7c6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f4ebd377-f598-4a37-81d7-d518b8d4f7c6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

