### PR TITLE
Reject zero-sized painter images

### DIFF
--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/ast/PainterLiteral.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/ast/PainterLiteral.kt
@@ -1,5 +1,7 @@
 package org.maplibre.compose.expressions.ast
 
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.geometry.isSpecified
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.DefaultAlpha
 import androidx.compose.ui.graphics.painter.Painter
@@ -33,6 +35,15 @@ private constructor(
       stretch: ImageStretch?,
       alpha: Float = DefaultAlpha,
       colorFilter: ColorFilter? = null,
-    ): PainterLiteral = PainterLiteral(value, size, drawAsSdf, stretch, alpha, colorFilter)
+    ): PainterLiteral {
+      val dimensions =
+        size?.let { Size(it.width.value, it.height.value) }
+          ?: value.intrinsicSize.takeIf { it.isSpecified }
+      require(dimensions == null || (dimensions.width > 0f && dimensions.height > 0f)) {
+        "Painter image size must have positive width and height, but was $dimensions. " +
+          "Pass a size with positive width and height to image()."
+      }
+      return PainterLiteral(value, size, drawAsSdf, stretch, alpha, colorFilter)
+    }
   }
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/dsl/image.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/dsl/image.kt
@@ -85,6 +85,8 @@ public fun image(
  *   [Signed Distance Field](https://docs.mapbox.com/help/troubleshooting/using-recolorable-images-in-mapbox-maps/).
  *   Ideal for monochrome vector icons.
  * @param stretch Stretch and content box used when a symbol layer sizes the icon to wrap its text.
+ * @throws IllegalArgumentException If the provided size or the painter's intrinsic size has a
+ *   non-positive dimension.
  */
 public fun image(
   value: Painter,
@@ -115,6 +117,8 @@ public fun image(
  * @param stretch Stretch and content box used when a symbol layer sizes the icon to wrap its text.
  * @param alpha passed to [Painter.draw]
  * @param colorFilter passed to [Painter.draw]
+ * @throws IllegalArgumentException If the provided size or the painter's intrinsic size has a
+ *   non-positive dimension.
  * @see Painter.draw
  */
 public fun image(

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/expressions/dsl/PainterImageTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/expressions/dsl/PainterImageTest.kt
@@ -1,0 +1,50 @@
+package org.maplibre.compose.expressions.dsl
+
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertFailsWith
+
+class PainterImageTest {
+  @Test
+  fun zero_intrinsic_size_requires_an_explicit_size() {
+    val error = assertFailsWith<IllegalArgumentException> { image(TestPainter(Size.Zero)) }
+
+    assertContains(
+      error.message.orEmpty(),
+      "Painter image size must have positive width and height",
+    )
+    assertContains(error.message.orEmpty(), "Pass a size with positive width and height to image()")
+  }
+
+  @Test
+  fun explicit_positive_size_accepts_a_zero_intrinsic_size() {
+    image(TestPainter(Size.Zero), size = DpSize(24.dp, 24.dp))
+  }
+
+  @Test
+  fun unspecified_intrinsic_size_uses_the_default_size() {
+    image(TestPainter(Size.Unspecified))
+  }
+
+  @Test
+  fun explicit_zero_size_is_rejected() {
+    val error =
+      assertFailsWith<IllegalArgumentException> {
+        image(TestPainter(Size.Unspecified), size = DpSize.Zero)
+      }
+
+    assertContains(
+      error.message.orEmpty(),
+      "Painter image size must have positive width and height",
+    )
+  }
+
+  private class TestPainter(override val intrinsicSize: Size) : Painter() {
+    override fun DrawScope.onDraw() = Unit
+  }
+}


### PR DESCRIPTION
## Description

Reject painter image dimensions that are zero or negative with an actionable error while preserving explicit positive sizes and the fallback for unspecified intrinsic sizes.

## Validation

`mise run test:android` and `mise run check` pass on macOS.

## AI assistance

OpenAI Codex wrote the implementation, tests, and pull request text under user direction.