### PR TITLE
Remove runtime capabilities inspection

### DIFF
--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
@@ -45,9 +45,9 @@ import org.maplibre.compose.expressions.dsl.const
 import org.maplibre.compose.expressions.value.BooleanValue
 import org.maplibre.compose.layers.LayerHandle
 import org.maplibre.compose.layers.layerHandle
-import org.maplibre.compose.offline.CapabilityCheckedOfflineManager
-import org.maplibre.compose.offline.EmptyOfflineManager
 import org.maplibre.compose.offline.OfflineManager
+import org.maplibre.compose.offline.RuntimeBoundOfflineManager
+import org.maplibre.compose.offline.UnsupportedOfflineManager
 import org.maplibre.compose.resource.MapRequestInterceptor
 import org.maplibre.compose.resource.MapResourceConfig
 import org.maplibre.compose.sources.SourceHandle
@@ -75,19 +75,8 @@ public expect fun createMapRuntime(options: MapRuntimeOptions): MapRuntime
  */
 @Composable public expect fun rememberDefaultMapRuntime(): MapRuntime
 
-/** Reports the optional operations that one [MapRuntime] supports. */
-public data class MapRuntimeCapabilities(
-  /** Whether the runtime supports offline-pack operations. */
-  public val supportsOfflinePacks: Boolean,
-  /** Whether the runtime supports ambient-cache management operations. */
-  public val supportsAmbientCacheManagement: Boolean,
-)
-
 /** Creates logical maps that share one application-level configuration. */
 public interface MapRuntime {
-  /** The optional operations that this runtime supports. */
-  public val capabilities: MapRuntimeCapabilities
-
   /** The offline packs and ambient cache managed by this runtime. */
   public val offlineManager: OfflineManager
 
@@ -916,12 +905,7 @@ internal class RuntimeImplementation(
   internal val platformOptions: Any?,
   private val resources: MapRuntimeResources,
   internal val logger: Logger?,
-  override val capabilities: MapRuntimeCapabilities =
-    MapRuntimeCapabilities(
-      supportsOfflinePacks = false,
-      supportsAmbientCacheManagement = false,
-    ),
-  offlineManagerBackend: OfflineManager = EmptyOfflineManager,
+  offlineManagerBackend: OfflineManager = UnsupportedOfflineManager,
   internal val physicalScope: CoroutineScope =
     CoroutineScope(SupervisorJob() + Dispatchers.Default),
   internal val snapshotterAdapterFactory: SnapshotterAdapterFactory =
@@ -930,8 +914,7 @@ internal class RuntimeImplementation(
   internal val resourceConfig: MapResourceConfig = MapResourceConfig(),
 ) : MapRuntime {
   override val offlineManager: OfflineManager =
-    CapabilityCheckedOfflineManager(
-      capabilities = capabilities,
+    RuntimeBoundOfflineManager(
       delegate = offlineManagerBackend,
       requireRuntimeOpen = ::requireOpen,
     )

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/offline/OfflineManager.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/offline/OfflineManager.kt
@@ -1,7 +1,5 @@
 package org.maplibre.compose.offline
 
-import org.maplibre.compose.map.MapRuntimeCapabilities
-
 /** Manages the offline packs and ambient cache that belong to one map runtime. */
 public interface OfflineManager {
 
@@ -74,99 +72,87 @@ public interface OfflineManager {
   public suspend fun setMaximumAmbientCacheSize(size: Long)
 }
 
-internal class CapabilityCheckedOfflineManager(
-  private val capabilities: MapRuntimeCapabilities,
+internal class RuntimeBoundOfflineManager(
   private val delegate: OfflineManager,
   private val requireRuntimeOpen: () -> Unit,
 ) : OfflineManager {
   override val packs: Set<OfflinePack>
-    get() =
-      if (capabilities.supportsOfflinePacks) delegate.packs.onEach(::bindToRuntime) else emptySet()
+    get() = delegate.packs.onEach(::bindToRuntime)
 
   override suspend fun create(
     definition: OfflinePackDefinition,
     metadata: ByteArray,
   ): OfflinePack {
-    requireOfflinePackOperation()
+    requireRuntimeOpen()
     return bindToRuntime(delegate.create(definition, metadata))
   }
 
   override fun resume(pack: OfflinePack) {
-    requireOfflinePackOperation()
+    requireRuntimeOpen()
     delegate.resume(pack)
   }
 
   override fun pause(pack: OfflinePack) {
-    requireOfflinePackOperation()
+    requireRuntimeOpen()
     delegate.pause(pack)
   }
 
   override suspend fun delete(pack: OfflinePack) {
-    requireOfflinePackOperation()
+    requireRuntimeOpen()
     delegate.delete(pack)
   }
 
   override suspend fun invalidate(pack: OfflinePack) {
-    requireOfflinePackOperation()
+    requireRuntimeOpen()
     delegate.invalidate(pack)
   }
 
   override suspend fun invalidateAmbientCache() {
-    requireAmbientCacheOperation()
+    requireRuntimeOpen()
     delegate.invalidateAmbientCache()
   }
 
   override suspend fun clearAmbientCache() {
-    requireAmbientCacheOperation()
+    requireRuntimeOpen()
     delegate.clearAmbientCache()
   }
 
   override suspend fun setMaximumAmbientCacheSize(size: Long) {
-    requireAmbientCacheOperation()
+    requireRuntimeOpen()
     delegate.setMaximumAmbientCacheSize(size)
   }
 
   private fun bindToRuntime(pack: OfflinePack): OfflinePack = pack.bindToRuntime(requireRuntimeOpen)
-
-  private fun requireOfflinePackOperation() {
-    requireRuntimeOpen()
-    if (!capabilities.supportsOfflinePacks) {
-      throw UnsupportedOperationException("This map runtime does not support offline packs")
-    }
-  }
-
-  private fun requireAmbientCacheOperation() {
-    requireRuntimeOpen()
-    if (!capabilities.supportsAmbientCacheManagement) {
-      throw UnsupportedOperationException(
-        "This map runtime does not support ambient-cache management"
-      )
-    }
-  }
 }
 
-internal object EmptyOfflineManager : OfflineManager {
+internal object UnsupportedOfflineManager : OfflineManager {
   override val packs: Set<OfflinePack> = emptySet()
 
   override suspend fun create(
     definition: OfflinePackDefinition,
     metadata: ByteArray,
-  ): OfflinePack = unsupported()
+  ): OfflinePack = unsupportedOfflinePacks()
 
-  override fun resume(pack: OfflinePack): Unit = unsupported()
+  override fun resume(pack: OfflinePack): Unit = unsupportedOfflinePacks()
 
-  override fun pause(pack: OfflinePack): Unit = unsupported()
+  override fun pause(pack: OfflinePack): Unit = unsupportedOfflinePacks()
 
-  override suspend fun delete(pack: OfflinePack): Unit = unsupported()
+  override suspend fun delete(pack: OfflinePack): Unit = unsupportedOfflinePacks()
 
-  override suspend fun invalidate(pack: OfflinePack): Unit = unsupported()
+  override suspend fun invalidate(pack: OfflinePack): Unit = unsupportedOfflinePacks()
 
-  override suspend fun invalidateAmbientCache(): Unit = unsupported()
+  override suspend fun invalidateAmbientCache(): Unit = unsupportedAmbientCacheManagement()
 
-  override suspend fun clearAmbientCache(): Unit = unsupported()
+  override suspend fun clearAmbientCache(): Unit = unsupportedAmbientCacheManagement()
 
-  override suspend fun setMaximumAmbientCacheSize(size: Long): Unit = unsupported()
+  override suspend fun setMaximumAmbientCacheSize(size: Long): Unit =
+    unsupportedAmbientCacheManagement()
 
-  private fun unsupported(): Nothing =
-    error("The capability wrapper must reject unsupported offline operations")
+  private fun unsupportedOfflinePacks(): Nothing =
+    throw UnsupportedOperationException("This map runtime does not support offline packs")
+
+  private fun unsupportedAmbientCacheManagement(): Nothing =
+    throw UnsupportedOperationException(
+      "This map runtime does not support ambient-cache management"
+    )
 }

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/offline/RuntimeBoundOfflineManagerTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/offline/RuntimeBoundOfflineManagerTest.kt
@@ -6,40 +6,35 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertSame
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.test.runTest
-import org.maplibre.compose.map.MapRuntimeCapabilities
 import org.maplibre.compose.map.MapRuntimeClosedException
 import org.maplibre.compose.map.MapRuntimeResources
 import org.maplibre.compose.map.RuntimeImplementation
 import org.maplibre.spatialk.geojson.BoundingBox
 
-class OfflineManagerCapabilitiesTest {
+class RuntimeBoundOfflineManagerTest {
   @Test
-  fun offline_pack_operations_require_only_the_offline_pack_capability() = runTest {
-    val backend = RecordingOfflineManager()
-    val runtime =
-      runtime(backend, supportsOfflinePacks = false, supportsAmbientCacheManagement = true)
+  fun unsupported_backend_rejects_every_operation() = runTest {
+    val pack = RecordingOfflineManager().pack
+    val runtime = runtime(UnsupportedOfflineManager)
     val manager = runtime.offlineManager
 
     assertEquals(emptySet(), manager.packs)
     assertFailsWith<UnsupportedOperationException> { manager.create(definition) }
-    assertFailsWith<UnsupportedOperationException> { manager.resume(backend.pack) }
-    assertFailsWith<UnsupportedOperationException> { manager.pause(backend.pack) }
-    assertFailsWith<UnsupportedOperationException> { manager.delete(backend.pack) }
-    assertFailsWith<UnsupportedOperationException> { manager.invalidate(backend.pack) }
-    assertEquals(emptyList(), backend.calls)
-
-    manager.invalidateAmbientCache()
-    manager.clearAmbientCache()
-    manager.setMaximumAmbientCacheSize(1)
-    assertEquals(listOf("invalidate ambient", "clear ambient", "set ambient size"), backend.calls)
+    assertFailsWith<UnsupportedOperationException> { manager.resume(pack) }
+    assertFailsWith<UnsupportedOperationException> { manager.pause(pack) }
+    assertFailsWith<UnsupportedOperationException> { manager.delete(pack) }
+    assertFailsWith<UnsupportedOperationException> { manager.invalidate(pack) }
+    assertFailsWith<UnsupportedOperationException> { manager.invalidateAmbientCache() }
+    assertFailsWith<UnsupportedOperationException> { manager.clearAmbientCache() }
+    assertFailsWith<UnsupportedOperationException> { manager.setMaximumAmbientCacheSize(1) }
     runtime.close()
+    runtime.awaitClosed()
   }
 
   @Test
-  fun ambient_cache_operations_require_only_the_ambient_cache_capability() = runTest {
+  fun supported_backend_receives_every_operation() = runTest {
     val backend = RecordingOfflineManager()
-    val runtime =
-      runtime(backend, supportsOfflinePacks = true, supportsAmbientCacheManagement = false)
+    val runtime = runtime(backend)
     val manager = runtime.offlineManager
 
     assertSame(backend.pack, manager.packs.single())
@@ -53,11 +48,24 @@ class OfflineManagerCapabilitiesTest {
       backend.calls,
     )
 
-    assertFailsWith<UnsupportedOperationException> { manager.invalidateAmbientCache() }
-    assertFailsWith<UnsupportedOperationException> { manager.clearAmbientCache() }
-    assertFailsWith<UnsupportedOperationException> { manager.setMaximumAmbientCacheSize(1) }
-    assertEquals(5, backend.calls.size)
+    manager.invalidateAmbientCache()
+    manager.clearAmbientCache()
+    manager.setMaximumAmbientCacheSize(1)
+    assertEquals(
+      listOf(
+        "create",
+        "resume",
+        "pause",
+        "delete",
+        "invalidate",
+        "invalidate ambient",
+        "clear ambient",
+        "set ambient size",
+      ),
+      backend.calls,
+    )
     runtime.close()
+    runtime.awaitClosed()
   }
 
   @Test
@@ -67,8 +75,6 @@ class OfflineManagerCapabilitiesTest {
     val runtime =
       runtime(
         backend,
-        supportsOfflinePacks = true,
-        supportsAmbientCacheManagement = true,
         resources = MapRuntimeResources { releaseCleanup.await() },
       )
     val manager = runtime.offlineManager
@@ -96,19 +102,12 @@ class OfflineManagerCapabilitiesTest {
 
   private fun runtime(
     backend: OfflineManager,
-    supportsOfflinePacks: Boolean,
-    supportsAmbientCacheManagement: Boolean,
     resources: MapRuntimeResources = MapRuntimeResources {},
   ) =
     RuntimeImplementation(
       platformOptions = null,
       resources = resources,
       logger = null,
-      capabilities =
-        MapRuntimeCapabilities(
-          supportsOfflinePacks = supportsOfflinePacks,
-          supportsAmbientCacheManagement = supportsAmbientCacheManagement,
-        ),
       offlineManagerBackend = backend,
     )
 

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/MapRuntime.js.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/MapRuntime.js.kt
@@ -2,17 +2,11 @@ package org.maplibre.compose.map
 
 import androidx.compose.runtime.Composable
 import co.touchlab.kermit.Logger
-import org.maplibre.compose.offline.EmptyOfflineManager
+import org.maplibre.compose.offline.UnsupportedOfflineManager
 import org.maplibre.compose.resource.GlJsRequestController
 import org.maplibre.compose.resource.MapRequestInterceptor
 import org.maplibre.compose.resource.MapResourceConfig
 import org.maplibre.compose.resource.MapResourceProvider
-
-private val webMapRuntimeCapabilities =
-  MapRuntimeCapabilities(
-    supportsOfflinePacks = false,
-    supportsAmbientCacheManagement = false,
-  )
 
 /** Browser runtime configuration. */
 public actual data class MapRuntimeOptions(
@@ -35,8 +29,7 @@ public actual fun createMapRuntime(options: MapRuntimeOptions): MapRuntime {
     platformOptions = JsRuntimePlatform(options, requests),
     resources = MapRuntimeResources { requests.close() },
     logger = options.logger,
-    capabilities = webMapRuntimeCapabilities,
-    offlineManagerBackend = EmptyOfflineManager,
+    offlineManagerBackend = UnsupportedOfflineManager,
     snapshotterAdapterFactory = GlJsSnapshotterAdapterFactory(options.logger, requests),
     resourceConfig = resourceConfig,
   )

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserOfflineManagerTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserOfflineManagerTest.kt
@@ -10,14 +10,12 @@ import org.maplibre.compose.offline.OfflinePackDefinition
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.spatialk.geojson.BoundingBox
 
-class BrowserMapRuntimeCapabilitiesTest {
+class BrowserOfflineManagerTest {
   @Test
-  fun web_reports_unsupported_offline_features_without_disabling_runtime_children() = runTest {
+  fun web_rejects_offline_operations_without_disabling_runtime_children() = runTest {
     val runtime = createMapRuntime(MapRuntimeOptions())
     val manager = runtime.offlineManager
 
-    assertFalse(runtime.capabilities.supportsOfflinePacks)
-    assertFalse(runtime.capabilities.supportsAmbientCacheManagement)
     assertTrue(manager.packs.isEmpty())
     assertFailsWith<UnsupportedOperationException> {
       manager.create(

--- a/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/desktop/DesktopRuntimeConfigurationTest.kt
+++ b/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/desktop/DesktopRuntimeConfigurationTest.kt
@@ -52,8 +52,6 @@ class DesktopRuntimeConfigurationTest {
     val firstState = first.createMapState()
     val secondState = second.createMapState()
 
-    assertTrue(first.capabilities.supportsOfflinePacks)
-    assertTrue(first.capabilities.supportsAmbientCacheManagement)
     assertNotSame(first.offlineManager, second.offlineManager)
 
     first.close()

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/NativeMapRuntime.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/NativeMapRuntime.kt
@@ -8,12 +8,6 @@ import org.maplibre.compose.mlnffi.withLock
 import org.maplibre.compose.offline.MlnFfiOfflineManager
 import org.maplibre.compose.resource.MapResourceConfig
 
-private val nativeMapRuntimeCapabilities =
-  MapRuntimeCapabilities(
-    supportsOfflinePacks = true,
-    supportsAmbientCacheManagement = true,
-  )
-
 internal object DefaultMapRuntime {
   private val lock = MlnFfiLock()
   private var current: RuntimeImplementation? = null
@@ -57,7 +51,6 @@ private fun createNativeMapRuntimeImplementation(
         check(offlineManager.close()) { "The offline manager did not stop" }
       },
     logger = options.logger,
-    capabilities = nativeMapRuntimeCapabilities,
     offlineManagerBackend = offlineManager,
     snapshotterAdapterFactory = NativeSnapshotterAdapterFactory(options, resourceConfig),
     resourceConfig = resourceConfig,


### PR DESCRIPTION
## Description

Remove the target-constant runtime capability API, keep offline operations common, and make unsupported Web operations throw from the selected offline manager while preserving runtime closure and pack ownership checks.

## Validation

`mise run check`, `mise run test:android`, and `mise run test:desktop` pass; `mise run test:js` compiled the changed sources and tests, but Kotlin/JS linking exhausted its configured 4 GiB heap before Chrome ran.

## AI assistance

OpenAI Codex desktop with GPT-5 implemented, tested, and reviewed the change under human direction.