### PR TITLE
Rename internal style handles as installations

### DIFF
--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleInstallations.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleInstallations.kt
@@ -19,7 +19,7 @@ import org.maplibre.compose.sources.GeometryTileProvider
 import org.maplibre.compose.sources.VectorTileProvider
 
 /** A source installed in exactly one loaded-style generation. */
-internal class SourceHandle(
+internal class SourceInstallation(
   private val style: StyleBinding,
   definition: SourceDefinition,
 ) {
@@ -174,7 +174,7 @@ internal class SourceHandle(
 }
 
 /** A layer installed in exactly one loaded-style generation. */
-internal class LayerHandle(
+internal class LayerInstallation(
   private val style: StyleBinding,
   definition: LayerDefinition,
   beforeLayerId: String,

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleReconciler.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleReconciler.kt
@@ -40,7 +40,7 @@ internal class StyleReconciler {
       when {
         desired == null -> removeSource(applied)
         applied.definition.canUpdateTo(desired) -> {
-          applied.handle.update(desired)
+          applied.installation.update(desired)
           applied.definition = desired
         }
         else -> {
@@ -76,18 +76,18 @@ internal class StyleReconciler {
               AppliedLayer(
                 definition = desired.definition,
                 anchor = anchor,
-                handle = LayerHandle(style, desired.definition, before),
+                installation = LayerInstallation(style, desired.definition, before),
               )
             layers[id] = applied
             if (anchor is Anchor.Replace && group.first() === desired) {
               style.removeLayer(anchor.layerId)
             }
           } else {
-            applied.handle.update(desired.definition)
+            applied.installation.update(desired.definition)
             applied.definition = desired.definition
             if (shouldMoveLayer(style, anchor, previousId, id, nextDesiredId)) {
               val before = beforeLayerId(style, anchor, previousId, id)
-              if (before != id) applied.handle.move(before)
+              if (before != id) applied.installation.move(before)
             }
           }
           previousId = id
@@ -104,11 +104,11 @@ internal class StyleReconciler {
   }
 
   private fun addSource(style: StyleBinding, definition: SourceDefinition) {
-    sources[definition.id] = AppliedSource(definition, SourceHandle(style, definition))
+    sources[definition.id] = AppliedSource(definition, SourceInstallation(style, definition))
   }
 
   private fun removeSource(applied: AppliedSource) {
-    applied.handle.remove()
+    applied.installation.remove()
     sources.remove(applied.definition.id)
   }
 
@@ -120,7 +120,7 @@ internal class StyleReconciler {
       val original = requireNotNull(replacedLayers.remove(anchor))
       style.addLayer(original, beforeLayerId = applied.definition.id)
     }
-    applied.handle.remove()
+    applied.installation.remove()
     layers.remove(applied.definition.id)
   }
 
@@ -204,12 +204,12 @@ internal class StyleReconciler {
 
   private class AppliedSource(
     var definition: SourceDefinition,
-    val handle: SourceHandle,
+    val installation: SourceInstallation,
   )
 
   private class AppliedLayer(
     var definition: LayerDefinition,
     val anchor: Anchor,
-    val handle: LayerHandle,
+    val installation: LayerInstallation,
   )
 }

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/sources/CustomSourceDefinitionTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/sources/CustomSourceDefinitionTest.kt
@@ -6,7 +6,7 @@ import kotlin.test.assertSame
 import kotlinx.coroutines.test.runTest
 import org.maplibre.compose.style.RecordingStyleBinding
 import org.maplibre.compose.style.SourceDefinition
-import org.maplibre.compose.style.SourceHandle
+import org.maplibre.compose.style.SourceInstallation
 
 class CustomSourceDefinitionTest {
   @Test
@@ -16,7 +16,7 @@ class CustomSourceDefinitionTest {
     val source = CustomVectorSource("custom", provider = first)
     val firstDefinition = source.definition() as SourceDefinition.CustomVector
     val binding = RecordingStyleBinding()
-    val handle = SourceHandle(binding, firstDefinition)
+    val handle = SourceInstallation(binding, firstDefinition)
     val installedProvider = requireNotNull(binding.customVectorProvider)
 
     source.setDesiredProvider(second)

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/sources/GeoJsonConflationTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/sources/GeoJsonConflationTest.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.JsonObject
 import org.maplibre.compose.style.PreparedGeoJson
 import org.maplibre.compose.style.RecordingStyleBinding
-import org.maplibre.compose.style.SourceHandle
+import org.maplibre.compose.style.SourceInstallation
 import org.maplibre.compose.style.StyleBinding
 import org.maplibre.spatialk.geojson.Point
 import org.maplibre.spatialk.geojson.Position
@@ -41,7 +41,7 @@ class GeoJsonConflationTest {
   fun an_older_install_cannot_overwrite_a_newer_one() = runTest {
     val binding = DeferringBinding()
     val source = GeoJsonSource("s", pointAt(0.0), GeoJsonOptions())
-    val handle = SourceHandle(binding, source.definition())
+    val handle = SourceInstallation(binding, source.definition())
 
     val older = pointAt(1.0)
     val newer = pointAt(2.0)
@@ -65,7 +65,7 @@ class GeoJsonConflationTest {
     source.setDesiredData(replacement)
     assertEquals(replacement.toDataJson(), source.toJson()["data"])
 
-    SourceHandle(binding, source.definition())
+    SourceInstallation(binding, source.definition())
     assertEquals(replacement.toDataJson(), (binding.sources["s"] as JsonObject)["data"])
   }
 }

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/sources/RasterDemSourceJsonTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/sources/RasterDemSourceJsonTest.kt
@@ -9,7 +9,7 @@ import kotlin.test.assertNotNull
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonPrimitive
 import org.maplibre.compose.style.RecordingStyleBinding
-import org.maplibre.compose.style.SourceHandle
+import org.maplibre.compose.style.SourceInstallation
 
 /** A raster DEM definition resolves against the capabilities of each loaded engine. */
 class RasterDemSourceJsonTest {
@@ -40,7 +40,7 @@ class RasterDemSourceJsonTest {
         demEncoding = RasterDemEncoding.Custom(redFactor = 2f),
       )
 
-    SourceHandle(binding, source.definition())
+    SourceInstallation(binding, source.definition())
 
     val json = assertNotNull(binding.sources["dem"])
     assertEquals("mapbox", json["encoding"]?.jsonPrimitive?.content)
@@ -57,7 +57,7 @@ class RasterDemSourceJsonTest {
         demEncoding = RasterDemEncoding.Custom(redFactor = 2f, baseShift = 3f),
       )
 
-    SourceHandle(binding, source.definition())
+    SourceInstallation(binding, source.definition())
 
     val json = assertNotNull(binding.sources["dem"])
     assertEquals("custom", json["encoding"]?.jsonPrimitive?.content)
@@ -89,7 +89,7 @@ class RasterDemSourceJsonTest {
         options = TileSetOptions(tileCoordinateSystem = TileCoordinateSystem.XYZ),
       )
 
-    SourceHandle(binding, source.definition())
+    SourceInstallation(binding, source.definition())
 
     assertFalse("scheme" in assertNotNull(binding.sources["dem"]))
   }
@@ -105,7 +105,7 @@ class RasterDemSourceJsonTest {
       )
 
     val error =
-      assertFailsWith<IllegalStateException> { SourceHandle(binding, source.definition()) }
+      assertFailsWith<IllegalStateException> { SourceInstallation(binding, source.definition()) }
 
     assertContains(error.message.orEmpty(), "TileCoordinateSystem.XYZ")
     assertFalse("dem" in binding.sources)
@@ -124,7 +124,7 @@ class RasterDemSourceJsonTest {
     val binding = RecordingStyleBinding(supportsRasterDemScheme = false)
     val source = RasterDemSource(id = "dem", uri = "https://example.invalid/tiles.json")
 
-    SourceHandle(binding, source.definition())
+    SourceInstallation(binding, source.definition())
 
     val json = assertNotNull(binding.sources["dem"])
     assertFalse("scheme" in json)

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/style/StyleDefinitionAndIdentityTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/style/StyleDefinitionAndIdentityTest.kt
@@ -71,7 +71,7 @@ class StyleDefinitionAndIdentityTest {
   fun a_handle_for_an_invalidated_identity_fails_clearly() = runTest {
     val definition = SourceDefinition.Json("stale", buildJsonObject { put("type", "vector") })
     val style = RecordingStyleBinding()
-    val handle = SourceHandle(style, definition)
+    val handle = SourceInstallation(style, definition)
     val identity = style.identity
 
     style.invalidate()

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/style/TestStyleInstallation.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/style/TestStyleInstallation.kt
@@ -3,19 +3,19 @@ package org.maplibre.compose.style
 import org.maplibre.compose.layers.Layer
 import org.maplibre.compose.sources.Source
 
-internal fun StyleBinding.install(source: Source): SourceHandle =
-  SourceHandle(this, source.definition())
+internal fun StyleBinding.install(source: Source): SourceInstallation =
+  SourceInstallation(this, source.definition())
 
-internal fun StyleBinding.install(definition: SourceDefinition): SourceHandle =
-  SourceHandle(this, definition)
+internal fun StyleBinding.install(definition: SourceDefinition): SourceInstallation =
+  SourceInstallation(this, definition)
 
-internal fun StyleBinding.install(layer: Layer, beforeLayerId: String = ""): LayerHandle =
-  LayerHandle(this, layer.definition(), beforeLayerId)
+internal fun StyleBinding.install(layer: Layer, beforeLayerId: String = ""): LayerInstallation =
+  LayerInstallation(this, layer.definition(), beforeLayerId)
 
 internal fun StyleBinding.install(
   definition: LayerDefinition,
   beforeLayerId: String = "",
-): LayerHandle = LayerHandle(this, definition, beforeLayerId)
+): LayerInstallation = LayerInstallation(this, definition, beforeLayerId)
 
 internal fun StyleBinding.uninstall(source: Source) {
   removeSource(source.id)

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/layers/LayerPropertyRoundTripTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/layers/LayerPropertyRoundTripTest.kt
@@ -61,7 +61,7 @@ import org.maplibre.compose.sources.RasterSource
 import org.maplibre.compose.sources.Source
 import org.maplibre.compose.sources.TileSetOptions
 import org.maplibre.compose.style.BaseStyle
-import org.maplibre.compose.style.LayerHandle
+import org.maplibre.compose.style.LayerInstallation
 import org.maplibre.compose.style.StyleBinding
 import org.maplibre.compose.style.install
 import org.maplibre.compose.testing.MapLibreFlavor
@@ -208,12 +208,12 @@ class LayerPropertyRoundTripTest {
     val path = if (attachFirst) "after attach" else "before attach"
     try {
       if (attachFirst) {
-        val handle = LayerHandle(style, layer.definition(), beforeLayerId = "")
+        val handle = LayerInstallation(style, layer.definition(), beforeLayerId = "")
         case.apply(layer)
         handle.update(layer.definition())
       } else {
         case.apply(layer)
-        LayerHandle(style, layer.definition(), beforeLayerId = "")
+        LayerInstallation(style, layer.definition(), beforeLayerId = "")
       }
     } catch (error: Throwable) {
       return listOf("${case.property} $path: MapLibre refused it: ${error.message}")


### PR DESCRIPTION
## Description

Renames the internal reconciliation objects to `SourceInstallation` and `LayerInstallation` so the public `SourceHandle` and `LayerHandle` names refer only to imperative API types.

## Validation

`mise run check` and `mise run test:android` pass on macOS.

## AI assistance

OpenAI Codex with a GPT-5 family model investigated, renamed, and validated the code under user direction.