### PR TITLE
Separate location backend availability from request failures

### DIFF
--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/LocationDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/LocationDemo.kt
@@ -190,7 +190,6 @@ private fun LocationState.trackingStatusMessage(): String =
         LocationUnavailableReason.ServicesDisabled -> "Location services are turned off"
         LocationUnavailableReason.TemporarilyUnavailable -> "Location is temporarily unavailable"
         LocationUnavailableReason.Unsupported -> "Location is not available on this device"
-        LocationUnavailableReason.Misconfigured -> "Location is misconfigured on this device"
         LocationUnavailableReason.PermissionDenied -> "Location permission was denied"
         LocationUnavailableReason.UnexpectedFailure -> "Location failed"
       }

--- a/lib/location-runtime-linux/src/main/kotlin/org/maplibre/compose/location/desktop/linux/DbusLocationPortal.kt
+++ b/lib/location-runtime-linux/src/main/kotlin/org/maplibre/compose/location/desktop/linux/DbusLocationPortal.kt
@@ -49,8 +49,7 @@ internal class DbusLocationPortal(private val window: XdgPortalWindow? = null) :
 
   override suspend fun requestPermission(): PortalPermissionResult =
     withContext(Dispatchers.IO) {
-      if (!available)
-        return@withContext PortalPermissionResult.Unavailable(LocationUnavailableReason.Unsupported)
+      check(available) { "Location permission requires an available XDG Location portal" }
 
       var connection: DBusConnection? = null
       var session: PortalSession? = null
@@ -79,11 +78,7 @@ internal class DbusLocationPortal(private val window: XdgPortalWindow? = null) :
     }
 
   override fun updates(request: LocationRequest): Flow<LocationEvent> = callbackFlow {
-    if (!available) {
-      trySend(LocationEvent.Unavailable(LocationUnavailableReason.Unsupported))
-      close()
-      return@callbackFlow
-    }
+    check(available) { "Location updates require an available XDG Location portal" }
 
     var connection: DBusConnection? = null
     var session: PortalSession? = null

--- a/lib/location-runtime-linux/src/main/kotlin/org/maplibre/compose/location/desktop/linux/LinuxPortalLocationBackend.kt
+++ b/lib/location-runtime-linux/src/main/kotlin/org/maplibre/compose/location/desktop/linux/LinuxPortalLocationBackend.kt
@@ -68,8 +68,7 @@ internal suspend fun <T> XdgPortalWindow?.withPortalParentWindow(action: suspend
  * position never moves.
  *
  * A missing portal maps [LocationProvider.backendAvailability] to
- * [LocationBackendAvailability.Unsupported], and collection emits
- * [LocationUnavailableReason.Unsupported]. A cancelled
+ * [LocationBackendAvailability.Unsupported]. A cancelled
  * [`Request.Response`](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Request.html#org-freedesktop-portal-request-response)
  * maps to [LocationUnavailableReason.PermissionDenied]. A closed session, a stopped portal service,
  * another non-success response, or a D-Bus transport failure maps to
@@ -98,9 +97,8 @@ internal constructor(
   override fun requestPermission(): Unit = requester.requestForegroundPermission()
 
   override fun updates(request: LocationRequest): Flow<LocationEvent> = flow {
-    if (!portal.available) {
-      emit(LocationEvent.Unavailable(LocationUnavailableReason.Unsupported))
-      return@flow
+    check(backendAvailability == LocationBackendAvailability.Available) {
+      "Location updates require an available backend: $backendAvailability"
     }
     portal.updates(request).collect { emit(it) }
   }

--- a/lib/location-runtime-linux/src/test/kotlin/org/maplibre/compose/location/desktop/linux/LinuxPortalLocationProviderTest.kt
+++ b/lib/location-runtime-linux/src/test/kotlin/org/maplibre/compose/location/desktop/linux/LinuxPortalLocationProviderTest.kt
@@ -3,6 +3,7 @@ package org.maplibre.compose.location.desktop.linux
 import java.util.ServiceLoader
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
 import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
@@ -100,6 +101,7 @@ class LinuxPortalLocationProviderTest {
     val provider = LinuxPortalLocationProvider(portal, backgroundScope)
 
     assertEquals(LocationBackendAvailability.Unsupported, provider.backendAvailability)
+    assertFailsWith<IllegalStateException> { provider.updates(LocationRequest()).first() }
     provider.requestPermission()
     runCurrent()
     assertEquals(0, portal.permissionRequests)

--- a/lib/location-runtime-macos/src/main/kotlin/org/maplibre/compose/location/desktop/macos/MacosLocationBackend.kt
+++ b/lib/location-runtime-macos/src/main/kotlin/org/maplibre/compose/location/desktop/macos/MacosLocationBackend.kt
@@ -94,20 +94,8 @@ internal constructor(
   override fun requestPermission(): Unit = requester.requestForegroundPermission()
 
   override fun updates(request: LocationRequest): Flow<LocationEvent> = callbackFlow {
-    when (val availability = backendAvailability) {
-      is LocationBackendAvailability.Misconfigured -> {
-        trySend(
-          LocationEvent.Unavailable(LocationUnavailableReason.Misconfigured, availability.cause)
-        )
-        close()
-        return@callbackFlow
-      }
-      LocationBackendAvailability.Unsupported -> {
-        trySend(LocationEvent.Unavailable(LocationUnavailableReason.Unsupported))
-        close()
-        return@callbackFlow
-      }
-      LocationBackendAvailability.Available -> Unit
+    check(backendAvailability == LocationBackendAvailability.Available) {
+      "Location updates require an available backend: $backendAvailability"
     }
     val locationServicesEnabled = withContext(ioDispatcher) { client.locationServicesEnabled }
     if (!locationServicesEnabled) {

--- a/lib/location-runtime-macos/src/test/kotlin/org/maplibre/compose/location/desktop/macos/MacosLocationProviderTest.kt
+++ b/lib/location-runtime-macos/src/test/kotlin/org/maplibre/compose/location/desktop/macos/MacosLocationProviderTest.kt
@@ -357,8 +357,7 @@ class MacosLocationProviderTest {
     val provider = MacosLocationProvider(client, Dispatchers.Unconfined)
 
     assertIs<LocationBackendAvailability.Misconfigured>(provider.backendAvailability)
-    val event = assertIs<LocationEvent.Unavailable>(provider.updates(LocationRequest()).first())
-    assertEquals(LocationUnavailableReason.Misconfigured, event.reason)
+    assertFailsWith<IllegalStateException> { provider.updates(LocationRequest()).first() }
     provider.requestPermission()
     assertEquals(0, client.managers.single().whenInUseRequests)
   }

--- a/lib/location-runtime-windows/src/main/kotlin/org/maplibre/compose/location/desktop/windows/WindowsLocationBackend.kt
+++ b/lib/location-runtime-windows/src/main/kotlin/org/maplibre/compose/location/desktop/windows/WindowsLocationBackend.kt
@@ -68,20 +68,8 @@ internal constructor(private val client: WindowsLocationClient) : DesktopLocatio
   override fun requestPermission(): Unit = requester.requestForegroundPermission()
 
   override fun updates(request: LocationRequest): Flow<LocationEvent> = callbackFlow {
-    when (val availability = backendAvailability) {
-      is LocationBackendAvailability.Misconfigured -> {
-        trySend(
-          LocationEvent.Unavailable(LocationUnavailableReason.Misconfigured, availability.cause)
-        )
-        close()
-        return@callbackFlow
-      }
-      LocationBackendAvailability.Unsupported -> {
-        trySend(LocationEvent.Unavailable(LocationUnavailableReason.Unsupported))
-        close()
-        return@callbackFlow
-      }
-      LocationBackendAvailability.Available -> Unit
+    check(backendAvailability == LocationBackendAvailability.Available) {
+      "Location updates require an available backend: $backendAvailability"
     }
     if (closed.get()) {
       trySend(

--- a/lib/location-runtime-windows/src/test/kotlin/org/maplibre/compose/location/desktop/windows/WindowsLocationProviderTest.kt
+++ b/lib/location-runtime-windows/src/test/kotlin/org/maplibre/compose/location/desktop/windows/WindowsLocationProviderTest.kt
@@ -3,6 +3,7 @@ package org.maplibre.compose.location.desktop.windows
 import java.util.ServiceLoader
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNull
@@ -296,7 +297,7 @@ class WindowsLocationProviderTest {
   }
 
   @Test
-  fun misconfiguredBackendEmitsMisconfiguredWithoutOpeningSession() = runTest {
+  fun misconfiguredBackendRejectsUpdatesWithoutOpeningSession() = runTest {
     val cause = IllegalStateException("activation failed")
     val client =
       FakeWindowsLocationClient(
@@ -304,9 +305,7 @@ class WindowsLocationProviderTest {
       )
     val provider = WindowsLocationProvider(client)
 
-    val event = assertIs<LocationEvent.Unavailable>(provider.updates(LocationRequest()).first())
-    assertEquals(LocationUnavailableReason.Misconfigured, event.reason)
-    assertEquals(cause, event.cause)
+    assertFailsWith<IllegalStateException> { provider.updates(LocationRequest()).first() }
     assertTrue(client.sessions.isEmpty())
   }
 

--- a/lib/location/src/androidMain/kotlin/org/maplibre/compose/location/AndroidLocationBackend.kt
+++ b/lib/location/src/androidMain/kotlin/org/maplibre/compose/location/AndroidLocationBackend.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import java.util.ServiceConfigurationError
 import java.util.ServiceLoader
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.flow
 
 /**
  * An Android location implementation discovered through [ServiceLoader].
@@ -85,6 +85,9 @@ internal class MisconfiguredLocationProvider(private val cause: Throwable) : Loc
   override val backendAvailability: LocationBackendAvailability =
     LocationBackendAvailability.Misconfigured(cause)
 
-  override fun updates(request: LocationRequest): Flow<LocationEvent> =
-    flowOf(LocationEvent.Unavailable(LocationUnavailableReason.Misconfigured, cause))
+  override fun updates(request: LocationRequest): Flow<LocationEvent> = flow {
+    check(backendAvailability == LocationBackendAvailability.Available) {
+      "Location updates require an available backend: $backendAvailability"
+    }
+  }
 }

--- a/lib/location/src/commonMain/kotlin/org/maplibre/compose/location/LocationProvider.kt
+++ b/lib/location/src/commonMain/kotlin/org/maplibre/compose/location/LocationProvider.kt
@@ -6,7 +6,7 @@ import kotlin.time.TimeMark
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.flow
 import org.maplibre.spatialk.units.Length
 import org.maplibre.spatialk.units.extensions.inMeters
 import org.maplibre.spatialk.units.extensions.meters
@@ -29,7 +29,7 @@ public interface LocationProvider {
   public val backendId: String?
     get() = null
 
-  /** Whether this provider has a usable platform implementation. */
+  /** Whether this provider has a usable platform implementation, stable for its lifetime. */
   public val backendAvailability: LocationBackendAvailability
     get() = LocationBackendAvailability.Available
 
@@ -57,6 +57,10 @@ public interface LocationProvider {
 
   /**
    * Returns a cold stream of foreground location updates.
+   *
+   * Collecting this stream requires [backendAvailability] to be
+   * [LocationBackendAvailability.Available]. An unavailable provider fails collection with an
+   * [IllegalStateException].
    *
    * Each collector starts an independent platform location request. Cancelling collection stops
    * that request and unregisters its callbacks.
@@ -188,20 +192,12 @@ public enum class LocationUnavailableReason {
   TemporarilyUnavailable,
 
   /**
-   * No location implementation is available for the current target or host.
+   * An active request discovered that the target or host cannot provide location.
    *
-   * For example, a browser may omit the Geolocation API, or a desktop application may omit the
-   * location backend for its operating system.
+   * For example, an initialized Windows provider may report that location is not available on the
+   * device.
    */
   Unsupported,
-
-  /**
-   * The application installed or configured its provider incorrectly.
-   *
-   * For example, a desktop runtime may contain multiple location backends when exactly one is
-   * required.
-   */
-  Misconfigured,
 
   /**
    * Foreground location permission has not been granted.
@@ -259,6 +255,9 @@ public object UnsupportedLocationProvider : LocationProvider {
   override val backendAvailability: LocationBackendAvailability =
     LocationBackendAvailability.Unsupported
 
-  override fun updates(request: LocationRequest): Flow<LocationEvent> =
-    flowOf(LocationEvent.Unavailable(LocationUnavailableReason.Unsupported))
+  override fun updates(request: LocationRequest): Flow<LocationEvent> = flow {
+    check(backendAvailability == LocationBackendAvailability.Available) {
+      "Location updates require an available backend: $backendAvailability"
+    }
+  }
 }

--- a/lib/location/src/commonTest/kotlin/org/maplibre/compose/location/LocationProviderTest.kt
+++ b/lib/location/src/commonTest/kotlin/org/maplibre/compose/location/LocationProviderTest.kt
@@ -1,12 +1,14 @@
 package org.maplibre.compose.location
 
 import kotlin.test.Test
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runCurrent
@@ -17,6 +19,13 @@ class LocationProviderTest {
   @Test
   fun backendIdDefaultsToNull() {
     assertNull(FakeLocationProvider().backendId)
+  }
+
+  @Test
+  fun unsupportedProviderRejectsUpdateCollection() = runTest {
+    assertFailsWith<IllegalStateException> {
+      UnsupportedLocationProvider.updates(LocationRequest()).first()
+    }
   }
 
   @Test

--- a/lib/location/src/jsMain/kotlin/org/maplibre/compose/location/BrowserLocationProvider.kt
+++ b/lib/location/src/jsMain/kotlin/org/maplibre/compose/location/BrowserLocationProvider.kt
@@ -49,8 +49,7 @@ import web.permissions.query
  * no distance threshold.
  *
  * A missing Geolocation API maps [LocationProvider.backendAvailability] to
- * [LocationBackendAvailability.Unsupported], and collection emits
- * [LocationUnavailableReason.Unsupported].
+ * [LocationBackendAvailability.Unsupported].
  * [`GeolocationPositionError.PERMISSION_DENIED`](https://developer.mozilla.org/en-US/docs/Web/API/GeolocationPositionError/code#geolocationpositionerror.permission_denied)
  * maps to [LocationUnavailableReason.PermissionDenied].
  * [`POSITION_UNAVAILABLE`](https://developer.mozilla.org/en-US/docs/Web/API/GeolocationPositionError/code#geolocationpositionerror.position_unavailable)
@@ -93,10 +92,8 @@ internal constructor(
   override fun requestPermission(): Unit = requester.requestForegroundPermission()
 
   override fun updates(request: LocationRequest): Flow<LocationEvent> = callbackFlow {
-    if (!boundary.supported) {
-      trySend(LocationEvent.Unavailable(LocationUnavailableReason.Unsupported))
-      close()
-      return@callbackFlow
+    check(backendAvailability == LocationBackendAvailability.Available) {
+      "Location updates require an available backend: $backendAvailability"
     }
     var previous: BrowserPosition? = null
     fun publish(result: BrowserResult) {

--- a/lib/location/src/jsTest/kotlin/org/maplibre/compose/location/BrowserLocationProviderTest.kt
+++ b/lib/location/src/jsTest/kotlin/org/maplibre/compose/location/BrowserLocationProviderTest.kt
@@ -2,6 +2,7 @@ package org.maplibre.compose.location
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
 import kotlin.test.assertNull
 import kotlin.time.Duration.Companion.seconds
@@ -11,6 +12,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
@@ -26,6 +28,7 @@ class BrowserLocationProviderTest {
     val provider = BrowserLocationProvider(boundary, backgroundScope)
 
     assertEquals(LocationBackendAvailability.Unsupported, provider.backendAvailability)
+    assertFailsWith<IllegalStateException> { provider.updates(LocationRequest()).first() }
     provider.requestPermission()
     runCurrent()
     assertEquals(emptyList(), boundary.requestedOptions)

--- a/lib/location/src/jvmMain/kotlin/org/maplibre/compose/location/DesktopLocationProvider.kt
+++ b/lib/location/src/jvmMain/kotlin/org/maplibre/compose/location/DesktopLocationProvider.kt
@@ -3,7 +3,7 @@ package org.maplibre.compose.location
 import java.util.ServiceConfigurationError
 import java.util.ServiceLoader
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.flow
 
 /**
  * A host-specific desktop location implementation discovered through [ServiceLoader].
@@ -85,20 +85,11 @@ internal object DesktopLocationBackendResolver {
 private class UnavailableDesktopLocationProvider(
   override val backendAvailability: LocationBackendAvailability
 ) : DesktopLocationProvider {
-  override fun updates(request: LocationRequest): Flow<LocationEvent> =
-    flowOf(
-      when (val availability = backendAvailability) {
-        LocationBackendAvailability.Available ->
-          error("An unavailable provider cannot report an available backend")
-        is LocationBackendAvailability.Misconfigured ->
-          LocationEvent.Unavailable(
-            LocationUnavailableReason.Misconfigured,
-            availability.cause,
-          )
-        LocationBackendAvailability.Unsupported ->
-          LocationEvent.Unavailable(LocationUnavailableReason.Unsupported)
-      }
-    )
+  override fun updates(request: LocationRequest): Flow<LocationEvent> = flow {
+    check(backendAvailability == LocationBackendAvailability.Available) {
+      "Location updates require an available backend: $backendAvailability"
+    }
+  }
 
   override fun close() = Unit
 }

--- a/lib/location/src/jvmTest/kotlin/org/maplibre/compose/location/DesktopLocationBackendResolverTest.kt
+++ b/lib/location/src/jvmTest/kotlin/org/maplibre/compose/location/DesktopLocationBackendResolverTest.kt
@@ -3,6 +3,7 @@ package org.maplibre.compose.location
 import java.util.ServiceConfigurationError
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
 import kotlin.test.assertSame
 import kotlinx.coroutines.flow.emptyFlow
@@ -21,10 +22,7 @@ class DesktopLocationBackendResolverTest {
 
     providers.forEach { provider ->
       assertEquals(LocationBackendAvailability.Unsupported, provider.backendAvailability)
-      assertEquals(
-        LocationUnavailableReason.Unsupported,
-        (provider.updates(LocationRequest()).first() as LocationEvent.Unavailable).reason,
-      )
+      assertFailsWith<IllegalStateException> { provider.updates(LocationRequest()).first() }
     }
     assertEquals(0, unavailableBackend.createCalls)
   }
@@ -35,10 +33,7 @@ class DesktopLocationBackendResolverTest {
     val provider = DesktopLocationBackendResolver.resolve(backends)
 
     assertIs<LocationBackendAvailability.Misconfigured>(provider.backendAvailability)
-    assertEquals(
-      LocationUnavailableReason.Misconfigured,
-      (provider.updates(LocationRequest()).first() as LocationEvent.Unavailable).reason,
-    )
+    assertFailsWith<IllegalStateException> { provider.updates(LocationRequest()).first() }
   }
 
   @Test
@@ -60,13 +55,11 @@ class DesktopLocationBackendResolverTest {
     val backend = FakeBackend("broken", failure = failure)
 
     val provider = DesktopLocationBackendResolver.resolve(listOf(backend))
-    val event = assertIs<LocationEvent.Unavailable>(provider.updates(LocationRequest()).first())
+    assertFailsWith<IllegalStateException> { provider.updates(LocationRequest()).first() }
 
     val availability =
       assertIs<LocationBackendAvailability.Misconfigured>(provider.backendAvailability)
-    assertEquals(LocationUnavailableReason.Misconfigured, event.reason)
     assertSame(failure, availability.cause)
-    assertSame(failure, event.cause)
     assertEquals(1, backend.createCalls)
   }
 
@@ -74,10 +67,8 @@ class DesktopLocationBackendResolverTest {
   fun serviceDiscoveryFailureBecomesMisconfiguration() = runTest {
     val failure = ServiceConfigurationError("provider constructor failed")
     val provider = DesktopLocationBackendResolver.discover(loadBackends = { throw failure })
-    val event = assertIs<LocationEvent.Unavailable>(provider.updates(LocationRequest()).first())
+    assertFailsWith<IllegalStateException> { provider.updates(LocationRequest()).first() }
 
-    assertEquals(LocationUnavailableReason.Misconfigured, event.reason)
-    assertSame(failure, event.cause)
     assertSame(
       failure,
       assertIs<LocationBackendAvailability.Misconfigured>(provider.backendAvailability).cause,


### PR DESCRIPTION
## Description

Separate stable backend setup from active request failures, remove `LocationUnavailableReason.Misconfigured`, and reject update collection when `backendAvailability` is not `Available`.

## Validation

Passed `mise run check`, `mise run test:android`, `mise run test:desktop`, and `mise run test:js` on macOS.

## AI assistance

Used OpenAI Codex with GPT-5 to inspect, edit, test, and prepare this PR.