### PR TITLE
Make declarative map styling state-owned

### DIFF
--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoAppState.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoAppState.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -32,17 +33,23 @@ enum class DemoShell {
 
 /** The state the shell owns: the shared map, the selection, and the settings. */
 @Stable
-class DemoAppState(
+class DemoAppState
+internal constructor(
   val mapRuntime: MapRuntime,
   val mapState: MapState,
   val settings: DemoSettings,
   val frameRateState: FrameRateState,
+  private val mapConfiguration: DemoMapConfiguration,
 ) {
   /**
    * The demo shown on the map. Select demos through [selectDemo] so the panel can align its
    * destination.
    */
-  var selectedDemo by mutableStateOf<Demo?>(null)
+  var selectedDemo: Demo?
+    get() = mapConfiguration.selectedDemo
+    set(value) {
+      mapConfiguration.selectedDemo = value
+    }
 
   /**
    * Selects [demo] in the Demos shell. The one selection path for both the panel's demo list and
@@ -54,28 +61,25 @@ class DemoAppState(
   }
 
   /** The style applied when [MapStyleMode] resolves to light. */
-  var chosenLightStyle by mutableStateOf<DemoStyle>(Protomaps.Light)
+  var chosenLightStyle: DemoStyle
+    get() = mapConfiguration.chosenLightStyle
+    set(value) {
+      mapConfiguration.chosenLightStyle = value
+    }
 
   /** The style applied when [MapStyleMode] resolves to dark. */
-  var chosenDarkStyle by mutableStateOf<DemoStyle>(Protomaps.Dark)
+  var chosenDarkStyle: DemoStyle
+    get() = mapConfiguration.chosenDarkStyle
+    set(value) {
+      mapConfiguration.chosenDarkStyle = value
+    }
 
   /**
    * The style applied to the map: the selected demo's if it provides one, else the chosen style for
    * the current [MapStyleMode].
    */
   val appliedStyle: DemoStyle
-    @Composable
-    get() {
-      selectedDemo?.preferredStyle?.let {
-        return it
-      }
-      val systemDark = isSystemInDarkTheme()
-      return when (settings.mapStyleMode) {
-        MapStyleMode.System -> if (systemDark) chosenDarkStyle else chosenLightStyle
-        MapStyleMode.Light -> chosenLightStyle
-        MapStyleMode.Dark -> chosenDarkStyle
-      }
-    }
+    @Composable get() = mapConfiguration.appliedStyle(settings)
 
   /**
    * The style the map composition most recently applied. Kept as plain state because [appliedStyle]
@@ -113,13 +117,44 @@ class DemoAppState(
   }
 }
 
+@Stable
+internal class DemoMapConfiguration {
+  var selectedDemo by mutableStateOf<Demo?>(null)
+  var chosenLightStyle by mutableStateOf<DemoStyle>(Protomaps.Light)
+  var chosenDarkStyle by mutableStateOf<DemoStyle>(Protomaps.Dark)
+
+  @Composable
+  fun appliedStyle(settings: DemoSettings): DemoStyle {
+    selectedDemo?.preferredStyle?.let {
+      return it
+    }
+    val systemDark = isSystemInDarkTheme()
+    return when (settings.mapStyleMode) {
+      MapStyleMode.System -> if (systemDark) chosenDarkStyle else chosenLightStyle
+      MapStyleMode.Light -> chosenLightStyle
+      MapStyleMode.Dark -> chosenDarkStyle
+    }
+  }
+}
+
 internal data class StyleLoad(val count: Int, val base: BaseStyle?)
 
 @Composable
 fun rememberDemoAppState(): DemoAppState {
   val mapRuntime = rememberDefaultMapRuntime()
-  val mapState = rememberMapState(runtime = mapRuntime, initialCameraPosition = StartPosition)
   val settings = rememberDemoSettings()
+  val mapConfiguration = remember { DemoMapConfiguration() }
+  val appliedStyle = mapConfiguration.appliedStyle(settings)
+  val mapState =
+    rememberMapState(
+      runtime = mapRuntime,
+      baseStyle = appliedStyle.base,
+      initialCameraPosition = StartPosition,
+    ) {
+      mapConfiguration.selectedDemo?.let { demo -> key(demo) { demo.MapContent(mapState) } }
+    }
   val frameRateState = remember { FrameRateState() }
-  return remember { DemoAppState(mapRuntime, mapState, settings, frameRateState) }
+  return remember {
+    DemoAppState(mapRuntime, mapState, settings, frameRateState, mapConfiguration)
+  }
 }

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoMap.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoMap.kt
@@ -44,7 +44,6 @@ import org.maplibre.compose.material3.Material3
 import org.maplibre.compose.material3.PointerPinButton
 import org.maplibre.compose.overlay.MapOverlay
 import org.maplibre.compose.overlay.include
-import org.maplibre.compose.style.StyleComposition
 import org.maplibre.spatialk.geojson.Position
 
 /** How long the camera takes to fly to a newly selected demo. */
@@ -77,10 +76,7 @@ fun DemoMap(state: DemoAppState, viewportInsets: MapViewportInsets) {
   val scope = rememberCoroutineScope()
   val appliedStyle = state.appliedStyle
   val appliedBase = appliedStyle.base
-  SideEffect {
-    state.appliedStyleSnapshot = appliedStyle
-    state.mapState.style.baseStyle = appliedBase
-  }
+  SideEffect { state.appliedStyleSnapshot = appliedStyle }
   // Composing the map with a base means its load is in flight until noteStyleLoad clears it.
   DisposableEffect(appliedBase) {
     state.pendingStyleLoad = appliedBase
@@ -89,12 +85,6 @@ fun DemoMap(state: DemoAppState, viewportInsets: MapViewportInsets) {
     }
   }
   val selectedDemo = state.selectedDemo
-  val styleComposition =
-    remember(state.mapState, selectedDemo) {
-      StyleComposition {
-        selectedDemo?.let { demo -> key(demo) { demo.MapContent(state.mapState) } }
-      }
-    }
   LaunchedEffect(state.mapState.style.loadState, appliedBase) {
     when (state.mapState.style.loadState) {
       StyleLoadState.Ready,
@@ -114,7 +104,6 @@ fun DemoMap(state: DemoAppState, viewportInsets: MapViewportInsets) {
   Box(Modifier.fillMaxSize()) {
     MaplibreMap(
       state = state.mapState,
-      styleComposition = styleComposition,
       presentationOptions =
         MapPresentationOptions(
           cameraPadding = viewportInsets.asPaddingValues(),
@@ -124,29 +113,25 @@ fun DemoMap(state: DemoAppState, viewportInsets: MapViewportInsets) {
         ),
       callbacks = MapPresentationCallbacks(onFrame = { state.frameRateState.record() }),
       contentWindowInsets = viewportInsets.asWindowInsets(),
-      overlay =
-        MapOverlay {
-          include(
-            if (state.settings.useMaterial3Controls) MapOverlay.Material3 else MapOverlay.Default
-          )
-          selectedDemo?.let { demo ->
-            key(demo) {
-              with(demo) { Overlay(state) }
-              pointerPin?.let {
-                PointerPinButton(
-                  targetPosition = it.target,
-                  onClick = { scope.launch { state.mapState.flyTo(it.destination) } },
-                ) {
-                  Icon(
-                    vectorResource(Res.drawable.filter_center_focus_24px),
-                    contentDescription = "Fly back to ${demo.name}",
-                  )
-                }
-              }
+    ) {
+      include(if (state.settings.useMaterial3Controls) MapOverlay.Material3 else MapOverlay.Default)
+      selectedDemo?.let { demo ->
+        key(demo) {
+          with(demo) { Overlay(state) }
+          pointerPin?.let {
+            PointerPinButton(
+              targetPosition = it.target,
+              onClick = { scope.launch { state.mapState.flyTo(it.destination) } },
+            ) {
+              Icon(
+                vectorResource(Res.drawable.filter_center_focus_24px),
+                contentDescription = "Fly back to ${demo.name}",
+              )
             }
           }
-        },
-    )
+        }
+      }
+    }
 
     if (state.settings.showPointerPinDiagnostics && pointerPin != null) {
       PointerPinDestinationOverlay(

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/benchmark/BenchmarkMap.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/benchmark/BenchmarkMap.kt
@@ -10,7 +10,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.withFrameNanos
@@ -37,13 +36,12 @@ import org.maplibre.compose.demoapp.MapViewportInsets
 import org.maplibre.compose.map.GestureOptions
 import org.maplibre.compose.map.MapPresentationCallbacks
 import org.maplibre.compose.map.MapPresentationOptions
+import org.maplibre.compose.map.MapState
 import org.maplibre.compose.map.MaplibreMap
 import org.maplibre.compose.map.RenderOptions
 import org.maplibre.compose.map.StyleLoadState
 import org.maplibre.compose.map.rememberMapState
-import org.maplibre.compose.overlay.MapOverlay
 import org.maplibre.compose.style.BaseStyle
-import org.maplibre.compose.style.StyleComposition
 
 private val benchLog = Logger.withTag(BenchmarkReport.LogPrefix)
 
@@ -56,21 +54,23 @@ internal fun BenchmarkMap(state: DemoAppState, viewportInsets: MapViewportInsets
   val scenario = state.selectedScenario
   val density = LocalDensity.current
   val prefetcher = rememberTilePrefetcher()
-  val mapState =
-    rememberMapState(runtime = state.mapRuntime, initialCameraPosition = scenario.camera)
-  SideEffect { mapState.style.baseStyle = scenario.style.base }
   val session =
-    remember(mapState, prefetcher, density) {
+    remember(prefetcher, density) {
       BenchmarkSession(
-        mapState = mapState,
         ui = state.benchmark,
         prefetcher = prefetcher,
         density = density,
       )
     }
+  val mapState =
+    rememberMapState(
+      runtime = state.mapRuntime,
+      baseStyle = scenario.style.base,
+      initialCameraPosition = scenario.camera,
+    ) {
+      scenario.MapContent(session)
+    }
   val mapLoaded = remember(scenario.id) { CompletableDeferred<Unit>() }
-  val styleComposition =
-    remember(scenario, session) { StyleComposition { scenario.MapContent(session) } }
   LaunchedEffect(mapState.style.loadState, mapLoaded) {
     when (val load = mapState.style.loadState) {
       StyleLoadState.Ready -> mapLoaded.complete(Unit)
@@ -126,12 +126,12 @@ internal fun BenchmarkMap(state: DemoAppState, viewportInsets: MapViewportInsets
                 session.frames.recordComposeFrameMs((now - lastNanos) / 1_000_000.0)
               }
               lastNanos = now
-              samplePin(session)
+              samplePin(mapState, session)
             }
           }
         }
         try {
-          running.run(session)
+          running.run(mapState, session)
         } finally {
           composeJob.cancel()
         }
@@ -197,13 +197,12 @@ internal fun BenchmarkMap(state: DemoAppState, viewportInsets: MapViewportInsets
       }
       .drawWithContent {
         drawContent()
-        drawTrail(session)
+        drawTrail(mapState, session)
       }
   ) {
     key(scenario.id) {
       MaplibreMap(
         state = mapState,
-        styleComposition = styleComposition,
         presentationOptions =
           MapPresentationOptions(
             cameraPadding = viewportInsets.asPaddingValues(),
@@ -213,8 +212,7 @@ internal fun BenchmarkMap(state: DemoAppState, viewportInsets: MapViewportInsets
           ),
         callbacks = MapPresentationCallbacks(onFrame = { fps -> session.frames.recordMapFps(fps) }),
         contentWindowInsets = viewportInsets.asWindowInsets(),
-        overlay = MapOverlay.None,
-      )
+      ) {}
     }
 
     Box(Modifier.fillMaxSize().padding(viewportInsets.asPaddingValues())) {
@@ -238,17 +236,20 @@ internal fun BenchmarkMap(state: DemoAppState, viewportInsets: MapViewportInsets
   }
 }
 
-private fun samplePin(session: BenchmarkSession) {
+private fun samplePin(mapState: MapState, session: BenchmarkSession) {
   val pin = session.pin ?: return
-  val projected = session.mapState.presentation?.screenLocationFromPosition(pin) ?: return
+  val projected = mapState.presentation?.screenLocationFromPosition(pin) ?: return
   val px = with(session.density) { Offset(projected.x.toPx(), projected.y.toPx()) }
   session.gestures.onMapProjection(px.x.toDouble(), px.y.toDouble())
 }
 
-private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawTrail(session: BenchmarkSession) {
+private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawTrail(
+  mapState: MapState,
+  session: BenchmarkSession,
+) {
   val composePoint = session.pointerPx
   val pin = session.pin
-  val projected = pin?.let { session.mapState.presentation?.screenLocationFromPosition(it) }
+  val projected = pin?.let { mapState.presentation?.screenLocationFromPosition(it) }
   val mapPoint = projected?.let { with(session.density) { Offset(it.x.toPx(), it.y.toPx()) } }
   if (composePoint != null) {
     val arm = 12.dp.toPx()

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/benchmark/BenchmarkModels.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/benchmark/BenchmarkModels.kt
@@ -43,13 +43,12 @@ interface BenchmarkScenario {
 
   @MaplibreComposable @Composable fun MapContent(session: BenchmarkSession) {}
 
-  suspend fun run(session: BenchmarkSession)
+  suspend fun run(mapState: MapState, session: BenchmarkSession)
 }
 
 /** Mutable state one scenario run reads and writes while the isolated map is live. */
 @Stable
 class BenchmarkSession(
-  val mapState: MapState,
   val ui: BenchmarkUiState,
   val prefetcher: TilePrefetcher,
   val density: Density,

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/benchmark/FlyAroundScenario.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/benchmark/FlyAroundScenario.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.withFrameNanos
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.TimeSource
 import org.maplibre.compose.camera.CameraPosition
+import org.maplibre.compose.map.MapState
 
 internal object FlyAroundScenario : BenchmarkScenario {
   override val id = "fly-around"
@@ -14,12 +15,12 @@ internal object FlyAroundScenario : BenchmarkScenario {
   override val maxZoom = 16
   override val camera = CameraPosition(target = BenchmarkCenter, zoom = OrbitZoom, tilt = OrbitTilt)
 
-  override suspend fun run(session: BenchmarkSession) {
+  override suspend fun run(mapState: MapState, session: BenchmarkSession) {
     val start = TimeSource.Monotonic.markNow()
     val durationNs = Duration.inWholeNanoseconds.toDouble()
     while (true) {
       val t = (start.elapsedNow().inWholeNanoseconds.toDouble() / durationNs).coerceIn(0.0, 1.0)
-      session.mapState.presentation?.setCameraPosition(
+      mapState.presentation?.setCameraPosition(
         CameraPosition(
           target = orbitPosition(BenchmarkCenter, RadiusLon, RadiusLat, t),
           zoom = OrbitZoom,

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/benchmark/GeoJsonLoadScenario.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/benchmark/GeoJsonLoadScenario.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.withContext
 import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.expressions.dsl.const
 import org.maplibre.compose.layers.CircleLayer
+import org.maplibre.compose.map.MapState
 import org.maplibre.compose.sources.GeoJsonData
 import org.maplibre.compose.sources.GeoJsonOptions
 import org.maplibre.compose.sources.rememberGeoJsonSource
@@ -52,7 +53,7 @@ internal class GeoJsonLoadScenario(private val synchronousUpdate: Boolean) : Ben
     )
   }
 
-  override suspend fun run(session: BenchmarkSession) {
+  override suspend fun run(mapState: MapState, session: BenchmarkSession) {
     session.ui.status = "Building $PointCount points"
     session.geoJson = withContext(Dispatchers.Default) { collection(phase = 0.0) }
     repeat(SettleFrames) { withFrameNanos {} }

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/benchmark/TrailScenarios.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/benchmark/TrailScenarios.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.unit.dp
 import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.expressions.dsl.const
 import org.maplibre.compose.layers.CircleLayer
+import org.maplibre.compose.map.MapState
 import org.maplibre.compose.sources.GeoJsonData
 import org.maplibre.compose.sources.rememberGeoJsonSource
 import org.maplibre.spatialk.geojson.Feature
@@ -29,7 +30,7 @@ internal object GestureTrailScenario : BenchmarkScenario {
     PinLayer(session.pin)
   }
 
-  override suspend fun run(session: BenchmarkSession) {
+  override suspend fun run(mapState: MapState, session: BenchmarkSession) {
     session.ui.status = "Drag the map"
     session.gestures.arm()
     session.gestures.awaitQualifyingDrag()

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/benchmark/ZoomPumpScenario.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/benchmark/ZoomPumpScenario.kt
@@ -2,6 +2,7 @@ package org.maplibre.compose.demoapp.benchmark
 
 import kotlin.time.Duration.Companion.milliseconds
 import org.maplibre.compose.camera.CameraPosition
+import org.maplibre.compose.map.MapState
 
 internal object ZoomPumpScenario : BenchmarkScenario {
   override val id = "zoom-pump"
@@ -12,13 +13,13 @@ internal object ZoomPumpScenario : BenchmarkScenario {
   override val maxZoom = 16
   override val camera = CameraPosition(target = BenchmarkCenter, zoom = WideZoom)
 
-  override suspend fun run(session: BenchmarkSession) {
+  override suspend fun run(mapState: MapState, session: BenchmarkSession) {
     val wide = CameraPosition(target = BenchmarkCenter, zoom = WideZoom)
     val tight = CameraPosition(target = BenchmarkCenter, zoom = TightZoom)
-    session.mapState.presentation?.setCameraPosition(wide)
+    mapState.presentation?.setCameraPosition(wide)
     repeat(Cycles) {
-      playCamera(session.mapState, wide, tight, HalfCycle)
-      playCamera(session.mapState, tight, wide, HalfCycle)
+      playCamera(mapState, wide, tight, HalfCycle)
+      playCamera(mapState, tight, wide, HalfCycle)
     }
   }
 

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/MagnifyingLensDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/MagnifyingLensDemo.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableDoubleStateOf
 import androidx.compose.runtime.mutableFloatStateOf
@@ -96,9 +95,8 @@ object MagnifyingLensDemo : Demo {
 
   @Composable
   override fun MapOverlayScope.Overlay(state: DemoAppState) {
-    val lensState = rememberMapState(runtime = state.mapRuntime)
     val appliedStyle = state.appliedStyle
-    SideEffect { lensState.style.baseStyle = appliedStyle.base }
+    val lensState = rememberMapState(runtime = state.mapRuntime, baseStyle = appliedStyle.base)
     val density = LocalDensity.current
     val layoutDirection = LocalLayoutDirection.current
     val lensSizePx = with(density) { lensSize.dp.toPx() }
@@ -171,8 +169,7 @@ object MagnifyingLensDemo : Demo {
             gestureOptions = GestureOptions.AllDisabled,
           ),
         contentWindowInsets = WindowInsets(0),
-        overlay = MapOverlay.None,
-      )
+      ) {}
       Box(
         Modifier.fillMaxSize()
           .background(

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Camera.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Camera.kt
@@ -23,7 +23,7 @@ fun Camera() {
       initialCameraPosition =
         CameraPosition(target = Position(latitude = 45.521, longitude = -122.675), zoom = 13.0)
     )
-  MaplibreMap(state = mapState)
+  MaplibreMap(mapState)
   // #endregion first-position
 
   // #region animate

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Composition.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Composition.kt
@@ -3,12 +3,10 @@
 package org.maplibre.compose.docsnippets
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import org.maplibre.compose.map.MaplibreMap
 import org.maplibre.compose.map.rememberDefaultMapRuntime
 import org.maplibre.compose.map.rememberMapState
 import org.maplibre.compose.style.BaseStyle
-import org.maplibre.compose.style.StyleComposition
 
 @Composable
 fun Composition() {
@@ -17,13 +15,10 @@ fun Composition() {
   val state =
     rememberMapState(
       runtime = runtime,
-      initialBaseStyle = BaseStyle.Uri("https://tiles.openfreemap.org/styles/liberty"),
-    )
-  val composition = remember {
-    StyleComposition {
+      baseStyle = BaseStyle.Uri("https://tiles.openfreemap.org/styles/liberty"),
+    ) {
       // Sources and layers declared here are added to the base style.
     }
-  }
-  MaplibreMap(state = state, styleComposition = composition)
+  MaplibreMap(state)
   // #endregion base-plus-content
 }

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Controls.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Controls.kt
@@ -29,20 +29,17 @@ fun Controls() {
   // #endregion default
 
   // #region disabled
-  MaplibreMap(overlay = MapOverlay.None)
+  MaplibreMap {}
   // #endregion disabled
 
   // #region custom
-  MaplibreMap(
-    overlay =
-      MapOverlay {
-        MaplibreLogo(Modifier.align(Alignment.BottomStart))
-        ExpandingAttributionButton(
-          modifier = Modifier.align(Alignment.TopEnd),
-          contentAlignment = Alignment.TopEnd,
-        )
-      }
-  )
+  MaplibreMap {
+    MaplibreLogo(Modifier.align(Alignment.BottomStart))
+    ExpandingAttributionButton(
+      modifier = Modifier.align(Alignment.TopEnd),
+      contentAlignment = Alignment.TopEnd,
+    )
+  }
   // #endregion custom
 
   // #region insets
@@ -57,34 +54,28 @@ fun Controls() {
 @Composable
 fun LocationOverlay(position: Position) {
   // #region placedAt
-  MaplibreMap(
-    overlay =
-      MapOverlay {
-        include(MapOverlay.Default)
-        Text(
-          "Next sailing 12:40",
-          Modifier.placedAt(position, Alignment.BottomCenter).padding(bottom = 8.dp), // (1)!
-        )
-      }
-  )
+  MaplibreMap {
+    include(MapOverlay.Default)
+    Text(
+      "Next sailing 12:40",
+      Modifier.placedAt(position, Alignment.BottomCenter).padding(bottom = 8.dp), // (1)!
+    )
+  }
   // #endregion placedAt
 }
 
 @Composable
 fun OffScreenIndicator(position: Position) {
   // #region placedTowards
-  MaplibreMap(
-    overlay =
-      MapOverlay {
-        include(MapOverlay.Default)
-        val placement = rememberPlacedTowardsState() // (1)!
-        Text(
-          "▲",
-          Modifier.placedTowards(position, placement).graphicsLayer {
-            rotationZ = placement.angleDegrees // (2)!
-          },
-        )
-      }
-  )
+  MaplibreMap {
+    include(MapOverlay.Default)
+    val placement = rememberPlacedTowardsState() // (1)!
+    Text(
+      "▲",
+      Modifier.placedTowards(position, placement).graphicsLayer {
+        rotationZ = placement.angleDegrees // (2)!
+      },
+    )
+  }
   // #endregion placedTowards
 }

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Expressions.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Expressions.kt
@@ -3,7 +3,6 @@
 package org.maplibre.compose.docsnippets
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import org.maplibre.compose.expressions.dsl.asNumber
@@ -18,69 +17,67 @@ import org.maplibre.compose.expressions.dsl.switch
 import org.maplibre.compose.expressions.dsl.zoom
 import org.maplibre.compose.layers.CircleLayer
 import org.maplibre.compose.map.MaplibreMap
+import org.maplibre.compose.map.rememberMapState
 import org.maplibre.compose.sources.GeoJsonData
 import org.maplibre.compose.sources.rememberGeoJsonSource
-import org.maplibre.compose.style.StyleComposition
 
 @Composable
 fun Expressions() {
-  val composition = remember {
-    StyleComposition {
-      // #region constants
-      val earthquakes =
-        rememberGeoJsonSource(
-          GeoJsonData.Uri("https://maplibre.org/maplibre-gl-js/docs/assets/earthquakes.geojson")
-        )
-
-      CircleLayer(
-        id = "quakes-constant",
-        source = earthquakes,
-        radius = const(4.dp),
-        color = const(Color.Red),
+  val state = rememberMapState {
+    // #region constants
+    val earthquakes =
+      rememberGeoJsonSource(
+        GeoJsonData.Uri("https://maplibre.org/maplibre-gl-js/docs/assets/earthquakes.geojson")
       )
-      // #endregion constants
 
-      // #region feature-data
-      CircleLayer(
-        id = "quakes-by-magnitude",
-        source = earthquakes,
-        radius =
-          step(
-            input = feature["mag"].asNumber(),
-            fallback = const(4.dp),
-            4 to const(8.dp),
-            6 to const(16.dp),
-          ),
-        color =
-          switch(
-            condition(test = feature["mag"].asNumber() gt const(5), output = const(Color.Red)),
-            fallback = const(Color.Yellow),
-          ),
-      )
-      // #endregion feature-data
+    CircleLayer(
+      id = "quakes-constant",
+      source = earthquakes,
+      radius = const(4.dp),
+      color = const(Color.Red),
+    )
+    // #endregion constants
 
-      // #region zoom
-      CircleLayer(
-        id = "quakes-by-zoom",
-        source = earthquakes,
-        radius =
-          interpolate(
-            type = exponential(2f),
-            input = zoom(),
-            5 to const(2.dp),
-            10 to const(8.dp),
-          ),
-      )
-      // #endregion zoom
+    // #region feature-data
+    CircleLayer(
+      id = "quakes-by-magnitude",
+      source = earthquakes,
+      radius =
+        step(
+          input = feature["mag"].asNumber(),
+          fallback = const(4.dp),
+          4 to const(8.dp),
+          6 to const(16.dp),
+        ),
+      color =
+        switch(
+          condition(test = feature["mag"].asNumber() gt const(5), output = const(Color.Red)),
+          fallback = const(Color.Yellow),
+        ),
+    )
+    // #endregion feature-data
 
-      // #region filter
-      CircleLayer(
-        id = "large-quakes",
-        source = earthquakes,
-        filter = feature["mag"].asNumber() gt const(5),
-      )
-      // #endregion filter
-    }
+    // #region zoom
+    CircleLayer(
+      id = "quakes-by-zoom",
+      source = earthquakes,
+      radius =
+        interpolate(
+          type = exponential(2f),
+          input = zoom(),
+          5 to const(2.dp),
+          10 to const(8.dp),
+        ),
+    )
+    // #endregion zoom
+
+    // #region filter
+    CircleLayer(
+      id = "large-quakes",
+      source = earthquakes,
+      filter = feature["mag"].asNumber() gt const(5),
+    )
+    // #endregion filter
   }
-  MaplibreMap(styleComposition = composition)
+  MaplibreMap(state)
 }

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Images.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Images.kt
@@ -3,7 +3,6 @@
 package org.maplibre.compose.docsnippets
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.resources.ExperimentalResourceApi
@@ -15,51 +14,46 @@ import org.maplibre.compose.expressions.dsl.image
 import org.maplibre.compose.layers.RasterLayer
 import org.maplibre.compose.layers.SymbolLayer
 import org.maplibre.compose.map.MaplibreMap
+import org.maplibre.compose.map.rememberMapState
 import org.maplibre.compose.sources.GeoJsonData
 import org.maplibre.compose.sources.rememberGeoJsonSource
 import org.maplibre.compose.sources.rememberImageSource
-import org.maplibre.compose.style.StyleComposition
 import org.maplibre.compose.util.PositionQuad
 import org.maplibre.spatialk.geojson.Position
 
 @Composable
 @OptIn(ExperimentalResourceApi::class)
 fun Images() {
-  val iconComposition = remember {
-    StyleComposition {
-      // #region icon-painter
-      val stations =
-        rememberGeoJsonSource(GeoJsonData.Uri(Res.getUri("files/data/amtrak_stations.geojson")))
+  val iconState = rememberMapState {
+    // #region icon-painter
+    val stations =
+      rememberGeoJsonSource(GeoJsonData.Uri(Res.getUri("files/data/amtrak_stations.geojson")))
 
-      SymbolLayer(
-        id = "station-icons",
-        source = stations,
-        iconImage = image(painterResource(Res.drawable.map_24px), size = DpSize(24.dp, 24.dp)),
+    SymbolLayer(
+      id = "station-icons",
+      source = stations,
+      iconImage = image(painterResource(Res.drawable.map_24px), size = DpSize(24.dp, 24.dp)),
+    )
+    // #endregion icon-painter
+
+    // #region icon-sprite
+    SymbolLayer(id = "station-markers", source = stations, iconImage = image("marker"))
+    // #endregion icon-sprite
+  }
+  MaplibreMap(iconState)
+
+  val imageState = rememberMapState {
+    // #region image-source
+    val corners =
+      PositionQuad(
+        topLeft = Position(longitude = -74.0178, latitude = 40.7040),
+        topRight = Position(longitude = -74.0118, latitude = 40.7100),
+        bottomRight = Position(longitude = -74.0060, latitude = 40.7067),
+        bottomLeft = Position(longitude = -74.0120, latitude = 40.7006),
       )
-      // #endregion icon-painter
-
-      // #region icon-sprite
-      SymbolLayer(id = "station-markers", source = stations, iconImage = image("marker"))
-      // #endregion icon-sprite
-    }
+    val plan = rememberImageSource(position = corners, uri = Res.getUri("files/castello-plan.jpg"))
+    RasterLayer(id = "castello-plan", source = plan, opacity = const(0.8f))
+    // #endregion image-source
   }
-  MaplibreMap(styleComposition = iconComposition)
-
-  val imageComposition = remember {
-    StyleComposition {
-      // #region image-source
-      val corners =
-        PositionQuad(
-          topLeft = Position(longitude = -74.0178, latitude = 40.7040),
-          topRight = Position(longitude = -74.0118, latitude = 40.7100),
-          bottomRight = Position(longitude = -74.0060, latitude = 40.7067),
-          bottomLeft = Position(longitude = -74.0120, latitude = 40.7006),
-        )
-      val plan =
-        rememberImageSource(position = corners, uri = Res.getUri("files/castello-plan.jpg"))
-      RasterLayer(id = "castello-plan", source = plan, opacity = const(0.8f))
-      // #endregion image-source
-    }
-  }
-  MaplibreMap(styleComposition = imageComposition)
+  MaplibreMap(imageState)
 }

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Layers.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Layers.kt
@@ -3,7 +3,6 @@
 package org.maplibre.compose.docsnippets
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.resources.ExperimentalResourceApi
@@ -23,7 +22,6 @@ import org.maplibre.compose.sources.GeoJsonData
 import org.maplibre.compose.sources.getBaseSource
 import org.maplibre.compose.sources.rememberGeoJsonSource
 import org.maplibre.compose.style.BaseStyle
-import org.maplibre.compose.style.StyleComposition
 import org.maplibre.compose.util.ClickResult
 import org.maplibre.spatialk.geojson.toJson
 
@@ -32,83 +30,76 @@ import org.maplibre.spatialk.geojson.toJson
 fun Layers() {
   // #region simple
   val baseState =
-    rememberMapState(
-      initialBaseStyle = BaseStyle.Uri("https://tiles.openfreemap.org/styles/liberty")
-    )
-  val baseComposition = remember {
-    StyleComposition {
+    rememberMapState(baseStyle = BaseStyle.Uri("https://tiles.openfreemap.org/styles/liberty")) {
       getBaseSource(id = "openmaptiles")?.let { tiles ->
         CircleLayer(id = "example", source = tiles, sourceLayer = "poi")
       }
     }
-  }
-  MaplibreMap(state = baseState, styleComposition = baseComposition)
+  MaplibreMap(baseState)
   // #endregion simple
 
-  val amtrakComposition = remember {
-    StyleComposition {
-      // #region amtrak-1
-      val amtrakStations =
-        rememberGeoJsonSource(GeoJsonData.Uri(Res.getUri("files/data/amtrak_stations.geojson")))
+  val amtrakState = rememberMapState {
+    // #region amtrak-1
+    val amtrakStations =
+      rememberGeoJsonSource(GeoJsonData.Uri(Res.getUri("files/data/amtrak_stations.geojson")))
 
-      val amtrakRoutes =
-        rememberGeoJsonSource(GeoJsonData.Uri(Res.getUri("files/data/amtrak_routes.geojson")))
-      LineLayer(
-        id = "amtrak-routes-casing",
-        source = amtrakRoutes,
-        color = const(Color.White),
-        width = const(6.dp),
-      )
-      LineLayer(
-        id = "amtrak-routes",
-        source = amtrakRoutes,
-        color = const(Color.Blue),
-        width = const(4.dp),
-      )
-      // #endregion amtrak-1
+    val amtrakRoutes =
+      rememberGeoJsonSource(GeoJsonData.Uri(Res.getUri("files/data/amtrak_routes.geojson")))
+    LineLayer(
+      id = "amtrak-routes-casing",
+      source = amtrakRoutes,
+      color = const(Color.White),
+      width = const(6.dp),
+    )
+    LineLayer(
+      id = "amtrak-routes",
+      source = amtrakRoutes,
+      color = const(Color.Blue),
+      width = const(4.dp),
+    )
+    // #endregion amtrak-1
 
-      // #region amtrak-2
-      val detailedAmtrakRoutes =
-        rememberGeoJsonSource(GeoJsonData.Uri(Res.getUri("files/data/amtrak_routes.geojson")))
-      LineLayer(
-        id = "amtrak-routes",
-        source = detailedAmtrakRoutes,
-        cap = const(LineCap.Round),
-        join = const(LineJoin.Round),
-        color = const(Color.Blue),
-        width =
-          interpolate(
-            type = exponential(1.2f),
-            input = zoom(),
-            5 to const(0.4.dp),
-            6 to const(0.7.dp),
-            7 to const(1.75.dp),
-            20 to const(22.dp),
-          ),
-      )
-      // #endregion amtrak-2
+    // #region amtrak-2
+    val detailedAmtrakRoutes =
+      rememberGeoJsonSource(GeoJsonData.Uri(Res.getUri("files/data/amtrak_routes.geojson")))
+    LineLayer(
+      id = "amtrak-routes",
+      source = detailedAmtrakRoutes,
+      cap = const(LineCap.Round),
+      join = const(LineJoin.Round),
+      color = const(Color.Blue),
+      width =
+        interpolate(
+          type = exponential(1.2f),
+          input = zoom(),
+          5 to const(0.4.dp),
+          6 to const(0.7.dp),
+          7 to const(1.75.dp),
+          20 to const(22.dp),
+        ),
+    )
+    // #endregion amtrak-2
 
-      // #region anchors
-      val anchoredAmtrakRoutes =
-        rememberGeoJsonSource(GeoJsonData.Uri(Res.getUri("files/data/amtrak_routes.geojson")))
-      Anchor.Above("road_motorway") {
-        LineLayer(id = "amtrak-routes", source = anchoredAmtrakRoutes)
-      }
-      // #endregion anchors
-
-      // #region interaction
-      val interactiveAmtrakStations =
-        rememberGeoJsonSource(GeoJsonData.Uri(Res.getUri("files/data/amtrak_stations.geojson")))
-      CircleLayer(
-        id = "amtrak-stations",
-        source = interactiveAmtrakStations,
-        onClick = { features ->
-          println("Clicked on ${features[0].toJson()}")
-          ClickResult.Consume
-        },
-      )
-      // #endregion interaction
+    // #region anchors
+    val anchoredAmtrakRoutes =
+      rememberGeoJsonSource(GeoJsonData.Uri(Res.getUri("files/data/amtrak_routes.geojson")))
+    Anchor.Above("road_motorway") {
+      LineLayer(id = "amtrak-routes", source = anchoredAmtrakRoutes)
     }
+    // #endregion anchors
+
+    // #region interaction
+    val interactiveAmtrakStations =
+      rememberGeoJsonSource(GeoJsonData.Uri(Res.getUri("files/data/amtrak_stations.geojson")))
+    CircleLayer(
+      id = "amtrak-stations",
+      source = interactiveAmtrakStations,
+      onClick = { features ->
+        println("Clicked on ${features[0].toJson()}")
+        ClickResult.Consume
+      },
+    )
+    // #endregion interaction
   }
-  MaplibreMap(styleComposition = amtrakComposition)
+  MaplibreMap(amtrakState)
 }

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Location.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Location.kt
@@ -3,7 +3,6 @@
 package org.maplibre.compose.docsnippets
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.location.LocationPuck
@@ -13,7 +12,6 @@ import org.maplibre.compose.location.rememberDefaultLocationProvider
 import org.maplibre.compose.location.rememberLocationState
 import org.maplibre.compose.map.MaplibreMap
 import org.maplibre.compose.map.rememberMapState
-import org.maplibre.compose.style.StyleComposition
 
 @Composable
 @OptIn(ExperimentalResourceApi::class)
@@ -21,8 +19,6 @@ import org.maplibre.compose.style.StyleComposition
 // app, which the documentation covers in prose.
 fun Location() {
   // #region puck
-  val mapState = rememberMapState()
-
   val locationProvider = rememberDefaultLocationProvider()
   val headingProvider = rememberDefaultHeadingProvider() // optional: get heading from sensors
 
@@ -32,21 +28,18 @@ fun Location() {
       headingProvider = headingProvider,
     )
 
-  val composition =
-    remember(locationState) {
-      StyleComposition {
-        LocationPuck(
-          idPrefix = "user",
-          locationState = locationState,
-        )
+  val mapState = rememberMapState {
+    LocationPuck(
+      idPrefix = "user",
+      locationState = locationState,
+    )
 
-        LocationTrackingEffect(locationState = locationState) {
-          mapState.presentation?.animateCameraPosition(
-            CameraPosition(target = currentLocation.position, zoom = 15.0)
-          )
-        }
-      }
+    LocationTrackingEffect(locationState = locationState) {
+      mapState.presentation?.animateCameraPosition(
+        CameraPosition(target = currentLocation.position, zoom = 15.0)
+      )
     }
-  MaplibreMap(state = mapState, styleComposition = composition)
+  }
+  MaplibreMap(mapState)
   // #endregion puck
 }

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Material3.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Material3.kt
@@ -12,28 +12,26 @@ import org.maplibre.compose.material3.Material3
 import org.maplibre.compose.material3.ScaleBar
 import org.maplibre.compose.overlay.MapOverlay
 import org.maplibre.compose.overlay.MaplibreLogo
+import org.maplibre.compose.overlay.include
 
 @Composable
 fun Material3() {
   // #region overlay
-  MaplibreMap(overlay = MapOverlay.Material3)
+  MaplibreMap { include(MapOverlay.Material3) }
   // #endregion overlay
 
   // #region controls
-  MaplibreMap(
-    overlay =
-      MapOverlay {
-        ScaleBar(
-          presentation?.viewport?.metersPerDpAtTarget ?: 0.0,
-          modifier = Modifier.align(Alignment.TopStart),
-        ) // (1)!
-        CompassButton(modifier = Modifier.align(Alignment.TopEnd))
-        MaplibreLogo(Modifier.align(Alignment.BottomStart))
-        ExpandingAttributionButton(
-          modifier = Modifier.align(Alignment.BottomEnd),
-          contentAlignment = Alignment.BottomEnd,
-        )
-      }
-  )
+  MaplibreMap {
+    ScaleBar(
+      presentation?.viewport?.metersPerDpAtTarget ?: 0.0,
+      modifier = Modifier.align(Alignment.TopStart),
+    ) // (1)!
+    CompassButton(modifier = Modifier.align(Alignment.TopEnd))
+    MaplibreLogo(Modifier.align(Alignment.BottomStart))
+    ExpandingAttributionButton(
+      modifier = Modifier.align(Alignment.BottomEnd),
+      contentAlignment = Alignment.BottomEnd,
+    )
+  }
   // #endregion controls
 }

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Requests.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Requests.kt
@@ -24,7 +24,7 @@ fun InterceptorMap(token: String) {
     }
     onDispose { runtime.setRequestInterceptor(null) }
   }
-  MaplibreMap(state = rememberMapState(runtime))
+  MaplibreMap(rememberMapState(runtime))
   // #endregion interceptor
 }
 

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Snapshotter.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Snapshotter.kt
@@ -16,14 +16,14 @@ import org.maplibre.compose.style.StyleComposition
 suspend fun captureCurrentMap(
   runtime: MapRuntime,
   mapState: MapState,
-  content: StyleComposition,
+  styleComposition: StyleComposition,
   density: Density,
   layoutDirection: LayoutDirection,
 ): ImageBitmap {
   val snapshotter =
     runtime.createSnapshotter(
       baseStyle = mapState.style.baseStyle,
-      styleComposition = content,
+      styleComposition = styleComposition,
     )
   return try {
     snapshotter.capture(

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Styling.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Styling.kt
@@ -4,7 +4,6 @@ package org.maplibre.compose.docsnippets
 
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.SideEffect
 import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.maplibre.compose.demoapp.generated.Res
 import org.maplibre.compose.map.MaplibreMap
@@ -16,24 +15,21 @@ import org.maplibre.compose.style.BaseStyle
 fun Styling() {
   // #region simple
   val simple =
-    rememberMapState(
-      initialBaseStyle = BaseStyle.Uri("https://tiles.openfreemap.org/styles/liberty")
-    )
-  MaplibreMap(state = simple)
+    rememberMapState(baseStyle = BaseStyle.Uri("https://tiles.openfreemap.org/styles/liberty"))
+  MaplibreMap(simple)
   // #endregion simple
 
   // #region dynamic
   val variant = if (isSystemInDarkTheme()) "dark" else "light"
-  val dynamic = rememberMapState()
-  SideEffect {
-    dynamic.style.baseStyle =
-      BaseStyle.Uri("https://api.protomaps.com/styles/v4/$variant/en.json?key=MY_KEY")
-  }
-  MaplibreMap(state = dynamic)
+  val dynamic =
+    rememberMapState(
+      baseStyle = BaseStyle.Uri("https://api.protomaps.com/styles/v4/$variant/en.json?key=MY_KEY")
+    )
+  MaplibreMap(dynamic)
   // #endregion dynamic
 
   // #region local
-  val local = rememberMapState(initialBaseStyle = BaseStyle.Uri(Res.getUri("files/style.json")))
-  MaplibreMap(state = local)
+  val local = rememberMapState(baseStyle = BaseStyle.Uri(Res.getUri("files/style.json")))
+  MaplibreMap(local)
   // #endregion local
 }

--- a/docs/src/content/docs/composition.mdx
+++ b/docs/src/content/docs/composition.mdx
@@ -9,29 +9,28 @@ import { region } from "../../snippets";
 
 import composition from "../../../../demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Composition.kt?raw";
 
-MapLibre Compose has no public map view object. <Api of="MaplibreMap" />
-presents a durable <Api of="MapState" />. Its <Api of="MapStyleState" /> exposes
-the base style and load status, while <Api of="MapPresentation" /> provides
-viewport-bound operations. This page explains how the library applies a
-<Api of="StyleComposition" /> to the underlying MapLibre style.
+MapLibre Compose has no public map view object. <Api of="MapState" /> defines a
+logical map, including its base style and declarative style content.
+<Api of="MaplibreMap" /> presents that state and provides viewport-bound
+operations through <Api of="MapPresentation" />.
 
 ## The style is base plus content
 
 A MapLibre style is a document with sources and layers. The `baseStyle`
-state loads that document without modification. `StyleComposition` declares
-additions to it: your sources, your layers, and their positions in the layer
-stack.
+parameter loads that document without modification. The trailing
+<Api of="rememberMapState" /> block declares your sources, layers, and their
+positions in the layer stack.
 
 <Code code={region(composition, "base-plus-content")} lang="kotlin" title="App.kt" />
 
-The library manages the sources and layers in the `StyleComposition` block. It
+The library manages the sources and layers in the style block. It
 does not modify the rest of the base style. To change a base style layer,
 replace it with <Api of="Anchor.Replace" /> and declare its replacement yourself.
 
 ## Recomposition updates the style
 
-`StyleComposition` is evaluated as a Compose composition. When the state that it reads
-changes, it recomposes, and the library applies the difference to the style: a
+The style block is evaluated as a Compose composition. When the state that it
+reads changes, it recomposes, and the library applies the difference to the style: a
 layer that is no longer in the composition is removed from the style, a new
 layer is added, and a changed property is updated in place. You do not call
 add or remove functions yourself.
@@ -41,11 +40,16 @@ current state, and let the runtime reconcile it.
 
 ## Style switches re-apply your content
 
-When `MapState.style.baseStyle` changes, the map loads the new style and
-evaluates the style composition against it. Each evaluation declares your
+When the `baseStyle` input changes, the map loads the new style and evaluates
+the style block against it. Each evaluation declares your
 sources and layers against the new style. They persist across the switch
 without extra code. An `Anchor` that names a base layer applies only when that
 layer exists in the new style.
+
+Use a <Api of="StyleComposition" /> value when several map states or a
+snapshotter share one definition. Pass the value to `rememberMapState` or
+`MapRuntime.createMapState` with the same `baseStyle` pair that
+`MapRuntime.createSnapshotter` accepts.
 
 ## Layer and source IDs
 

--- a/docs/src/content/docs/controls.mdx
+++ b/docs/src/content/docs/controls.mdx
@@ -11,10 +11,10 @@ import controls from "../../../../demo-app/common/src/commonMain/kotlin/org/mapl
 import material3 from "../../../../demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Material3.kt?raw";
 
 <Api of="MaplibreMap" /> draws controls on top of the map. The `overlay`
-parameter sets which ones. The default is a scale bar and a compass along the
-top edge, and
-the MapLibre logo and an attribution button along the bottom edge. The scale
-bar and the compass appear only while they are relevant.
+block replaces the default controls when you supply it. The default draws a
+scale bar and a compass along the top edge. It draws the MapLibre logo and an
+attribution button along the bottom edge. The scale bar and the compass appear
+only while they are relevant.
 
 <Code code={region(controls, "default")} lang="kotlin" title="App.kt" />
 
@@ -24,19 +24,19 @@ bar and the compass appear only while they are relevant.
   attribution yourself.
 </Aside>
 
-## Choose an overlay
+## Replace the overlay
 
-<Api of="MapOverlay.None" /> draws no controls. Use it when your app shows the
-attribution somewhere else, such as an about screen.
+An empty block draws no controls. Use it when your app shows the attribution
+somewhere else, such as an about screen.
 
 <Code code={region(controls, "disabled")} lang="kotlin" title="App.kt" />
 
-A <Api of="MapOverlay" /> block draws the controls you list in it.
-`Modifier.align` positions a control against an inset edge of the map.
+The trailing block draws the controls that you list. `Modifier.align` positions
+a control against an inset edge of the map.
 
 <Code code={region(controls, "custom")} lang="kotlin" title="App.kt" />
 
-The controls use the map state from the `MapOverlay` block.
+The controls use the map state from the trailing block.
 
 ## Theme the controls with Material 3
 
@@ -56,14 +56,12 @@ commonMain.dependencies {
 ```
 
 <Api of="Material3" display="MapOverlay.Material3" /> draws the same controls
-as
-<Api of="MapOverlay.Default" /> in the same places, so switching to it is one
-parameter:
+as <Api of="MapOverlay.Default" /> in the same places. Include it in the block:
 
 <Code code={region(material3, "overlay")} lang="kotlin" title="App.kt" />
 
-Each Material 3 control is also a composable you can place in a `MapOverlay`
-of your own:
+Each Material 3 control is also a composable that you can place in the trailing
+block:
 
 <Code code={region(material3, "controls")} lang="kotlin" title="App.kt" />
 
@@ -85,9 +83,8 @@ Padding on a bounding-box camera move adds to `cameraPadding` for that fit.
 ## Pin Compose UI to a location
 
 <Api of="MapOverlayScope.placedAt" /> puts a child on a geographic position.
-Keep the default controls with <Api of="include" />, then add the child in the
-same overlay. A pan, a zoom,
-or a window resize moves the child with the map.
+Include <Api of="MapOverlay.Default" /> to keep the default controls. A pan, a
+zoom, or a window resize moves the child with the map.
 
 <Code code={region(controls, "placedAt")} lang="kotlin" title="App.kt" />
 

--- a/docs/src/content/docs/expressions.mdx
+++ b/docs/src/content/docs/expressions.mdx
@@ -5,7 +5,7 @@ description: The expression DSL that computes layer properties from feature data
 
 import { Code } from "@astrojs/starlight/components";
 import Api from "../../components/Api.astro";
-import { region, styleComposition } from "../../snippets";
+import { region, rememberedMapStyle } from "../../snippets";
 
 import expressions from "../../../../demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Expressions.kt?raw";
 
@@ -23,7 +23,7 @@ sizes, `Color` for colors, and `DpOffset` for offsets.
 A constant value must also be an expression. Wrap a plain value in
 <Api of="const" />:
 
-<Code code={styleComposition(region(expressions, "constants"))} lang="kotlin" title="App.kt" />
+<Code code={rememberedMapStyle(region(expressions, "constants"))} lang="kotlin" title="App.kt" />
 
 ## Read feature data
 
@@ -32,7 +32,7 @@ The result is untyped, so convert it with functions such as `asNumber()` or
 `asString()`. Functions such as <Api of="step" /> and <Api of="switch" />
 select an output from the value:
 
-<Code code={styleComposition(region(expressions, "feature-data"))} lang="kotlin" title="App.kt" />
+<Code code={rememberedMapStyle(region(expressions, "feature-data"))} lang="kotlin" title="App.kt" />
 
 The map evaluates this formula once per feature: each earthquake receives a
 radius and a color computed from its own magnitude.
@@ -42,14 +42,14 @@ radius and a color computed from its own magnitude.
 <Api of="zoom" /> is the current zoom level. <Api of="interpolate" /> computes
 a smooth value between stops:
 
-<Code code={styleComposition(region(expressions, "zoom"))} lang="kotlin" title="App.kt" />
+<Code code={rememberedMapStyle(region(expressions, "zoom"))} lang="kotlin" title="App.kt" />
 
 ## Filter features
 
 The `filter` parameter takes a boolean expression. The layer renders only the
 features for which it is true:
 
-<Code code={styleComposition(region(expressions, "filter"))} lang="kotlin" title="App.kt" />
+<Code code={rememberedMapStyle(region(expressions, "filter"))} lang="kotlin" title="App.kt" />
 
 ## Where the code runs
 

--- a/docs/src/content/docs/images.mdx
+++ b/docs/src/content/docs/images.mdx
@@ -5,7 +5,7 @@ description: Draw icons from Compose painters or the style sprite, and place an 
 
 import { Code } from "@astrojs/starlight/components";
 import Api from "../../components/Api.astro";
-import { region, styleComposition } from "../../snippets";
+import { region, rememberedMapStyle } from "../../snippets";
 
 import images from "../../../../demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Images.kt?raw";
 
@@ -19,18 +19,18 @@ Pass a painter to `image()`. The library rasterizes it and registers it with
 the style. This works with `painterResource`, vector drawables, and any other
 painter:
 
-<Code code={styleComposition(region(images, "icon-painter"))} lang="kotlin" title="App.kt" />
+<Code code={rememberedMapStyle(region(images, "icon-painter"))} lang="kotlin" title="App.kt" />
 
 ## Draw icons from the style sprite
 
 Base styles usually bundle a sprite: a named set of icons. Pass the icon name
 to `image()`:
 
-<Code code={styleComposition(region(images, "icon-sprite"))} lang="kotlin" title="App.kt" />
+<Code code={rememberedMapStyle(region(images, "icon-sprite"))} lang="kotlin" title="App.kt" />
 
 ## Place an image on the map
 
 An <Api of="ImageSource" /> positions one image on the map by its four corner
 coordinates. A <Api of="RasterLayer" /> draws it:
 
-<Code code={styleComposition(region(images, "image-source"))} lang="kotlin" title="App.kt" />
+<Code code={rememberedMapStyle(region(images, "image-source"))} lang="kotlin" title="App.kt" />

--- a/docs/src/content/docs/interaction.mdx
+++ b/docs/src/content/docs/interaction.mdx
@@ -5,7 +5,7 @@ description: Configure gestures, and respond to clicks on the map and on layers.
 
 import { Code } from "@astrojs/starlight/components";
 import Api from "../../components/Api.astro";
-import { region, styleComposition } from "../../snippets";
+import { region, rememberedMapStyle } from "../../snippets";
 
 import interaction from "../../../../demo-app/common/src/androidMain/kotlin/org/maplibre/compose/docsnippets/Interaction.kt?raw";
 import layers from "../../../../demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Layers.kt?raw";
@@ -38,7 +38,7 @@ click on to the layer listeners:
 Layer composables in a `StyleComposition` have click listeners that receive the
 features that were clicked in that layer:
 
-<Code code={styleComposition(region(layers, "interaction"))} lang="kotlin" title="App.kt" />
+<Code code={rememberedMapStyle(region(layers, "interaction"))} lang="kotlin" title="App.kt" />
 
 Click listeners run on the map first, then on layers from the top to the bottom
 of the map. The first listener that returns <Api of="ClickResult.Consume" />

--- a/docs/src/content/docs/layers.mdx
+++ b/docs/src/content/docs/layers.mdx
@@ -5,14 +5,14 @@ description: Declare sources and layers as composables, and anchor them in the l
 
 import { Code } from "@astrojs/starlight/components";
 import Api from "../../components/Api.astro";
-import { region, styleComposition } from "../../snippets";
+import { region, rememberedMapStyle } from "../../snippets";
 
 import layers from "../../../../demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Layers.kt?raw";
 
 The base style defines the map's content. To show your own data on top of it,
-declare sources and layers in a <Api of="StyleComposition" />, then pass that
-value to <Api of="MaplibreMap" />. A source holds the data, and a layer draws
-data from a source.
+declare sources and layers in the trailing <Api of="rememberMapState" /> block,
+then pass that state to <Api of="MaplibreMap" />. A source holds the data, and a
+layer draws data from a source.
 
 ## Reference a base style source
 
@@ -26,7 +26,7 @@ layer of yours can draw data that the style already loads:
 <Api of="rememberGeoJsonSource" /> creates a source from a GeoJSON URI or
 string. Layers reference the source object directly:
 
-<Code code={styleComposition(region(layers, "amtrak-1"))} lang="kotlin" title="App.kt" />
+<Code code={rememberedMapStyle(region(layers, "amtrak-1"))} lang="kotlin" title="App.kt" />
 
 Other source types cover vector tiles, raster tiles, and images. The API
 reference documents them under <Api of="org.maplibre.compose.sources" />.
@@ -37,7 +37,7 @@ Layer properties accept expressions: formulas that the map evaluates at render
 time. Wrap a constant value in <Api of="const" />. Functions such as
 <Api of="interpolate" /> and <Api of="zoom" /> build dynamic values:
 
-<Code code={styleComposition(region(layers, "amtrak-2"))} lang="kotlin" title="App.kt" />
+<Code code={rememberedMapStyle(region(layers, "amtrak-2"))} lang="kotlin" title="App.kt" />
 
 [Expressions in Kotlin](/maplibre-compose/expressions/) explains the expression
 system. The [MapLibre Style Specification][spec-layers] documents every layer
@@ -49,6 +49,6 @@ By default, your layers draw above the base style layers. <Api of="Anchor" />
 inserts a layer at another position: at the `Bottom`, at the `Top`, `Above` or
 `Below` a named base layer, or as a `Replace`ment for a base layer:
 
-<Code code={styleComposition(region(layers, "anchors"))} lang="kotlin" title="App.kt" />
+<Code code={rememberedMapStyle(region(layers, "anchors"))} lang="kotlin" title="App.kt" />
 
 [spec-layers]: https://maplibre.org/maplibre-style-spec/layers/

--- a/docs/src/content/docs/snapshotter.mdx
+++ b/docs/src/content/docs/snapshotter.mdx
@@ -10,9 +10,10 @@ import { region } from "../../snippets";
 import snapshotter from "../../../../demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Snapshotter.kt?raw";
 
 An <Api of="MapSnapshotter" /> renders an independent, non-UI map to an
-`ImageBitmap`. Use the same <Api of="MapRuntime" />, <Api of="BaseStyle" />, and
-<Api of="StyleComposition" /> as the displayed map to capture its current
-camera and declared content.
+`ImageBitmap`. `createMapState` and `createSnapshotter` both accept a
+<Api of="BaseStyle" /> and <Api of="StyleComposition" />. Pass the same pair to
+capture the displayed map's declared content. Copy its current camera position
+into the capture request.
 
 Create and close the snapshotter in a coroutine. <Api of="MapSnapshotter.capture" />
 suspends until the image is ready:

--- a/docs/src/snippets.ts
+++ b/docs/src/snippets.ts
@@ -27,13 +27,13 @@ export function region(source: string, name: string): string {
   return dedent(trimBlankEdges(body)).join("\n");
 }
 
-/** Wraps a region in the style composition and map call that consume it. */
-export function styleComposition(body: string): string {
+/** Wraps a region in the remembered map state and map call that consume it. */
+export function rememberedMapStyle(body: string): string {
   const indented = body
     .split("\n")
     .map((line) => (line.trim() === "" ? line : `    ${line}`))
     .join("\n");
-  return `val composition = remember {\n  StyleComposition {\n${indented}\n  }\n}\nMaplibreMap(styleComposition = composition)`;
+  return `val state = rememberMapState {\n${indented}\n}\nMaplibreMap(state = state)`;
 }
 
 function isMarker(line: string, kind: string, name?: string): boolean {

--- a/lib/maplibre-compose/src/androidDeviceTest/kotlin/org/maplibre/compose/camera/AndroidMapStateRecreationTest.kt
+++ b/lib/maplibre-compose/src/androidDeviceTest/kotlin/org/maplibre/compose/camera/AndroidMapStateRecreationTest.kt
@@ -122,7 +122,7 @@ class MapStateRecreationActivity : ComponentActivity() {
     setContent {
       val firstRuntime: MapRuntime = rememberDefaultMapRuntime()
       val secondRuntime: MapRuntime = rememberDefaultMapRuntime()
-      val state = rememberMapState(firstRuntime, initialBaseStyle = BaseStyle.Empty)
+      val state = rememberMapState(firstRuntime, baseStyle = BaseStyle.Empty)
       SideEffect {
         mapState = state
         defaultRuntimeIsShared = firstRuntime === secondRuntime

--- a/lib/maplibre-compose/src/androidDeviceTest/kotlin/org/maplibre/compose/map/AndroidExplicitRuntimeTest.kt
+++ b/lib/maplibre-compose/src/androidDeviceTest/kotlin/org/maplibre/compose/map/AndroidExplicitRuntimeTest.kt
@@ -24,7 +24,7 @@ class AndroidExplicitRuntimeTest {
           logger = null,
         )
       )
-    val state = runtime.createMapState(initialBaseStyle = BaseStyle.Empty)
+    val state = runtime.createMapState(baseStyle = BaseStyle.Empty)
 
     try {
       assertSame(context.applicationContext, AndroidMlnFfiPlatform.applicationContext)

--- a/lib/maplibre-compose/src/androidDeviceTest/kotlin/org/maplibre/compose/mlnffi/AndroidSurfaceReplacementTest.kt
+++ b/lib/maplibre-compose/src/androidDeviceTest/kotlin/org/maplibre/compose/mlnffi/AndroidSurfaceReplacementTest.kt
@@ -31,6 +31,7 @@ import org.maplibre.compose.map.MaplibreMap
 import org.maplibre.compose.map.MlnFfiMapSession
 import org.maplibre.compose.map.rememberMapState
 import org.maplibre.compose.overlay.MapOverlay
+import org.maplibre.compose.overlay.include
 import org.maplibre.compose.style.BaseStyle
 
 class AndroidSurfaceReplacementTest {
@@ -196,7 +197,7 @@ class SurfaceReplacementActivity : ComponentActivity() {
     setContent {
       if (showingReplacement) {
         TestMap(
-          overlay = MapOverlay.None,
+          overlay = MapOverlay {},
           onState = { replacementState = it },
           onPresentation = { replacementPresentation.countDown() },
           onFrame = {
@@ -247,7 +248,7 @@ private fun TestMap(
   onPresentation: () -> Unit,
   onFrame: () -> Unit,
 ) {
-  val state = rememberMapState(initialBaseStyle = SOLID_STYLE)
+  val state = rememberMapState(baseStyle = SOLID_STYLE)
   LaunchedEffect(state) {
     onState(state)
     snapshotFlow { state.presentation }.first { it != null }
@@ -257,8 +258,9 @@ private fun TestMap(
     state = state,
     modifier = Modifier.fillMaxSize(),
     callbacks = MapPresentationCallbacks(onFrame = { onFrame() }),
-    overlay = overlay,
-  )
+  ) {
+    include(overlay)
+  }
 }
 
 private fun View.descendants(): Sequence<View> = sequence {

--- a/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/layers/LayerClickOrderTest.kt
+++ b/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/layers/LayerClickOrderTest.kt
@@ -29,7 +29,6 @@ import org.maplibre.compose.mlnffi.setFfiTestMapContent
 import org.maplibre.compose.sources.GeoJsonData
 import org.maplibre.compose.sources.rememberGeoJsonSource
 import org.maplibre.compose.style.BaseStyle
-import org.maplibre.compose.style.StyleComposition
 import org.maplibre.compose.util.ClickResult
 import org.maplibre.spatialk.geojson.Position
 
@@ -142,56 +141,51 @@ class LayerClickOrderTest {
       mapState =
         rememberMapState(
           initialCameraPosition = CameraPosition(target = Position(0.0, 0.0), zoom = START_ZOOM),
-          initialBaseStyle = BaseStyle.Empty,
-        )
-      MaplibreMap(
-        state = mapState,
-        modifier = Modifier.fillMaxSize(),
-        styleComposition =
-          StyleComposition {
-            val source = rememberGeoJsonSource(data = GeoJsonData.JsonString(WORLD_POLYGON))
+          baseStyle = BaseStyle.Empty,
+        ) {
+          val source = rememberGeoJsonSource(data = GeoJsonData.JsonString(WORLD_POLYGON))
 
-            val front: @Composable () -> Unit = {
-              FillLayer(
-                id = FRONT,
-                source = source,
-                color = const(Color.Red),
-                onClick = {
-                  clicked += FRONT
-                  frontResult
-                },
-                onLongClick = {
-                  longClicked += FRONT
-                  frontResult
-                },
-              )
-            }
-            val back: @Composable () -> Unit = {
-              FillLayer(
-                id = BACK,
-                source = source,
-                color = const(Color.Blue),
-                onClick = {
-                  clicked += BACK
-                  ClickResult.Consume
-                },
-                onLongClick = {
-                  longClicked += BACK
-                  ClickResult.Consume
-                },
-              )
-            }
+          val front: @Composable () -> Unit = {
+            FillLayer(
+              id = FRONT,
+              source = source,
+              color = const(Color.Red),
+              onClick = {
+                clicked += FRONT
+                frontResult
+              },
+              onLongClick = {
+                longClicked += FRONT
+                frontResult
+              },
+            )
+          }
+          val back: @Composable () -> Unit = {
+            FillLayer(
+              id = BACK,
+              source = source,
+              color = const(Color.Blue),
+              onClick = {
+                clicked += BACK
+                ClickResult.Consume
+              },
+              onLongClick = {
+                longClicked += BACK
+                ClickResult.Consume
+              },
+            )
+          }
 
-            if (composeFrontLayerFirst) {
-              // `back` is composed second, and the anchor is the only reason it ends up behind.
-              front()
-              Anchor.Bottom { back() }
-            } else {
-              back()
-              front()
-            }
-          },
-      )
+          if (composeFrontLayerFirst) {
+            // `back` is composed second, and the anchor is the only reason it ends up behind.
+            front()
+            Anchor.Bottom { back() }
+          } else {
+            back()
+            front()
+          }
+        }
+      MaplibreMap(state = mapState, modifier = Modifier.fillMaxSize())
     }
 
     waitUntil(timeoutMillis = TIMEOUT) { mapState.presentation != null }

--- a/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MlnFfiMapCompositionTest.kt
+++ b/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MlnFfiMapCompositionTest.kt
@@ -58,6 +58,7 @@ import org.maplibre.compose.mlnffi.runFfiComposeUiTest
 import org.maplibre.compose.mlnffi.setFfiTestMapContent
 import org.maplibre.compose.offline.rememberOfflinePacksSource
 import org.maplibre.compose.overlay.MapOverlay
+import org.maplibre.compose.overlay.include
 import org.maplibre.compose.sources.GeoJsonData
 import org.maplibre.compose.sources.RasterSource
 import org.maplibre.compose.sources.rememberGeoJsonSource
@@ -101,7 +102,7 @@ class MlnFfiMapCompositionTest {
   @Test
   fun map_state_renders_a_base_style_and_publishes_one_presentation() = runFfiComposeUiTest {
     val runtime = createNativeMapRuntime(runtimeOptions)
-    val state = runtime.createMapState(initialBaseStyle = BaseStyle.Empty)
+    val state = runtime.createMapState(baseStyle = BaseStyle.Empty)
 
     setFfiTestMapContent(runtimeOptions) { MaplibreMap(state) }
     waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) {
@@ -123,7 +124,7 @@ class MlnFfiMapCompositionTest {
   @Test
   fun presentation_options_update_without_replacing_the_native_map() = runFfiComposeUiTest {
     val runtime = createNativeMapRuntime(runtimeOptions)
-    val state = runtime.createMapState(initialBaseStyle = BaseStyle.Empty)
+    val state = runtime.createMapState(baseStyle = BaseStyle.Empty)
     var options by mutableStateOf(MapPresentationOptions())
 
     setFfiTestMapContent(runtimeOptions) {
@@ -146,8 +147,6 @@ class MlnFfiMapCompositionTest {
   @Test
   fun one_style_composition_is_evaluated_independently_for_two_maps() = runFfiComposeUiTest {
     val runtime = createNativeMapRuntime(runtimeOptions)
-    val first = runtime.createMapState(initialBaseStyle = BaseStyle.Empty)
-    val second = runtime.createMapState(initialBaseStyle = BaseStyle.Empty)
     val evaluatorIdentities = mutableSetOf<Any>()
     var showFirst by mutableStateOf(true)
     val style = StyleComposition {
@@ -166,9 +165,11 @@ class MlnFfiMapCompositionTest {
         onDispose {}
       }
     }
+    val first = runtime.createMapState(baseStyle = BaseStyle.Empty, styleComposition = style)
+    val second = runtime.createMapState(baseStyle = BaseStyle.Empty, styleComposition = style)
 
     setFfiTestMapContent(runtimeOptions, presentationCount = 2) {
-      if (showFirst) MaplibreMap(first, style) else MaplibreMap(second, style)
+      if (showFirst) MaplibreMap(first) else MaplibreMap(second)
     }
     waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) {
       first.presentation != null &&
@@ -208,7 +209,6 @@ class MlnFfiMapCompositionTest {
   fun one_style_composition_is_evaluated_independently_for_a_map_and_snapshotter() =
     runFfiComposeUiTest {
       val runtime = createNativeMapRuntime(runtimeOptions)
-      val state = runtime.createMapState(initialBaseStyle = BaseStyle.Empty)
       val evaluatorIdentities = mutableSetOf<Any>()
       val composition = StyleComposition {
         val evaluatorIdentity = remember { Any() }
@@ -218,8 +218,10 @@ class MlnFfiMapCompositionTest {
           onDispose {}
         }
       }
+      val state =
+        runtime.createMapState(baseStyle = BaseStyle.Empty, styleComposition = composition)
 
-      setFfiTestMapContent(runtimeOptions) { MaplibreMap(state, composition) }
+      setFfiTestMapContent(runtimeOptions) { MaplibreMap(state) }
       waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) {
         state.presentation != null &&
           state.style.loadState == StyleLoadState.Ready &&
@@ -241,7 +243,6 @@ class MlnFfiMapCompositionTest {
   fun detached_native_map_keeps_its_applied_revision_until_current_state_is_reattached() =
     runFfiComposeUiTest {
       val runtime = createNativeMapRuntime(runtimeOptions)
-      val state = runtime.createMapState(initialBaseStyle = BaseStyle.Empty)
       var presented by mutableStateOf(true)
       var latest by mutableStateOf(false)
       val composition = StyleComposition {
@@ -250,9 +251,11 @@ class MlnFfiMapCompositionTest {
           color = const(if (latest) Color.Blue else Color.Red),
         )
       }
+      val state =
+        runtime.createMapState(baseStyle = BaseStyle.Empty, styleComposition = composition)
 
       setFfiTestMapContent(runtimeOptions, presentationCount = 2) {
-        if (presented) MaplibreMap(state, composition)
+        if (presented) MaplibreMap(state)
       }
       waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) {
         state.style.loadState == StyleLoadState.Ready && state.presentation != null
@@ -288,7 +291,6 @@ class MlnFfiMapCompositionTest {
   fun a_later_revision_supersedes_reconciliation_failure_before_the_surface_is_revealed() =
     runFfiComposeUiTest {
       val runtime = createNativeMapRuntime(runtimeOptions)
-      val state = runtime.createMapState(initialBaseStyle = BaseStyle.Empty)
       var invalidAnchor by mutableStateOf(true)
       val composition = StyleComposition {
         if (invalidAnchor) {
@@ -299,8 +301,10 @@ class MlnFfiMapCompositionTest {
           BackgroundLayer(id = "application-background", color = const(Color.Blue))
         }
       }
+      val state =
+        runtime.createMapState(baseStyle = BaseStyle.Empty, styleComposition = composition)
 
-      setFfiTestMapContent(runtimeOptions) { MaplibreMap(state, composition) }
+      setFfiTestMapContent(runtimeOptions) { MaplibreMap(state) }
       waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) {
         state.style.loadState is StyleLoadState.Failed
       }
@@ -325,8 +329,7 @@ class MlnFfiMapCompositionTest {
   fun a_map_state_retains_its_native_map_between_presentations() = runFfiComposeUiTest {
     val runtime = createNativeMapRuntime(runtimeOptions)
     val camera = CameraPosition(target = Position(longitude = 11.0, latitude = 47.0), zoom = 6.0)
-    val state =
-      runtime.createMapState(initialCameraPosition = camera, initialBaseStyle = BaseStyle.Empty)
+    val state = runtime.createMapState(initialCameraPosition = camera, baseStyle = BaseStyle.Empty)
     var presented by mutableStateOf(true)
 
     setFfiTestMapContent(runtimeOptions, presentationCount = 2) {
@@ -375,7 +378,7 @@ class MlnFfiMapCompositionTest {
       val state =
         runtime.createMapState(
           initialCameraPosition = camera,
-          initialBaseStyle = REPLACEMENT_STYLE,
+          baseStyle = REPLACEMENT_STYLE,
         )
       var presented by mutableStateOf(true)
       var scaleFactor by mutableStateOf(1f)
@@ -753,19 +756,20 @@ private fun TestMap(
   val state =
     rememberMapState(
       initialCameraPosition = initialCameraPosition,
-      initialBaseStyle = baseStyle,
-    )
-  val styleComposition = remember(content) { StyleComposition(content) }
+      baseStyle = baseStyle,
+    ) {
+      content()
+    }
   val loadState = state.style.loadState
   LaunchedEffect(loadState) {
     if (loadState is StyleLoadState.Failed) onMapLoadFailed(loadState.reason)
   }
   MaplibreMap(
     state = state,
-    styleComposition = styleComposition,
     modifier = modifier,
     callbacks = MapPresentationCallbacks(onFrame = onFrame),
-    overlay = overlay,
-  )
+  ) {
+    include(overlay)
+  }
   return state
 }

--- a/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MlnFfiStyleSwitchTest.kt
+++ b/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MlnFfiStyleSwitchTest.kt
@@ -60,7 +60,6 @@ class MlnFfiStyleSwitchTest {
   @Test
   fun rotating_the_base_style_with_content_composed_over_it() = runFfiComposeUiTest {
     val runtime = createNativeMapRuntime(runtimeOptions)
-    val state = runtime.createMapState(initialBaseStyle = STYLES[0].base)
     var style by mutableStateOf(STYLES[0])
     var extraLayer by mutableStateOf(false)
     val composition = StyleComposition {
@@ -78,8 +77,9 @@ class MlnFfiStyleSwitchTest {
         }
       }
     }
+    val state = runtime.createMapState(baseStyle = STYLES[0].base, styleComposition = composition)
 
-    setFfiTestMapContent(runtimeOptions) { MaplibreMap(state, composition, Modifier) }
+    setFfiTestMapContent(runtimeOptions) { MaplibreMap(state, Modifier) }
 
     // Each style finishes loading before the next is chosen; switching mid-load is a separate race
     // this test deliberately does not cover.
@@ -112,7 +112,6 @@ class MlnFfiStyleSwitchTest {
   @Test
   fun recreating_a_replacement_layer_while_switching_the_base_style() = runFfiComposeUiTest {
     val runtime = createNativeMapRuntime(runtimeOptions)
-    val state = runtime.createMapState(initialBaseStyle = REPLACEMENT_STYLES[0])
     var style by mutableStateOf(REPLACEMENT_STYLES[0])
     var sourceLayer by mutableStateOf("places")
     var showReplacement by mutableStateOf(true)
@@ -129,8 +128,13 @@ class MlnFfiStyleSwitchTest {
         }
       }
     }
+    val state =
+      runtime.createMapState(
+        baseStyle = REPLACEMENT_STYLES[0],
+        styleComposition = composition,
+      )
 
-    setFfiTestMapContent(runtimeOptions) { MaplibreMap(state, composition, Modifier) }
+    setFfiTestMapContent(runtimeOptions) { MaplibreMap(state, Modifier) }
 
     waitUntil(timeoutMillis = SETTLE_TIMEOUT_MILLIS) {
       state.presentation != null && state.style.loadState == StyleLoadState.Ready
@@ -179,7 +183,6 @@ class MlnFfiStyleSwitchTest {
         },
       )
     val runtime = createNativeMapRuntime(options)
-    val state = runtime.createMapState(initialBaseStyle = INITIAL_STYLE)
     var showLatestLayer by mutableStateOf(false)
     val composition = StyleComposition {
       if (showLatestLayer) {
@@ -188,8 +191,9 @@ class MlnFfiStyleSwitchTest {
         }
       }
     }
+    val state = runtime.createMapState(baseStyle = INITIAL_STYLE, styleComposition = composition)
 
-    setFfiTestMapContent(options) { MaplibreMap(state, composition, Modifier) }
+    setFfiTestMapContent(options) { MaplibreMap(state, Modifier) }
 
     waitUntil(timeoutMillis = SETTLE_TIMEOUT_MILLIS) {
       state.presentation != null && state.style.loadState == StyleLoadState.Ready

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
@@ -6,8 +6,12 @@ import androidx.compose.foundation.MutatorMutex
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
@@ -54,9 +58,11 @@ import org.maplibre.compose.sources.SourceHandle
 import org.maplibre.compose.sources.sourceHandle
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.compose.style.DesiredStyleRevision
+import org.maplibre.compose.style.LocalMapState
 import org.maplibre.compose.style.StyleBinding
 import org.maplibre.compose.style.StyleComposition
 import org.maplibre.compose.style.StyleHandleOperationGuard
+import org.maplibre.compose.util.MaplibreComposable
 import org.maplibre.compose.util.VisibleRegion
 import org.maplibre.spatialk.geojson.BoundingBox
 import org.maplibre.spatialk.geojson.Feature
@@ -99,13 +105,20 @@ public interface MapRuntime {
    */
   public fun setRequestInterceptor(interceptor: MapRequestInterceptor?)
 
-  /** Creates a logical map. The caller must close the result. */
+  /**
+   * Creates a logical map with [baseStyle] and [styleComposition]. The caller must close the
+   * result.
+   */
   public fun createMapState(
+    baseStyle: BaseStyle = BaseStyle.Demo,
+    styleComposition: StyleComposition = StyleComposition.Empty,
     initialCameraPosition: CameraPosition = CameraPosition(),
-    initialBaseStyle: BaseStyle = BaseStyle.Demo,
   ): MapState
 
-  /** Creates an independent non-UI map for image capture. The caller must close the result. */
+  /**
+   * Creates an independent non-UI map with [baseStyle] and [styleComposition] for image capture.
+   * The caller must close the result.
+   */
   public fun createSnapshotter(
     baseStyle: BaseStyle,
     styleComposition: StyleComposition = StyleComposition.Empty,
@@ -433,12 +446,13 @@ internal constructor(
   }
 }
 
-/** Represents a logical map independently from a temporary UI presentation. */
+/** Represents a logical map and its style independently from a temporary UI presentation. */
 public class MapState
 internal constructor(
   internal val runtime: RuntimeImplementation,
   initialCameraPosition: CameraPosition,
   initialBaseStyle: BaseStyle,
+  internal val styleComposition: StyleComposition,
 ) {
   internal val lifecycle = MapLifecycleAuthority(this, runtime.physicalScope)
   private var baseStyleCommandRevision = 0L
@@ -839,23 +853,56 @@ internal class MapStateCleanupException(failures: List<Throwable>) :
 
 internal class MapPresentationOwnerToken
 
+/** Receiver for the trailing style block of [rememberMapState]. */
+@Stable
+public interface MapStyleScope {
+  /** The logical map whose style this composition defines. */
+  public val mapState: MapState
+}
+
+private class MapStyleScopeImpl(override val mapState: MapState) : MapStyleScope
+
 /**
- * Remembers a logical map and closes it when this call leaves composition. Restoration creates a
- * new map with the saved camera position and the caller's current [initialBaseStyle].
+ * Remembers a logical map and closes it when this call leaves composition.
+ *
+ * [baseStyle], [styleComposition], and [content] define the desired style. Changes to these inputs
+ * update the remembered map. Restoration creates a new map with the saved camera position and the
+ * current style inputs.
+ *
+ * [content] adds sources and layers after [styleComposition]. Its [MapStyleScope.mapState] value
+ * refers to the returned state when the library evaluates the block.
  */
 @Composable
 public fun rememberMapState(
   runtime: MapRuntime = rememberDefaultMapRuntime(),
+  baseStyle: BaseStyle = BaseStyle.Demo,
+  styleComposition: StyleComposition = StyleComposition.Empty,
   initialCameraPosition: CameraPosition = CameraPosition(),
-  initialBaseStyle: BaseStyle = BaseStyle.Demo,
+  content: @Composable @MaplibreComposable MapStyleScope.() -> Unit = {},
 ): MapState {
+  val currentStyleComposition by rememberUpdatedState(styleComposition)
+  val currentContent by rememberUpdatedState(content)
+  val combinedStyleComposition = remember {
+    StyleComposition {
+      currentStyleComposition.content()
+      val mapState = checkNotNull(LocalMapState.current)
+      with(MapStyleScopeImpl(mapState)) { currentContent() }
+    }
+  }
   val state =
     rememberSaveable(
       runtime,
-      saver = mapStateSaver(runtime, initialBaseStyle),
+      saver = mapStateSaver(runtime, baseStyle, combinedStyleComposition),
     ) {
-      runtime.createMapState(initialCameraPosition, initialBaseStyle)
+      runtime.createMapState(
+        baseStyle = baseStyle,
+        styleComposition = combinedStyleComposition,
+        initialCameraPosition = initialCameraPosition,
+      )
     }
+  SideEffect {
+    if (state.style.baseStyle != baseStyle) state.style.baseStyle = baseStyle
+  }
   DisposableEffect(state) { onDispose { state.close() } }
   return state
 }
@@ -870,7 +917,8 @@ private data class SavedCameraPosition(
 
 private fun mapStateSaver(
   runtime: MapRuntime,
-  initialBaseStyle: BaseStyle,
+  baseStyle: BaseStyle,
+  styleComposition: StyleComposition,
 ): Saver<MapState, List<Double>> =
   Saver(
     save = { state ->
@@ -879,6 +927,8 @@ private fun mapStateSaver(
     restore = { values ->
       val saved = values.toSavedCameraPosition()
       runtime.createMapState(
+        baseStyle = baseStyle,
+        styleComposition = styleComposition,
         initialCameraPosition =
           CameraPosition(
             bearing = saved.bearing,
@@ -886,7 +936,6 @@ private fun mapStateSaver(
             tilt = saved.tilt,
             zoom = saved.zoom,
           ),
-        initialBaseStyle = initialBaseStyle,
       )
     },
   )
@@ -943,11 +992,12 @@ internal class RuntimeImplementation(
   private var closedState: Boolean by mutableStateOf(false)
 
   final override fun createMapState(
+    baseStyle: BaseStyle,
+    styleComposition: StyleComposition,
     initialCameraPosition: CameraPosition,
-    initialBaseStyle: BaseStyle,
   ): MapState = lock.withLock {
     requireOpenLocked()
-    MapState(this, initialCameraPosition, initialBaseStyle).also(children::add)
+    MapState(this, initialCameraPosition, baseStyle, styleComposition).also(children::add)
   }
 
   final override fun createSnapshotter(

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MaplibreMap.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MaplibreMap.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.UiComposable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.unit.DpOffset
@@ -23,10 +24,11 @@ import kotlinx.coroutines.launch
 import org.maplibre.compose.camera.CameraMoveReason
 import org.maplibre.compose.overlay.MapOverlay
 import org.maplibre.compose.overlay.MapOverlayHost
+import org.maplibre.compose.overlay.MapOverlayScope
+import org.maplibre.compose.overlay.include
 import org.maplibre.compose.style.DesiredStyleLayer
 import org.maplibre.compose.style.DesiredStyleRevision
 import org.maplibre.compose.style.StyleBinding
-import org.maplibre.compose.style.StyleComposition
 import org.maplibre.compose.style.rememberStyleComposition
 import org.maplibre.compose.util.FeaturesClickHandler
 import org.maplibre.compose.util.MapClickHandler
@@ -69,17 +71,19 @@ private class MapStateAttachment(
  * Displays [state] through one temporary presentation.
  *
  * The caller controls the lifetime of [state]. This composable creates the current presentation and
- * releases it when the call leaves composition.
+ * releases it when the call leaves composition. [overlay] draws Compose UI over the map. The
+ * default draws [MapOverlay.Default]. A supplied block replaces the default.
  */
 @Composable
 public fun MaplibreMap(
   state: MapState = rememberMapState(),
-  styleComposition: StyleComposition = StyleComposition.Empty,
   modifier: Modifier = Modifier,
   presentationOptions: MapPresentationOptions = MapPresentationOptions(),
   callbacks: MapPresentationCallbacks = MapPresentationCallbacks(),
   contentWindowInsets: WindowInsets = WindowInsets.safeDrawing,
-  overlay: MapOverlay = MapOverlay.Default,
+  overlay: @Composable @UiComposable MapOverlayScope.() -> Unit = {
+    include(MapOverlay.Default)
+  },
 ) {
   if (LocalInspectionMode.current) {
     Box(modifier = modifier.fillMaxSize().background(Color.Gray))
@@ -92,7 +96,6 @@ public fun MaplibreMap(
     PresentedMaplibreMap(
       state = state,
       presentationOwner = presentationOwner,
-      styleComposition = styleComposition,
       modifier = modifier,
       presentationOptions = presentationOptions,
       callbacks = callbacks,
@@ -106,12 +109,11 @@ public fun MaplibreMap(
 private fun PresentedMaplibreMap(
   state: MapState,
   presentationOwner: MapPresentationOwnerToken,
-  styleComposition: StyleComposition,
   modifier: Modifier,
   presentationOptions: MapPresentationOptions,
   callbacks: MapPresentationCallbacks,
   contentWindowInsets: WindowInsets,
-  overlay: MapOverlay,
+  overlay: @Composable @UiComposable MapOverlayScope.() -> Unit,
 ) {
   val token = remember(state, presentationOwner) { state.reservePresentation(presentationOwner) }
   val attachment = remember(state, token) { MapStateAttachment(state, token) }
@@ -119,7 +121,6 @@ private fun PresentedMaplibreMap(
   MaplibreMapPresentation(
     state = state,
     attachment = attachment,
-    styleComposition = styleComposition,
     modifier = modifier,
     presentationOptions = presentationOptions,
     callbacks = callbacks,
@@ -132,17 +133,16 @@ private fun PresentedMaplibreMap(
 private fun MaplibreMapPresentation(
   state: MapState,
   attachment: MapStateAttachment,
-  styleComposition: StyleComposition,
   modifier: Modifier,
   presentationOptions: MapPresentationOptions,
   callbacks: MapPresentationCallbacks,
   contentWindowInsets: WindowInsets,
-  overlay: MapOverlay,
+  overlay: @Composable @UiComposable MapOverlayScope.() -> Unit,
 ) {
   var rememberedStyle by remember { mutableStateOf<StyleBinding?>(null) }
   val desiredRevision by
     rememberStyleComposition(
-      composition = styleComposition,
+      composition = state.styleComposition,
       maybeStyle = rememberedStyle,
       mapState = state,
       replaceableSourceIds = state.desiredStyleRevision.sources.mapTo(mutableSetOf()) { it.id },

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/MapOverlay.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/MapOverlay.kt
@@ -129,10 +129,8 @@ public fun MapOverlayScope.include(overlay: MapOverlay) {
 }
 
 /**
- * The controls that a [MaplibreMap][org.maplibre.compose.map.MaplibreMap] draws on top of itself.
+ * Reusable controls that a [MaplibreMap][org.maplibre.compose.map.MaplibreMap] draws over itself.
  */
-// A holder rather than a parameter of MaplibreMap: a composable lambda parameter that has a
-// receiver breaks the composable target inference of the map's own `content` parameter.
 @Immutable
 public class MapOverlay(
   internal val content: @Composable @UiComposable MapOverlayScope.() -> Unit
@@ -167,15 +165,12 @@ public class MapOverlay(
         overlayScope.ExpandingAttributionButton()
       }
     }
-
-    /** Draws the map alone. Use this when you draw the attribution your style requires yourself. */
-    public val None: MapOverlay = MapOverlay {}
   }
 }
 
 @Composable
 internal fun MapOverlayHost(
-  overlay: MapOverlay,
+  overlay: @Composable @UiComposable MapOverlayScope.() -> Unit,
   mapState: MapState,
   contentWindowInsets: WindowInsets,
   modifier: Modifier = Modifier,
@@ -184,7 +179,10 @@ internal fun MapOverlayHost(
     remember(mapState, contentWindowInsets) {
       MapOverlayScopeImpl(mapState, contentWindowInsets)
     }
-  Layout(modifier = modifier, content = { overlay.content(scope) }) { measurables, constraints ->
+  Layout(
+    modifier = modifier,
+    content = { overlay(scope) },
+  ) { measurables, constraints ->
     val width = if (constraints.hasBoundedWidth) constraints.maxWidth else 0
     val height = if (constraints.hasBoundedHeight) constraints.maxHeight else 0
     val spacing = MapOverlay.Spacing.roundToPx()

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapRuntimeTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapRuntimeTest.kt
@@ -83,7 +83,7 @@ class MapRuntimeTest {
         zoom = 9.0,
       )
 
-    val state = runtime.createMapState(camera, BaseStyle.Empty)
+    val state = runtime.createMapState(baseStyle = BaseStyle.Empty, initialCameraPosition = camera)
 
     assertTrue(state.cameraPosition == camera)
     assertTrue(state.style.baseStyle == BaseStyle.Empty)

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserMapLifecycleTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserMapLifecycleTest.kt
@@ -74,7 +74,7 @@ class BrowserMapLifecycleTest {
       val state =
         runtime.createMapState(
           initialCameraPosition = initialCamera,
-          initialBaseStyle = STYLE_A,
+          baseStyle = STYLE_A,
         )
       val presented = mutableStateOf(true)
 

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserMapStyleStateTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserMapStyleStateTest.kt
@@ -1,9 +1,7 @@
 package org.maplibre.compose.gljs
 
 import androidx.compose.foundation.layout.size
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.unit.dp
@@ -124,7 +122,6 @@ class BrowserMapStyleStateTest {
   fun a_detached_web_map_keeps_its_desired_style_pending_and_replays_it(): Promise<*> =
     runBrowserMapTest {
       val runtime = createMapRuntime(MapRuntimeOptions())
-      val state = runtime.createMapState(initialBaseStyle = STYLE_A)
       val presented = mutableStateOf(true)
       val useLatestRevision = mutableStateOf(false)
       val composition = StyleComposition {
@@ -135,10 +132,9 @@ class BrowserMapStyleStateTest {
           visible = true,
         )
       }
+      val state = runtime.createMapState(baseStyle = STYLE_A, styleComposition = composition)
 
-      setBrowserMapContent {
-        if (presented.value) MaplibreMap(state, styleComposition = composition)
-      }
+      setBrowserMapContent { if (presented.value) MaplibreMap(state) }
       waitUntilMap("style A to become ready") {
         state.presentation != null && state.style.loadState == StyleLoadState.Ready
       }
@@ -203,7 +199,7 @@ class BrowserMapStyleStateTest {
   fun a_web_presentation_waits_for_a_viewport_and_survives_style_failure(): Promise<*> =
     runBrowserMapTest {
       val runtime = createMapRuntime(MapRuntimeOptions())
-      val state = runtime.createMapState(initialBaseStyle = STYLE_A)
+      val state = runtime.createMapState(baseStyle = STYLE_A)
       val size = mutableStateOf(0.dp)
 
       setBrowserMapContent { MaplibreMap(state, modifier = Modifier.size(size.value)) }
@@ -242,7 +238,7 @@ class BrowserMapStyleStateTest {
       var styleState: MapStyleState? = null
       var mapState: MapState? = null
       setBrowserMapContent {
-        val current = rememberMapState(initialBaseStyle = tileJsonStyle)
+        val current = rememberMapState(baseStyle = tileJsonStyle)
         mapState = current
         styleState = current.style
         MaplibreMap(state = current, modifier = Modifier)
@@ -270,10 +266,9 @@ class BrowserMapStyleStateTest {
       var styleState: MapStyleState? = null
       var mapState: MapState? = null
       setBrowserMapContent {
-        val logicalMap = rememberMapState(initialBaseStyle = current.value)
+        val logicalMap = rememberMapState(baseStyle = current.value)
         mapState = logicalMap
         styleState = logicalMap.style
-        SideEffect { logicalMap.style.baseStyle = current.value }
         MaplibreMap(state = logicalMap, modifier = Modifier)
       }
       waitUntilMap("the first style to load") {
@@ -299,21 +294,15 @@ class BrowserMapStyleStateTest {
         var styleState: MapStyleState? = null
         var mapState: MapState? = null
         setBrowserMapContent {
-          val logicalMap = rememberMapState(initialBaseStyle = BaseStyle.Empty)
-          mapState = logicalMap
-          styleState = logicalMap.style
-          val composition = remember {
-            StyleComposition {
+          val logicalMap =
+            rememberMapState(baseStyle = BaseStyle.Empty) {
               if (showLateSource.value) {
                 RasterLayer(id = "late-layer", source = source, visible = true)
               }
             }
-          }
-          MaplibreMap(
-            state = logicalMap,
-            styleComposition = composition,
-            modifier = Modifier,
-          )
+          mapState = logicalMap
+          styleState = logicalMap.style
+          MaplibreMap(state = logicalMap, modifier = Modifier)
         }
         waitUntilMap("the empty map to finish loading") {
           mapState?.style?.loadState == StyleLoadState.Ready
@@ -348,18 +337,13 @@ class BrowserMapStyleStateTest {
     var identity: StyleIdentity? = null
     var mapState: MapState? = null
     setBrowserMapContent {
-      val logicalMap = rememberMapState(initialBaseStyle = current.value)
+      val logicalMap =
+        rememberMapState(baseStyle = current.value) {
+          identity = LocalStyleNode.current.style.identity
+        }
       mapState = logicalMap
       styleState = logicalMap.style
-      SideEffect { logicalMap.style.baseStyle = current.value }
-      val composition = remember {
-        StyleComposition { identity = LocalStyleNode.current.style.identity }
-      }
-      MaplibreMap(
-        state = logicalMap,
-        styleComposition = composition,
-        modifier = Modifier,
-      )
+      MaplibreMap(state = logicalMap, modifier = Modifier)
     }
     waitUntilMap("the first style to load") {
       mapState?.style?.loadState == StyleLoadState.Ready &&

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserStyleConformanceTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserStyleConformanceTest.kt
@@ -4,7 +4,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -32,7 +31,6 @@ import org.maplibre.compose.sources.rememberVectorSource
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.compose.style.LocalStyleNode
 import org.maplibre.compose.style.StyleBinding
-import org.maplibre.compose.style.StyleComposition
 import org.maplibre.compose.util.MaplibreComposable
 
 @OptIn(ExperimentalTestApi::class)
@@ -260,12 +258,11 @@ class BrowserStyleConformanceTest {
     onMapLoadFailed: (String?) -> Unit = {},
     content: @Composable @MaplibreComposable () -> Unit = {},
   ) {
-    val state = rememberMapState(initialBaseStyle = baseStyle)
-    val composition = remember(content) { StyleComposition(content) }
+    val state = rememberMapState(baseStyle = baseStyle) { content() }
     val loadState = state.style.loadState
     LaunchedEffect(loadState) {
       if (loadState is StyleLoadState.Failed) onMapLoadFailed(loadState.reason)
     }
-    MaplibreMap(state = state, styleComposition = composition, modifier = modifier)
+    MaplibreMap(state = state, modifier = modifier)
   }
 }

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserCameraTransitionLifecycleTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserCameraTransitionLifecycleTest.kt
@@ -75,8 +75,7 @@ class BrowserCameraTransitionLifecycleTest {
   fun a_destroyed_web_map_cannot_move_the_logical_map_or_a_cached_presentation(): Promise<*> =
     runBrowserMapTest {
       val runtime = createMapRuntime(MapRuntimeOptions())
-      val state =
-        runtime.createMapState(initialCameraPosition = CURRENT_CAMERA, initialBaseStyle = STYLE)
+      val state = runtime.createMapState(initialCameraPosition = CURRENT_CAMERA, baseStyle = STYLE)
       val presented = mutableStateOf(true)
 
       setBrowserMapContent { if (presented.value) MaplibreMap(state) }

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserMapSnapshotterTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserMapSnapshotterTest.kt
@@ -92,12 +92,10 @@ class BrowserMapSnapshotterTest {
         POINT_STYLE.content()
       }
       val runtime = createMapRuntime(MapRuntimeOptions())
-      val state = runtime.createMapState(initialBaseStyle = BASE_STYLE)
+      val state = runtime.createMapState(baseStyle = BASE_STYLE, styleComposition = composition)
       val snapshotter = runtime.createSnapshotter(BASE_STYLE, composition)
       try {
-        setBrowserMapContent(size = SIZE) {
-          MaplibreMap(state = state, styleComposition = composition)
-        }
+        setBrowserMapContent(size = SIZE) { MaplibreMap(state) }
         waitUntilMap("the interactive map to become ready") {
           state.presentation != null && state.style.loadState == StyleLoadState.Ready
         }

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserMapStateTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserMapStateTest.kt
@@ -30,7 +30,7 @@ class BrowserMapStateTest {
       firstRuntime = rememberDefaultMapRuntime()
       secondRuntime = rememberDefaultMapRuntime()
       if (includeState.value) {
-        val remembered = rememberMapState(firstRuntime, initialBaseStyle = BaseStyle.Empty)
+        val remembered = rememberMapState(firstRuntime, baseStyle = BaseStyle.Empty)
         SideEffect { state = remembered }
       }
     }
@@ -50,7 +50,7 @@ class BrowserMapStateTest {
   fun map_state_renders_a_base_style_and_publishes_one_presentation(): Promise<*> =
     runBrowserMapTest {
       val runtime = createMapRuntime(MapRuntimeOptions())
-      val state = runtime.createMapState(initialBaseStyle = BaseStyle.Empty)
+      val state = runtime.createMapState(baseStyle = BaseStyle.Empty)
       val includeRival = mutableStateOf(false)
 
       setBrowserMapContent {

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/testing/GlJsMapFixture.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/testing/GlJsMapFixture.kt
@@ -35,7 +35,7 @@ internal class GlJsMapFixture(private val extent: MapExtent) : MapFixture {
   override val state =
     runtime.createMapState(
       initialCameraPosition = CameraPosition(zoom = 0.0),
-      initialBaseStyle = BaseStyle.Empty,
+      baseStyle = BaseStyle.Empty,
     )
   private val glJsSession =
     GlJsMapSession(state.lifecycle, recorder, Logger.withTag("gljs-map"), LayoutDirection.Ltr)

--- a/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/map/DesktopPresentationHostLifetimeTest.kt
+++ b/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/map/DesktopPresentationHostLifetimeTest.kt
@@ -38,7 +38,7 @@ class DesktopPresentationHostLifetimeTest {
   fun replacing_a_compatible_presentation_host_keeps_the_runtime_logical_map_and_engine() =
     runFfiComposeUiTest {
       val runtime = createNativeMapRuntime(runtimeOptions)
-      val state = runtime.createMapState(initialBaseStyle = BaseStyle.Empty)
+      val state = runtime.createMapState(baseStyle = BaseStyle.Empty)
       var host by
         mutableStateOf(
           ContextlessPresentationHost("first", equalityKey = "same"),
@@ -73,7 +73,7 @@ class DesktopPresentationHostLifetimeTest {
   @Test
   fun inspection_mode_does_not_require_a_presentation_host() = runFfiComposeUiTest {
     val runtime = createNativeMapRuntime(runtimeOptions)
-    val state = runtime.createMapState(initialBaseStyle = BaseStyle.Empty)
+    val state = runtime.createMapState(baseStyle = BaseStyle.Empty)
 
     setContent {
       CompositionLocalProvider(LocalInspectionMode provides true) { MaplibreMap(state) }

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/overlay/MapOverlayTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/overlay/MapOverlayTest.kt
@@ -21,15 +21,14 @@ import org.maplibre.spatialk.geojson.Position
 class MapOverlayTest {
   @Test
   fun overlay_composes_before_the_map_attaches() = runComposeUiTest {
-    val mapState = mapRuntimeForTest().createMapState(initialBaseStyle = BaseStyle.Empty)
+    val mapState = mapRuntimeForTest().createMapState(baseStyle = BaseStyle.Empty)
     setContent {
       MapOverlayHost(
-        overlay =
-          MapOverlay {
-            Box(Modifier.size(8.dp).placedAt(Position(0.0, 0.0)))
-            Box(Modifier.size(8.dp).placedTowards(Position(90.0, 0.0)))
-            Box(Modifier.size(8.dp).align(Alignment.TopStart))
-          },
+        overlay = {
+          Box(Modifier.size(8.dp).placedAt(Position(0.0, 0.0)))
+          Box(Modifier.size(8.dp).placedTowards(Position(90.0, 0.0)))
+          Box(Modifier.size(8.dp).align(Alignment.TopStart))
+        },
         mapState = mapState,
         contentWindowInsets = WindowInsets(0),
       )
@@ -39,17 +38,16 @@ class MapOverlayTest {
 
   @Test
   fun removing_a_placed_towards_child_resets_its_state() = runComposeUiTest {
-    val mapState = mapRuntimeForTest().createMapState(initialBaseStyle = BaseStyle.Empty)
+    val mapState = mapRuntimeForTest().createMapState(baseStyle = BaseStyle.Empty)
     val state = PlacedTowardsState().apply { isPlaced = true }
     var show by mutableStateOf(true)
     setContent {
       MapOverlayHost(
-        overlay =
-          MapOverlay {
-            if (show) {
-              Box(Modifier.size(8.dp).placedTowards(Position(90.0, 0.0), state))
-            }
-          },
+        overlay = {
+          if (show) {
+            Box(Modifier.size(8.dp).placedTowards(Position(90.0, 0.0), state))
+          }
+        },
         mapState = mapState,
         contentWindowInsets = WindowInsets(0),
       )

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/PlatformMapAccessTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/PlatformMapAccessTest.kt
@@ -203,7 +203,7 @@ class PlatformMapAccessTest {
         resources = MapRuntimeResources {},
         logger = null,
       )
-    val state = runtime.createMapState(initialBaseStyle = BaseStyle.Empty)
+    val state = runtime.createMapState(baseStyle = BaseStyle.Empty)
     try {
       block(state, runtime)
     } finally {

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/testing/MlnFfiMapFixture.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/testing/MlnFfiMapFixture.kt
@@ -21,7 +21,7 @@ internal class MlnFfiMapFixture(val bridge: BridgeMapFixture, private val extent
   override val state =
     runtime.createMapState(
       initialCameraPosition = CameraPosition(zoom = 0.0),
-      initialBaseStyle = BaseStyle.Empty,
+      baseStyle = BaseStyle.Empty,
     )
   private val token = state.reservePresentation()
 


### PR DESCRIPTION
## Description

Move base-style and style-composition ownership into `MapState`, align `createMapState` with `createSnapshotter`, and reserve `MaplibreMap`'s trailing block for replacement overlay UI.

## Validation

Validated on macOS with `mise run check`, `mise run test:android`, `mise run test:desktop`, `caffeinate -dimsu mise run test:js`, `mise run test:ios`, and `mise run build:docs`.

## AI assistance

Codex desktop with GPT-5 implemented the change and ran validation under user direction.
