### PR TITLE
Represent location speed as distance per second

### DIFF
--- a/lib/location-runtime-linux/src/main/kotlin/org/maplibre/compose/location/desktop/linux/DbusLocationPortal.kt
+++ b/lib/location-runtime-linux/src/main/kotlin/org/maplibre/compose/location/desktop/linux/DbusLocationPortal.kt
@@ -282,7 +282,7 @@ internal fun Map<String, Variant<*>>.toLocationEvent(): LocationEvent.Update {
           altitude = number("Altitude")?.takeIf { it != -Double.MAX_VALUE },
         ),
       horizontalAccuracy = number("Accuracy")?.meters,
-      speed = number("Speed")?.takeIf { it >= 0.0 }?.meters,
+      distancePerSecond = number("Speed")?.takeIf { it >= 0.0 }?.meters,
       course = number("Heading")?.takeIf { it >= 0.0 }?.let { Bearing.North + it.degrees },
       measuredAt = capturedAt,
     )

--- a/lib/location-runtime-linux/src/test/kotlin/org/maplibre/compose/location/desktop/linux/LinuxPortalLocationProviderTest.kt
+++ b/lib/location-runtime-linux/src/test/kotlin/org/maplibre/compose/location/desktop/linux/LinuxPortalLocationProviderTest.kt
@@ -146,7 +146,7 @@ class LinuxPortalLocationProviderTest {
     assertEquals(13.0, event.measurement.position.longitude)
     assertEquals(40.0, event.measurement.position.altitude)
     assertEquals(8.0, event.measurement.horizontalAccuracy?.inMeters)
-    assertEquals(3.0, event.measurement.speed?.inMeters)
+    assertEquals(3.0, event.measurement.distancePerSecond?.inMeters)
     assertEquals(Bearing.North + 90.degrees, event.measurement.course)
     assertTrue(event.measurementMark.elapsedNow() < 1.seconds)
   }
@@ -164,7 +164,7 @@ class LinuxPortalLocationProviderTest {
         .toLocationEvent()
 
     assertEquals(null, event.measurement.position.altitude)
-    assertEquals(null, event.measurement.speed)
+    assertEquals(null, event.measurement.distancePerSecond)
     assertEquals(null, event.measurement.course)
   }
 

--- a/lib/location-runtime-macos/src/main/kotlin/org/maplibre/compose/location/desktop/macos/CoreLocation.kt
+++ b/lib/location-runtime-macos/src/main/kotlin/org/maplibre/compose/location/desktop/macos/CoreLocation.kt
@@ -122,8 +122,9 @@ internal fun CoreLocationMeasurement.asMapLibreLocationMeasurement(): LocationMe
     altitudeAccuracy = if (verticalAccuracy >= 0.0) verticalAccuracy.meters else null,
     course = if (course >= 0.0) Bearing.North + course.degrees else null,
     courseAccuracy = if (course >= 0.0 && courseAccuracy >= 0.0) courseAccuracy.degrees else null,
-    speed = if (speed >= 0.0) speed.meters else null,
-    speedAccuracy = if (speed >= 0.0 && speedAccuracy >= 0.0) speedAccuracy.meters else null,
+    distancePerSecond = if (speed >= 0.0) speed.meters else null,
+    distancePerSecondAccuracy =
+      if (speed >= 0.0 && speedAccuracy >= 0.0) speedAccuracy.meters else null,
     measuredAt = Clock.System.now() - ageAtReceipt(),
   )
 

--- a/lib/location-runtime-macos/src/test/kotlin/org/maplibre/compose/location/desktop/macos/MacosLocationProviderTest.kt
+++ b/lib/location-runtime-macos/src/test/kotlin/org/maplibre/compose/location/desktop/macos/MacosLocationProviderTest.kt
@@ -136,8 +136,8 @@ class MacosLocationProviderTest {
     assertEquals(40.0, location.position.altitude)
     assertEquals(8.0, location.horizontalAccuracy?.inMeters)
     assertEquals(3.0, location.altitudeAccuracy?.inMeters)
-    assertEquals(3.0, location.speed?.inMeters)
-    assertEquals(0.5, location.speedAccuracy?.inMeters)
+    assertEquals(3.0, location.distancePerSecond?.inMeters)
+    assertEquals(0.5, location.distancePerSecondAccuracy?.inMeters)
     assertEquals(Bearing.North + 90.degrees, location.course)
     assertEquals(5.degrees, location.courseAccuracy)
     assertTrue(Clock.System.now() - location.measuredAt >= 2.seconds)
@@ -162,7 +162,7 @@ class MacosLocationProviderTest {
 
     assertNull(location.altitudeAccuracy)
     assertNull(location.course)
-    assertNull(location.speed)
+    assertNull(location.distancePerSecond)
   }
 
   @Test

--- a/lib/location-runtime-windows/src/main/kotlin/org/maplibre/compose/location/desktop/windows/WindowsLocation.kt
+++ b/lib/location-runtime-windows/src/main/kotlin/org/maplibre/compose/location/desktop/windows/WindowsLocation.kt
@@ -116,7 +116,7 @@ internal fun WindowsLocationMeasurement.asMapLibreLocationMeasurement(): Locatio
     position = Position(longitude = longitude, latitude = latitude, altitude = altitude),
     horizontalAccuracy = horizontalAccuracyMeters.meters,
     altitudeAccuracy = verticalAccuracy,
-    speed = speed,
+    distancePerSecond = speed,
     course = course,
     measuredAt = Instant.fromEpochMilliseconds(capturedAtMillis),
   )

--- a/lib/location-runtime-windows/src/test/kotlin/org/maplibre/compose/location/desktop/windows/WindowsLocationProviderTest.kt
+++ b/lib/location-runtime-windows/src/test/kotlin/org/maplibre/compose/location/desktop/windows/WindowsLocationProviderTest.kt
@@ -170,8 +170,8 @@ class WindowsLocationProviderTest {
     assertEquals(40.0, location.position.altitude)
     assertEquals(8.0, location.horizontalAccuracy?.inMeters)
     assertEquals(3.0, location.altitudeAccuracy?.inMeters)
-    assertEquals(4.0, location.speed?.inMeters)
-    assertNull(location.speedAccuracy)
+    assertEquals(4.0, location.distancePerSecond?.inMeters)
+    assertNull(location.distancePerSecondAccuracy)
     assertEquals(Bearing.North + 90.degrees, location.course)
     assertNull(location.courseAccuracy)
     assertEquals(Instant.fromEpochMilliseconds(currentTimeMillis - 2_000), location.measuredAt)
@@ -200,7 +200,7 @@ class WindowsLocationProviderTest {
     assertNull(location.position.altitude)
     assertNull(location.altitudeAccuracy)
     assertNull(location.course)
-    assertNull(location.speed)
+    assertNull(location.distancePerSecond)
   }
 
   @Test

--- a/lib/location/src/androidMain/kotlin/org/maplibre/compose/location/LocationMeasurement.android.kt
+++ b/lib/location/src/androidMain/kotlin/org/maplibre/compose/location/LocationMeasurement.android.kt
@@ -29,8 +29,8 @@ public fun AndroidLocation.asMapLibreLocationMeasurement(): LocationMeasurement 
       } else {
         null
       },
-    speed = if (hasSpeed()) speed.toDouble().meters else null,
-    speedAccuracy =
+    distancePerSecond = if (hasSpeed()) speed.toDouble().meters else null,
+    distancePerSecondAccuracy =
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && hasSpeed() && hasSpeedAccuracy()) {
         speedAccuracyMetersPerSecond.toDouble().meters
       } else {

--- a/lib/location/src/commonMain/kotlin/org/maplibre/compose/location/LocationMeasurement.kt
+++ b/lib/location/src/commonMain/kotlin/org/maplibre/compose/location/LocationMeasurement.kt
@@ -10,17 +10,17 @@ import org.maplibre.spatialk.units.Rotation
 /**
  * One measured geographic location.
  *
- * [Position.altitude] is expressed in meters. Speed and speed accuracy are expressed as a [Length]
- * travelled per second.
+ * [Position.altitude] is expressed in meters. [distancePerSecond] and [distancePerSecondAccuracy]
+ * store the distance that corresponds to one second at the reported rate.
  *
  * @property position Geographic position, with an optional altitude in meters.
  * @property horizontalAccuracy Estimated horizontal error radius, or `null` when unknown.
  * @property altitudeAccuracy Estimated altitude error, or `null` when unknown or when [position]
  *   contains no altitude.
- * @property speed Speed in meters per second. The [Length] meter value represents the per-second
- *   rate. A `null` value means that the source reports no speed.
- * @property speedAccuracy Estimated speed error in meters per second. The [Length] meter value
- *   represents the per-second error. A `null` value means that the error is unknown.
+ * @property distancePerSecond Distance that corresponds to one second at the reported speed, or
+ *   `null` when the source reports no speed.
+ * @property distancePerSecondAccuracy Estimated error in [distancePerSecond], or `null` when the
+ *   error is unknown.
  * @property course Bearing in the direction of travel, or `null` when the source reports no course.
  * @property courseAccuracy Estimated course error, or `null` when unknown.
  * @property measuredAt Wall-clock instant when the location was measured.
@@ -30,8 +30,8 @@ public data class LocationMeasurement(
   val position: Position,
   val horizontalAccuracy: Length? = null,
   val altitudeAccuracy: Length? = null,
-  val speed: Length? = null,
-  val speedAccuracy: Length? = null,
+  val distancePerSecond: Length? = null,
+  val distancePerSecondAccuracy: Length? = null,
   val course: Bearing? = null,
   val courseAccuracy: Rotation? = null,
   val measuredAt: Instant,
@@ -40,7 +40,9 @@ public data class LocationMeasurement(
     require(position.altitude != null || altitudeAccuracy == null) {
       "altitudeAccuracy requires position altitude"
     }
-    require(speed != null || speedAccuracy == null) { "speedAccuracy requires speed" }
+    require(distancePerSecond != null || distancePerSecondAccuracy == null) {
+      "distancePerSecondAccuracy requires distancePerSecond"
+    }
     require(course != null || courseAccuracy == null) { "courseAccuracy requires course" }
   }
 }

--- a/lib/location/src/commonTest/kotlin/org/maplibre/compose/location/LocationMeasurementTest.kt
+++ b/lib/location/src/commonTest/kotlin/org/maplibre/compose/location/LocationMeasurementTest.kt
@@ -26,7 +26,7 @@ class LocationMeasurementTest {
     assertFailsWith<IllegalArgumentException> {
       LocationMeasurement(
         position = Position(longitude = 13.0, latitude = 52.0),
-        speedAccuracy = 0.5.meters,
+        distancePerSecondAccuracy = 0.5.meters,
         measuredAt = measuredAt,
       )
     }
@@ -46,8 +46,8 @@ class LocationMeasurementTest {
         position = Position(longitude = 13.0, latitude = 52.0, altitude = 42.0),
         horizontalAccuracy = null,
         altitudeAccuracy = null,
-        speed = 3.0.meters,
-        speedAccuracy = null,
+        distancePerSecond = 3.0.meters,
+        distancePerSecondAccuracy = null,
         course = Bearing.North + 90.0.degrees,
         courseAccuracy = null,
         measuredAt = Instant.parse("2026-08-28T12:34:56Z"),

--- a/lib/location/src/iosMain/kotlin/org/maplibre/compose/location/LocationMeasurement.ios.kt
+++ b/lib/location/src/iosMain/kotlin/org/maplibre/compose/location/LocationMeasurement.ios.kt
@@ -22,8 +22,9 @@ public fun CLLocation.asMapLibreLocationMeasurement(): LocationMeasurement =
     altitudeAccuracy = if (verticalAccuracy >= 0.0) verticalAccuracy.meters else null,
     course = if (course >= 0.0) Bearing.North + course.degrees else null,
     courseAccuracy = if (course >= 0.0 && courseAccuracy >= 0.0) courseAccuracy.degrees else null,
-    speed = if (speed >= 0.0) speed.meters else null,
-    speedAccuracy = if (speed >= 0.0 && speedAccuracy >= 0.0) speedAccuracy.meters else null,
+    distancePerSecond = if (speed >= 0.0) speed.meters else null,
+    distancePerSecondAccuracy =
+      if (speed >= 0.0 && speedAccuracy >= 0.0) speedAccuracy.meters else null,
     measuredAt = Instant.fromEpochMilliseconds((timestamp.timeIntervalSince1970 * 1_000).toLong()),
   )
 

--- a/lib/location/src/jsMain/kotlin/org/maplibre/compose/location/BrowserLocationProvider.kt
+++ b/lib/location/src/jsMain/kotlin/org/maplibre/compose/location/BrowserLocationProvider.kt
@@ -403,7 +403,7 @@ private fun BrowserPosition.asLocationMeasurement(): LocationMeasurement =
     position = Position(longitude, latitude, altitude),
     horizontalAccuracy = horizontalAccuracyMeters.meters,
     altitudeAccuracy = if (altitude != null) altitudeAccuracyMeters?.meters else null,
-    speed = speedMetersPerSecond?.meters,
+    distancePerSecond = speedMetersPerSecond?.meters,
     course = headingDegrees?.takeIf { it.isFinite() }?.let { Bearing.North + it.degrees },
     measuredAt = capturedAt,
   )

--- a/lib/location/src/jsTest/kotlin/org/maplibre/compose/location/BrowserLocationProviderTest.kt
+++ b/lib/location/src/jsTest/kotlin/org/maplibre/compose/location/BrowserLocationProviderTest.kt
@@ -54,7 +54,7 @@ class BrowserLocationProviderTest {
     assertEquals(12.0, first.position.altitude)
     assertEquals(4.0, first.horizontalAccuracy?.inMeters)
     assertEquals(2.0, first.altitudeAccuracy?.inMeters)
-    assertEquals(3.0, first.speed?.inMeters)
+    assertEquals(3.0, first.distancePerSecond?.inMeters)
     assertEquals(Bearing.North + 45.degrees, first.course)
 
     collection.cancel()


### PR DESCRIPTION
## Description

Rename LocationMeasurement.speed and speedAccuracy to distancePerSecond and distancePerSecondAccuracy so their Length values describe normalized one-second distances.

## Validation

Passed mise run check, mise run test:android, mise run test:desktop, mise run test:js, and mise run test:ios.

## AI assistance

Used the Codex desktop harness with GPT-5 for API analysis, implementation, and validation.