### PR TITLE
Simplify map lifecycle exceptions

### DIFF
--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/agent/AgentDriver.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/agent/AgentDriver.kt
@@ -8,7 +8,10 @@ import kotlin.math.log2
 import kotlin.math.pow
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.TimeSource
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.Serializable
@@ -20,7 +23,6 @@ import org.maplibre.compose.demoapp.DemoStyle
 import org.maplibre.compose.demoapp.allDemoStyles
 import org.maplibre.compose.demoapp.allDemos
 import org.maplibre.compose.demoapp.flyTo
-import org.maplibre.compose.map.MapNotAttachedException
 import org.maplibre.compose.map.MapState
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.spatialk.geojson.FeatureCollection
@@ -327,10 +329,15 @@ internal class AgentDriver(
 
   suspend fun featuresJson(xPx: Float, yPx: Float, layerIds: Set<String>?): String {
     val offset = with(density) { DpOffset(xPx.toDp(), yPx.toDp()) }
+    if (state.mapState.viewport == null) throw AgentException(503, "the map has no viewport")
     val features =
       try {
         state.mapState.queryRenderedFeatures(offset = offset, layerIds = layerIds)
-      } catch (_: MapNotAttachedException) {
+      } catch (_: CancellationException) {
+        currentCoroutineContext().ensureActive()
+        throw AgentException(503, "the map has no viewport")
+      } catch (error: IllegalStateException) {
+        if (state.mapState.viewport != null) throw error
         throw AgentException(503, "the map has no viewport")
       }
     return FeatureCollection(features).toJson()

--- a/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/map/NativeSnapshotRenderTarget.android.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/map/NativeSnapshotRenderTarget.android.kt
@@ -30,19 +30,18 @@ private constructor(private val delegate: Delegate) : AutoCloseable {
   actual override fun close() = delegate.close()
 
   actual companion object {
-    actual fun create(backends: Set<MapRenderBackend>): NativeSnapshotRenderTarget {
-      val delegate =
-        when {
-          MapRenderBackend.VULKAN in backends ->
-            VulkanDelegate(AndroidVulkanOffscreenContext.create())
-          MapRenderBackend.OPENGL in backends -> OpenGlDelegate.create()
-          else ->
-            throw UnsupportedOperationException(
-              "No offscreen Android snapshot backend is available from ${backends.joinToString()}"
-            )
-        }
-      return NativeSnapshotRenderTarget(delegate)
-    }
+    actual fun select(backends: Set<MapRenderBackend>): NativeSnapshotRenderTargetPlan? =
+      when {
+        MapRenderBackend.VULKAN in backends ->
+          NativeSnapshotRenderTargetPlan {
+            NativeSnapshotRenderTarget(VulkanDelegate(AndroidVulkanOffscreenContext.create()))
+          }
+        MapRenderBackend.OPENGL in backends ->
+          NativeSnapshotRenderTargetPlan {
+            NativeSnapshotRenderTarget(OpenGlDelegate.create())
+          }
+        else -> null
+      }
   }
 
   private interface Delegate : AutoCloseable {

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapCleanupException.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapCleanupException.kt
@@ -1,0 +1,33 @@
+package org.maplibre.compose.map
+
+/** Reports one or more nonfatal failures while closing map resources. */
+public class MapCleanupException
+internal constructor(resourceName: String, failures: List<Throwable>) :
+  RuntimeException(
+    "$resourceName cleanup failed in ${failures.size} resource(s)",
+    failures.firstOrNull(),
+  ) {
+  /** Every cleanup failure, in cleanup order. */
+  public val failures: List<Throwable> = failures.toList()
+
+  init {
+    require(this.failures.isNotEmpty()) { "A cleanup exception must contain at least one failure" }
+    this.failures.drop(1).forEach(::addSuppressed)
+  }
+}
+
+internal fun List<Throwable>.cleanupResult(resourceName: String): Result<Unit> =
+  when {
+    isEmpty() -> Result.success(Unit)
+    else ->
+      firstOrNull { it is Error }?.let { Result.failure(it) }
+        ?: Result.failure(MapCleanupException(resourceName, this))
+  }
+
+internal fun MutableList<Throwable>.addCleanupFailure(failure: Throwable) {
+  if (failure is MapCleanupException) {
+    failure.failures.forEach(::addCleanupFailure)
+  } else if (none { it === failure }) {
+    add(failure)
+  }
+}

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleAuthority.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleAuthority.kt
@@ -73,19 +73,9 @@ internal class MapAlreadyAttachedException :
   IllegalStateException("The map already has a presentation")
 
 internal class MapLeaseInvalidatedException :
-  IllegalStateException("The presentation lease ended before attachment completed")
+  CancellationException("The presentation lease ended before attachment completed")
 
 internal class MapClosedException : IllegalStateException("The map is closed")
-
-internal open class AggregateCleanupException(message: String, failures: List<Throwable>) :
-  RuntimeException(message, failures.first()) {
-  init {
-    failures.drop(1).forEach(::addSuppressed)
-  }
-}
-
-internal class MapLifecycleCleanupException internal constructor(val failures: List<Throwable>) :
-  AggregateCleanupException("Map cleanup failed in ${failures.size} resource(s)", failures)
 
 internal data class PendingAttachment(
   val lease: RenderLease,
@@ -139,10 +129,7 @@ internal class MapLifecycleAuthority(
     if (maps.isEmpty() && releases.isEmpty()) {
       val failures = mutableListOf<Throwable>()
       recordedFailures.forEach { addCleanupFailure(failures, it) }
-      completeClosure(
-        if (failures.isEmpty()) Result.success(Unit)
-        else Result.failure(MapStateCleanupException(failures))
-      )
+      completeClosure(failures.cleanupResult("Map state"))
       return
     }
     maps.forEach(MapAdapter::close)
@@ -155,10 +142,7 @@ internal class MapLifecycleAuthority(
       maps.forEach { map ->
         runCatching { map.awaitClosed() }.exceptionOrNull()?.let { addCleanupFailure(failures, it) }
       }
-      completeClosure(
-        if (failures.isEmpty()) Result.success(Unit)
-        else Result.failure(MapStateCleanupException(failures))
-      )
+      completeClosure(failures.cleanupResult("Map state"))
     }
   }
 
@@ -393,7 +377,7 @@ internal class MapLifecycleAuthority(
   inline fun <T> serialized(action: () -> T): T = lock.withLock(action)
 
   private fun requireOpen() {
-    if (closed) throw MapStateClosedException()
+    check(!closed) { "The map state is closed" }
   }
 
   private fun selectAdapterLocked(current: Attachment, adapter: MapAdapter) {
@@ -439,11 +423,7 @@ internal class MapLifecycleAuthority(
   }
 
   private fun addCleanupFailure(failures: MutableList<Throwable>, failure: Throwable) {
-    if (failure is MapLifecycleCleanupException) {
-      failure.failures.forEach { addCleanupFailure(failures, it) }
-    } else if (failures.none { it === failure }) {
-      failures += failure
-    }
+    failures.addCleanupFailure(failure)
   }
 
   private class Attachment(
@@ -680,19 +660,51 @@ internal class MapLifecycleBinding(
               performEngineCreation(observed)
             }
           }
-          observed.result.await().getOrThrow()
+          awaitEngineTransition(observed.result)
         }
-        is InternalState.Attaching -> observed.result.await().getOrThrow()
+        is InternalState.Attaching -> {
+          try {
+            awaitEngineTransition(observed.result)
+          } catch (_: MapLeaseInvalidatedException) {
+            // Engine access survives presentation churn. Re-read the lifecycle to find the
+            // retained engine or wait for its replacement.
+          }
+        }
         is InternalState.Attached -> return observed.engine
-        is InternalState.Detaching -> observed.result.await().getOrThrow()
+        is InternalState.Detaching -> {
+          try {
+            awaitEngineTransition(observed.result)
+          } catch (_: MapLeaseInvalidatedException) {
+            // A replacement presentation may have superseded this lease.
+          }
+        }
         is InternalState.OpenDetached ->
           observed.engine?.let {
             return it
           }
         is InternalState.Closing,
-        InternalState.Closed -> throw MapClosedException()
+        InternalState.Closed ->
+          throw CancellationException("The map closed before engine access could begin")
       }
     }
+  }
+
+  private suspend fun <T> awaitEngineTransition(result: CompletableDeferred<Result<T>>): T {
+    val outcome = result.await()
+    val failure = outcome.exceptionOrNull()
+    val state = current.load()
+    if (
+      failure != null &&
+        failure !is CancellationException &&
+        failure !is Error &&
+        (state is InternalState.Closing || state === InternalState.Closed)
+    ) {
+      throw CancellationException(
+        "The map closed before engine access could begin",
+        failure,
+      )
+    }
+    return outcome.getOrThrow()
   }
 
   private suspend fun performEngineCreation(creating: InternalState.CreatingEngine) {
@@ -988,9 +1000,7 @@ internal class MapLifecycleBinding(
       currentStyle.store(null)
       currentStyleRequest.store(null)
     }
-    val outcome =
-      if (failures.isEmpty()) Result.success(Unit)
-      else Result.failure(MapLifecycleCleanupException(failures))
+    val outcome = failures.cleanupResult("Map")
     val nextEngine =
       detaching.engine.takeIf { adapter.engineRetention == EngineRetention.RETAIN && engineCreated }
     serialized {
@@ -1031,10 +1041,7 @@ internal class MapLifecycleBinding(
     collectFailure(failures) { adapter.closeResources() }
 
     serialized { if (current.load() === closing) current.store(InternalState.Closed) }
-    closure.complete(
-      if (failures.isEmpty()) Result.success(Unit)
-      else Result.failure(MapLifecycleCleanupException(failures))
-    )
+    closure.complete(failures.cleanupResult("Map"))
   }
 
   private suspend fun collectFailure(
@@ -1045,8 +1052,7 @@ internal class MapLifecycleBinding(
   }
 
   private fun addCleanupFailure(failures: MutableList<Throwable>, failure: Throwable) {
-    if (failure is MapLifecycleCleanupException) failures += failure.failures
-    else failures += failure
+    failures.addCleanupFailure(failure)
   }
 
   /** Serializes non-suspending lifecycle commits with callback validation and delivery. */

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
@@ -29,6 +29,7 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.atomicfu.locks.reentrantLock
 import kotlinx.atomicfu.locks.withLock
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
@@ -126,19 +127,13 @@ public interface MapRuntime {
   /** Marks this runtime as closed and starts child and shared-resource cleanup. */
   public fun close()
 
-  /** Waits until every child and shared resource has finished cleanup. */
+  /**
+   * Waits until every child and shared resource has finished cleanup.
+   *
+   * @throws MapCleanupException if cleanup fails.
+   */
   public suspend fun awaitClosed()
 }
-
-/** Thrown when an operation targets a closed runtime. */
-public class MapRuntimeClosedException : IllegalStateException("The map runtime is closed")
-
-/** Thrown when an operation targets a closed logical map. */
-public class MapStateClosedException : IllegalStateException("The map state is closed")
-
-/** Thrown when an operation requires a map that is attached to a UI surface. */
-public class MapNotAttachedException :
-  IllegalStateException("The map is not attached to a UI surface")
 
 /** Reports the load state for the desired base style of one logical map. */
 public sealed interface StyleLoadState {
@@ -528,6 +523,8 @@ internal constructor(
 
   internal fun invalidate() {
     validState = false
+    viewportState = null
+    cameraMovingState = false
     invalidated.complete(Unit)
   }
 
@@ -537,26 +534,29 @@ internal constructor(
   }
 
   private fun <T> withViewport(block: (MapAdapter) -> T): T? =
-    owner.withCurrent(this) { if (viewportState == null) null else block(adapter) }
+    owner.withCurrentOrNull(this) { if (viewportState == null) null else block(adapter) }
 
   private suspend fun awaitViewportState(): Viewport = firstViewport.await()
 
   private suspend fun <T> runLeaseBound(block: suspend () -> T): T = coroutineScope {
-    owner.requireCurrent(this@MapAttachment)
+    if (!owner.isCurrent(this@MapAttachment)) throw MapAttachmentChangedException()
     val operation =
       async(start = CoroutineStart.UNDISPATCHED) {
-        owner.requireCurrent(this@MapAttachment)
+        if (!owner.isCurrent(this@MapAttachment)) throw MapAttachmentChangedException()
         block()
       }
     select {
       operation.onAwait { it }
       invalidated.onAwait {
         operation.cancelAndJoin()
-        throw MapNotAttachedException()
+        throw MapAttachmentChangedException()
       }
     }
   }
 }
+
+private class MapAttachmentChangedException :
+  CancellationException("The map attachment changed during the operation")
 
 /** Holds the observable style, camera, and map operations for one logical map. */
 @Stable
@@ -650,7 +650,11 @@ internal constructor(
   /** Marks this state as closed and starts cleanup of the current map surface. */
   public fun close(): Unit = lifecycle.close()
 
-  /** Waits until map-surface cleanup has completed. */
+  /**
+   * Waits until map-surface cleanup has completed.
+   *
+   * @throws MapCleanupException if cleanup fails.
+   */
   public suspend fun awaitClosed(): Unit = lifecycle.awaitClosed()
 
   /**
@@ -747,11 +751,12 @@ internal constructor(
     retryAcrossAttachments(MapAttachment::awaitViewport)
 
   private suspend fun <T> retryAcrossAttachments(operation: suspend (MapAttachment) -> T): T {
+    var attachment = awaitAttachment()
     while (true) {
       try {
-        return operation(awaitAttachment())
-      } catch (_: MapNotAttachedException) {
-        // A replacement surface can attach after this lease ends.
+        return operation(attachment)
+      } catch (_: MapAttachmentChangedException) {
+        attachment = awaitReplacementAttachment()
       }
     }
   }
@@ -1127,27 +1132,21 @@ internal constructor(
     }
   }
 
-  internal fun requireCurrent(candidate: MapAttachment) {
-    lifecycle.serialized { requireCurrentLocked(candidate) }
+  internal fun isCurrent(candidate: MapAttachment): Boolean = lifecycle.serialized {
+    isCurrentLocked(candidate)
   }
 
-  internal fun <T> withCurrent(candidate: MapAttachment, block: () -> T): T {
-    lifecycle.serialized { requireCurrentLocked(candidate) }
+  internal fun <T> withCurrentOrNull(candidate: MapAttachment, block: () -> T): T? {
+    if (!isCurrent(candidate)) return null
     val result = block()
-    lifecycle.serialized { requireCurrentLocked(candidate) }
-    return result
+    return result.takeIf { isCurrent(candidate) }
   }
 
-  private fun requireCurrentLocked(candidate: MapAttachment) {
-    if (
-      currentMapAttachment !== candidate || !lifecycle.isCurrent(candidate.token, candidate.adapter)
-    ) {
-      throw MapNotAttachedException()
-    }
-  }
+  private fun isCurrentLocked(candidate: MapAttachment): Boolean =
+    currentMapAttachment === candidate && lifecycle.isCurrent(candidate.token, candidate.adapter)
 
   private fun requireOpenLocked() {
-    if (lifecycle.isClosed) throw MapStateClosedException()
+    check(!lifecycle.isClosed) { "The map state is closed" }
   }
 
   internal fun commitClosed() {
@@ -1157,7 +1156,9 @@ internal constructor(
       closedState = true
       currentMapAttachment?.invalidate()
       currentMapAttachment = null
-      nextMapAttachment.completeExceptionally(MapStateClosedException())
+      nextMapAttachment.completeExceptionally(
+        CancellationException("The map closed while waiting for an attachment")
+      )
     }
   }
 
@@ -1265,11 +1266,24 @@ internal constructor(
   }
 
   private fun requireAttachment(): MapAttachment =
-    currentMapAttachment ?: throw MapNotAttachedException()
+    checkNotNull(currentMapAttachment) { "The map is not attached to a UI surface" }
 
   private suspend fun awaitAttachment(): MapAttachment {
     val pending = lifecycle.serialized {
       requireOpenLocked()
+      currentMapAttachment?.let {
+        return it
+      }
+      nextMapAttachment
+    }
+    return pending.await()
+  }
+
+  private suspend fun awaitReplacementAttachment(): MapAttachment {
+    val pending = lifecycle.serialized {
+      if (lifecycle.isClosed) {
+        throw CancellationException("The map closed during the operation")
+      }
       currentMapAttachment?.let {
         return it
       }
@@ -1286,7 +1300,7 @@ internal constructor(
     val attachment = currentMapAttachment ?: return null
     return try {
       block(attachment)
-    } catch (_: MapNotAttachedException) {
+    } catch (_: MapAttachmentChangedException) {
       null
     }
   }
@@ -1319,9 +1333,6 @@ internal constructor(
     val sourceChangeRevision: Long,
   )
 }
-
-internal class MapStateCleanupException(failures: List<Throwable>) :
-  AggregateCleanupException("Map state cleanup failed in ${failures.size} resource(s)", failures)
 
 @JvmInline internal value class MapPresentationToken(val value: Long)
 
@@ -1488,7 +1499,7 @@ internal class RuntimeImplementation(
   }
 
   private fun requireOpenLocked() {
-    if (closed) throw MapRuntimeClosedException()
+    check(!closed) { "The map runtime is closed" }
   }
 
   override fun close() {
@@ -1504,16 +1515,13 @@ internal class RuntimeImplementation(
     physicalScope.launch(start = CoroutineStart.UNDISPATCHED) {
       val failures = mutableListOf<Throwable>()
       closingStates.forEach { child ->
-        runCatching { child.awaitClosed() }.exceptionOrNull()?.let(failures::add)
+        runCatching { child.awaitClosed() }.exceptionOrNull()?.let(failures::addCleanupFailure)
       }
       closingSnapshotters.forEach { child ->
-        runCatching { child.awaitClosed() }.exceptionOrNull()?.let(failures::add)
+        runCatching { child.awaitClosed() }.exceptionOrNull()?.let(failures::addCleanupFailure)
       }
-      runCatching { resources.close() }.exceptionOrNull()?.let(failures::add)
-      closure.complete(
-        if (failures.isEmpty()) Result.success(Unit)
-        else Result.failure(MapRuntimeCleanupException(failures))
-      )
+      runCatching { resources.close() }.exceptionOrNull()?.let(failures::addCleanupFailure)
+      closure.complete(failures.cleanupResult("Map runtime"))
     }
   }
 
@@ -1532,6 +1540,3 @@ internal class RuntimeImplementation(
     lock.withLock { snapshotters.remove(child) }
   }
 }
-
-internal class MapRuntimeCleanupException(failures: List<Throwable>) :
-  AggregateCleanupException("Map runtime cleanup failed in ${failures.size} resource(s)", failures)

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapSnapshotter.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapSnapshotter.kt
@@ -72,8 +72,14 @@ public data class MapSnapshotRequest(
   }
 }
 
+/** Reports a failed snapshot capture. */
+public class MapSnapshotException internal constructor(message: String, cause: Throwable) :
+  RuntimeException(message, cause)
+
 /** Platform work for one snapshotter engine map. */
 internal interface SnapshotterAdapter {
+  fun validate(request: MapSnapshotRequest) = Unit
+
   suspend fun prepare(
     baseStyle: BaseStyle,
     baseStyleRevision: Long,
@@ -176,9 +182,6 @@ internal object DefaultStyleCompositionEvaluator : StyleCompositionEvaluator {
   }
 }
 
-/** Thrown when an operation targets a closed snapshotter. */
-public class MapSnapshotterClosedException : IllegalStateException("The map snapshotter is closed")
-
 /** An independent non-UI map that captures images. */
 public interface MapSnapshotter {
   /** Desired and applied style state for this snapshotter's engine map. */
@@ -190,7 +193,11 @@ public interface MapSnapshotter {
    * Cancelling the caller removes a queued request or abandons an active result. After active
    * cancellation, the next request waits until platform rendering and terminal cleanup end.
    *
-   * @throws MapSnapshotterClosedException if this snapshotter closes before returning an image
+   * @throws IllegalStateException if the snapshotter is closed before this call.
+   * @throws IllegalArgumentException if the request cannot be rendered on the current platform.
+   * @throws UnsupportedOperationException if snapshots are unavailable on the current platform.
+   * @throws CancellationException if the snapshotter closes after accepting this capture.
+   * @throws MapSnapshotException if style evaluation or rendering fails.
    */
   public suspend fun capture(request: MapSnapshotRequest): ImageBitmap
 
@@ -202,6 +209,8 @@ public interface MapSnapshotter {
 
   /**
    * Waits until this snapshotter has released its physical resources and reports cleanup errors.
+   *
+   * @throws MapCleanupException if cleanup fails.
    */
   public suspend fun awaitClosed()
 }
@@ -291,7 +300,9 @@ internal class MapSnapshotterImplementation(
         if (worker == null) worker = runtime.physicalScope.launch { runQueue() }
         true
       }
-      if (!accepted) continuation.resumeWithException(MapSnapshotterClosedException())
+      if (!accepted) {
+        continuation.resumeWithException(IllegalStateException("The map snapshotter is closed"))
+      }
     }
 
   override fun close() {
@@ -299,12 +310,13 @@ internal class MapSnapshotterImplementation(
     val finishNow = lock.withLock {
       if (closed) return
       closed = true
+      styleHandleEpoch++
       val queued = queue.toList()
       queue.clear()
-      queued.forEach { it.continuation.resumeWithException(MapSnapshotterClosedException()) }
+      queued.forEach { it.continuation.resumeWithException(snapshotterClosedCancellation()) }
       active?.also {
         cancellation = markCancellationLocked(it)
-        it.abandon(MapSnapshotterClosedException())
+        it.abandon(snapshotterClosedCancellation())
         it.operation?.cancel()
       }
       active == null && worker == null
@@ -347,11 +359,17 @@ internal class MapSnapshotterImplementation(
       try {
         adapter ?: adapterFactory.create().also { adapter = it }
       } catch (error: Throwable) {
-        capture.resumeFailure(error)
+        capture.resumeFailure(error.toSnapshotAvailabilityFailure())
         return@coroutineScope
       }
     val operation =
       launch(start = CoroutineStart.LAZY) {
+        try {
+          platform.validate(capture.request)
+        } catch (error: Throwable) {
+          capture.resumeFailure(error.toSnapshotRequestFailure())
+          return@launch
+        }
         var claim: StyleClaim? = null
         var binding: StyleBinding? = null
         val result =
@@ -386,7 +404,7 @@ internal class MapSnapshotterImplementation(
           } finally {
             claim?.let(::completeStyleClaim)
           }
-        result.fold(capture::resume, capture::resumeFailure)
+        result.fold(capture::resume) { capture.resumeFailure(it.toSnapshotFailure()) }
       }
     lock.withLock {
       capture.operation = operation
@@ -424,7 +442,7 @@ internal class MapSnapshotterImplementation(
         Unit
       }
       result.exceptionOrNull()?.let { error ->
-        lock.withLock { if (cleanupFailures.none { it === error }) cleanupFailures += error }
+        lock.withLock { cleanupFailures.addCleanupFailure(error) }
       }
       cancellation.complete(result)
     }
@@ -462,17 +480,9 @@ internal class MapSnapshotterImplementation(
     }
     val result = lock.withLock {
       val failures = cleanupFailures.toMutableList()
-      closeResult.exceptionOrNull()?.let { error ->
-        if (failures.none { it === error }) failures += error
-      }
-      styleResult.exceptionOrNull()?.let { error ->
-        if (failures.none { it === error }) failures += error
-      }
-      when (failures.size) {
-        0 -> Result.success(Unit)
-        1 -> Result.failure(failures.single())
-        else -> Result.failure(MapSnapshotterCleanupException(failures))
-      }
+      closeResult.exceptionOrNull()?.let(failures::addCleanupFailure)
+      styleResult.exceptionOrNull()?.let(failures::addCleanupFailure)
+      failures.cleanupResult("Map snapshotter")
     }
     runtime.childClosed(this)
     check(closure.complete(result)) { "Snapshotter closure completed more than once" }
@@ -689,10 +699,10 @@ internal class MapSnapshotterImplementation(
     checkpoint: Long,
   ) {
     lock.withLock {
-      requireStyleHandleLocked(binding)
-      check(checkpoint == styleHandleEpoch) {
-        "Style operation crossed a loaded-style resource change"
+      if (checkpoint != styleHandleEpoch) {
+        throw CancellationException("The loaded style changed during the operation")
       }
+      requireStyleHandleLocked(binding)
     }
   }
 
@@ -805,7 +815,7 @@ internal class MapSnapshotterImplementation(
   }
 
   private fun requireOpenLocked() {
-    if (closed) throw MapSnapshotterClosedException()
+    check(!closed) { "The map snapshotter is closed" }
   }
 
   private data class StyleClaim(
@@ -837,8 +847,23 @@ internal class MapSnapshotterImplementation(
   }
 }
 
-internal class MapSnapshotterCleanupException(val failures: List<Throwable>) :
-  AggregateCleanupException(
-    "Map snapshotter cleanup failed in ${failures.size} resource(s)",
-    failures,
-  )
+internal fun snapshotterClosedCancellation(): CancellationException =
+  CancellationException("The map snapshotter closed during capture")
+
+private fun Throwable.toSnapshotAvailabilityFailure(): Throwable =
+  if (this is UnsupportedOperationException) this else toSnapshotFailure()
+
+private fun Throwable.toSnapshotRequestFailure(): Throwable =
+  if (this is IllegalArgumentException) this else toSnapshotFailure()
+
+private fun Throwable.toSnapshotFailure(): Throwable =
+  when (this) {
+    is CancellationException,
+    is Error,
+    is MapSnapshotException -> this
+    else ->
+      MapSnapshotException(
+        message = "Snapshot capture failed: ${message ?: this::class.simpleName.orEmpty()}",
+        cause = this,
+      )
+  }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/PlatformMapAccess.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/PlatformMapAccess.kt
@@ -27,11 +27,14 @@ public annotation class DelicateMapApi
  * prevent retention. A long-running block stops the map from processing other work.
  *
  * Native platforms create the engine map when necessary and permit access without an attached UI
- * surface. Web requires an attached surface. The call fails without running [block] if the map
- * closes or the engine changes before execution. On Web, the call also fails if the current surface
- * detaches before execution. Cancelling while the invocation is queued prevents [block] from
- * running. Once execution starts, cancellation does not interrupt [block], but its result is
- * discarded.
+ * surface. Web requires an attached surface. Cancelling while the invocation is queued prevents
+ * [block] from running. Once execution starts, cancellation does not interrupt [block], but its
+ * result is discarded.
+ *
+ * @throws IllegalStateException if the map is already closed. Web also throws this exception if no
+ *   surface is attached when the call starts.
+ * @throws kotlinx.coroutines.CancellationException if the map, engine, or Web attachment changes
+ *   before [block] starts.
  */
 @DelicateMapApi
 public expect suspend fun <T> MapState.withPlatformMap(block: PlatformMapScope.() -> T): T

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/offline/OfflineManagerException.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/offline/OfflineManagerException.kt
@@ -1,4 +1,5 @@
 package org.maplibre.compose.offline
 
 /** Reports a failed operation on an [OfflineManager]. */
-public class OfflineManagerException(message: String) : Exception(message)
+public class OfflineManagerException(message: String, cause: Throwable? = null) :
+  RuntimeException(message, cause)

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/offline/OfflinePack.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/offline/OfflinePack.kt
@@ -30,7 +30,7 @@ internal constructor(
   /**
    * Replaces the arbitrary metadata that is associated with this offline pack.
    *
-   * @throws org.maplibre.compose.map.MapRuntimeClosedException if the pack's runtime is closed.
+   * @throws IllegalStateException if the pack's runtime is closed.
    * @throws [OfflineManagerException] if the operation failed.
    */
   public suspend fun setMetadata(metadata: ByteArray) {

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleHandleException.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleHandleException.kt
@@ -2,7 +2,7 @@ package org.maplibre.compose.style
 
 /** A live style handle operation that MapLibre refused. */
 public class StyleHandleException(message: String, cause: Throwable? = null) :
-  IllegalStateException(message, cause)
+  RuntimeException(message, cause)
 
 internal interface StyleHandleOperationGuard {
   fun <T> run(action: () -> T): T

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapLifecycleBindingTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapLifecycleBindingTest.kt
@@ -4,7 +4,9 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
@@ -163,10 +165,21 @@ class MapLifecycleBindingTest {
     lifecycle.attach()
 
     lifecycle.close()
-    val failure = assertFailsWith<MapLifecycleCleanupException> { lifecycle.awaitClosed() }
+    val failure = assertFailsWith<MapCleanupException> { lifecycle.awaitClosed() }
 
     assertEquals(listOf("detach", "engine", "resources"), failure.failures.map { it.message })
     assertIs<MapLifecycleState.Closed>(lifecycle.state)
+  }
+
+  @Test
+  fun cleanup_preserves_a_fatal_error() = runTest {
+    val fatal = FatalLifecycleError()
+    val lifecycle = bindLifecycle(FakeMapLifecycleAdapter().apply { resourcesFailure = fatal })
+
+    lifecycle.close()
+    val reported = assertFailsWith<FatalLifecycleError> { lifecycle.awaitClosed() }
+
+    assertSame(fatal, reported)
   }
 
   @Test
@@ -237,7 +250,7 @@ class MapLifecycleBindingTest {
 
     lifecycle.close()
     adapter.allowDetach.complete(Unit)
-    val failure = assertFailsWith<MapLifecycleCleanupException> { lifecycle.awaitClosed() }
+    val failure = assertFailsWith<MapCleanupException> { lifecycle.awaitClosed() }
 
     assertEquals(listOf("detach"), failure.failures.map { it.message })
     assertTrue(detaching.await().isFailure)
@@ -378,7 +391,62 @@ class MapLifecycleBindingTest {
     assertEquals(MapLifecycleState.OpenDetached(null), lifecycle.state)
     assertEquals(1, adapter.commands.count { it.startsWith("destroy ") })
   }
+
+  @Test
+  fun detached_engine_access_survives_an_interrupted_presentation_attach() = runTest {
+    val adapter = FakeMapLifecycleAdapter().apply { allowAttach = CompletableDeferred() }
+    val lifecycle = bindLifecycle(adapter)
+    val attaching = async { runCatching { lifecycle.attach() } }
+    adapter.attachStarted.await()
+    val attachingState = assertIs<MapLifecycleState.Attaching>(lifecycle.state)
+    val access = async { lifecycle.ensureEngine() }
+    val detaching = async { lifecycle.detach(attachingState.lease) }
+    runCurrent()
+
+    adapter.allowAttach.complete(Unit)
+
+    assertTrue(detaching.await())
+    assertIs<MapLeaseInvalidatedException>(attaching.await().exceptionOrNull())
+    assertEquals(attachingState.engine, access.await())
+    assertEquals(MapLifecycleState.OpenDetached(attachingState.engine), lifecycle.state)
+  }
+
+  @Test
+  fun closing_after_detached_engine_access_starts_cancels_the_access() = runTest {
+    val adapter = FakeMapLifecycleAdapter().apply { allowCreate = CompletableDeferred() }
+    val lifecycle = bindLifecycle(adapter)
+    val access = async { lifecycle.ensureEngine() }
+    adapter.createStarted.await()
+
+    lifecycle.close()
+    adapter.allowCreate.complete(Unit)
+
+    assertFailsWith<CancellationException> { access.await() }
+    lifecycle.awaitClosed()
+  }
+
+  @Test
+  fun closing_during_failed_engine_creation_cancels_with_the_failure_as_cause() = runTest {
+    val failure = TestFailure("create")
+    val adapter =
+      FakeMapLifecycleAdapter().apply {
+        allowCreate = CompletableDeferred()
+        createFailure = failure
+      }
+    val lifecycle = bindLifecycle(adapter)
+    val access = async { lifecycle.ensureEngine() }
+    adapter.createStarted.await()
+
+    lifecycle.close()
+    adapter.allowCreate.complete(Unit)
+
+    val cancellation = assertFailsWith<CancellationException> { access.await() }
+    assertTrue(generateSequence(cancellation as Throwable?) { it.cause }.any { it === failure })
+    lifecycle.awaitClosed()
+  }
 }
+
+private class FatalLifecycleError : Error("fatal lifecycle cleanup failure")
 
 private class FakeMapLifecycleAdapter : MapLifecyclePlatformAdapter {
   val commands = mutableListOf<String>()

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
@@ -19,6 +19,7 @@ import kotlin.test.assertSame
 import kotlin.test.assertTrue
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
@@ -122,7 +123,7 @@ class MapPresentationTest {
     assertEquals(StyleLoadState.Pending, state.style.loadState)
     assertFalse(session.lifecycle.state == MapLifecycleState.Closed)
     finishCleanup.complete(Unit)
-    assertFailsWith<MapLifecycleCleanupException> { session.awaitClosed() }
+    assertFailsWith<MapCleanupException> { session.awaitClosed() }
     testScheduler.runCurrent()
 
     state.durableStyleCallbacks().onMapFailLoading(session, "stale callback")
@@ -134,7 +135,7 @@ class MapPresentationTest {
     assertSame(replacement, state.currentMapAttachment?.adapter)
 
     state.close()
-    val failure = assertFailsWith<MapStateCleanupException> { state.awaitClosed() }
+    val failure = assertFailsWith<MapCleanupException> { state.awaitClosed() }
     assertTrue(
       generateSequence(failure as Throwable) { it.cause }
         .any { it.message.orEmpty().contains("bound session cleanup failed") }
@@ -214,7 +215,7 @@ class MapPresentationTest {
     state.close()
 
     first.finishDetach.complete(Unit)
-    val failure = assertFailsWith<MapStateCleanupException> { state.awaitClosed() }
+    val failure = assertFailsWith<MapCleanupException> { state.awaitClosed() }
     assertTrue(
       generateSequence(failure as Throwable) { it.cause }.any { it.message == "detach failed" }
     )
@@ -243,7 +244,7 @@ class MapPresentationTest {
     state.close()
     finishDetach.complete(Unit)
 
-    val failure = assertFailsWith<MapStateCleanupException> { state.awaitClosed() }
+    val failure = assertFailsWith<MapCleanupException> { state.awaitClosed() }
     assertEquals("Map state cleanup failed in 1 resource(s)", failure.message)
     assertEquals("detach failed", failure.cause?.message)
     runtime.close()
@@ -387,7 +388,7 @@ class MapPresentationTest {
     fixture.state.setCameraPosition(position)
     assertEquals(position, fixture.state.cameraPosition)
     assertEquals(CameraPosition(), fixture.adapter.lastCameraPosition)
-    assertFailsWith<MapNotAttachedException> {
+    assertFailsWith<IllegalStateException> {
       fixture.state.queryRenderedFeatures(DpOffset.Zero)
     }
     val viewportReads = fixture.adapter.viewportReads
@@ -441,7 +442,7 @@ class MapPresentationTest {
     testScheduler.advanceUntilIdle()
 
     state.close()
-    val failure = assertFailsWith<MapStateCleanupException> { state.awaitClosed() }
+    val failure = assertFailsWith<MapCleanupException> { state.awaitClosed() }
     assertTrue(failure.message.orEmpty().contains("cleanup failed"))
     runtime.close()
   }
@@ -1105,7 +1106,7 @@ class MapPresentationTest {
       fixture.adapter.queryStarted.await()
       fixture.state.releasePresentation(fixture.token, fixture.adapter)
 
-      assertFailsWith<MapNotAttachedException> { query.await() }
+      assertFailsWith<CancellationException> { query.await() }
     }
     fixture.close()
   }
@@ -1120,7 +1121,7 @@ class MapPresentationTest {
 
       fixture.state.releasePresentation(fixture.token, fixture.adapter)
 
-      assertFailsWith<MapNotAttachedException> { query.await() }
+      assertFailsWith<CancellationException> { query.await() }
     }
     fixture.close()
   }
@@ -1194,7 +1195,7 @@ class MapPresentationTest {
 
       state.close()
 
-      assertFailsWith<MapStateClosedException> { animation.await() }
+      assertFailsWith<CancellationException> { animation.await() }
     }
     state.awaitClosed()
     runtime.close()

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapRuntimeTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapRuntimeTest.kt
@@ -31,7 +31,7 @@ class MapRuntimeTest {
 
     assertTrue(first.isClosed)
     assertTrue(second.isClosed)
-    assertFailsWith<MapRuntimeClosedException> { runtime.createMapState(BaseStyle.Demo) }
+    assertFailsWith<IllegalStateException> { runtime.createMapState(BaseStyle.Demo) }
     runtime.awaitClosed()
     assertTrue(resourcesClosed)
   }
@@ -121,10 +121,10 @@ class MapRuntimeTest {
 
     runtime.close()
 
-    assertFailsWith<MapRuntimeClosedException> {
+    assertFailsWith<IllegalStateException> {
       runtime.createSnapshotter(BaseStyle.Empty, StyleComposition.Empty)
     }
-    assertFailsWith<MapSnapshotterClosedException> {
+    assertFailsWith<IllegalStateException> {
       snapshotter.capture(MapSnapshotRequest(1, 1))
     }
     runtime.awaitClosed()

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapSnapshotterTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapSnapshotterTest.kt
@@ -524,6 +524,78 @@ class MapSnapshotterTest {
   }
 
   @Test
+  fun standard_exceptions_after_validation_are_snapshot_failures() = runTest {
+    val prepareFailure = UnsupportedOperationException("offscreen renderer initialization failed")
+    val styleFailure = IllegalArgumentException("base style layer not found")
+    val cases =
+      listOf(
+        prepareFailure to
+          runtimeWith(FakeSnapshotterAdapter(prepare = { _, _ -> throw prepareFailure })),
+        styleFailure to
+          runtimeWith(
+            FakeSnapshotterAdapter(),
+            StyleCompositionEvaluator { _, _, _, _, _ -> throw styleFailure },
+          ),
+      )
+
+    cases.forEach { (cause, runtime) ->
+      val snapshotter = runtime.createSnapshotter(BaseStyle.Empty)
+
+      val failure =
+        assertFailsWith<MapSnapshotException> {
+          snapshotter.capture(MapSnapshotRequest(1, 1))
+        }
+
+      assertTrue(generateSequence(failure as Throwable?) { it.cause }.any { it === cause })
+      close(snapshotter, runtime)
+    }
+  }
+
+  @Test
+  fun capture_preserves_platform_unavailability() = runTest {
+    val runtime = mapRuntimeForTest()
+    val snapshotter = runtime.createSnapshotter(BaseStyle.Empty)
+
+    assertFailsWith<UnsupportedOperationException> {
+      snapshotter.capture(MapSnapshotRequest(1, 1))
+    }
+
+    close(snapshotter, runtime)
+  }
+
+  @Test
+  fun capture_does_not_wrap_fatal_errors() = runTest {
+    val cause = FatalSnapshotError()
+    val adapter = FakeSnapshotterAdapter(capture = { _, _ -> throw cause })
+    val runtime = runtimeWith(adapter)
+    val snapshotter = runtime.createSnapshotter(BaseStyle.Empty)
+
+    val failure =
+      assertFailsWith<FatalSnapshotError> {
+        snapshotter.capture(MapSnapshotRequest(1, 1))
+      }
+
+    assertSame(cause, failure)
+    close(snapshotter, runtime)
+  }
+
+  @Test
+  fun style_invalidation_failure_is_reported_without_stalling_close() = runTest {
+    val cause = IllegalStateException("style invalidation failed")
+    val binding = RecordingStyleBinding(onInvalidate = { throw cause })
+    val runtime = runtimeWith(FakeSnapshotterAdapter(prepare = { _, _ -> binding }))
+    val snapshotter = runtime.createSnapshotter(BaseStyle.Empty)
+    snapshotter.capture(MapSnapshotRequest(1, 1))
+
+    snapshotter.close()
+    val reported = assertFailsWith<MapCleanupException> { snapshotter.awaitClosed() }
+
+    assertEquals(listOf(cause), reported.failures)
+    runtime.close()
+    runtime.awaitClosed()
+  }
+
+  @Test
   fun cleanup_failures_do_not_stall_the_queue_and_are_all_reported_on_close() = runTest {
     val firstStarted = CompletableDeferred<Unit>()
     val cleanupFailure = IllegalStateException("terminal cleanup failed")
@@ -550,7 +622,7 @@ class MapSnapshotterTest {
     active.cancelAndJoin()
     assertSame(nextImage, next.await())
     snapshotter.close()
-    val reported = assertFailsWith<MapSnapshotterCleanupException> { snapshotter.awaitClosed() }
+    val reported = assertFailsWith<MapCleanupException> { snapshotter.awaitClosed() }
     assertEquals(2, reported.failures.size)
     assertSame(cleanupFailure, reported.failures[0])
     assertSame(closeFailure, reported.failures[1])
@@ -559,15 +631,24 @@ class MapSnapshotterTest {
   }
 
   @Test
-  fun closure_refuses_new_work_clears_the_queue_and_waits_for_active_cleanup() = runTest {
+  fun closure_cancels_work_before_style_cleanup_and_waits_for_active_cleanup() = runTest {
     supervisorScope {
       val started = CompletableDeferred<Unit>()
       val releaseCleanup = CompletableDeferred<Unit>()
+      var callerCancelled = false
+      var cancelledBeforeInvalidation = false
+      val binding =
+        RecordingStyleBinding(onInvalidate = { cancelledBeforeInvalidation = callerCancelled })
+      var captureCount = 0
       val adapter =
         FakeSnapshotterAdapter(
-          capture = { _, _ ->
-            started.complete(Unit)
-            awaitCancellation()
+          prepare = { _, _ -> binding },
+          capture = { request, _ ->
+            if (captureCount++ == 0) FakeImageBitmap(request.width, request.height)
+            else {
+              started.complete(Unit)
+              awaitCancellation()
+            }
           },
           cancel = {
             releaseCleanup.await()
@@ -576,30 +657,45 @@ class MapSnapshotterTest {
         )
       val runtime = runtimeWith(adapter)
       val snapshotter = runtime.createSnapshotter(BaseStyle.Empty)
-      val active = async { snapshotter.capture(MapSnapshotRequest(1, 1)) }
-      val queued = async { snapshotter.capture(MapSnapshotRequest(2, 2)) }
+      snapshotter.capture(MapSnapshotRequest(1, 1))
+      val active =
+        async(Dispatchers.Unconfined) {
+          try {
+            snapshotter.capture(MapSnapshotRequest(2, 2))
+          } catch (error: CancellationException) {
+            callerCancelled = true
+            throw error
+          }
+        }
+      val queued = async(Dispatchers.Unconfined) { snapshotter.capture(MapSnapshotRequest(3, 3)) }
       started.await()
 
       snapshotter.close()
       val closure = async { snapshotter.awaitClosed() }
 
-      assertFailsWith<MapSnapshotterClosedException> { queued.await() }
-      assertFailsWith<MapSnapshotterClosedException> {
+      assertFailsWith<CancellationException> { queued.await() }
+      assertFailsWith<IllegalStateException> {
         snapshotter.capture(MapSnapshotRequest(3, 3))
       }
       assertFalse(closure.isCompleted)
       releaseCleanup.complete(Unit)
-      assertFailsWith<MapSnapshotterClosedException> { active.await() }
+      assertFailsWith<CancellationException> { active.await() }
       closure.await()
+      assertTrue(cancelledBeforeInvalidation)
       runtime.close()
       runtime.awaitClosed()
     }
   }
 
-  private fun runtimeWith(adapter: SnapshotterAdapter): MapRuntime =
+  private fun runtimeWith(
+    adapter: SnapshotterAdapter,
+    styleEvaluator: StyleCompositionEvaluator = StyleCompositionEvaluator { _, _, _, _, _ ->
+      DesiredStyleRevision.Empty
+    },
+  ): MapRuntime =
     mapRuntimeForTest(
       snapshotterAdapterFactory = SnapshotterAdapterFactory { adapter },
-      styleEvaluator = StyleCompositionEvaluator { _, _, _, _, _ -> DesiredStyleRevision.Empty },
+      styleEvaluator = styleEvaluator,
     )
 
   private suspend fun close(snapshotter: MapSnapshotter, runtime: MapRuntime) {
@@ -615,6 +711,8 @@ class MapSnapshotterTest {
       tiles = listOf("https://example.com/{z}/{x}/{y}.pbf"),
       options = TileSetOptions(attributionHtml = attribution),
     )
+
+  private class FatalSnapshotError : Error("fatal snapshot failure")
 
   private class FakeSnapshotterAdapter(
     private val prepare: suspend (BaseStyle, MapSnapshotRequest) -> StyleBinding = { _, _ ->

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/offline/RuntimeBoundOfflineManagerTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/offline/RuntimeBoundOfflineManagerTest.kt
@@ -7,7 +7,6 @@ import kotlin.test.assertSame
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.test.runTest
 import kotlinx.io.files.Path
-import org.maplibre.compose.map.MapRuntimeClosedException
 import org.maplibre.compose.map.MapRuntimeResources
 import org.maplibre.compose.map.RuntimeImplementation
 import org.maplibre.spatialk.geojson.BoundingBox
@@ -88,17 +87,17 @@ class RuntimeBoundOfflineManagerTest {
 
     runtime.close()
 
-    assertFailsWith<MapRuntimeClosedException> { manager.create(definition) }
-    assertFailsWith<MapRuntimeClosedException> { manager.resume(backend.pack) }
-    assertFailsWith<MapRuntimeClosedException> { manager.pause(backend.pack) }
-    assertFailsWith<MapRuntimeClosedException> { manager.delete(backend.pack) }
-    assertFailsWith<MapRuntimeClosedException> { manager.invalidate(backend.pack) }
-    assertFailsWith<MapRuntimeClosedException> { manager.mergeDatabase(databaseFile) }
-    assertFailsWith<MapRuntimeClosedException> { manager.invalidateAmbientCache() }
-    assertFailsWith<MapRuntimeClosedException> { manager.clearAmbientCache() }
-    assertFailsWith<MapRuntimeClosedException> { manager.setMaximumAmbientCacheSize(1) }
-    assertFailsWith<MapRuntimeClosedException> { retainedPack.setMetadata(byteArrayOf(1)) }
-    assertFailsWith<MapRuntimeClosedException> { createdPack.setMetadata(byteArrayOf(1)) }
+    assertFailsWith<IllegalStateException> { manager.create(definition) }
+    assertFailsWith<IllegalStateException> { manager.resume(backend.pack) }
+    assertFailsWith<IllegalStateException> { manager.pause(backend.pack) }
+    assertFailsWith<IllegalStateException> { manager.delete(backend.pack) }
+    assertFailsWith<IllegalStateException> { manager.invalidate(backend.pack) }
+    assertFailsWith<IllegalStateException> { manager.mergeDatabase(databaseFile) }
+    assertFailsWith<IllegalStateException> { manager.invalidateAmbientCache() }
+    assertFailsWith<IllegalStateException> { manager.clearAmbientCache() }
+    assertFailsWith<IllegalStateException> { manager.setMaximumAmbientCacheSize(1) }
+    assertFailsWith<IllegalStateException> { retainedPack.setMetadata(byteArrayOf(1)) }
+    assertFailsWith<IllegalStateException> { createdPack.setMetadata(byteArrayOf(1)) }
     assertEquals(emptyList(), backend.calls)
 
     releaseCleanup.complete(Unit)

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/resource/MapRequestInterceptorTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/resource/MapRequestInterceptorTest.kt
@@ -2,10 +2,10 @@ package org.maplibre.compose.resource
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlinx.coroutines.test.runTest
-import org.maplibre.compose.map.MapRuntimeClosedException
 import org.maplibre.compose.map.RuntimeImplementation
 import org.maplibre.compose.map.mapRuntimeForTest
 
@@ -62,10 +62,9 @@ class MapRequestInterceptorTest {
     val runtime = mapRuntimeForTest()
     runtime.close()
     runtime.awaitClosed()
-    try {
+    assertFailsWith<IllegalStateException> {
       runtime.setRequestInterceptor(MapRequestInterceptor { MapRequestTransform() })
-      error("expected MapRuntimeClosedException")
-    } catch (_: MapRuntimeClosedException) {}
+    }
   }
 
   @Test

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/style/RecordingStyleBinding.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/style/RecordingStyleBinding.kt
@@ -31,6 +31,8 @@ internal class RecordingStyleBinding(
   override val supportsRasterDemScheme: Boolean = true,
   private val refusedSourceRemovals: Set<String> = emptySet(),
   private val beforeAddImage: ((String) -> Unit)? = null,
+  private val beforeClusterExpansionZoomResult: suspend () -> Unit = {},
+  private val onInvalidate: () -> Unit = {},
 ) : StyleBinding {
 
   override val identity: StyleIdentity = StyleIdentity.create()
@@ -69,7 +71,9 @@ internal class RecordingStyleBinding(
   }
 
   override fun invalidate() {
+    if (!isLoaded) return
     isLoaded = false
+    onInvalidate()
   }
 
   override val logger: Logger? = null
@@ -190,7 +194,10 @@ internal class RecordingStyleBinding(
   override suspend fun clusterExpansionZoom(
     sourceId: String,
     feature: Feature<*, JsonObject?>,
-  ): Double? = null
+  ): Double? {
+    beforeClusterExpansionZoomResult()
+    return null
+  }
 
   override suspend fun clusterChildren(
     sourceId: String,

--- a/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/map/NativeSnapshotRenderTarget.ios.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/map/NativeSnapshotRenderTarget.ios.kt
@@ -35,14 +35,16 @@ private constructor(private var device: MTLDeviceProtocol?) : AutoCloseable {
   }
 
   actual companion object {
-    actual fun create(backends: Set<MapRenderBackend>): NativeSnapshotRenderTarget {
-      check(MapRenderBackend.METAL in backends) {
-        "The packaged MapLibre runtime has no Metal snapshot backend"
+    actual fun select(backends: Set<MapRenderBackend>): NativeSnapshotRenderTargetPlan? =
+      if (MapRenderBackend.METAL in backends) {
+        NativeSnapshotRenderTargetPlan {
+          NativeSnapshotRenderTarget(
+            checkNotNull(MTLCreateSystemDefaultDevice()) { "This device has no Metal GPU" }
+          )
+        }
+      } else {
+        null
       }
-      return NativeSnapshotRenderTarget(
-        checkNotNull(MTLCreateSystemDefaultDevice()) { "This device has no Metal GPU" }
-      )
-    }
   }
 
   private fun MTLDeviceProtocol.rawAddress(): Long = (this as ObjCObject).objcPtr().toLong()

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
@@ -445,10 +445,10 @@ internal class GlJsMapSession(
   internal suspend fun <T> withPlatformMap(block: PlatformMapScope.() -> T): T {
     val engine =
       lifecycle.engineIdentity
-        ?: throw IllegalStateException("The Web platform map changed before access could begin")
+        ?: throw CancellationException("The Web platform map changed before access could begin")
     val lease =
       lifecycle.renderLease
-        ?: throw IllegalStateException("The Web platform map changed before access could begin")
+        ?: throw CancellationException("The Web platform map changed before access could begin")
     return suspendCancellableCoroutine { continuation ->
       val invocation = PlatformMapInvocation(continuation)
       lateinit var action: PendingMapAction
@@ -464,13 +464,13 @@ internal class GlJsMapSession(
                       result = runCatching { PlatformMapScope(map).block() }
                     }
                   if (!authorityAccepted) {
-                    throw IllegalStateException(
+                    throw CancellationException(
                       "The Web platform map changed before access could begin"
                     )
                   }
                 }
               if (!presentationAccepted) {
-                throw IllegalStateException(
+                throw CancellationException(
                   "The Web platform map changed before access could begin"
                 )
               }
@@ -479,7 +479,7 @@ internal class GlJsMapSession(
           },
           abandon = {
             invocation.fail(
-              IllegalStateException("The Web platform map changed before access could begin")
+              CancellationException("The Web platform map changed before access could begin")
             )
           },
         )

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsSnapshotterAdapter.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsSnapshotterAdapter.kt
@@ -57,6 +57,17 @@ private class GlJsSnapshotterAdapter(
   private val reconciler = StyleReconciler()
   private val cleanupFailures = mutableListOf<Throwable>()
 
+  override fun validate(request: MapSnapshotRequest) {
+    val extent = request.extent()
+    val pixelRatio = renderPixelRatio(request)
+    val renderedWidth = (extent.width * pixelRatio).toInt()
+    val renderedHeight = (extent.height * pixelRatio).toInt()
+    require(renderedWidth <= MAX_CANVAS_SIZE && renderedHeight <= MAX_CANVAS_SIZE) {
+      "The Web snapshot needs a ${renderedWidth}x$renderedHeight render canvas, " +
+        "which exceeds MapLibre GL JS's ${MAX_CANVAS_SIZE}px canvas limit"
+    }
+  }
+
   override suspend fun prepare(
     baseStyle: BaseStyle,
     baseStyleRevision: Long,
@@ -166,13 +177,8 @@ private class GlJsSnapshotterAdapter(
   override suspend fun close() {
     if (!open) return
     open = false
-    releaseEngine(MapSnapshotterClosedException())
-    if (cleanupFailures.isNotEmpty()) {
-      throw AggregateCleanupException(
-        "Web snapshotter cleanup failed in ${cleanupFailures.size} resource(s)",
-        cleanupFailures.toList(),
-      )
-    }
+    releaseEngine(snapshotterClosedCancellation())
+    cleanupFailures.cleanupResult("Web snapshotter").getOrThrow()
   }
 
   private suspend fun ensureMap(request: MapSnapshotRequest): MaplibreMap {
@@ -229,13 +235,6 @@ private class GlJsSnapshotterAdapter(
 
   private fun size(container: HTMLElement, request: MapSnapshotRequest) {
     val extent = request.extent()
-    val pixelRatio = renderPixelRatio(request)
-    val renderedWidth = (extent.width * pixelRatio).toInt()
-    val renderedHeight = (extent.height * pixelRatio).toInt()
-    require(renderedWidth <= MAX_CANVAS_SIZE && renderedHeight <= MAX_CANVAS_SIZE) {
-      "The Web snapshot needs a ${renderedWidth}x$renderedHeight render canvas, " +
-        "which exceeds MapLibre GL JS's ${MAX_CANVAS_SIZE}px canvas limit"
-    }
     container.style.width = "${extent.width}px"
     container.style.height = "${extent.height}px"
   }

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserPlatformMapAccessTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserPlatformMapAccessTest.kt
@@ -61,7 +61,7 @@ class BrowserPlatformMapAccessTest {
 
         fixture.detachPresentationForTest()
 
-        val failure = assertFailsWith<IllegalStateException> { access.await() }
+        val failure = assertFailsWith<CancellationException> { access.await() }
         assertEquals("The Web platform map changed before access could begin", failure.message)
       }
       assertFalse(callbackRan)

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/map/NativeSnapshotRenderTarget.desktop.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/map/NativeSnapshotRenderTarget.desktop.kt
@@ -31,22 +31,28 @@ private constructor(private val delegate: Delegate) : AutoCloseable {
   actual override fun close() = delegate.close()
 
   actual companion object {
-    actual fun create(backends: Set<MapRenderBackend>): NativeSnapshotRenderTarget {
-      val os = System.getProperty("os.name").orEmpty().lowercase()
-      val delegate =
-        when {
-          os.contains("mac") && MapRenderBackend.METAL in backends -> MetalDelegate.create()
-          MapRenderBackend.VULKAN in backends ->
-            VulkanDelegate(DesktopVulkanContext.createOffscreen())
-          MapRenderBackend.OPENGL in backends ->
-            OpenGlDelegate(DesktopOpenGlSnapshotContext.create(os))
-          else ->
-            throw UnsupportedOperationException(
-              "No offscreen snapshot backend is available for $os from ${backends.joinToString()}"
-            )
-        }
-      return NativeSnapshotRenderTarget(delegate)
-    }
+    actual fun select(backends: Set<MapRenderBackend>): NativeSnapshotRenderTargetPlan? =
+      select(System.getProperty("os.name").orEmpty().lowercase(), backends)
+
+    internal fun select(
+      os: String,
+      backends: Set<MapRenderBackend>,
+    ): NativeSnapshotRenderTargetPlan? =
+      when {
+        os.contains("mac") && MapRenderBackend.METAL in backends ->
+          NativeSnapshotRenderTargetPlan {
+            NativeSnapshotRenderTarget(MetalDelegate.create())
+          }
+        MapRenderBackend.VULKAN in backends ->
+          NativeSnapshotRenderTargetPlan {
+            NativeSnapshotRenderTarget(VulkanDelegate(DesktopVulkanContext.createOffscreen()))
+          }
+        (os.contains("linux") || os.contains("windows")) && MapRenderBackend.OPENGL in backends ->
+          NativeSnapshotRenderTargetPlan {
+            NativeSnapshotRenderTarget(OpenGlDelegate(DesktopOpenGlSnapshotContext.create(os)))
+          }
+        else -> null
+      }
   }
 
   private interface Delegate : AutoCloseable {

--- a/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/map/NativeSnapshotRenderTargetTest.kt
+++ b/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/map/NativeSnapshotRenderTargetTest.kt
@@ -1,0 +1,18 @@
+package org.maplibre.compose.map
+
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import org.maplibre.compose.mlnffi.MapRenderBackend
+
+class NativeSnapshotRenderTargetTest {
+  @Test
+  fun openGl_is_selected_only_where_an_offscreen_context_provider_exists() {
+    val openGl = setOf(MapRenderBackend.OPENGL)
+
+    assertNotNull(NativeSnapshotRenderTarget.select("linux", openGl))
+    assertNotNull(NativeSnapshotRenderTarget.select("windows", openGl))
+    assertNull(NativeSnapshotRenderTarget.select("mac os x", openGl))
+    assertNull(NativeSnapshotRenderTarget.select("plan 9", openGl))
+  }
+}

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -1634,13 +1634,13 @@ internal class MlnFfiMapSession(
                       result = runCatching { PlatformMapScope(map).block() }
                     }
                   if (!authorityAccepted) {
-                    throw IllegalStateException(
+                    throw CancellationException(
                       "The native platform map changed before access could begin"
                     )
                   }
                 }
               if (!engineAccepted) {
-                throw IllegalStateException(
+                throw CancellationException(
                   "The native platform map changed before access could begin"
                 )
               }
@@ -1649,11 +1649,13 @@ internal class MlnFfiMapSession(
           },
           abandon = {
             invocation.fail(
-              IllegalStateException("The native platform map changed before access could begin")
+              CancellationException("The native platform map changed before access could begin")
             )
           },
         )
-      if (!queued) invocation.fail(MapStateClosedException())
+      if (!queued) {
+        invocation.fail(CancellationException("The map state closed before access could begin"))
+      }
     }
   }
 

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapView.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapView.kt
@@ -139,12 +139,12 @@ internal fun MlnFfiMapView(
         if (state.currentMapAttachment?.adapter !== session) return@LaunchedEffect
       }
       session.publishRetainedStyle()
-    } catch (error: CancellationException) {
-      throw error
     } catch (_: MapClosedException) {
       // A still-mounted UI on a closed map is inert.
     } catch (_: MapLeaseInvalidatedException) {
       // Detach or close won before attach finished.
+    } catch (error: CancellationException) {
+      throw error
     } catch (error: Throwable) {
       callbacks.onMapFailLoading(session, error.message)
     }

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/NativeSnapshotterAdapter.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/NativeSnapshotterAdapter.kt
@@ -40,14 +40,26 @@ private val SNAPSHOT_EVENTS =
 internal class NativeSnapshotterAdapterFactory(
   private val options: MlnFfiRuntimeOptions,
   private val resourceConfig: MapResourceConfig,
+  private val runtimeBackends: () -> Set<MapRenderBackend> = {
+    loadRuntimeBackends(options.logger)
+  },
 ) : SnapshotterAdapterFactory {
-  override fun create(): SnapshotterAdapter = NativeSnapshotterAdapter(options, resourceConfig)
+  override fun create(): SnapshotterAdapter {
+    val backends = runtimeBackends()
+    val targetPlan =
+      NativeSnapshotRenderTarget.select(backends)
+        ?: throw UnsupportedOperationException(
+          "No compatible offscreen snapshot backend is available from ${backends.joinToString()}"
+        )
+    return NativeSnapshotterAdapter(options, resourceConfig, targetPlan)
+  }
 }
 
 /** One private map, offscreen render session, and retained reconciler for a native snapshotter. */
 private class NativeSnapshotterAdapter(
   private val options: MlnFfiRuntimeOptions,
   private val resourceConfig: MapResourceConfig,
+  private val targetPlan: NativeSnapshotRenderTargetPlan,
 ) : SnapshotterAdapter {
   @Volatile private var open = true
   @Volatile private var engine: NativeSnapshotEngine? = null
@@ -143,12 +155,7 @@ private class NativeSnapshotterAdapter(
   }
 
   private fun throwCleanupFailures(failures: List<Throwable>) {
-    if (failures.isNotEmpty()) {
-      throw AggregateCleanupException(
-        "Native snapshotter cleanup failed in ${failures.size} resource(s)",
-        failures,
-      )
-    }
+    failures.cleanupResult("Native snapshotter").getOrThrow()
   }
 
   private suspend fun ensureEngine(request: MapSnapshotRequest) {
@@ -165,7 +172,7 @@ private class NativeSnapshotterAdapter(
       throwCleanupFailures(failures)
     }
     val created = NativeSnapshotOperation(NativeSnapshotOperation.Kind.ENGINE_CREATION)
-    val resources = NativeSnapshotRenderResources(extent, options)
+    val resources = NativeSnapshotRenderResources(extent, targetPlan)
     lateinit var candidate: NativeSnapshotEngine
     val candidateLoop =
       MlnFfiMapRuntimeLoop(
@@ -230,13 +237,13 @@ private class NativeSnapshotterAdapter(
           { resized.completion.complete(Result.success(Unit)) },
           {
             resized.completion.complete(
-              Result.failure(currentLoop.failure ?: MapSnapshotterClosedException())
+              Result.failure(currentLoop.failure ?: snapshotterClosedCancellation())
             )
           },
         )
       ) {
         resized.completion.complete(
-          Result.failure(currentLoop.failure ?: MapSnapshotterClosedException())
+          Result.failure(currentLoop.failure ?: snapshotterClosedCancellation())
         )
       }
     } catch (error: Throwable) {
@@ -372,13 +379,13 @@ private class NativeSnapshotterAdapter(
         },
         abandon = {
           operation.completion.complete(
-            Result.failure(currentLoop.failure ?: MapSnapshotterClosedException())
+            Result.failure(currentLoop.failure ?: snapshotterClosedCancellation())
           )
         },
       )
     ) {
       operation.completion.complete(
-        Result.failure(currentLoop.failure ?: MapSnapshotterClosedException())
+        Result.failure(currentLoop.failure ?: snapshotterClosedCancellation())
       )
     }
   }
@@ -391,7 +398,7 @@ private class NativeSnapshotterAdapter(
         currentEngine.loop.call(
           action = { _ -> currentEngine.resources.withSession { it.renderUpdate() } }
         )
-          ?: throw MapSnapshotterClosedException().also { error ->
+          ?: throw snapshotterClosedCancellation().also { error ->
             operation.complete(Result.failure(error))
           }
       if (update.result == RenderResult.RENDERED) renderedFrame = true
@@ -428,7 +435,7 @@ private class NativeSnapshotEngine(
 /** Offscreen resources that are attached, accessed, and closed only on one map's owner thread. */
 private class NativeSnapshotRenderResources(
   private val extent: MapExtent,
-  private val options: MlnFfiRuntimeOptions,
+  private val targetPlan: NativeSnapshotRenderTargetPlan,
 ) {
   private var target: NativeSnapshotRenderTarget? = null
   private var session: RenderSessionHandle? = null
@@ -436,7 +443,7 @@ private class NativeSnapshotRenderResources(
   fun attach(map: MapHandle) {
     var createdTarget: NativeSnapshotRenderTarget? = null
     try {
-      createdTarget = NativeSnapshotRenderTarget.create(loadRuntimeBackends(options.logger))
+      createdTarget = targetPlan.create()
       val createdSession = createdTarget.attach(map, extent)
       target = createdTarget
       session = createdSession
@@ -483,13 +490,12 @@ private class NativeSnapshotRenderResources(
   }
 
   private fun throwCleanupFailures(failures: List<Throwable>) {
-    if (failures.isNotEmpty()) {
-      throw AggregateCleanupException(
-        "Native snapshotter cleanup failed in ${failures.size} resource(s)",
-        failures,
-      )
-    }
+    failures.cleanupResult("Native snapshotter").getOrThrow()
   }
+}
+
+internal fun interface NativeSnapshotRenderTargetPlan {
+  fun create(): NativeSnapshotRenderTarget
 }
 
 internal expect class NativeSnapshotRenderTarget : AutoCloseable {
@@ -500,6 +506,6 @@ internal expect class NativeSnapshotRenderTarget : AutoCloseable {
   override fun close()
 
   companion object {
-    fun create(backends: Set<MapRenderBackend>): NativeSnapshotRenderTarget
+    fun select(backends: Set<MapRenderBackend>): NativeSnapshotRenderTargetPlan?
   }
 }

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/offline/MlnFfiOfflineManager.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/offline/MlnFfiOfflineManager.kt
@@ -428,18 +428,18 @@ internal class MlnFfiOfflineManager(
   private fun Throwable.toOfflineManagerException(description: String): Throwable =
     when (this) {
       is OfflineManagerException,
-      is CancellationException -> this
+      is CancellationException,
+      is Error -> this
       is MaplibreException -> {
-        // OfflineManagerException carries no cause, so the native detail is logged before it is
-        // flattened into the message.
         logger?.d(this) { "Native failure while trying to $description" }
         val detail = diagnostic.ifBlank { message.orEmpty() }
-        OfflineManagerException("Failed to $description: $detail")
+        OfflineManagerException("Failed to $description: $detail", this)
       }
       else -> {
         logger?.d(this) { "Failure while trying to $description" }
         OfflineManagerException(
-          "Failed to $description: ${message ?: this::class.simpleName.orEmpty()}"
+          "Failed to $description: ${message ?: this::class.simpleName.orEmpty()}",
+          this,
         )
       }
     }

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/offline/MlnFfiOfflineRuntime.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/offline/MlnFfiOfflineRuntime.kt
@@ -171,7 +171,8 @@ internal class MlnFfiOfflineRuntime(
         rejectQueuedTasks(
           OfflineManagerException(
             "The MapLibre offline runtime could not be created: " +
-              (error.message ?: error::class.simpleName)
+              (error.message ?: error::class.simpleName),
+            error,
           )
         )
         return

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/DefaultMapRuntimeTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/DefaultMapRuntimeTest.kt
@@ -30,7 +30,7 @@ class DefaultMapRuntimeTest {
       assertSame(first, second)
       assertFalse(createdReplacement)
       assertTrue(second.isClosed)
-      assertFailsWith<MapRuntimeClosedException> { second.createMapState(BaseStyle.Demo) }
+      assertFailsWith<IllegalStateException> { second.createMapState(BaseStyle.Demo) }
     } finally {
       DefaultMapRuntime.resetForTest()
       FfiTestPlatform.deleteCacheFile(cacheFile)

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/NativeMapSnapshotterTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/NativeMapSnapshotterTest.kt
@@ -4,13 +4,16 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
+import kotlinx.io.files.Path
 import kotlinx.serialization.json.JsonObject
 import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.expressions.dsl.const
 import org.maplibre.compose.layers.CircleLayer
 import org.maplibre.compose.mlnffi.FfiTestPlatform
 import org.maplibre.compose.mlnffi.MlnFfiRuntimeOptions
+import org.maplibre.compose.resource.MapResourceConfig
 import org.maplibre.compose.sources.GeoJsonData
 import org.maplibre.compose.sources.GeoJsonOptions
 import org.maplibre.compose.sources.GeoJsonSource
@@ -26,6 +29,18 @@ import org.maplibre.spatialk.geojson.dsl.addFeature
 import org.maplibre.spatialk.geojson.dsl.buildFeatureCollection
 
 class NativeMapSnapshotterTest {
+
+  @Test
+  fun factory_rejects_a_runtime_without_an_offscreen_backend() {
+    val factory =
+      NativeSnapshotterAdapterFactory(
+        options = MlnFfiRuntimeOptions(cacheFile = Path("unused"), logger = null),
+        resourceConfig = MapResourceConfig(),
+        runtimeBackends = { emptySet() },
+      )
+
+    assertFailsWith<UnsupportedOperationException> { factory.create() }
+  }
 
   @Test
   fun composed_source_and_layer_render_into_an_offscreen_snapshot(): MapTestResult = runMapTest {

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/PlatformMapAccessTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/PlatformMapAccessTest.kt
@@ -80,7 +80,7 @@ class PlatformMapAccessTest {
       state.awaitClosed()
 
       var callbackRan = false
-      assertFailsWith<MapStateClosedException> {
+      assertFailsWith<IllegalStateException> {
         state.withPlatformMap {
           callbackRan = true
           map
@@ -147,7 +147,7 @@ class PlatformMapAccessTest {
         state.publishPresentation(token, replacement)
         releaseOwner.open()
 
-        val failure = assertFailsWith<IllegalStateException> { access.await() }
+        val failure = assertFailsWith<CancellationException> { access.await() }
         assertEquals("The native platform map changed before access could begin", failure.message)
       }
       assertFalse(callbackRan)


### PR DESCRIPTION
## Description

Replace noun-specific lifecycle exceptions with standard rejection and cancellation behavior, add stable snapshot and cleanup failures with preserved causes, and apply the same contract across map, style, snapshotter, offline, and platform access APIs.

## Exception design

Exception types describe why an operation failed, not which map object was involved.

- Reject work with a standard exception when the call is invalid at entry.
- Cancel work when the library accepted it but a lifetime required by that operation ended before completion.
- Use a domain exception for an operational failure that callers may handle, and preserve the original cause.
- Aggregate independent nonfatal cleanup failures. Let fatal errors escape unchanged.

Admission happens once. Native platform-map access depends on the retained engine, so presentation detach and reattach do not cancel it. Web platform-map access depends on the current presentation, so detachment does cancel it.

Snapshot capability selection returns the concrete render-target plan that preparation will execute. There is no separate availability predicate that can disagree with construction.

Future APIs should follow these rules instead of adding another object-specific closed or detached exception.

## Validation

The following pass locally after rebasing onto current main:

- mise run check
- mise run test:android
- mise run test:desktop
- caffeinate -dimsu mise run test:js
- mise run test:ios
- mise run build:docs

## AI assistance

OpenAI Codex desktop with GPT-5 assisted with design, implementation, cleanup, and validation.