### PR TITLE
Avoid main-thread Core Location status checks

### DIFF
--- a/lib/location/src/iosMain/kotlin/org/maplibre/compose/location/IosLocationProvider.kt
+++ b/lib/location/src/iosMain/kotlin/org/maplibre/compose/location/IosLocationProvider.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.flowOn
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 import org.maplibre.spatialk.units.extensions.inMeters
 import platform.CoreLocation.CLLocation
@@ -68,48 +68,51 @@ public class IosLocationProvider : LocationProvider {
 
   override fun requestPermission(): Unit = requester.requestForegroundPermission()
 
-  override fun updates(request: LocationRequest): Flow<LocationEvent> = callbackFlow {
-    val manager = CLLocationManager()
-    val delegate =
-      Delegate(channel) { error ->
-        launch { channel.trySend(LocationEvent.Unavailable(error.asUnavailableReason())) }
+  override fun updates(request: LocationRequest): Flow<LocationEvent> =
+    callbackFlow<IosLocationCallback> {
+        val manager = CLLocationManager()
+        val delegate = Delegate(channel)
+        manager.delegate = delegate
+        manager.desiredAccuracy =
+          when (request.accuracy) {
+            LocationAccuracy.BestForNavigation -> kCLLocationAccuracyBestForNavigation
+            LocationAccuracy.High -> kCLLocationAccuracyBest
+            LocationAccuracy.Balanced -> kCLLocationAccuracyHundredMeters
+            LocationAccuracy.Low -> kCLLocationAccuracyKilometer
+            LocationAccuracy.Lowest -> kCLLocationAccuracyReduced
+          }
+        manager.distanceFilter = request.minimumDistance.inMeters
+        manager.startUpdatingLocation()
+
+        // Retaining the delegate in this closure is required because CLLocationManager does not.
+        awaitClose { delegate.stop(manager) }
       }
-    manager.delegate = delegate
-    manager.desiredAccuracy =
-      when (request.accuracy) {
-        LocationAccuracy.BestForNavigation -> kCLLocationAccuracyBestForNavigation
-        LocationAccuracy.High -> kCLLocationAccuracyBest
-        LocationAccuracy.Balanced -> kCLLocationAccuracyHundredMeters
-        LocationAccuracy.Low -> kCLLocationAccuracyKilometer
-        LocationAccuracy.Lowest -> kCLLocationAccuracyReduced
+      .flowOn(Dispatchers.Main)
+      .map { callback ->
+        when (callback) {
+          is IosLocationCallback.Update -> callback.event
+          is IosLocationCallback.Failure ->
+            LocationEvent.Unavailable(callback.error.asUnavailableReason())
+        }
       }
-    manager.distanceFilter = request.minimumDistance.inMeters
 
-    manager.location?.let(delegate::sendLocation)
-    manager.startUpdatingLocation()
-
-    // Retaining the delegate in this closure is required because CLLocationManager does not.
-    awaitClose { delegate.stop(manager) }
-  }
-    .flowOn(Dispatchers.Main)
-
-  private class Delegate(
-    private val channel: SendChannel<LocationEvent>,
-    private val reportError: (NSError) -> Unit,
-  ) : NSObject(), CLLocationManagerDelegateProtocol {
+  private class Delegate(private val channel: SendChannel<IosLocationCallback>) :
+    NSObject(), CLLocationManagerDelegateProtocol {
     override fun locationManager(manager: CLLocationManager, didUpdateLocations: List<*>) {
       @Suppress("UNCHECKED_CAST") (didUpdateLocations as? List<CLLocation>)?.forEach(::sendLocation)
     }
 
     override fun locationManager(manager: CLLocationManager, didFailWithError: NSError) {
-      reportError(didFailWithError)
+      channel.trySend(IosLocationCallback.Failure(didFailWithError))
     }
 
     fun sendLocation(location: CLLocation) {
       channel.trySend(
-        LocationEvent.Update(
-          location.asMapLibreLocationMeasurement(),
-          TimeSource.Monotonic.markNow() - location.ageAtReceipt(),
+        IosLocationCallback.Update(
+          LocationEvent.Update(
+            location.asMapLibreLocationMeasurement(),
+            TimeSource.Monotonic.markNow() - location.ageAtReceipt(),
+          )
         )
       )
     }
@@ -121,8 +124,18 @@ public class IosLocationProvider : LocationProvider {
   }
 }
 
-private suspend fun locationServicesEnabled(): Boolean =
-  withContext(Dispatchers.Default) { CLLocationManager.locationServicesEnabled() }
+private suspend fun locationServicesEnabled(): Boolean = readLocationServicesEnabled {
+  CLLocationManager.locationServicesEnabled()
+}
+
+internal suspend fun readLocationServicesEnabled(read: () -> Boolean): Boolean =
+  withContext(Dispatchers.Default) { read() }
+
+private sealed interface IosLocationCallback {
+  data class Update(val event: LocationEvent.Update) : IosLocationCallback
+
+  data class Failure(val error: NSError) : IosLocationCallback
+}
 
 internal suspend fun NSError.asUnavailableReason(
   locationServicesEnabled: suspend () -> Boolean = ::locationServicesEnabled

--- a/lib/location/src/iosMain/kotlin/org/maplibre/compose/location/IosLocationProvider.kt
+++ b/lib/location/src/iosMain/kotlin/org/maplibre/compose/location/IosLocationProvider.kt
@@ -8,6 +8,8 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.maplibre.spatialk.units.extensions.inMeters
 import platform.CoreLocation.CLLocation
 import platform.CoreLocation.CLLocationManager
@@ -67,14 +69,11 @@ public class IosLocationProvider : LocationProvider {
   override fun requestPermission(): Unit = requester.requestForegroundPermission()
 
   override fun updates(request: LocationRequest): Flow<LocationEvent> = callbackFlow {
-    if (!CLLocationManager.locationServicesEnabled()) {
-      trySend(LocationEvent.Unavailable(LocationUnavailableReason.ServicesDisabled))
-      close()
-      return@callbackFlow
-    }
-
     val manager = CLLocationManager()
-    val delegate = Delegate(channel)
+    val delegate =
+      Delegate(channel) { error ->
+        launch { channel.trySend(LocationEvent.Unavailable(error.asUnavailableReason())) }
+      }
     manager.delegate = delegate
     manager.desiredAccuracy =
       when (request.accuracy) {
@@ -94,14 +93,16 @@ public class IosLocationProvider : LocationProvider {
   }
     .flowOn(Dispatchers.Main)
 
-  private class Delegate(private val channel: SendChannel<LocationEvent>) :
-    NSObject(), CLLocationManagerDelegateProtocol {
+  private class Delegate(
+    private val channel: SendChannel<LocationEvent>,
+    private val reportError: (NSError) -> Unit,
+  ) : NSObject(), CLLocationManagerDelegateProtocol {
     override fun locationManager(manager: CLLocationManager, didUpdateLocations: List<*>) {
       @Suppress("UNCHECKED_CAST") (didUpdateLocations as? List<CLLocation>)?.forEach(::sendLocation)
     }
 
     override fun locationManager(manager: CLLocationManager, didFailWithError: NSError) {
-      channel.trySend(LocationEvent.Unavailable(didFailWithError.asUnavailableReason()))
+      reportError(didFailWithError)
     }
 
     fun sendLocation(location: CLLocation) {
@@ -120,13 +121,16 @@ public class IosLocationProvider : LocationProvider {
   }
 }
 
-internal fun NSError.asUnavailableReason(
-  locationServicesEnabled: Boolean = CLLocationManager.locationServicesEnabled()
+private suspend fun locationServicesEnabled(): Boolean =
+  withContext(Dispatchers.Default) { CLLocationManager.locationServicesEnabled() }
+
+internal suspend fun NSError.asUnavailableReason(
+  locationServicesEnabled: suspend () -> Boolean = ::locationServicesEnabled
 ): LocationUnavailableReason =
   when {
     domain != kCLErrorDomain -> LocationUnavailableReason.UnexpectedFailure
     code == kCLErrorDenied ->
-      if (locationServicesEnabled) {
+      if (locationServicesEnabled()) {
         LocationUnavailableReason.PermissionDenied
       } else {
         LocationUnavailableReason.ServicesDisabled

--- a/lib/location/src/iosTest/kotlin/org/maplibre/compose/location/IosLocationProviderTest.kt
+++ b/lib/location/src/iosTest/kotlin/org/maplibre/compose/location/IosLocationProviderTest.kt
@@ -3,12 +3,14 @@ package org.maplibre.compose.location
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 import kotlinx.coroutines.test.runTest
 import platform.CoreLocation.kCLErrorDenied
 import platform.CoreLocation.kCLErrorDomain
 import platform.CoreLocation.kCLErrorLocationUnknown
 import platform.CoreLocation.kCLErrorNetwork
 import platform.Foundation.NSError
+import platform.Foundation.NSThread
 
 class IosLocationProviderTest {
   @Test
@@ -17,6 +19,12 @@ class IosLocationProviderTest {
       IosLocationPermissionRequester().status.value,
       IosLocationProvider().permission.value,
     )
+  }
+
+  @Test
+  fun readsLocationServicesStatusOffMainThread() = runTest {
+    assertTrue(NSThread.isMainThread)
+    assertFalse(readLocationServicesEnabled { NSThread.isMainThread })
   }
 
   @Test

--- a/lib/location/src/iosTest/kotlin/org/maplibre/compose/location/IosLocationProviderTest.kt
+++ b/lib/location/src/iosTest/kotlin/org/maplibre/compose/location/IosLocationProviderTest.kt
@@ -2,6 +2,8 @@ package org.maplibre.compose.location
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlinx.coroutines.test.runTest
 import platform.CoreLocation.kCLErrorDenied
 import platform.CoreLocation.kCLErrorDomain
 import platform.CoreLocation.kCLErrorLocationUnknown
@@ -18,27 +20,34 @@ class IosLocationProviderTest {
   }
 
   @Test
-  fun mapsCoreLocationErrorsByRecoverability() {
+  fun mapsCoreLocationErrorsByRecoverability() = runTest {
     assertEquals(
       LocationUnavailableReason.ServicesDisabled,
-      coreLocationError(kCLErrorDenied).asUnavailableReason(locationServicesEnabled = false),
+      coreLocationError(kCLErrorDenied).asUnavailableReason { false },
     )
     assertEquals(
       LocationUnavailableReason.PermissionDenied,
-      coreLocationError(kCLErrorDenied).asUnavailableReason(locationServicesEnabled = true),
+      coreLocationError(kCLErrorDenied).asUnavailableReason { true },
+    )
+    var locationServicesQueried = false
+    val locationServicesEnabled = {
+      locationServicesQueried = true
+      true
+    }
+    assertEquals(
+      LocationUnavailableReason.TemporarilyUnavailable,
+      coreLocationError(kCLErrorLocationUnknown).asUnavailableReason(locationServicesEnabled),
     )
     assertEquals(
       LocationUnavailableReason.TemporarilyUnavailable,
-      coreLocationError(kCLErrorLocationUnknown).asUnavailableReason(),
-    )
-    assertEquals(
-      LocationUnavailableReason.TemporarilyUnavailable,
-      coreLocationError(kCLErrorNetwork).asUnavailableReason(),
+      coreLocationError(kCLErrorNetwork).asUnavailableReason(locationServicesEnabled),
     )
     assertEquals(
       LocationUnavailableReason.UnexpectedFailure,
-      NSError.errorWithDomain("example.error", 1, null).asUnavailableReason(),
+      NSError.errorWithDomain("example.error", 1, null)
+        .asUnavailableReason(locationServicesEnabled),
     )
+    assertFalse(locationServicesQueried)
   }
 
   private fun coreLocationError(code: Long): NSError =


### PR DESCRIPTION
## Description

Remove the eager location-services preflight and query device-wide status off the main thread only when Core Location reports a denied error.

## Validation

`mise run check` and `mise run test:ios` pass with an iOS 26.5 simulator.

## AI assistance

GPT-5.6 Sol in the Codex desktop app investigated, implemented, and validated the change.