### PR TITLE
Simplify map overlay control state

### DIFF
--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/LocationDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/LocationDemo.kt
@@ -112,7 +112,6 @@ object LocationDemo : Demo {
     LocationPuck(
       idPrefix = "user",
       locationState = locationState,
-      presentation = presentation,
       colors = LocationPuckDefaults.colors(),
     )
   }

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Controls.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Controls.kt
@@ -38,8 +38,6 @@ fun Controls() {
       MapOverlay {
         MaplibreLogo(Modifier.align(Alignment.BottomStart))
         ExpandingAttributionButton(
-          presentation = presentation, // (1)!
-          styleState = styleState,
           modifier = Modifier.align(Alignment.TopEnd),
           contentAlignment = Alignment.TopEnd,
         )

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Location.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Location.kt
@@ -38,7 +38,6 @@ fun Location() {
         LocationPuck(
           idPrefix = "user",
           locationState = locationState,
-          presentation = mapState.presentation,
         )
 
         LocationTrackingEffect(locationState = locationState) {

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Material3.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Material3.kt
@@ -27,11 +27,9 @@ fun Material3() {
           presentation?.viewport?.metersPerDpAtTarget ?: 0.0,
           modifier = Modifier.align(Alignment.TopStart),
         ) // (1)!
-        CompassButton(mapState, presentation, modifier = Modifier.align(Alignment.TopEnd))
+        CompassButton(modifier = Modifier.align(Alignment.TopEnd))
         MaplibreLogo(Modifier.align(Alignment.BottomStart))
         ExpandingAttributionButton(
-          presentation = presentation,
-          styleState = styleState,
           modifier = Modifier.align(Alignment.BottomEnd),
           contentAlignment = Alignment.BottomEnd,
         )

--- a/docs/src/content/docs/controls.mdx
+++ b/docs/src/content/docs/controls.mdx
@@ -36,7 +36,7 @@ A <Api of="MapOverlay" /> block draws the controls you list in it.
 
 <Code code={region(controls, "custom")} lang="kotlin" title="App.kt" />
 
-1. The block provides the `mapState`, current `presentation`, and `styleState`.
+The controls use the map state from the `MapOverlay` block.
 
 ## Theme the controls with Material 3
 

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/org/maplibre/compose/material3/AttributionButton.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/org/maplibre/compose/material3/AttributionButton.kt
@@ -17,12 +17,11 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import org.maplibre.compose.map.MapPresentation
-import org.maplibre.compose.map.MapStyleState
 import org.maplibre.compose.overlay.AttributionDefaults
 import org.maplibre.compose.overlay.AttributionLinks as BaseAttributionLinks
 import org.maplibre.compose.overlay.AttributionStyle
 import org.maplibre.compose.overlay.ExpandingAttributionButton as BaseExpandingAttributionButton
+import org.maplibre.compose.overlay.MapOverlayScope
 
 /**
  * Info button from which an attribution popup text is expanded. This version retracts when the user
@@ -31,8 +30,6 @@ import org.maplibre.compose.overlay.ExpandingAttributionButton as BaseExpandingA
  * This is [org.maplibre.compose.overlay.ExpandingAttributionButton] with its colors, typography,
  * and widgets taken from the Material 3 theme.
  *
- * @param presentation Used to dismiss the attribution when the user interacts with the map.
- * @param styleState Used to get the attribution links to display.
  * @param contentAlignment Will be used to determine layout of the attribution icon and text.
  * @param toggleButton Composable that defines the button used to toggle the attribution display.
  *   Takes an onClick function parameter that should be called to switch states.
@@ -46,9 +43,7 @@ import org.maplibre.compose.overlay.ExpandingAttributionButton as BaseExpandingA
  *   the given alignment
  */
 @Composable
-public fun ExpandingAttributionButton(
-  presentation: MapPresentation?,
-  styleState: MapStyleState,
+public fun MapOverlayScope.ExpandingAttributionButton(
   modifier: Modifier = Modifier,
   contentAlignment: Alignment = Alignment.BottomEnd,
   toggleButton: @Composable (onClick: () -> Unit) -> Unit = AttributionButtonDefaults.button,
@@ -60,60 +55,6 @@ public fun ExpandingAttributionButton(
   collapse: (Alignment) -> ExitTransition = AttributionDefaults.collapse,
 ) {
   BaseExpandingAttributionButton(
-    presentation = presentation,
-    styleState = styleState,
-    modifier = modifier,
-    contentAlignment = contentAlignment,
-    toggleButton = toggleButton,
-    expandedContent = expandedContent,
-    expandedStyle = expandedStyle,
-    collapsedStyle = collapsedStyle,
-    expand = expand,
-    collapse = collapse,
-  )
-}
-
-/**
- * Info button from which an attribution popup text is expanded. This version allows the caller to
- * manage the state.
- *
- * This is [org.maplibre.compose.overlay.ExpandingAttributionButton] with its colors, typography,
- * and widgets taken from the Material 3 theme.
- *
- * @param expanded Whether the attribution text is expanded.
- * @param onClick Called when the button is pressed. Should toggle the expanded state.
- * @param styleState Used to get the attribution links to display.
- * @param contentAlignment Will be used to determine layout of the attribution icon and text.
- * @param toggleButton Composable that defines the button used to toggle the attribution display.
- *   Takes an onClick function parameter that should be called to switch states.
- * @param expandedContent Composable that defines how the attribution content is displayed when
- *   expanded. Takes the list of HTML strings to display and the resolved text style.
- * @param expandedStyle Style of the attribution container when it is expanded.
- * @param collapsedStyle Style of the attribution container when it is collapsed.
- * @param expand Function that returns an [EnterTransition] for the expanding animation based on the
- *   given alignment
- * @param collapse Function that returns an [ExitTransition] for the collapsing animation based on
- *   the given alignment
- */
-@Composable
-public fun ExpandingAttributionButton(
-  expanded: Boolean,
-  onClick: () -> Unit,
-  styleState: MapStyleState,
-  modifier: Modifier = Modifier,
-  contentAlignment: Alignment = Alignment.BottomEnd,
-  toggleButton: @Composable (onClick: () -> Unit) -> Unit = AttributionButtonDefaults.button,
-  expandedContent: @Composable (attributions: List<String>, textStyle: TextStyle) -> Unit =
-    AttributionButtonDefaults.content,
-  expandedStyle: AttributionStyle = AttributionButtonDefaults.expandedStyle(),
-  collapsedStyle: AttributionStyle = AttributionButtonDefaults.collapsedStyle(),
-  expand: (Alignment) -> EnterTransition = AttributionDefaults.expand,
-  collapse: (Alignment) -> ExitTransition = AttributionDefaults.collapse,
-) {
-  BaseExpandingAttributionButton(
-    expanded = expanded,
-    onClick = onClick,
-    styleState = styleState,
     modifier = modifier,
     contentAlignment = contentAlignment,
     toggleButton = toggleButton,

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/org/maplibre/compose/material3/CompassButton.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/org/maplibre/compose/material3/CompassButton.kt
@@ -18,12 +18,11 @@ import androidx.compose.ui.unit.dp
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 import org.maplibre.compose.camera.CameraPosition
-import org.maplibre.compose.map.MapPresentation
-import org.maplibre.compose.map.MapState
 import org.maplibre.compose.overlay.CompassButton as BaseCompassButton
 import org.maplibre.compose.overlay.CompassButtonStyle
 import org.maplibre.compose.overlay.CompassDefaults
 import org.maplibre.compose.overlay.DisappearingCompassButton as BaseDisappearingCompassButton
+import org.maplibre.compose.overlay.MapOverlayScope
 
 /**
  * A compass that points north and returns the camera to [getHomePosition] when it is clicked.
@@ -31,8 +30,6 @@ import org.maplibre.compose.overlay.DisappearingCompassButton as BaseDisappearin
  * This is [org.maplibre.compose.overlay.CompassButton] with the colors, shape, and elevation of an
  * [ElevatedButton].
  *
- * @param mapState The logical map whose durable camera position the needle follows.
- * @param presentation The current presentation that a click resets.
  * @param onClick Called after the camera animation starts.
  * @param colors Container and content colors, defaulting to those of an [ElevatedButton].
  * @param contentDescription Accessibility label for the needle.
@@ -43,9 +40,7 @@ import org.maplibre.compose.overlay.DisappearingCompassButton as BaseDisappearin
  * @param getHomePosition The camera position that a click returns to.
  */
 @Composable
-public fun CompassButton(
-  mapState: MapState,
-  presentation: MapPresentation?,
+public fun MapOverlayScope.CompassButton(
   modifier: Modifier = Modifier,
   onClick: () -> Unit = {},
   colors: ButtonColors = ButtonDefaults.elevatedButtonColors(),
@@ -57,8 +52,6 @@ public fun CompassButton(
   getHomePosition: (CameraPosition) -> CameraPosition = { it.copy(bearing = 0.0, tilt = 0.0) },
 ) {
   BaseCompassButton(
-    mapState = mapState,
-    presentation = presentation,
     modifier = modifier,
     onClick = onClick,
     style = elevatedButtonStyle(colors, shape),
@@ -82,9 +75,7 @@ public fun CompassButton(
  *   degrees.
  */
 @Composable
-public fun DisappearingCompassButton(
-  mapState: MapState,
-  presentation: MapPresentation?,
+public fun MapOverlayScope.DisappearingCompassButton(
   modifier: Modifier = Modifier,
   onClick: () -> Unit = {},
   colors: ButtonColors = ButtonDefaults.elevatedButtonColors(),
@@ -100,8 +91,6 @@ public fun DisappearingCompassButton(
   slop: Double = 0.5,
 ) {
   BaseDisappearingCompassButton(
-    mapState = mapState,
-    presentation = presentation,
     modifier = modifier,
     onClick = onClick,
     style = elevatedButtonStyle(colors, shape),

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/org/maplibre/compose/material3/MapOverlay.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/org/maplibre/compose/material3/MapOverlay.kt
@@ -15,22 +15,16 @@ private val Material3Overlay = MapOverlay {
     modifier = Modifier.align(Alignment.TopStart),
   )
 
-  DisappearingCompassButton(
-    mapState = mapState,
-    presentation = presentation,
-    modifier = Modifier.align(Alignment.TopEnd),
-  )
+  DisappearingCompassButton(modifier = Modifier.align(Alignment.TopEnd))
 
-  // Read before entering the Row, whose scope shadows this one.
-  val currentPresentation = presentation
-  val style = styleState
+  val overlayScope = this
   Row(
     Modifier.align(Alignment.BottomStart).fillMaxWidth(),
     horizontalArrangement = Arrangement.SpaceBetween,
     verticalAlignment = Alignment.CenterVertically,
   ) {
     MaplibreLogo()
-    ExpandingAttributionButton(presentation = currentPresentation, styleState = style)
+    overlayScope.ExpandingAttributionButton()
   }
 }
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/location/LocationPuck.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/location/LocationPuck.kt
@@ -47,10 +47,10 @@ import org.maplibre.compose.expressions.value.IconRotationAlignment
 import org.maplibre.compose.expressions.value.SymbolAnchor
 import org.maplibre.compose.layers.CircleLayer
 import org.maplibre.compose.layers.SymbolLayer
-import org.maplibre.compose.map.MapPresentation
 import org.maplibre.compose.sources.GeoJsonData
 import org.maplibre.compose.sources.GeoJsonSource
 import org.maplibre.compose.sources.rememberGeoJsonSource
+import org.maplibre.compose.style.LocalMapState
 import org.maplibre.compose.util.ClickResult
 import org.maplibre.spatialk.geojson.Feature
 import org.maplibre.spatialk.geojson.FeatureCollection
@@ -72,9 +72,6 @@ import org.maplibre.spatialk.units.extensions.meters
  *
  * @param idPrefix The prefix used for the layers to display the location indicator.
  * @param locationState State providing the location and heading measurements to display.
- * @param presentation The current map presentation, used only for
- *   [Viewport.metersPerDpAtTarget][org.maplibre.compose.camera.Viewport.metersPerDpAtTarget] to
- *   correctly draw the accuracy circle.
  * @param oldLocationThreshold Locations older than this will be styled differently.
  * @param accuracyThreshold A circle showing the accuracy range will be drawn when
  *   [LocationMeasurement.horizontalAccuracy] is larger than this value. Use
@@ -90,7 +87,6 @@ import org.maplibre.spatialk.units.extensions.meters
 public fun LocationPuck(
   idPrefix: String,
   locationState: LocationState,
-  presentation: MapPresentation?,
   oldLocationThreshold: Duration = 30.seconds,
   accuracyThreshold: Length = 50.meters,
   colors: LocationPuckColors = LocationPuckColors(),
@@ -107,7 +103,6 @@ public fun LocationPuck(
         bearing = locationState.mostAccurateBearing(),
         bearingAccuracy = locationState.mostAccurateBearingAccuracy(),
       ),
-    presentation = presentation,
     oldLocationThreshold = oldLocationThreshold,
     accuracyThreshold = accuracyThreshold,
     colors = colors,
@@ -132,10 +127,6 @@ public fun LocationPuck(
  *   `location.course`, the direction of travel.
  * @param bearingAccuracy Estimated bearing error. Defaults to `location.courseAccuracy` when
  *   [bearing] is the location course.
- * @param presentation The current map presentation, used only for
- *   [Viewport.metersPerDpAtTarget][org.maplibre.compose.camera.Viewport.metersPerDpAtTarget] to
- *   correctly draw the accuracy circle. The presentation is not modified by this composable; if you
- *   want the camera to track the current location, use [LocationTrackingEffect].
  * @param oldLocationThreshold Locations older than this will be styled differently.
  * @param accuracyThreshold A circle showing the accuracy range will be drawn when
  *   [LocationMeasurement.horizontalAccuracy] is larger than this value. Use
@@ -151,7 +142,6 @@ public fun LocationPuck(
 public fun LocationPuck(
   idPrefix: String,
   location: LocationMeasurement?,
-  presentation: MapPresentation?,
   measurementMark: TimeMark? = null,
   bearing: Bearing? = location?.course,
   bearingAccuracy: Rotation? = defaultBearingAccuracy(location, bearing),
@@ -165,7 +155,6 @@ public fun LocationPuck(
   LocationPuckContent(
     idPrefix = idPrefix,
     measurement = locationPuckMeasurement(location, measurementMark, bearing, bearingAccuracy),
-    presentation = presentation,
     oldLocationThreshold = oldLocationThreshold,
     accuracyThreshold = accuracyThreshold,
     colors = colors,
@@ -179,7 +168,6 @@ public fun LocationPuck(
 private fun LocationPuckContent(
   idPrefix: String,
   measurement: LocationPuckMeasurement?,
-  presentation: MapPresentation?,
   oldLocationThreshold: Duration,
   accuracyThreshold: Length,
   colors: LocationPuckColors,
@@ -187,6 +175,7 @@ private fun LocationPuckContent(
   onClick: LocationClickHandler?,
   onLongClick: LocationClickHandler?,
 ) {
+  val presentation = LocalMapState.current?.presentation
   val location = measurement?.location
   val bearing = measurement?.bearing
   val bearingAccuracy = measurement?.bearingAccuracy

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MaplibreMap.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MaplibreMap.kt
@@ -144,6 +144,7 @@ private fun MaplibreMapPresentation(
     rememberStyleComposition(
       composition = styleComposition,
       maybeStyle = rememberedStyle,
+      mapState = state,
       replaceableSourceIds = state.desiredStyleRevision.sources.mapTo(mutableSetOf()) { it.id },
       replaceableLayerIds =
         state.desiredStyleRevision.layers.mapTo(mutableSetOf()) {

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/Attribution.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/Attribution.kt
@@ -62,7 +62,6 @@ import org.maplibre.compose.camera.CameraMoveReason
 import org.maplibre.compose.generated.Res
 import org.maplibre.compose.generated.attribution
 import org.maplibre.compose.generated.info
-import org.maplibre.compose.map.MapPresentation
 import org.maplibre.compose.map.MapStyleState
 import org.maplibre.compose.util.horizontal
 import org.maplibre.compose.util.reverse
@@ -76,8 +75,6 @@ import org.maplibre.compose.util.vertical
  * This component draws with Compose Foundation alone. The Material 3 module provides a themed
  * version of it.
  *
- * @param presentation Used to dismiss the attribution when the user interacts with the map.
- * @param styleState Used to get the attribution links to display.
  * @param contentAlignment Will be used to determine layout of the attribution icon and text.
  * @param toggleButton Composable that defines the button used to toggle the attribution display.
  *   Takes an onClick function parameter that should be called to switch states.
@@ -91,9 +88,7 @@ import org.maplibre.compose.util.vertical
  *   the given alignment
  */
 @Composable
-public fun ExpandingAttributionButton(
-  presentation: MapPresentation?,
-  styleState: MapStyleState,
+public fun MapOverlayScope.ExpandingAttributionButton(
   modifier: Modifier = Modifier,
   contentAlignment: Alignment = Alignment.BottomEnd,
   toggleButton: @Composable (onClick: () -> Unit) -> Unit = AttributionDefaults.button,
@@ -105,83 +100,35 @@ public fun ExpandingAttributionButton(
   collapse: (Alignment) -> ExitTransition = AttributionDefaults.collapse,
 ) {
   var expanded by remember { mutableStateOf(true) }
+  val currentPresentation = presentation
 
   // dismiss on any map gesture
-  LaunchedEffect(presentation?.isCameraMoving, presentation?.cameraMoveReason) {
+  LaunchedEffect(currentPresentation?.isCameraMoving, currentPresentation?.cameraMoveReason) {
     if (
-      presentation?.isCameraMoving == true &&
-        presentation.cameraMoveReason == CameraMoveReason.GESTURE
+      currentPresentation?.isCameraMoving == true &&
+        currentPresentation.cameraMoveReason == CameraMoveReason.GESTURE
     ) {
       expanded = false
     }
   }
 
-  ExpandingAttributionButton(
-    expanded = expanded,
-    onClick = { expanded = !expanded },
-    styleState = styleState,
-    modifier = modifier,
-    contentAlignment = contentAlignment,
-    toggleButton = toggleButton,
-    expandedContent = expandedContent,
-    expandedStyle = expandedStyle,
-    collapsedStyle = collapsedStyle,
-    expand = expand,
-    collapse = collapse,
-  )
-}
-
-/**
- * Info button from which an attribution popup text is expanded. This version allows the caller to
- * manage the state.
- *
- * This component draws with Compose Foundation alone. The Material 3 module provides a themed
- * version of it.
- *
- * @param expanded Whether the attribution text is expanded.
- * @param onClick Called when the button is pressed. Should toggle the expanded state.
- * @param styleState Used to get the attribution links to display.
- * @param contentAlignment Will be used to determine layout of the attribution icon and text.
- * @param toggleButton Composable that defines the button used to toggle the attribution display.
- *   Takes an onClick function parameter that should be called to switch states.
- * @param expandedContent Composable that defines how the attribution content is displayed when
- *   expanded. Takes the list of HTML strings to display and the resolved text style.
- * @param expandedStyle Style of the attribution container when it is expanded.
- * @param collapsedStyle Style of the attribution container when it is collapsed.
- * @param expand Function that returns an [EnterTransition] for the expanding animation based on the
- *   given alignment
- * @param collapse Function that returns an [ExitTransition] for the collapsing animation based on
- *   the given alignment
- */
-@Composable
-public fun ExpandingAttributionButton(
-  expanded: Boolean,
-  onClick: () -> Unit,
-  styleState: MapStyleState,
-  modifier: Modifier = Modifier,
-  contentAlignment: Alignment = Alignment.BottomEnd,
-  toggleButton: @Composable (onClick: () -> Unit) -> Unit = AttributionDefaults.button,
-  expandedContent: @Composable (attributions: List<String>, textStyle: TextStyle) -> Unit =
-    AttributionDefaults.content,
-  expandedStyle: AttributionStyle = AttributionDefaults.expandedStyle(),
-  collapsedStyle: AttributionStyle = AttributionDefaults.collapsedStyle(),
-  expand: (Alignment) -> EnterTransition = AttributionDefaults.expand,
-  collapse: (Alignment) -> ExitTransition = AttributionDefaults.collapse,
-) {
-  val attributions by remember(styleState) { derivedStateOf { styleState.attributions() } }
+  val mapStyle = style
+  val attributions by remember(mapStyle) { derivedStateOf { mapStyle.attributions() } }
   if (attributions.isEmpty()) return
 
-  val style = if (expanded) expandedStyle else collapsedStyle
-  val containerColor by animateColorAsState(style.containerColor)
-  val contentColor by animateColorAsState(style.contentColor)
-  val shadowElevation by animateDpAsState(style.shadowElevation)
+  val attributionStyle = if (expanded) expandedStyle else collapsedStyle
+  val containerColor by animateColorAsState(attributionStyle.containerColor)
+  val contentColor by animateColorAsState(attributionStyle.contentColor)
+  val shadowElevation by animateDpAsState(attributionStyle.shadowElevation)
 
   Box(
     modifier
-      .shadow(shadowElevation, style.shape, clip = false)
-      .then(style.border?.let { Modifier.border(it, style.shape) } ?: Modifier)
-      .background(containerColor, style.shape)
-      .clip(style.shape)
+      .shadow(shadowElevation, attributionStyle.shape, clip = false)
+      .then(
+        attributionStyle.border?.let { Modifier.border(it, attributionStyle.shape) } ?: Modifier
+      )
+      .background(containerColor, attributionStyle.shape)
+      .clip(attributionStyle.shape)
       // Without this, a drag across the attribution pans the map underneath it.
       .pointerInput(Unit) {}
       .semantics { isTraversalGroup = true }
@@ -200,7 +147,7 @@ public fun ExpandingAttributionButton(
         if (rowArrangement == Arrangement.End) layoutDir.reverse() else layoutDir
     ) {
       Row(horizontalArrangement = rowArrangement, verticalAlignment = Alignment.CenterVertically) {
-        Box(Modifier.align(contentAlignment.vertical)) { toggleButton(onClick) }
+        Box(Modifier.align(contentAlignment.vertical)) { toggleButton { expanded = !expanded } }
 
         AnimatedVisibility(
           visible = expanded,
@@ -210,7 +157,7 @@ public fun ExpandingAttributionButton(
         ) {
           Box(Modifier.padding(start = 0.dp, end = 16.dp, top = 8.dp, bottom = 8.dp)) {
             CompositionLocalProvider(LocalLayoutDirection provides layoutDir) {
-              expandedContent(attributions, style.textStyle.copy(color = contentColor))
+              expandedContent(attributions, attributionStyle.textStyle.copy(color = contentColor))
             }
           }
         }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/CompassButton.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/CompassButton.kt
@@ -50,8 +50,6 @@ import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.generated.Res
 import org.maplibre.compose.generated.compass
 import org.maplibre.compose.generated.compass_needle
-import org.maplibre.compose.map.MapPresentation
-import org.maplibre.compose.map.MapState
 import org.maplibre.compose.util.AngleMath
 
 /**
@@ -60,8 +58,6 @@ import org.maplibre.compose.util.AngleMath
  * This component draws with Compose Foundation alone. The Material 3 module provides a themed
  * version of it.
  *
- * @param mapState The logical map whose durable camera position the needle follows.
- * @param presentation The current presentation that a click resets.
  * @param onClick Called after the camera animation starts.
  * @param style Colors, shape, and elevation of the button behind the needle.
  * @param contentDescription Accessibility label for the needle.
@@ -71,9 +67,7 @@ import org.maplibre.compose.util.AngleMath
  * @param getHomePosition The camera position that a click returns to.
  */
 @Composable
-public fun CompassButton(
-  mapState: MapState,
-  presentation: MapPresentation?,
+public fun MapOverlayScope.CompassButton(
   modifier: Modifier = Modifier,
   onClick: () -> Unit = {},
   style: CompassButtonStyle = CompassDefaults.style(),
@@ -83,6 +77,8 @@ public fun CompassButton(
   needlePainter: Painter = CompassDefaults.needlePainter(),
   getHomePosition: (CameraPosition) -> CameraPosition = { it.copy(bearing = 0.0, tilt = 0.0) },
 ) {
+  val currentMapState = mapState
+  val currentPresentation = presentation
   val coroutineScope = rememberCoroutineScope()
   val interactionSource = remember { MutableInteractionSource() }
   val hovered by interactionSource.collectIsHoveredAsState()
@@ -101,9 +97,9 @@ public fun CompassButton(
         indication = LocalIndication.current,
         role = Role.Button,
       ) {
-        presentation?.let { current ->
+        currentPresentation?.let { current ->
           coroutineScope.launch {
-            current.animateCameraPosition(getHomePosition(mapState.cameraPosition))
+            current.animateCameraPosition(getHomePosition(currentMapState.cameraPosition))
           }
         }
         onClick()
@@ -117,8 +113,8 @@ public fun CompassButton(
       modifier =
         Modifier.fillMaxSize()
           .graphicsLayer(
-            rotationZ = -mapState.cameraPosition.bearing.toFloat(),
-            rotationX = mapState.cameraPosition.tilt.toFloat(),
+            rotationZ = -currentMapState.cameraPosition.bearing.toFloat(),
+            rotationX = currentMapState.cameraPosition.tilt.toFloat(),
           ),
     )
   }
@@ -136,9 +132,7 @@ public fun CompassButton(
  *   degrees.
  */
 @Composable
-public fun DisappearingCompassButton(
-  mapState: MapState,
-  presentation: MapPresentation?,
+public fun MapOverlayScope.DisappearingCompassButton(
   modifier: Modifier = Modifier,
   onClick: () -> Unit = {},
   style: CompassButtonStyle = CompassDefaults.style(),
@@ -152,6 +146,7 @@ public fun DisappearingCompassButton(
   getHomePosition: (CameraPosition) -> CameraPosition = { it.copy(bearing = 0.0, tilt = 0.0) },
   slop: Double = 0.5,
 ) {
+  val overlayScope = this
   val visible = remember { MutableTransitionState(false) }
 
   val currentGetHomePosition by rememberUpdatedState(getHomePosition)
@@ -184,9 +179,7 @@ public fun DisappearingCompassButton(
     enter = enterTransition,
     exit = exitTransition,
   ) {
-    CompassButton(
-      mapState = mapState,
-      presentation = presentation,
+    overlayScope.CompassButton(
       onClick = onClick,
       style = style,
       contentDescription = contentDescription,

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/MapOverlay.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/MapOverlay.kt
@@ -52,7 +52,7 @@ public interface MapOverlayScope {
     get() = mapState.presentation
 
   /** The style state of the map that this overlay belongs to. */
-  public val styleState: MapStyleState
+  public val style: MapStyleState
     get() = mapState.style
 
   /**
@@ -155,22 +155,16 @@ public class MapOverlay(
         modifier = Modifier.align(Alignment.TopStart),
       )
 
-      DisappearingCompassButton(
-        mapState = mapState,
-        presentation = presentation,
-        modifier = Modifier.align(Alignment.TopEnd),
-      )
+      DisappearingCompassButton(modifier = Modifier.align(Alignment.TopEnd))
 
-      // Read before entering the Row, whose scope shadows this one.
-      val currentPresentation = presentation
-      val style = styleState
+      val overlayScope = this
       Row(
         Modifier.align(Alignment.BottomStart).fillMaxWidth(),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
       ) {
         MaplibreLogo()
-        ExpandingAttributionButton(presentation = currentPresentation, styleState = style)
+        overlayScope.ExpandingAttributionButton()
       }
     }
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/rememberStyleComposition.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/rememberStyleComposition.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCompositionContext
 import androidx.compose.runtime.staticCompositionLocalOf
 import kotlinx.coroutines.awaitCancellation
+import org.maplibre.compose.map.MapState
 import org.maplibre.compose.util.MaplibreComposable
 
 /**
@@ -24,6 +25,7 @@ import org.maplibre.compose.util.MaplibreComposable
 internal fun rememberStyleComposition(
   composition: StyleComposition,
   maybeStyle: StyleBinding?,
+  mapState: MapState? = null,
   replaceableSourceIds: Set<String> = emptySet(),
   replaceableLayerIds: Set<String> = emptySet(),
 ): State<DesiredStyleRevision?> {
@@ -31,7 +33,7 @@ internal fun rememberStyleComposition(
     remember(composition, maybeStyle) { mutableStateOf<DesiredStyleRevision?>(null) }
   val compositionContext = rememberCompositionContext()
 
-  LaunchedEffect(composition, maybeStyle) {
+  LaunchedEffect(composition, maybeStyle, mapState) {
     val style = maybeStyle ?: return@LaunchedEffect
     if (!style.isLoaded) return@LaunchedEffect
     val rootNode =
@@ -46,6 +48,7 @@ internal fun rememberStyleComposition(
     evaluator.setContent {
       StyleContent(
         rootNode = rootNode,
+        mapState = mapState,
         publish = { revisionState.value = it },
         content = composition.content,
       )
@@ -64,10 +67,13 @@ internal fun rememberStyleComposition(
 @Composable
 internal fun StyleContent(
   rootNode: StyleNode,
+  mapState: MapState? = null,
   publish: (DesiredStyleRevision) -> Unit = {},
   content: @Composable @MaplibreComposable () -> Unit,
 ) {
-  CompositionLocalProvider(LocalStyleNode provides rootNode) { content() }
+  CompositionLocalProvider(LocalStyleNode provides rootNode, LocalMapState provides mapState) {
+    content()
+  }
   key(rootNode.currentApplyGeneration) {
     // Side effects run after remember observers, so the evaluator publishes a complete revision.
     SideEffect { publish(rootNode.snapshotRevision()) }
@@ -75,3 +81,5 @@ internal fun StyleContent(
 }
 
 internal val LocalStyleNode = staticCompositionLocalOf<StyleNode> { throw IllegalStateException() }
+
+internal val LocalMapState = staticCompositionLocalOf<MapState?> { null }


### PR DESCRIPTION
## Description

Make map-coupled controls use `MapOverlayScope`, remove the state-hoisted attribution overload, and provide the current map internally to style content such as `LocationPuck`.

## Validation

Validated on macOS with `mise run check`, `mise run build:desktop-app`, and `mise run test:desktop`.

## AI assistance

Codex with GPT-5 implemented and validated the change under user direction.