### PR TITLE
Temporarily disable Android 26 CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,10 +73,8 @@ jobs:
         include:
           - api-level: 36
             artifact_name: demo-app-android
-          # API 24 is minSdk. Its Package Manager hangs on UTP streamed
-          # install-write (#1047). Oreo is the oldest image that completes
-          # that path.
-          - api-level: 26
+          # Re-enable API 26 after maplibre-native-ffi#654 reaches the pinned Kotlin runtime.
+          # https://github.com/maplibre/maplibre-native-ffi/pull/654
     timeout-minutes: 45
     runs-on: ubuntu-24.04
     steps:


### PR DESCRIPTION
## Description

Temporarily remove API 26 from the Android CI matrix until a published maplibre-native-ffi Kotlin runtime includes the Goldfish emulator mitigation from maplibre-native-ffi#654.

The API 36 Android job and the shared native tests on other platforms remain enabled.

## Validation

Passed `mise run check`.

The API 26 investigation run recorded the snapshot style-reload test as skipped and completed the device suite without stalling. The same run then failed in `LocationIndicatorLayerTest` with `rendering update: std::bad_alloc`, another failure covered by the missing Goldfish mitigation.

## AI assistance

OpenAI Codex with GPT-5.6 Sol assisted with investigation, implementation, and validation.