### PR TITLE
Expose offline database merging

### DIFF
--- a/lib/maplibre-compose/build.gradle.kts
+++ b/lib/maplibre-compose/build.gradle.kts
@@ -61,6 +61,7 @@ kotlin {
       api(libs.kermit)
       implementation(libs.kotlinx.coroutines.core)
       implementation(libs.kotlinx.atomicfu)
+      api(libs.kotlinx.io.core)
       api(libs.spatialk.geojson)
       api(libs.spatialk.units)
     }
@@ -83,8 +84,6 @@ kotlin {
         dependencies {
           // Backend-independent binding only; the application selects the native runtime.
           api(libs.maplibre.nativeFfi)
-          // Multiplatform filesystem paths, so this source set stays free of java.io.File.
-          implementation(libs.kotlinx.io.core)
         }
       }
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/offline/OfflineManager.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/offline/OfflineManager.kt
@@ -1,5 +1,7 @@
 package org.maplibre.compose.offline
 
+import kotlinx.io.files.Path
+
 /** Manages the offline packs and ambient cache that belong to one map runtime. */
 public interface OfflineManager {
 
@@ -46,6 +48,22 @@ public interface OfflineManager {
    * @throws OfflineManagerException if the operation failed.
    */
   public suspend fun invalidate(pack: OfflinePack)
+
+  /**
+   * Merges the offline packs and their resources from [databaseFile] into this manager's database.
+   *
+   * [databaseFile] must identify a readable MapLibre offline database with the same schema version
+   * as this runtime's database. The merge does not modify the source database. Ambient-cache
+   * resources are not imported.
+   *
+   * The returned set contains the packs represented by the source database. It includes an existing
+   * pack when the source contains the same definition and metadata. Imported packs can be
+   * incomplete when the source database does not contain every required resource.
+   *
+   * @throws UnsupportedOperationException if the runtime does not support offline packs.
+   * @throws OfflineManagerException if the operation failed.
+   */
+  public suspend fun mergeDatabase(databaseFile: Path): Set<OfflinePack>
 
   /**
    * Checks ambient-cache resources against the server and downloads changed resources.
@@ -107,6 +125,11 @@ internal class RuntimeBoundOfflineManager(
     delegate.invalidate(pack)
   }
 
+  override suspend fun mergeDatabase(databaseFile: Path): Set<OfflinePack> {
+    requireRuntimeOpen()
+    return delegate.mergeDatabase(databaseFile).onEach(::bindToRuntime)
+  }
+
   override suspend fun invalidateAmbientCache() {
     requireRuntimeOpen()
     delegate.invalidateAmbientCache()
@@ -140,6 +163,9 @@ internal object UnsupportedOfflineManager : OfflineManager {
   override suspend fun delete(pack: OfflinePack): Unit = unsupportedOfflinePacks()
 
   override suspend fun invalidate(pack: OfflinePack): Unit = unsupportedOfflinePacks()
+
+  override suspend fun mergeDatabase(databaseFile: Path): Set<OfflinePack> =
+    unsupportedOfflinePacks()
 
   override suspend fun invalidateAmbientCache(): Unit = unsupportedAmbientCacheManagement()
 

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/offline/RuntimeBoundOfflineManagerTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/offline/RuntimeBoundOfflineManagerTest.kt
@@ -6,6 +6,7 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertSame
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.test.runTest
+import kotlinx.io.files.Path
 import org.maplibre.compose.map.MapRuntimeClosedException
 import org.maplibre.compose.map.MapRuntimeResources
 import org.maplibre.compose.map.RuntimeImplementation
@@ -24,6 +25,7 @@ class RuntimeBoundOfflineManagerTest {
     assertFailsWith<UnsupportedOperationException> { manager.pause(pack) }
     assertFailsWith<UnsupportedOperationException> { manager.delete(pack) }
     assertFailsWith<UnsupportedOperationException> { manager.invalidate(pack) }
+    assertFailsWith<UnsupportedOperationException> { manager.mergeDatabase(databaseFile) }
     assertFailsWith<UnsupportedOperationException> { manager.invalidateAmbientCache() }
     assertFailsWith<UnsupportedOperationException> { manager.clearAmbientCache() }
     assertFailsWith<UnsupportedOperationException> { manager.setMaximumAmbientCacheSize(1) }
@@ -43,8 +45,9 @@ class RuntimeBoundOfflineManagerTest {
     manager.pause(backend.pack)
     manager.delete(backend.pack)
     manager.invalidate(backend.pack)
+    assertEquals(setOf(backend.mergedPack), manager.mergeDatabase(databaseFile))
     assertEquals(
-      listOf("create", "resume", "pause", "delete", "invalidate"),
+      listOf("create", "resume", "pause", "delete", "invalidate", "merge"),
       backend.calls,
     )
 
@@ -58,6 +61,7 @@ class RuntimeBoundOfflineManagerTest {
         "pause",
         "delete",
         "invalidate",
+        "merge",
         "invalidate ambient",
         "clear ambient",
         "set ambient size",
@@ -89,6 +93,7 @@ class RuntimeBoundOfflineManagerTest {
     assertFailsWith<MapRuntimeClosedException> { manager.pause(backend.pack) }
     assertFailsWith<MapRuntimeClosedException> { manager.delete(backend.pack) }
     assertFailsWith<MapRuntimeClosedException> { manager.invalidate(backend.pack) }
+    assertFailsWith<MapRuntimeClosedException> { manager.mergeDatabase(databaseFile) }
     assertFailsWith<MapRuntimeClosedException> { manager.invalidateAmbientCache() }
     assertFailsWith<MapRuntimeClosedException> { manager.clearAmbientCache() }
     assertFailsWith<MapRuntimeClosedException> { manager.setMaximumAmbientCacheSize(1) }
@@ -115,6 +120,7 @@ class RuntimeBoundOfflineManagerTest {
     val calls = mutableListOf<String>()
     val pack = pack(regionId = 1)
     val createdPack = pack(regionId = 2)
+    val mergedPack = pack(regionId = 3)
 
     override val packs: Set<OfflinePack> = setOf(pack)
 
@@ -138,6 +144,9 @@ class RuntimeBoundOfflineManagerTest {
     override suspend fun invalidate(pack: OfflinePack) {
       calls += "invalidate"
     }
+
+    override suspend fun mergeDatabase(databaseFile: Path): Set<OfflinePack> =
+      setOf(mergedPack).also { calls += "merge" }
 
     override suspend fun invalidateAmbientCache() {
       calls += "invalidate ambient"
@@ -167,5 +176,7 @@ class RuntimeBoundOfflineManagerTest {
         bounds = BoundingBox(west = -1.0, south = -1.0, east = 1.0, north = 1.0),
         pixelRatio = 1f,
       )
+
+    val databaseFile = Path("source-offline.db")
   }
 }

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/offline/MlnFfiOfflineManager.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/offline/MlnFfiOfflineManager.kt
@@ -229,12 +229,16 @@ internal class MlnFfiOfflineManager(
   // region owner-thread bookkeeping
 
   /**
-   * Adopts a region MapLibre reported, or returns null when its definition cannot be represented.
-   * Runs on the owner thread; there is at most one [OfflinePack] per region.
+   * Adopts or reuses a region that MapLibre reported, or returns null when its definition cannot be
+   * represented. Runs on the owner thread; there is at most one [OfflinePack] per region.
    */
   private fun registerRegion(info: OfflineRegionInfo): OfflinePack? {
     val existing = packsById[info.id]
-    if (existing != null) return existing
+    if (existing != null) {
+      // An operation such as a database merge can change the resources of an existing region.
+      refreshStatus(info.id)
+      return existing
+    }
 
     val definition = info.definition.toOfflinePackDefinition(logger) ?: return null
     val pack = OfflinePack(this, info.id, definition, info.metadata.copyOf())

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/offline/MlnFfiOfflineManager.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/offline/MlnFfiOfflineManager.kt
@@ -8,8 +8,10 @@ import kotlin.coroutines.resumeWithException
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.io.files.Path
 import org.maplibre.compose.mlnffi.MlnFfiGate
 import org.maplibre.compose.mlnffi.MlnFfiRuntimeOptions
+import org.maplibre.compose.mlnffi.normalizeMlnFfiPath
 import org.maplibre.compose.resource.MapResourceConfig
 import org.maplibre.nativeffi.error.MaplibreException
 import org.maplibre.nativeffi.error.MaplibreStatus
@@ -161,6 +163,23 @@ internal class MlnFfiOfflineManager(
       description = "invalidate offline pack ${pack.regionId}",
       start = { it.startInvalidateOfflineRegion(pack.regionId) },
       finish = { _, _ -> },
+    )
+  }
+
+  override suspend fun mergeDatabase(databaseFile: Path): Set<OfflinePack> {
+    val sourceFile = normalizeMlnFfiPath(databaseFile)
+    require(sourceFile != options.cacheFile) {
+      "The source database must differ from this manager's database"
+    }
+    return runOperation(
+      description = "merge offline database $sourceFile",
+      start = { it.startMergeOfflineRegionsDatabase(sourceFile.toString()) },
+      finish = { nativeRuntime, handle ->
+        nativeRuntime
+          .takeMergeOfflineRegionsDatabaseResult(handle)
+          .mapNotNull(::registerRegion)
+          .toSet()
+      },
     )
   }
 

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/offline/MlnFfiOfflinePackTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/offline/MlnFfiOfflinePackTest.kt
@@ -197,6 +197,34 @@ class MlnFfiOfflinePackTest {
     assertEquals(listOf(kept.regionId), second.packs.map { it.regionId })
   }
 
+  @Test
+  fun merging_a_database_registers_its_packs_and_reuses_an_identical_pack() = runBlocking {
+    val definition = tilePyramid(writeStyle("merge.json"))
+    val sharedMetadata = "same pack".encodeToByteArray()
+    val sourceFile = Path(directory, "merge-source.db")
+
+    val source = manager(options.copy(cacheFile = sourceFile))
+    withTimeout(OPERATION_TIMEOUT_MILLIS) { source.create(definition, sharedMetadata) }
+    withTimeout(OPERATION_TIMEOUT_MILLIS) {
+      source.create(definition, "source-only pack".encodeToByteArray())
+    }
+    assertTrue(source.close(), "the source manager should stop before its database is merged")
+
+    val destination = manager()
+    val existing =
+      withTimeout(OPERATION_TIMEOUT_MILLIS) { destination.create(definition, sharedMetadata) }
+
+    val merged = withTimeout(OPERATION_TIMEOUT_MILLIS) { destination.mergeDatabase(sourceFile) }
+
+    assertEquals(2, merged.size)
+    assertTrue(existing in merged, "an identical source pack should reuse the destination pack")
+    assertEquals(merged, destination.packs)
+    assertEquals(
+      setOf("same pack", "source-only pack"),
+      merged.map { requireNotNull(it.metadata).decodeToString() }.toSet(),
+    )
+  }
+
   /**
    * The style points at a closed loopback port rather than a missing `file:` URL: MapLibre treats a
    * missing style as a permanent failure and deactivates the region, while a refused connection is
@@ -304,7 +332,7 @@ class MlnFfiOfflinePackTest {
 
   // region fixtures
 
-  private fun manager(): MlnFfiOfflineManager =
+  private fun manager(options: MlnFfiRuntimeOptions = this.options): MlnFfiOfflineManager =
     MlnFfiOfflineManager(options).also { managers += it }
 
   /** Creates a pack over a local style and starts it; the caller waits for the part it needs. */


### PR DESCRIPTION
## Description

Expose MapLibre Native FFI database merging as a suspending OfflineManager operation that publishes imported packs through Compose state and preserves the source database.

## Validation

Passed mise run test:desktop on macOS with Metal and mise run check.

## AI assistance

OpenAI Codex with GPT-5.6 assisted with source tracing, implementation, tests, and PR preparation.