### PR TITLE
Document map snapshot capture

### DIFF
--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Snapshotter.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Snapshotter.kt
@@ -1,0 +1,46 @@
+@file:Suppress("unused")
+
+package org.maplibre.compose.docsnippets
+
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.withContext
+import org.maplibre.compose.map.MapRuntime
+import org.maplibre.compose.map.MapSnapshotRequest
+import org.maplibre.compose.map.MapState
+import org.maplibre.compose.style.StyleComposition
+
+// #region capture
+suspend fun captureCurrentMap(
+  runtime: MapRuntime,
+  mapState: MapState,
+  content: StyleComposition,
+  density: Density,
+  layoutDirection: LayoutDirection,
+): ImageBitmap {
+  val snapshotter =
+    runtime.createSnapshotter(
+      baseStyle = mapState.style.baseStyle,
+      styleComposition = content,
+    )
+  return try {
+    snapshotter.capture(
+      MapSnapshotRequest(
+        width = 640,
+        height = 360,
+        cameraPosition = mapState.cameraPosition,
+        density = density.density,
+        fontScale = density.fontScale,
+        layoutDirection = layoutDirection,
+      )
+    )
+  } finally {
+    withContext(NonCancellable) {
+      snapshotter.close()
+      snapshotter.awaitClosed()
+    }
+  }
+}
+// #endregion capture

--- a/docs/astro.config.mts
+++ b/docs/astro.config.mts
@@ -54,6 +54,7 @@ export default defineConfig({
           items: [
             { label: "Style the map", slug: "styling" },
             { label: "Control the camera", slug: "camera" },
+            { label: "Capture a map image", slug: "snapshotter" },
             { label: "Handle gestures and clicks", slug: "interaction" },
             { label: "Add data to the map", slug: "layers" },
             { label: "Add images and icons", slug: "images" },

--- a/docs/src/content/docs/snapshotter.mdx
+++ b/docs/src/content/docs/snapshotter.mdx
@@ -1,0 +1,31 @@
+---
+title: Capture a map image
+description: Render a map to an ImageBitmap without displaying it.
+---
+
+import { Code } from "@astrojs/starlight/components";
+import Api from "../../components/Api.astro";
+import { region } from "../../snippets";
+
+import snapshotter from "../../../../demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Snapshotter.kt?raw";
+
+An <Api of="MapSnapshotter" /> renders an independent, non-UI map to an
+`ImageBitmap`. Use the same <Api of="MapRuntime" />, <Api of="BaseStyle" />, and
+<Api of="StyleComposition" /> as the displayed map to capture its current
+camera and declared content.
+
+Create and close the snapshotter in a coroutine. <Api of="MapSnapshotter.capture" />
+suspends until the image is ready:
+
+<Code code={region(snapshotter, "capture")} lang="kotlin" title="App.kt" />
+
+The request width and height are logical pixels. Its density scales the output
+bitmap and evaluates `Dp` values in the style composition. Pass
+`LocalDensity.current` and `LocalLayoutDirection.current` from the calling
+composable to match the displayed map. The `640` by `360` request uses a `640`
+by `360` logical-pixel viewport.
+
+For repeated captures, keep one snapshotter and call `capture` again with a new
+request. Calls that overlap execute in submission order. Close the snapshotter
+when its owner leaves the composition, then call
+<Api of="MapSnapshotter.awaitClosed" /> from a non-cancellable cleanup block.


### PR DESCRIPTION
## Description

Adds a focused guide for capturing the displayed map camera with `MapSnapshotter`, including compiled example code and cleanup guidance.

## Validation

Passed `mise run check`, `mise run build:desktop-app`, `mise run build:docs`, and `git diff --check`.

## AI assistance

Codex with GPT-5 helped write and validate this change.