### PR TITLE
Capture Android emulator diagnostics after cancelled device tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,14 +125,18 @@ jobs:
           allow-missing-junit-files: "false"
         env:
           TRUNK_API_TOKEN: ${{ secrets.TRUNK_API_TOKEN }}
+      # Job timeout is cancelled, not failure. Logcat's TestRunner lines name a
+      # hung test, so capture after every device-test outcome, including cancel.
       - name: Capture Android emulator diagnostics
-        if: ${{ failure() && steps.android-device-tests.outcome == 'failure' }}
+        if: ${{ always() && steps.android-device-tests.outcome != 'skipped' }}
+        continue-on-error: true
         run: mise run android-emulator:diagnostics
       - name: Upload Android emulator diagnostics
-        if: ${{ failure() && steps.android-device-tests.outcome == 'failure' }}
+        if: ${{ always() && steps.android-device-tests.outcome != 'skipped' }}
+        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          if-no-files-found: error
+          if-no-files-found: warn
           name: android-${{ matrix.api-level }}-diagnostics
           path: |
             build/android-emulator/avd/**/*.ini


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Run Android emulator diagnostics and upload them after every device-test outcome, including job timeout, so logcat still names a hung test.

## Validation

Ran actionlint and the action-pins check on `.github/workflows/ci.yml`.

## AI assistance

Cursor Grok 4.6 cloud agent.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fcbd397a-4c2a-4e63-8621-dfa89729d0eb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fcbd397a-4c2a-4e63-8621-dfa89729d0eb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

