### PR TITLE
Simplify the map presentation API

### DIFF
--- a/.agents/docs/COMMON_API_GAPS.md
+++ b/.agents/docs/COMMON_API_GAPS.md
@@ -21,7 +21,7 @@ The sequence they belong to is:
 3. ~~Redesign the public API and internal architecture around that one native
    integration, deciding along the way whether web folds in via Wasm or stays on
    MapLibre GL JS.~~ Done. Web stays on MapLibre GL JS. The public map API is
-   `MapRuntime`, `MapState`, and `MapPresentation`.
+   `MapRuntime` and `MapState`.
 4. Implement the missing common APIs once — twice at most, if web stays separate
    — against that shared integration.
 

--- a/demo-app/common/src/androidMain/kotlin/org/maplibre/compose/docsnippets/Interaction.kt
+++ b/demo-app/common/src/androidMain/kotlin/org/maplibre/compose/docsnippets/Interaction.kt
@@ -6,8 +6,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import kotlinx.coroutines.launch
 import org.maplibre.compose.map.GestureOptions
-import org.maplibre.compose.map.MapPresentationCallbacks
-import org.maplibre.compose.map.MapPresentationOptions
 import org.maplibre.compose.map.MaplibreMap
 import org.maplibre.compose.map.rememberMapState
 import org.maplibre.compose.util.ClickResult
@@ -16,22 +14,17 @@ import org.maplibre.spatialk.geojson.toJson
 @Composable
 fun Interaction() {
   // #region common-gestures
-  MaplibreMap(
-    presentationOptions = MapPresentationOptions(gestureOptions = GestureOptions.Standard)
-  )
+  MaplibreMap(gestureOptions = GestureOptions.Standard)
   // #endregion common-gestures
 
   // #region gesture-settings
   MaplibreMap(
-    presentationOptions =
-      MapPresentationOptions(
-        gestureOptions =
-          GestureOptions(
-            isTwoFingerTiltEnabled = true,
-            isPinchZoomEnabled = true,
-            isTwoFingerRotateEnabled = true,
-            isDragPanEnabled = true,
-          )
+    gestureOptions =
+      GestureOptions(
+        isTwoFingerTiltEnabled = true,
+        isPinchZoomEnabled = true,
+        isTwoFingerRotateEnabled = true,
+        isDragPanEnabled = true,
       )
   )
   // #endregion gesture-settings
@@ -42,22 +35,19 @@ fun Interaction() {
   val scope = rememberCoroutineScope()
   MaplibreMap(
     state = mapState,
-    callbacks =
-      MapPresentationCallbacks(
-        onClick = { pos, offset ->
-          scope.launch {
-            val features = mapState.presentation?.queryRenderedFeatures(offset).orEmpty()
-            if (features.isNotEmpty()) {
-              println("Clicked on ${features[0].toJson()}")
-            }
-          }
-          ClickResult.Pass
-        },
-        onLongClick = { pos, offset ->
-          println("Long click at $pos")
-          ClickResult.Pass
-        },
-      ),
+    onClick = { pos, offset ->
+      scope.launch {
+        val features = mapState.queryRenderedFeatures(offset)
+        if (features.isNotEmpty()) {
+          println("Clicked on ${features[0].toJson()}")
+        }
+      }
+      ClickResult.Pass
+    },
+    onLongClick = { pos, offset ->
+      println("Long click at $pos")
+      ClickResult.Pass
+    },
   )
   // #endregion click-listeners
 }

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoMap.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoMap.kt
@@ -34,9 +34,6 @@ import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.vectorResource
 import org.maplibre.compose.demoapp.generated.Res
 import org.maplibre.compose.demoapp.generated.filter_center_focus_24px
-import org.maplibre.compose.map.MapPresentation
-import org.maplibre.compose.map.MapPresentationCallbacks
-import org.maplibre.compose.map.MapPresentationOptions
 import org.maplibre.compose.map.MapState
 import org.maplibre.compose.map.MaplibreMap
 import org.maplibre.compose.map.StyleLoadState
@@ -53,15 +50,14 @@ val DemoFlightDuration = 2.seconds
 val DemoBoundsPadding = PaddingValues(48.dp)
 
 internal suspend fun MapState.flyTo(destination: DemoDestination) {
-  val currentPresentation = presentation ?: return
   when (destination) {
     is DemoDestination.ExactCamera ->
-      currentPresentation.animateCameraPosition(
+      animateCameraPosition(
         position = destination.position,
         duration = DemoFlightDuration,
       )
     is DemoDestination.FitBounds ->
-      currentPresentation.animateCameraPosition(
+      animateCameraPosition(
         boundingBox = destination.bounds,
         padding = DemoBoundsPadding,
         duration = DemoFlightDuration,
@@ -104,14 +100,11 @@ fun DemoMap(state: DemoAppState, viewportInsets: MapViewportInsets) {
   Box(Modifier.fillMaxSize()) {
     MaplibreMap(
       state = state.mapState,
-      presentationOptions =
-        MapPresentationOptions(
-          cameraPadding = viewportInsets.asPaddingValues(),
-          renderOptions = state.settings.renderOptions,
-          gestureOptions = state.settings.gestureOptions,
-          tileLodOptions = state.settings.tileLodOptions,
-        ),
-      callbacks = MapPresentationCallbacks(onFrame = { state.frameRateState.record() }),
+      cameraPadding = viewportInsets.asPaddingValues(),
+      renderOptions = state.settings.renderOptions,
+      gestureOptions = state.settings.gestureOptions,
+      tileLodOptions = state.settings.tileLodOptions,
+      onFrame = { state.frameRateState.record() },
       contentWindowInsets = viewportInsets.asWindowInsets(),
     ) {
       include(if (state.settings.useMaterial3Controls) MapOverlay.Material3 else MapOverlay.Default)
@@ -135,12 +128,12 @@ fun DemoMap(state: DemoAppState, viewportInsets: MapViewportInsets) {
 
     if (state.settings.showPointerPinDiagnostics && pointerPin != null) {
       PointerPinDestinationOverlay(
-        presentation = state.mapState.presentation,
+        mapState = state.mapState,
         destination = pointerPin.destination,
         modifier = Modifier.fillMaxSize(),
       )
       PointerPinPlacementOverlay(
-        presentation = state.mapState.presentation,
+        mapState = state.mapState,
         target = pointerPin.target,
         placementPadding = placementPadding,
         modifier = Modifier.fillMaxSize(),
@@ -155,17 +148,17 @@ fun DemoMap(state: DemoAppState, viewportInsets: MapViewportInsets) {
 
 @Composable
 private fun PointerPinDestinationOverlay(
-  presentation: MapPresentation?,
+  mapState: MapState,
   destination: DemoDestination,
   modifier: Modifier = Modifier,
 ) {
   // The viewport read recomputes the projection when the camera changes.
-  val viewport = presentation?.viewport
+  val viewport = mapState.viewport
   val projected =
     remember(destination, viewport) {
       when (destination) {
         is DemoDestination.ExactCamera ->
-          presentation?.screenLocationFromPosition(destination.position.target)?.let(::listOf)
+          mapState.screenLocationFromPosition(destination.position.target)?.let(::listOf)
         is DemoDestination.FitBounds -> {
           val bounds = destination.bounds
           listOf(
@@ -174,7 +167,7 @@ private fun PointerPinDestinationOverlay(
               Position(longitude = bounds.east, latitude = bounds.south),
               Position(longitude = bounds.west, latitude = bounds.south),
             )
-            .mapNotNull { presentation?.screenLocationFromPosition(it) }
+            .mapNotNull { mapState.screenLocationFromPosition(it) }
             .takeIf { it.size == 4 }
         }
         DemoDestination.None -> null
@@ -207,13 +200,13 @@ private fun PointerPinDestinationOverlay(
 
 @Composable
 private fun PointerPinPlacementOverlay(
-  presentation: MapPresentation?,
+  mapState: MapState,
   target: Position,
   placementPadding: PaddingValues,
   modifier: Modifier = Modifier,
 ) {
-  val viewport = presentation?.viewport
-  val projected = remember(target, viewport) { presentation?.screenLocationFromPosition(target) }
+  val viewport = mapState.viewport
+  val projected = remember(target, viewport) { mapState.screenLocationFromPosition(target) }
   val layoutDirection = LocalLayoutDirection.current
 
   Canvas(modifier) {

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/agent/AgentDriver.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/agent/AgentDriver.kt
@@ -12,7 +12,6 @@ import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.Serializable
-import org.maplibre.compose.camera.CameraMoveReason
 import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.demoapp.Demo
 import org.maplibre.compose.demoapp.DemoAppState
@@ -21,7 +20,6 @@ import org.maplibre.compose.demoapp.DemoStyle
 import org.maplibre.compose.demoapp.allDemoStyles
 import org.maplibre.compose.demoapp.allDemos
 import org.maplibre.compose.demoapp.flyTo
-import org.maplibre.compose.map.MapPresentation
 import org.maplibre.compose.map.MapState
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.spatialk.geojson.FeatureCollection
@@ -218,7 +216,7 @@ internal class AgentDriver(
   fun jumpCamera(request: CameraUpdateRequest): CameraDto {
     request.validateRanges()
     markDemoMapReload()
-    presentation().setCameraPosition(state.mapState.cameraPosition.merged(request))
+    map().setCameraPosition(state.mapState.cameraPosition.merged(request))
     return camera()
   }
 
@@ -227,7 +225,7 @@ internal class AgentDriver(
     val durationMs = request.durationMs ?: DEFAULT_ANIMATION_MS
     if (durationMs < 0) throw AgentException(400, "'durationMs' must be >= 0, got $durationMs")
     markDemoMapReload()
-    presentation()
+    map()
       .animateCameraPosition(
         position = state.mapState.cameraPosition.merged(request),
         duration = durationMs.milliseconds,
@@ -313,7 +311,7 @@ internal class AgentDriver(
         snapshotFlow {
           state.lastStyleLoad.count > 0 &&
             state.pendingStyleLoad == null &&
-            state.mapState.presentation?.isCameraMoving != true
+            !state.mapState.isCameraMoving
         }
           .first { it }
       }
@@ -329,7 +327,7 @@ internal class AgentDriver(
 
   suspend fun featuresJson(xPx: Float, yPx: Float, layerIds: Set<String>?): String {
     val offset = with(density) { DpOffset(xPx.toDp(), yPx.toDp()) }
-    val features = presentation().queryRenderedFeatures(offset = offset, layerIds = layerIds)
+    val features = map().queryRenderedFeatures(offset = offset, layerIds = layerIds)
     return FeatureCollection(features).toJson()
   }
 
@@ -337,19 +335,18 @@ internal class AgentDriver(
   fun pan(request: PanRequest): CameraDto {
     requireFinite("dxPx", request.dxPx)
     requireFinite("dyPx", request.dyPx)
-    val size =
-      presentation().viewport?.size ?: throw AgentException(503, "the map has no viewport yet")
+    val size = map().viewport?.size ?: throw AgentException(503, "the map has no viewport yet")
     val center = DpOffset(size.width / 2, size.height / 2)
     val moved =
       with(density) { DpOffset(center.x + request.dxPx.toDp(), center.y + request.dyPx.toDp()) }
     // Best effort: a screen point off the map has no position, so report the camera unchanged.
-    val presentation = presentation()
-    val atCenter = presentation.positionFromScreenLocation(center) ?: return camera()
-    val atMoved = presentation.positionFromScreenLocation(moved) ?: return camera()
+    val map = map()
+    val atCenter = map.positionFromScreenLocation(center) ?: return camera()
+    val atMoved = map.positionFromScreenLocation(moved) ?: return camera()
     val current = state.mapState.cameraPosition
     // The projection wraps longitude to ±180; take the short way across the antimeridian.
     val deltaLng = shortLongitudeDelta(from = atMoved.longitude, to = atCenter.longitude)
-    presentation.setCameraPosition(
+    map.setCameraPosition(
       current.copy(
         target =
           Position(
@@ -375,11 +372,11 @@ internal class AgentDriver(
     request.x?.let { requireFinite("x", it) }
     request.y?.let { requireFinite("y", it) }
     val current = state.mapState.cameraPosition
-    val presentation = presentation()
+    val map = map()
     val anchor =
       if (request.x != null && request.y != null) {
         with(density) { DpOffset(request.x.toDp(), request.y.toDp()) }
-          .let(presentation::positionFromScreenLocation)
+          .let(map::positionFromScreenLocation)
       } else {
         null
       }
@@ -395,7 +392,7 @@ internal class AgentDriver(
           latitude = current.target.latitude + (it.latitude - current.target.latitude) * fraction,
         )
       } ?: current.target
-    presentation.setCameraPosition(current.copy(target = target, zoom = newZoom))
+    map.setCameraPosition(current.copy(target = target, zoom = newZoom))
     return camera()
   }
 
@@ -474,13 +471,14 @@ internal class AgentDriver(
           bearing = position.bearing,
           tilt = position.tilt,
         ),
-      isCameraMoving = presentation?.isCameraMoving == true,
-      moveReason = presentation?.cameraMoveReason?.name ?: CameraMoveReason.NONE.name,
+      isCameraMoving = isCameraMoving,
+      moveReason = cameraMoveReason.name,
     )
   }
 
-  private fun presentation(): MapPresentation =
-    state.mapState.presentation ?: throw AgentException(503, "the map has no presentation")
+  private fun map(): MapState =
+    state.mapState.takeIf { it.viewport != null }
+      ?: throw AgentException(503, "the map has no viewport")
 
   private fun Demo.toDto() =
     DemoDto(name = name, description = description, preferredStyle = preferredStyle?.displayName)

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/agent/AgentDriver.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/agent/AgentDriver.kt
@@ -20,6 +20,7 @@ import org.maplibre.compose.demoapp.DemoStyle
 import org.maplibre.compose.demoapp.allDemoStyles
 import org.maplibre.compose.demoapp.allDemos
 import org.maplibre.compose.demoapp.flyTo
+import org.maplibre.compose.map.MapNotAttachedException
 import org.maplibre.compose.map.MapState
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.spatialk.geojson.FeatureCollection
@@ -216,7 +217,7 @@ internal class AgentDriver(
   fun jumpCamera(request: CameraUpdateRequest): CameraDto {
     request.validateRanges()
     markDemoMapReload()
-    map().setCameraPosition(state.mapState.cameraPosition.merged(request))
+    state.mapState.setCameraPosition(state.mapState.cameraPosition.merged(request))
     return camera()
   }
 
@@ -225,11 +226,10 @@ internal class AgentDriver(
     val durationMs = request.durationMs ?: DEFAULT_ANIMATION_MS
     if (durationMs < 0) throw AgentException(400, "'durationMs' must be >= 0, got $durationMs")
     markDemoMapReload()
-    map()
-      .animateCameraPosition(
-        position = state.mapState.cameraPosition.merged(request),
-        duration = durationMs.milliseconds,
-      )
+    state.mapState.animateCameraPosition(
+      position = state.mapState.cameraPosition.merged(request),
+      duration = durationMs.milliseconds,
+    )
     return camera()
   }
 
@@ -327,7 +327,12 @@ internal class AgentDriver(
 
   suspend fun featuresJson(xPx: Float, yPx: Float, layerIds: Set<String>?): String {
     val offset = with(density) { DpOffset(xPx.toDp(), yPx.toDp()) }
-    val features = map().queryRenderedFeatures(offset = offset, layerIds = layerIds)
+    val features =
+      try {
+        state.mapState.queryRenderedFeatures(offset = offset, layerIds = layerIds)
+      } catch (_: MapNotAttachedException) {
+        throw AgentException(503, "the map has no viewport")
+      }
     return FeatureCollection(features).toJson()
   }
 
@@ -335,12 +340,12 @@ internal class AgentDriver(
   fun pan(request: PanRequest): CameraDto {
     requireFinite("dxPx", request.dxPx)
     requireFinite("dyPx", request.dyPx)
-    val size = map().viewport?.size ?: throw AgentException(503, "the map has no viewport yet")
+    val map = state.mapState
+    val size = map.viewport?.size ?: throw AgentException(503, "the map has no viewport yet")
     val center = DpOffset(size.width / 2, size.height / 2)
     val moved =
       with(density) { DpOffset(center.x + request.dxPx.toDp(), center.y + request.dyPx.toDp()) }
     // Best effort: a screen point off the map has no position, so report the camera unchanged.
-    val map = map()
     val atCenter = map.positionFromScreenLocation(center) ?: return camera()
     val atMoved = map.positionFromScreenLocation(moved) ?: return camera()
     val current = state.mapState.cameraPosition
@@ -372,7 +377,7 @@ internal class AgentDriver(
     request.x?.let { requireFinite("x", it) }
     request.y?.let { requireFinite("y", it) }
     val current = state.mapState.cameraPosition
-    val map = map()
+    val map = state.mapState
     val anchor =
       if (request.x != null && request.y != null) {
         with(density) { DpOffset(request.x.toDp(), request.y.toDp()) }
@@ -475,10 +480,6 @@ internal class AgentDriver(
       moveReason = cameraMoveReason.name,
     )
   }
-
-  private fun map(): MapState =
-    state.mapState.takeIf { it.viewport != null }
-      ?: throw AgentException(503, "the map has no viewport")
 
   private fun Demo.toDto() =
     DemoDto(name = name, description = description, preferredStyle = preferredStyle?.displayName)

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/benchmark/BenchmarkMap.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/benchmark/BenchmarkMap.kt
@@ -34,8 +34,6 @@ import kotlinx.coroutines.launch
 import org.maplibre.compose.demoapp.DemoAppState
 import org.maplibre.compose.demoapp.MapViewportInsets
 import org.maplibre.compose.map.GestureOptions
-import org.maplibre.compose.map.MapPresentationCallbacks
-import org.maplibre.compose.map.MapPresentationOptions
 import org.maplibre.compose.map.MapState
 import org.maplibre.compose.map.MaplibreMap
 import org.maplibre.compose.map.RenderOptions
@@ -81,11 +79,11 @@ internal fun BenchmarkMap(state: DemoAppState, viewportInsets: MapViewportInsets
     }
   }
   val styleUrl = (scenario.style.base as BaseStyle.Uri).uri
-  val presentation = mapState.presentation
-  LaunchedEffect(scenario.id, presentation) {
-    val currentPresentation = presentation ?: return@LaunchedEffect
+  val viewport = mapState.viewport
+  LaunchedEffect(scenario.id, viewport) {
+    if (viewport == null) return@LaunchedEffect
     state.benchmark.abandonRun()
-    currentPresentation.setCameraPosition(scenario.camera)
+    mapState.setCameraPosition(scenario.camera)
     session.geoJson = null
     session.pin = null
     session.pointerPx = null
@@ -103,7 +101,7 @@ internal fun BenchmarkMap(state: DemoAppState, viewportInsets: MapViewportInsets
     try {
       ui.status = "Waiting for the map"
       mapLoaded.await()
-      requireNotNull(mapState.presentation).setCameraPosition(running.camera)
+      mapState.setCameraPosition(running.camera)
       ui.status = "Prefetching tiles"
       prefetcher.ensurePacked(
         scenarioId = running.id,
@@ -184,7 +182,7 @@ internal fun BenchmarkMap(state: DemoAppState, viewportInsets: MapViewportInsets
             }
             if (change.pressed && session.pin == null && scenario.usesGestures) {
               session.pin =
-                mapState.presentation?.positionFromScreenLocation(
+                mapState.positionFromScreenLocation(
                   with(density) { DpOffset(change.position.x.toDp(), change.position.y.toDp()) }
                 )
             }
@@ -203,14 +201,11 @@ internal fun BenchmarkMap(state: DemoAppState, viewportInsets: MapViewportInsets
     key(scenario.id) {
       MaplibreMap(
         state = mapState,
-        presentationOptions =
-          MapPresentationOptions(
-            cameraPadding = viewportInsets.asPaddingValues(),
-            renderOptions = RenderOptions.Standard,
-            gestureOptions =
-              if (scenario.usesGestures) GestureOptions.Standard else GestureOptions.AllDisabled,
-          ),
-        callbacks = MapPresentationCallbacks(onFrame = { fps -> session.frames.recordMapFps(fps) }),
+        cameraPadding = viewportInsets.asPaddingValues(),
+        renderOptions = RenderOptions.Standard,
+        gestureOptions =
+          if (scenario.usesGestures) GestureOptions.Standard else GestureOptions.AllDisabled,
+        onFrame = { fps -> session.frames.recordMapFps(fps) },
         contentWindowInsets = viewportInsets.asWindowInsets(),
       ) {}
     }
@@ -238,7 +233,7 @@ internal fun BenchmarkMap(state: DemoAppState, viewportInsets: MapViewportInsets
 
 private fun samplePin(mapState: MapState, session: BenchmarkSession) {
   val pin = session.pin ?: return
-  val projected = mapState.presentation?.screenLocationFromPosition(pin) ?: return
+  val projected = mapState.screenLocationFromPosition(pin) ?: return
   val px = with(session.density) { Offset(projected.x.toPx(), projected.y.toPx()) }
   session.gestures.onMapProjection(px.x.toDouble(), px.y.toDouble())
 }
@@ -249,7 +244,7 @@ private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawTrail(
 ) {
   val composePoint = session.pointerPx
   val pin = session.pin
-  val projected = pin?.let { mapState.presentation?.screenLocationFromPosition(it) }
+  val projected = pin?.let { mapState.screenLocationFromPosition(it) }
   val mapPoint = projected?.let { with(session.density) { Offset(it.x.toPx(), it.y.toPx()) } }
   if (composePoint != null) {
     val arm = 12.dp.toPx()

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/benchmark/BenchmarkMap.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/benchmark/BenchmarkMap.kt
@@ -79,9 +79,7 @@ internal fun BenchmarkMap(state: DemoAppState, viewportInsets: MapViewportInsets
     }
   }
   val styleUrl = (scenario.style.base as BaseStyle.Uri).uri
-  val viewport = mapState.viewport
-  LaunchedEffect(scenario.id, viewport) {
-    if (viewport == null) return@LaunchedEffect
+  LaunchedEffect(scenario.id, mapState) {
     state.benchmark.abandonRun()
     mapState.setCameraPosition(scenario.camera)
     session.geoJson = null

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/benchmark/CameraPlayback.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/benchmark/CameraPlayback.kt
@@ -18,11 +18,11 @@ internal suspend fun playCamera(
 ) {
   val start = TimeSource.Monotonic.markNow()
   val durationNs = duration.inWholeNanoseconds.toDouble().coerceAtLeast(1.0)
-  mapState.presentation?.setCameraPosition(from)
+  mapState.setCameraPosition(from)
   while (true) {
     val elapsedNs = start.elapsedNow().inWholeNanoseconds.toDouble()
     val t = (elapsedNs / durationNs).coerceIn(0.0, 1.0)
-    mapState.presentation?.setCameraPosition(lerp(from, to, t))
+    mapState.setCameraPosition(lerp(from, to, t))
     if (t >= 1.0) break
     withFrameNanos {}
   }

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/benchmark/FlyAroundScenario.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/benchmark/FlyAroundScenario.kt
@@ -20,7 +20,7 @@ internal object FlyAroundScenario : BenchmarkScenario {
     val durationNs = Duration.inWholeNanoseconds.toDouble()
     while (true) {
       val t = (start.elapsedNow().inWholeNanoseconds.toDouble() / durationNs).coerceIn(0.0, 1.0)
-      mapState.presentation?.setCameraPosition(
+      mapState.setCameraPosition(
         CameraPosition(
           target = orbitPosition(BenchmarkCenter, RadiusLon, RadiusLat, t),
           zoom = OrbitZoom,

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/benchmark/ZoomPumpScenario.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/benchmark/ZoomPumpScenario.kt
@@ -16,7 +16,7 @@ internal object ZoomPumpScenario : BenchmarkScenario {
   override suspend fun run(mapState: MapState, session: BenchmarkSession) {
     val wide = CameraPosition(target = BenchmarkCenter, zoom = WideZoom)
     val tight = CameraPosition(target = BenchmarkCenter, zoom = TightZoom)
-    mapState.presentation?.setCameraPosition(wide)
+    mapState.setCameraPosition(wide)
     repeat(Cycles) {
       playCamera(mapState, wide, tight, HalfCycle)
       playCamera(mapState, tight, wide, HalfCycle)

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/DragDropDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/DragDropDemo.kt
@@ -32,7 +32,6 @@ import org.maplibre.compose.demoapp.design.SegmentedRow
 import org.maplibre.compose.expressions.dsl.const
 import org.maplibre.compose.layers.FillLayer
 import org.maplibre.compose.layers.LineLayer
-import org.maplibre.compose.map.MapPresentation
 import org.maplibre.compose.map.MapState
 import org.maplibre.compose.overlay.MapOverlayScope
 import org.maplibre.compose.sources.GeoJsonData
@@ -73,21 +72,21 @@ object DragDropDemo : Demo {
    * Moves the overlay child with the pointer. The screen offset of [position] is captured on drag
    * start and pointer deltas are accumulated onto it, so the child never has to be read back while
    * it moves under the pointer. Pointer events report pixels, so the anchor captured from
-   * [MapPresentation.screenLocationFromPosition] is scaled up before the px-based projection
-   * receives the sum.
+   * [MapState.screenLocationFromPosition] is scaled up before the px-based projection receives the
+   * sum.
    */
   private fun Modifier.draggablePosition(
-    presentation: MapPresentation?,
+    mapState: MapState,
     position: () -> Position,
     onDrag: (Position) -> Unit,
   ): Modifier =
-    pointerInput(presentation) {
+    pointerInput(mapState) {
       var start: Offset? = null
       var accumulated = Offset.Zero
       detectDragGestures(
         onDragStart = {
           start =
-            presentation?.screenLocationFromPosition(position())?.let {
+            mapState.screenLocationFromPosition(position())?.let {
               Offset(it.x.toPx(), it.y.toPx())
             }
           accumulated = Offset.Zero
@@ -97,8 +96,8 @@ object DragDropDemo : Demo {
             val startOffset = start ?: return@onDrag
             accumulated += dragAmount
             val screen = startOffset + accumulated
-            presentation
-              ?.positionFromScreenLocation(DpOffset(screen.x.toDp(), screen.y.toDp()))
+            mapState
+              .positionFromScreenLocation(DpOffset(screen.x.toDp(), screen.y.toDp()))
               ?.let(onDrag)
           },
       )
@@ -153,7 +152,7 @@ object DragDropDemo : Demo {
       Mode.Pin ->
         Pin(
           Modifier.placedAt(pinPosition, Alignment.BottomCenter).draggablePosition(
-            presentation,
+            mapState,
             { pinPosition },
           ) {
             pinPosition = it
@@ -161,12 +160,12 @@ object DragDropDemo : Demo {
         )
       Mode.BoundingBox -> {
         Handle(
-          Modifier.placedAt(northwest).draggablePosition(presentation, { northwest }) {
+          Modifier.placedAt(northwest).draggablePosition(mapState, { northwest }) {
             northwest = it
           }
         )
         Handle(
-          Modifier.placedAt(southeast).draggablePosition(presentation, { southeast }) {
+          Modifier.placedAt(southeast).draggablePosition(mapState, { southeast }) {
             southeast = it
           }
         )

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/LiveTrackingDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/LiveTrackingDemo.kt
@@ -111,9 +111,8 @@ object LiveTrackingDemo : Demo {
 
   @Composable
   override fun MapContent(mapState: MapState) {
-    val presentation = mapState.presentation
-    LaunchedEffect(presentation?.cameraMoveReason) {
-      if (presentation?.cameraMoveReason == CameraMoveReason.GESTURE) {
+    LaunchedEffect(mapState.cameraMoveReason) {
+      if (mapState.cameraMoveReason == CameraMoveReason.GESTURE) {
         followVehicle = false
       }
     }
@@ -128,7 +127,7 @@ object LiveTrackingDemo : Demo {
           vehiclePosition = positionAt(routeLength - abs(phase - routeLength))
         }
         if (followVehicle) {
-          presentation?.setCameraPosition(mapState.cameraPosition.copy(target = vehiclePosition))
+          mapState.setCameraPosition(mapState.cameraPosition.copy(target = vehiclePosition))
         }
       }
     }

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/LocationDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/LocationDemo.kt
@@ -64,7 +64,6 @@ object LocationDemo : Demo {
 
   @Composable
   override fun MapContent(mapState: MapState) {
-    val presentation = mapState.presentation
     val locationProvider = engine.rememberLocationProvider()
     val locationState =
       rememberLocationState(
@@ -83,9 +82,9 @@ object LocationDemo : Demo {
     }
     LaunchedEffect(locationState) { locationState.requestPermission() }
 
-    LaunchedEffect(presentation) {
-      var previous = presentation?.cameraMoveReason ?: CameraMoveReason.NONE
-      snapshotFlow { presentation?.cameraMoveReason ?: CameraMoveReason.NONE }
+    LaunchedEffect(mapState) {
+      var previous = mapState.cameraMoveReason
+      snapshotFlow { mapState.cameraMoveReason }
         .collect { reason ->
           // Follow moves the camera programmatically; a pan is the GESTURE that interrupts it.
           if (previous != CameraMoveReason.GESTURE && reason == CameraMoveReason.GESTURE) {
@@ -100,12 +99,12 @@ object LocationDemo : Demo {
 
     LocationTrackingEffect(locationState = locationState, enabled = follow) {
       if (previousLocation == null) {
-        presentation?.animateCameraPosition(
+        mapState.animateCameraPosition(
           CameraPosition(target = currentLocation.position, zoom = 16.0),
           duration = DemoFlightDuration,
         )
       } else {
-        presentation?.let { updateCamera(mapState, it) }
+        updateCamera(mapState)
       }
     }
 

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/MagnifyingLensDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/MagnifyingLensDemo.kt
@@ -48,7 +48,6 @@ import org.maplibre.compose.demoapp.design.SegmentedRow
 import org.maplibre.compose.demoapp.design.SliderRow
 import org.maplibre.compose.demoapp.design.SwitchRow
 import org.maplibre.compose.map.GestureOptions
-import org.maplibre.compose.map.MapPresentationOptions
 import org.maplibre.compose.map.MaplibreMap
 import org.maplibre.compose.map.RenderOptions
 import org.maplibre.compose.map.rememberMapState
@@ -127,13 +126,13 @@ object MagnifyingLensDemo : Demo {
         val position = mapState.cameraPosition
         val target =
           currentLensCenter?.let {
-            presentation?.positionFromScreenLocation(
+            mapState.positionFromScreenLocation(
               with(density) { DpOffset(it.x.toDp(), it.y.toDp()) }
             )
           } ?: position.target
         position.copy(target = target, zoom = position.zoom + magnification)
       }
-        .collect { lensState.presentation?.setCameraPosition(it) }
+        .collect { lensState.setCameraPosition(it) }
     }
 
     Box(
@@ -163,11 +162,8 @@ object MagnifyingLensDemo : Demo {
             Modifier.fillMaxSize()
           },
         state = lensState,
-        presentationOptions =
-          MapPresentationOptions(
-            renderOptions = lensRenderOptions,
-            gestureOptions = GestureOptions.AllDisabled,
-          ),
+        renderOptions = lensRenderOptions,
+        gestureOptions = GestureOptions.AllDisabled,
         contentWindowInsets = WindowInsets(0),
       ) {}
       Box(

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/TransitNetworkDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/TransitNetworkDemo.kt
@@ -362,9 +362,8 @@ object TransitNetworkDemo : Demo {
     val network = (feedState as? FeedState.Loaded)?.network ?: return
     val selected = selectedRouteId
 
-    LaunchedEffect(selected, mapState.viewport) {
+    LaunchedEffect(selected, mapState) {
       val route = network.routes.find { it.id == selected } ?: return@LaunchedEffect
-      if (mapState.viewport == null) return@LaunchedEffect
       mapState.animateCameraPosition(
         boundingBox = route.bounds,
         padding = RouteFitPadding,

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/TransitNetworkDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/TransitNetworkDemo.kt
@@ -361,11 +361,11 @@ object TransitNetworkDemo : Demo {
   override fun MapContent(mapState: MapState) {
     val network = (feedState as? FeedState.Loaded)?.network ?: return
     val selected = selectedRouteId
-    val presentation = mapState.presentation
 
-    LaunchedEffect(selected, presentation) {
+    LaunchedEffect(selected, mapState.viewport) {
       val route = network.routes.find { it.id == selected } ?: return@LaunchedEffect
-      presentation?.animateCameraPosition(
+      if (mapState.viewport == null) return@LaunchedEffect
+      mapState.animateCameraPosition(
         boundingBox = route.bounds,
         padding = RouteFitPadding,
         duration = 1.seconds,

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Camera.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Camera.kt
@@ -28,7 +28,6 @@ fun Camera() {
 
   // #region animate
   LaunchedEffect(mapState) {
-    mapState.awaitViewport()
     mapState.animateCameraPosition(
       position =
         mapState.cameraPosition.copy(target = Position(latitude = 47.607, longitude = -122.342)),
@@ -39,7 +38,6 @@ fun Camera() {
 
   // #region fit-bounds
   LaunchedEffect(mapState) {
-    mapState.awaitViewport()
     mapState.animateCameraPosition(
       boundingBox = BoundingBox(west = -123.0, south = 47.0, east = -122.0, north = 48.0),
       padding = PaddingValues(32.dp),

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Camera.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Camera.kt
@@ -23,13 +23,13 @@ fun Camera() {
       initialCameraPosition =
         CameraPosition(target = Position(latitude = 45.521, longitude = -122.675), zoom = 13.0)
     )
-  MaplibreMap(mapState)
+  MaplibreMap(state = mapState)
   // #endregion first-position
 
   // #region animate
-  val presentation = mapState.presentation
-  LaunchedEffect(presentation) {
-    presentation?.animateCameraPosition(
+  LaunchedEffect(mapState) {
+    mapState.awaitViewport()
+    mapState.animateCameraPosition(
       position =
         mapState.cameraPosition.copy(target = Position(latitude = 47.607, longitude = -122.342)),
       duration = 3.seconds,
@@ -38,8 +38,9 @@ fun Camera() {
   // #endregion animate
 
   // #region fit-bounds
-  LaunchedEffect(presentation) {
-    presentation?.animateCameraPosition(
+  LaunchedEffect(mapState) {
+    mapState.awaitViewport()
+    mapState.animateCameraPosition(
       boundingBox = BoundingBox(west = -123.0, south = 47.0, east = -122.0, north = 48.0),
       padding = PaddingValues(32.dp),
     )
@@ -47,16 +48,14 @@ fun Camera() {
   // #endregion fit-bounds
 
   // #region viewport
-  val viewport = presentation?.viewport
+  val viewport = mapState.viewport
   if (viewport != null) {
     Text("Visible bounds: ${viewport.visibleBoundingBox}")
   }
   // #endregion viewport
 
   // #region convert
-  presentation?.let {
-    val screenOffset = it.screenLocationFromPosition(mapState.cameraPosition.target)
-    val geoPosition = it.positionFromScreenLocation(DpOffset(x = 100.dp, y = 150.dp))
-  }
+  val screenOffset = mapState.screenLocationFromPosition(mapState.cameraPosition.target)
+  val geoPosition = mapState.positionFromScreenLocation(DpOffset(x = 100.dp, y = 150.dp))
   // #endregion convert
 }

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Composition.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Composition.kt
@@ -19,6 +19,6 @@ fun Composition() {
     ) {
       // Sources and layers declared here are added to the base style.
     }
-  MaplibreMap(state)
+  MaplibreMap(state = state)
   // #endregion base-plus-content
 }

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Controls.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Controls.kt
@@ -13,7 +13,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.unit.dp
-import org.maplibre.compose.map.MapPresentationOptions
 import org.maplibre.compose.map.MaplibreMap
 import org.maplibre.compose.overlay.ExpandingAttributionButton
 import org.maplibre.compose.overlay.MapOverlay
@@ -46,7 +45,7 @@ fun Controls() {
   val mapInsets = WindowInsets.safeDrawing.union(WindowInsets(bottom = 128.dp))
   MaplibreMap(
     contentWindowInsets = mapInsets, // (1)!
-    presentationOptions = MapPresentationOptions(cameraPadding = mapInsets.asPaddingValues()),
+    cameraPadding = mapInsets.asPaddingValues(),
   )
   // #endregion insets
 }

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Expressions.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Expressions.kt
@@ -79,5 +79,5 @@ fun Expressions() {
     )
     // #endregion filter
   }
-  MaplibreMap(state)
+  MaplibreMap(state = state)
 }

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Images.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Images.kt
@@ -40,7 +40,7 @@ fun Images() {
     SymbolLayer(id = "station-markers", source = stations, iconImage = image("marker"))
     // #endregion icon-sprite
   }
-  MaplibreMap(iconState)
+  MaplibreMap(state = iconState)
 
   val imageState = rememberMapState {
     // #region image-source
@@ -55,5 +55,5 @@ fun Images() {
     RasterLayer(id = "castello-plan", source = plan, opacity = const(0.8f))
     // #endregion image-source
   }
-  MaplibreMap(imageState)
+  MaplibreMap(state = imageState)
 }

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Layers.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Layers.kt
@@ -35,7 +35,7 @@ fun Layers() {
         CircleLayer(id = "example", source = tiles, sourceLayer = "poi")
       }
     }
-  MaplibreMap(baseState)
+  MaplibreMap(state = baseState)
   // #endregion simple
 
   val amtrakState = rememberMapState {
@@ -101,5 +101,5 @@ fun Layers() {
     )
     // #endregion interaction
   }
-  MaplibreMap(amtrakState)
+  MaplibreMap(state = amtrakState)
 }

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Location.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Location.kt
@@ -35,11 +35,9 @@ fun Location() {
     )
 
     LocationTrackingEffect(locationState = locationState) {
-      mapState.presentation?.animateCameraPosition(
-        CameraPosition(target = currentLocation.position, zoom = 15.0)
-      )
+      mapState.animateCameraPosition(CameraPosition(target = currentLocation.position, zoom = 15.0))
     }
   }
-  MaplibreMap(mapState)
+  MaplibreMap(state = mapState)
   // #endregion puck
 }

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Material3.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Material3.kt
@@ -23,7 +23,7 @@ fun Material3() {
   // #region controls
   MaplibreMap {
     ScaleBar(
-      presentation?.viewport?.metersPerDpAtTarget ?: 0.0,
+      mapState.viewport?.metersPerDpAtTarget ?: 0.0,
       modifier = Modifier.align(Alignment.TopStart),
     ) // (1)!
     CompassButton(modifier = Modifier.align(Alignment.TopEnd))

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Requests.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Requests.kt
@@ -24,7 +24,7 @@ fun InterceptorMap(token: String) {
     }
     onDispose { runtime.setRequestInterceptor(null) }
   }
-  MaplibreMap(rememberMapState(runtime))
+  MaplibreMap(state = rememberMapState(runtime))
   // #endregion interceptor
 }
 

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Styling.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Styling.kt
@@ -16,7 +16,7 @@ fun Styling() {
   // #region simple
   val simple =
     rememberMapState(baseStyle = BaseStyle.Uri("https://tiles.openfreemap.org/styles/liberty"))
-  MaplibreMap(simple)
+  MaplibreMap(state = simple)
   // #endregion simple
 
   // #region dynamic
@@ -25,11 +25,11 @@ fun Styling() {
     rememberMapState(
       baseStyle = BaseStyle.Uri("https://api.protomaps.com/styles/v4/$variant/en.json?key=MY_KEY")
     )
-  MaplibreMap(dynamic)
+  MaplibreMap(state = dynamic)
   // #endregion dynamic
 
   // #region local
   val local = rememberMapState(baseStyle = BaseStyle.Uri(Res.getUri("files/style.json")))
-  MaplibreMap(local)
+  MaplibreMap(state = local)
   // #endregion local
 }

--- a/demo-app/common/src/jsMain/kotlin/org/maplibre/compose/demoapp/benchmark/TilePrefetch.kt
+++ b/demo-app/common/src/jsMain/kotlin/org/maplibre/compose/demoapp/benchmark/TilePrefetch.kt
@@ -34,11 +34,9 @@ private class HttpWarmupPrefetcher : TilePrefetcher {
       )
     for (zoom in minZoom..maxZoom) {
       onStatus("Warming zoom $zoom")
-      camera.presentation?.setCameraPosition(
-        CameraPosition(target = center, zoom = zoom.toDouble())
-      )
+      camera.setCameraPosition(CameraPosition(target = center, zoom = zoom.toDouble()))
       delay(350.milliseconds)
     }
-    camera.presentation?.setCameraPosition(origin)
+    camera.setCameraPosition(origin)
   }
 }

--- a/docs/src/content/docs/camera.mdx
+++ b/docs/src/content/docs/camera.mdx
@@ -18,14 +18,15 @@ initial <Api of="CameraPosition" /> to set the camera at startup:
 
 ## Animate the camera
 
-<Api of="MapPresentation.animateCameraPosition" /> is a suspend function that
-moves the current presentation to a new position over a duration. Call it from
-a coroutine after `MapState.presentation` becomes available:
+<Api of="MapState.animateCameraPosition" /> is a suspend function that moves
+the map to a new position over a duration. Call it from a coroutine after
+<Api of="MapState.awaitViewport" /> confirms that the map is attached:
 
 <Code code={region(camera, "animate")} lang="kotlin" title="App.kt" />
 
-Use <Api of="MapPresentation.setCameraPosition" /> to move without an
-animation.
+Use <Api of="MapState.setCameraPosition" /> to move without an animation. The
+position is durable: if the map is not attached, the next map surface starts
+there.
 
 ## Fit a bounding box
 
@@ -39,7 +40,7 @@ animation.
 
 ## Read the visible area
 
-<Api of="MapPresentation.viewport" /> reports the current rendered size,
+<Api of="MapState.viewport" /> reports the current rendered size,
 visible bounding box, and visible region. It is null until the map renders its
 first viewport. A composition that reads it recomposes when the camera moves or
 the map resizes:
@@ -48,9 +49,9 @@ the map resizes:
 
 ## Convert between screen and geographic coordinates
 
-<Api of="MapPresentation.screenLocationFromPosition" /> converts a geographic
+<Api of="MapState.screenLocationFromPosition" /> converts a geographic
 position to an offset from the top-left corner of the map composable.
-<Api of="MapPresentation.positionFromScreenLocation" /> converts in the other
+<Api of="MapState.positionFromScreenLocation" /> converts in the other
 direction:
 
 <Code code={region(camera, "convert")} lang="kotlin" title="App.kt" />

--- a/docs/src/content/docs/camera.mdx
+++ b/docs/src/content/docs/camera.mdx
@@ -19,8 +19,8 @@ initial <Api of="CameraPosition" /> to set the camera at startup:
 ## Animate the camera
 
 <Api of="MapState.animateCameraPosition" /> is a suspend function that moves
-the map to a new position over a duration. Call it from a coroutine after
-<Api of="MapState.awaitViewport" /> confirms that the map is attached:
+the map to a new position over a duration. Call it from a coroutine. The
+function waits until the map is attached:
 
 <Code code={region(camera, "animate")} lang="kotlin" title="App.kt" />
 

--- a/docs/src/content/docs/composition.mdx
+++ b/docs/src/content/docs/composition.mdx
@@ -11,8 +11,8 @@ import composition from "../../../../demo-app/common/src/commonMain/kotlin/org/m
 
 MapLibre Compose has no public map view object. <Api of="MapState" /> defines a
 logical map, including its base style and declarative style content.
-<Api of="MaplibreMap" /> presents that state and provides viewport-bound
-operations through <Api of="MapPresentation" />.
+<Api of="MaplibreMap" /> presents that state. `MapState` provides camera,
+viewport, projection, and feature-query operations while the map is attached.
 
 ## The style is base plus content
 

--- a/docs/src/content/docs/interaction.mdx
+++ b/docs/src/content/docs/interaction.mdx
@@ -24,12 +24,11 @@ individual fields:
 
 ## Map clicks
 
-<Api of="MapPresentationCallbacks" /> groups the map click and long-click
-callbacks. Each receives the clicked position and its screen offset. To
-identify the clicked feature, query the current
-<Api of="MapPresentation.queryRenderedFeatures" />. The query suspends, so
-launch it in a coroutine. Return <Api of="ClickResult.Pass" /> to send the
-click on to the layer listeners:
+The `onClick` and `onLongClick` parameters receive the clicked position and its
+screen offset. To identify the clicked feature, call
+<Api of="MapState.queryRenderedFeatures" />. The query suspends, so launch it
+in a coroutine. Return <Api of="ClickResult.Pass" /> to send the click on to
+the layer listeners:
 
 <Code code={region(interaction, "click-listeners")} lang="kotlin" title="App.kt" />
 

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/org/maplibre/compose/material3/MapOverlay.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/org/maplibre/compose/material3/MapOverlay.kt
@@ -10,7 +10,7 @@ import org.maplibre.compose.overlay.MaplibreLogo
 
 private val Material3Overlay = MapOverlay {
   DisappearingScaleBar(
-    metersPerDp = presentation?.viewport?.metersPerDpAtTarget ?: 0.0,
+    metersPerDp = mapState.viewport?.metersPerDpAtTarget ?: 0.0,
     zoom = mapState.cameraPosition.zoom,
     modifier = Modifier.align(Alignment.TopStart),
   )

--- a/lib/maplibre-compose/src/androidDeviceTest/kotlin/org/maplibre/compose/camera/AndroidMapStateRecreationTest.kt
+++ b/lib/maplibre-compose/src/androidDeviceTest/kotlin/org/maplibre/compose/camera/AndroidMapStateRecreationTest.kt
@@ -37,21 +37,25 @@ class AndroidMapStateRecreationTest {
 
     try {
       runAndroidComposeUiTest<MapStateRecreationActivity> {
-        waitUntil(timeoutMillis = TIMEOUT_MILLIS) { activity?.mapState?.presentation != null }
+        waitUntil(timeoutMillis = TIMEOUT_MILLIS) {
+          activity?.mapState?.currentMapAttachment != null
+        }
         val firstActivity = requireNotNull(activity)
         val firstState = requireNotNull(firstActivity.mapState)
         assertTrue(firstActivity.defaultRuntimeIsShared)
 
-        runOnIdle { requireNotNull(firstState.presentation).setCameraPosition(EXPECTED_CAMERA) }
+        runOnIdle {
+          requireNotNull(firstState.currentMapAttachment).setCameraPosition(EXPECTED_CAMERA)
+        }
         waitUntil(timeoutMillis = TIMEOUT_MILLIS) {
-          firstState.presentation?.adapter?.hasCamera(EXPECTED_CAMERA) == true
+          firstState.currentMapAttachment?.adapter?.hasCamera(EXPECTED_CAMERA) == true
         }
 
         runOnIdle { firstActivity.recreate() }
         waitUntil(timeoutMillis = TIMEOUT_MILLIS) {
           activity != null &&
             activity !== firstActivity &&
-            activity?.mapState?.presentation?.adapter?.hasCamera(EXPECTED_CAMERA) == true
+            activity?.mapState?.currentMapAttachment?.adapter?.hasCamera(EXPECTED_CAMERA) == true
         }
 
         val replacementActivity = requireNotNull(activity)
@@ -61,7 +65,7 @@ class AndroidMapStateRecreationTest {
         assertCamera(EXPECTED_CAMERA, restoredState.cameraPosition, "restored MapState")
         assertCamera(
           EXPECTED_CAMERA,
-          requireNotNull(restoredState.presentation).adapter.getCameraPosition(),
+          requireNotNull(restoredState.currentMapAttachment).adapter.getCameraPosition(),
           "replacement native map",
         )
         assertTrue(restoredState.style.baseStyle == BaseStyle.Empty)

--- a/lib/maplibre-compose/src/androidDeviceTest/kotlin/org/maplibre/compose/camera/AndroidMapStateRecreationTest.kt
+++ b/lib/maplibre-compose/src/androidDeviceTest/kotlin/org/maplibre/compose/camera/AndroidMapStateRecreationTest.kt
@@ -44,9 +44,7 @@ class AndroidMapStateRecreationTest {
         val firstState = requireNotNull(firstActivity.mapState)
         assertTrue(firstActivity.defaultRuntimeIsShared)
 
-        runOnIdle {
-          requireNotNull(firstState.currentMapAttachment).setCameraPosition(EXPECTED_CAMERA)
-        }
+        runOnIdle { firstState.setCameraPosition(EXPECTED_CAMERA) }
         waitUntil(timeoutMillis = TIMEOUT_MILLIS) {
           firstState.currentMapAttachment?.adapter?.hasCamera(EXPECTED_CAMERA) == true
         }

--- a/lib/maplibre-compose/src/androidDeviceTest/kotlin/org/maplibre/compose/mlnffi/AndroidSurfaceReplacementTest.kt
+++ b/lib/maplibre-compose/src/androidDeviceTest/kotlin/org/maplibre/compose/mlnffi/AndroidSurfaceReplacementTest.kt
@@ -25,7 +25,6 @@ import kotlin.test.Test
 import kotlin.test.assertTrue
 import kotlinx.coroutines.flow.first
 import org.maplibre.compose.map.DefaultMapRuntime
-import org.maplibre.compose.map.MapPresentationCallbacks
 import org.maplibre.compose.map.MapState
 import org.maplibre.compose.map.MaplibreMap
 import org.maplibre.compose.map.MlnFfiMapSession
@@ -225,7 +224,7 @@ class SurfaceReplacementActivity : ComponentActivity() {
 
   fun diagnostic(): String {
     val state = if (showingReplacement) replacementState else initialState
-    val session = state?.presentation?.adapter as? MlnFfiMapSession
+    val session = state?.currentMapAttachment?.adapter as? MlnFfiMapSession
     val surfaces =
       window.decorView.descendants().filterIsInstance<SurfaceView>().joinToString(
         prefix = "[",
@@ -235,7 +234,7 @@ class SurfaceReplacementActivity : ComponentActivity() {
           "size=${surface.width}x${surface.height}"
       }
     return "showingReplacement=$showingReplacement, " +
-      "presentation=${state?.presentation != null}, style=${state?.style?.loadState}, " +
+      "presentation=${state?.currentMapAttachment != null}, style=${state?.style?.loadState}, " +
       "frames=${initialFrameCount.get()}/${replacementFrameCount.get()}, " +
       "nativeTargets=${session?.attachCount}/${session?.retargetCount}, surfaces=$surfaces"
   }
@@ -251,13 +250,13 @@ private fun TestMap(
   val state = rememberMapState(baseStyle = SOLID_STYLE)
   LaunchedEffect(state) {
     onState(state)
-    snapshotFlow { state.presentation }.first { it != null }
+    snapshotFlow { state.currentMapAttachment }.first { it != null }
     onPresentation()
   }
   MaplibreMap(
     state = state,
     modifier = Modifier.fillMaxSize(),
-    callbacks = MapPresentationCallbacks(onFrame = { onFrame() }),
+    onFrame = { onFrame() },
   ) {
     include(overlay)
   }

--- a/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/layers/LayerClickOrderTest.kt
+++ b/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/layers/LayerClickOrderTest.kt
@@ -188,8 +188,8 @@ class LayerClickOrderTest {
       MaplibreMap(state = mapState, modifier = Modifier.fillMaxSize())
     }
 
-    waitUntil(timeoutMillis = TIMEOUT) { mapState.presentation != null }
-    val presentation = assertNotNull(mapState.presentation, "the map never published a lease")
+    waitUntil(timeoutMillis = TIMEOUT) { mapState.currentMapAttachment != null }
+    assertNotNull(mapState.currentMapAttachment, "the map never published a lease")
     val size = onRoot().fetchSemanticsNode().size
     val centerDp = with(density) { DpOffset((size.width / 2).toDp(), (size.height / 2).toDp()) }
 
@@ -197,7 +197,7 @@ class LayerClickOrderTest {
     // parsed source populates that. Both layers must be hittable, or the assertions prove nothing.
     waitUntil(timeoutMillis = TIMEOUT) {
       listOf(FRONT, BACK).all { id ->
-        runBlocking { presentation.queryRenderedFeatures(offset = centerDp, layerIds = setOf(id)) }
+        runBlocking { mapState.queryRenderedFeatures(offset = centerDp, layerIds = setOf(id)) }
           .isNotEmpty()
       }
     }

--- a/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MapLifecycleCallbackRaceTest.kt
+++ b/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MapLifecycleCallbackRaceTest.kt
@@ -141,14 +141,13 @@ class MapLifecycleCallbackRaceTest {
     val adapter = BlockingCameraAdapter()
     val token = state.reservePresentation()
     state.publishPresentation(token, adapter)
-    val presentation = requireNotNull(state.presentation)
     val first = CameraPosition(zoom = 4.0)
     val second = CameraPosition(zoom = 8.0)
     adapter.blockNextWrite = true
 
-    val firstThread = thread { presentation.setCameraPosition(first) }
+    val firstThread = thread { state.setCameraPosition(first) }
     assertTrue(adapter.blockedWriteEntered.await(5, TimeUnit.SECONDS))
-    val secondThread = thread { presentation.setCameraPosition(second) }
+    val secondThread = thread { state.setCameraPosition(second) }
     secondThread.join()
     assertEquals(second, state.cameraPosition)
 
@@ -208,7 +207,7 @@ class MapLifecycleCallbackRaceTest {
     firstPublicationThread.join()
 
     assertEquals(0, first.styleWrites)
-    assertTrue(state.presentation?.adapter === replacement)
+    assertTrue(state.currentMapAttachment?.adapter === replacement)
     state.close()
     runtime.close()
   }

--- a/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MlnFfiMapCompositionTest.kt
+++ b/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MlnFfiMapCompositionTest.kt
@@ -35,7 +35,6 @@ import kotlin.math.abs
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 import kotlin.test.assertNotSame
 import kotlin.test.assertNull
 import kotlin.test.assertSame
@@ -104,12 +103,12 @@ class MlnFfiMapCompositionTest {
     val runtime = createNativeMapRuntime(runtimeOptions)
     val state = runtime.createMapState(baseStyle = BaseStyle.Empty)
 
-    setFfiTestMapContent(runtimeOptions) { MaplibreMap(state) }
+    setFfiTestMapContent(runtimeOptions) { MaplibreMap(state = state) }
     waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) {
-      state.presentation != null && state.style.loadState == StyleLoadState.Ready
+      state.currentMapAttachment != null && state.style.loadState == StyleLoadState.Ready
     }
 
-    assertTrue(state.presentation?.isValid == true)
+    assertTrue(state.currentMapAttachment?.isValid == true)
     assertTrue(
       onAllNodesWithTag(MAP_LOAD_PLACEHOLDER_TAG).fetchSemanticsNodes().isEmpty(),
       "the load placeholder should be absent after the base style is ready",
@@ -118,28 +117,32 @@ class MlnFfiMapCompositionTest {
     runtime.close()
     runtime.awaitClosed()
     assertTrue(state.isClosed)
-    assertNull(state.presentation)
+    assertNull(state.currentMapAttachment)
   }
 
   @Test
-  fun presentation_options_update_without_replacing_the_native_map() = runFfiComposeUiTest {
+  fun camera_constraints_update_without_replacing_the_native_map() = runFfiComposeUiTest {
     val runtime = createNativeMapRuntime(runtimeOptions)
-    val state = runtime.createMapState(baseStyle = BaseStyle.Empty)
-    var options by mutableStateOf(MapPresentationOptions())
+    val state =
+      runtime.createMapState(
+        initialCameraPosition = CameraPosition(zoom = 1.0),
+        baseStyle = BaseStyle.Empty,
+      )
+    var constraints by mutableStateOf(CameraConstraints())
 
     setFfiTestMapContent(runtimeOptions) {
-      MaplibreMap(state, presentationOptions = options)
+      MaplibreMap(state = state, cameraConstraints = constraints)
     }
-    waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) { state.presentation != null }
-    val session = requireNotNull(state.presentation).adapter
-    val updated = MapPresentationOptions(zoomRange = 2f..18f, pitchRange = 3f..45f)
+    waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) { state.currentMapAttachment != null }
+    val session = requireNotNull(state.currentMapAttachment).adapter
+    val updated = CameraConstraints(minZoom = 2.0, maxZoom = 18.0, minPitch = 3.0, maxPitch = 45.0)
 
-    options = updated
+    constraints = updated
     waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) {
-      state.presentation?.options == updated
+      session.getCameraPosition().zoom >= updated.minZoom
     }
 
-    assertSame(session, requireNotNull(state.presentation).adapter)
+    assertSame(session, requireNotNull(state.currentMapAttachment).adapter)
     runtime.close()
     runtime.awaitClosed()
   }
@@ -169,23 +172,29 @@ class MlnFfiMapCompositionTest {
     val second = runtime.createMapState(baseStyle = BaseStyle.Empty, styleComposition = style)
 
     setFfiTestMapContent(runtimeOptions, presentationCount = 2) {
-      if (showFirst) MaplibreMap(first) else MaplibreMap(second)
+      if (showFirst) {
+        MaplibreMap(state = first)
+      } else {
+        MaplibreMap(state = second)
+      }
     }
     waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) {
-      first.presentation != null &&
+      first.currentMapAttachment != null &&
         evaluatorIdentities.size == 1 &&
         first.desiredStyleRevision.layers.any { it.definition.id == "shared-layer" }
     }
-    val firstSession = first.presentation?.adapter as MlnFfiMapSession
+    val firstSession = first.currentMapAttachment?.adapter as MlnFfiMapSession
     waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) {
       "shared-layer" in firstSession.currentStyleLayerIds()
     }
 
     showFirst = false
     waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) {
-      first.presentation == null && second.presentation != null && evaluatorIdentities.size == 2
+      first.currentMapAttachment == null &&
+        second.currentMapAttachment != null &&
+        evaluatorIdentities.size == 2
     }
-    val secondSession = second.presentation?.adapter as MlnFfiMapSession
+    val secondSession = second.currentMapAttachment?.adapter as MlnFfiMapSession
     waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) {
       "shared-layer" in secondSession.currentStyleLayerIds()
     }
@@ -221,9 +230,9 @@ class MlnFfiMapCompositionTest {
       val state =
         runtime.createMapState(baseStyle = BaseStyle.Empty, styleComposition = composition)
 
-      setFfiTestMapContent(runtimeOptions) { MaplibreMap(state) }
+      setFfiTestMapContent(runtimeOptions) { MaplibreMap(state = state) }
       waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) {
-        state.presentation != null &&
+        state.currentMapAttachment != null &&
           state.style.loadState == StyleLoadState.Ready &&
           evaluatorIdentities.size == 1
       }
@@ -255,25 +264,25 @@ class MlnFfiMapCompositionTest {
         runtime.createMapState(baseStyle = BaseStyle.Empty, styleComposition = composition)
 
       setFfiTestMapContent(runtimeOptions, presentationCount = 2) {
-        if (presented) MaplibreMap(state)
+        if (presented) MaplibreMap(state = state)
       }
       waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) {
-        state.style.loadState == StyleLoadState.Ready && state.presentation != null
+        state.style.loadState == StyleLoadState.Ready && state.currentMapAttachment != null
       }
-      val session = requireNotNull(state.presentation).adapter as MlnFfiMapSession
+      val session = requireNotNull(state.currentMapAttachment).adapter as MlnFfiMapSession
       waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) {
         "initial-background" in session.currentStyleLayerIds()
       }
 
       presented = false
-      waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) { state.presentation == null }
+      waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) { state.currentMapAttachment == null }
       latest = true
       assertTrue("initial-background" in session.currentStyleLayerIds())
       assertTrue("latest-background" !in session.currentStyleLayerIds())
 
       presented = true
       waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) {
-        state.presentation != null &&
+        state.currentMapAttachment != null &&
           state.desiredStyleRevision.layers.any {
             it.definition.id == "latest-background"
           }
@@ -304,7 +313,7 @@ class MlnFfiMapCompositionTest {
       val state =
         runtime.createMapState(baseStyle = BaseStyle.Empty, styleComposition = composition)
 
-      setFfiTestMapContent(runtimeOptions) { MaplibreMap(state) }
+      setFfiTestMapContent(runtimeOptions) { MaplibreMap(state = state) }
       waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) {
         state.style.loadState is StyleLoadState.Failed
       }
@@ -317,7 +326,7 @@ class MlnFfiMapCompositionTest {
       waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) {
         state.style.loadState == StyleLoadState.Ready
       }
-      val session = requireNotNull(state.presentation).adapter as MlnFfiMapSession
+      val session = requireNotNull(state.currentMapAttachment).adapter as MlnFfiMapSession
       assertTrue("application-background" in session.currentStyleLayerIds())
       assertTrue(onAllNodesWithTag(MAP_LOAD_PLACEHOLDER_TAG).fetchSemanticsNodes().isEmpty())
 
@@ -333,38 +342,37 @@ class MlnFfiMapCompositionTest {
     var presented by mutableStateOf(true)
 
     setFfiTestMapContent(runtimeOptions, presentationCount = 2) {
-      if (presented) MaplibreMap(state)
+      if (presented) MaplibreMap(state = state)
     }
     waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) {
-      state.presentation != null && state.style.loadState == StyleLoadState.Ready
+      state.currentMapAttachment != null && state.style.loadState == StyleLoadState.Ready
     }
-    val firstPresentation = requireNotNull(state.presentation)
-    val firstMap = firstPresentation.adapter
+    val firstAttachment = requireNotNull(state.currentMapAttachment)
+    val firstMap = firstAttachment.adapter
 
     presented = false
-    waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) { state.presentation == null }
+    waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) { state.currentMapAttachment == null }
 
-    assertTrue(!firstPresentation.isValid)
-    assertFailsWith<IllegalStateException> { firstPresentation.setCameraPosition(CameraPosition()) }
+    assertTrue(!firstAttachment.isValid)
     assertEquals(StyleLoadState.Ready, state.style.loadState)
     state.style.baseStyle = BaseStyle.Json("{")
     waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) {
-      state.presentation == null && state.style.loadState is StyleLoadState.Failed
+      state.currentMapAttachment == null && state.style.loadState is StyleLoadState.Failed
     }
     state.style.baseStyle = RETAINED_STYLE
     assertEquals(StyleLoadState.Loading, state.style.loadState)
 
     presented = true
     waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) {
-      state.presentation != null && state.style.loadState == StyleLoadState.Ready
+      state.currentMapAttachment != null && state.style.loadState == StyleLoadState.Ready
     }
 
-    assertSame(firstMap, requireNotNull(state.presentation).adapter)
+    assertSame(firstMap, requireNotNull(state.currentMapAttachment).adapter)
     assertCameraEquals(camera, state.cameraPosition)
     assertTrue("retained-style" in (firstMap as MlnFfiMapSession).currentStyleLayerIds())
 
     presented = false
-    waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) { state.presentation == null }
+    waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) { state.currentMapAttachment == null }
     runtime.close()
     runtime.awaitClosed()
   }
@@ -385,26 +393,26 @@ class MlnFfiMapCompositionTest {
 
       setFfiTestMapContent(runtimeOptions, presentationCount = 2) {
         CompositionLocalProvider(LocalDensity provides Density(scaleFactor)) {
-          if (presented) MaplibreMap(state)
+          if (presented) MaplibreMap(state = state)
         }
       }
       waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) {
-        state.presentation != null && state.style.loadState == StyleLoadState.Ready
+        state.currentMapAttachment != null && state.style.loadState == StyleLoadState.Ready
       }
-      val firstPresentation = requireNotNull(state.presentation)
+      val firstPresentation = requireNotNull(state.currentMapAttachment)
       val firstMap = firstPresentation.adapter
 
       presented = false
-      waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) { state.presentation == null }
+      waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) { state.currentMapAttachment == null }
       scaleFactor = 2f
       presented = true
       waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) {
-        state.presentation != null && state.style.loadState == StyleLoadState.Ready
+        state.currentMapAttachment != null && state.style.loadState == StyleLoadState.Ready
       }
 
-      val replacementMap = requireNotNull(state.presentation).adapter
+      val replacementMap = requireNotNull(state.currentMapAttachment).adapter
       assertTrue(!firstPresentation.isValid)
-      assertNotSame(firstPresentation, state.presentation)
+      assertNotSame(firstPresentation, state.currentMapAttachment)
       assertNotSame(firstMap, replacementMap)
       assertCameraEquals(camera, state.cameraPosition)
       assertTrue("replacement-style" in (replacementMap as MlnFfiMapSession).currentStyleLayerIds())
@@ -536,7 +544,7 @@ class MlnFfiMapCompositionTest {
     runBridgeMapTest(
       body = {
         val session =
-          requireNotNull(mapState.presentation?.adapter as? MlnFfiMapSession) {
+          requireNotNull(mapState.currentMapAttachment?.adapter as? MlnFfiMapSession) {
             "no native session"
           }
         waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) {
@@ -582,12 +590,12 @@ class MlnFfiMapCompositionTest {
 
     runBridgeMapTest(
       body = {
-        val session = requireNotNull(mapState.presentation?.adapter as? MlnFfiMapSession)
+        val session = requireNotNull(mapState.currentMapAttachment?.adapter as? MlnFfiMapSession)
 
         layoutDirection = LayoutDirection.Rtl
         waitForIdle()
 
-        assertSame(session, mapState.presentation?.adapter)
+        assertSame(session, mapState.currentMapAttachment?.adapter)
         assertEquals(LayoutDirection.Rtl, session.layoutDirection)
       }
     ) { errors, onFrame ->
@@ -615,7 +623,8 @@ class MlnFfiMapCompositionTest {
 
     runBridgeMapTest(
       body = {
-        val map = requireNotNull(mapState.presentation?.adapter) { "The map never published" }
+        val map =
+          requireNotNull(mapState.currentMapAttachment?.adapter) { "The map never published" }
         val actual = map.getCameraPosition()
         assertEquals(
           firstPosition.target.longitude,
@@ -767,7 +776,7 @@ private fun TestMap(
   MaplibreMap(
     state = state,
     modifier = modifier,
-    callbacks = MapPresentationCallbacks(onFrame = onFrame),
+    onFrame = onFrame,
   ) {
     include(overlay)
   }

--- a/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MlnFfiStyleSwitchTest.kt
+++ b/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MlnFfiStyleSwitchTest.kt
@@ -79,14 +79,16 @@ class MlnFfiStyleSwitchTest {
     }
     val state = runtime.createMapState(baseStyle = STYLES[0].base, styleComposition = composition)
 
-    setFfiTestMapContent(runtimeOptions) { MaplibreMap(state, Modifier) }
+    setFfiTestMapContent(runtimeOptions) {
+      MaplibreMap(modifier = Modifier, state = state)
+    }
 
     // Each style finishes loading before the next is chosen; switching mid-load is a separate race
     // this test deliberately does not cover.
     waitUntil(timeoutMillis = SETTLE_TIMEOUT_MILLIS) {
-      state.presentation != null && state.style.loadState == StyleLoadState.Ready
+      state.currentMapAttachment != null && state.style.loadState == StyleLoadState.Ready
     }
-    val session = requireNotNull(state.presentation).adapter as MlnFfiMapSession
+    val session = requireNotNull(state.currentMapAttachment).adapter as MlnFfiMapSession
     var identity = assertNotNull(session.loadedStyleIdentity)
     assertStyleLayers(session, style, extraLayer)
 
@@ -134,12 +136,14 @@ class MlnFfiStyleSwitchTest {
         styleComposition = composition,
       )
 
-    setFfiTestMapContent(runtimeOptions) { MaplibreMap(state, Modifier) }
+    setFfiTestMapContent(runtimeOptions) {
+      MaplibreMap(modifier = Modifier, state = state)
+    }
 
     waitUntil(timeoutMillis = SETTLE_TIMEOUT_MILLIS) {
-      state.presentation != null && state.style.loadState == StyleLoadState.Ready
+      state.currentMapAttachment != null && state.style.loadState == StyleLoadState.Ready
     }
-    val session = requireNotNull(state.presentation).adapter as MlnFfiMapSession
+    val session = requireNotNull(state.currentMapAttachment).adapter as MlnFfiMapSession
     fun replacementLayers(): List<String> =
       session.currentStyleLayerIds().filter { it in REPLACEMENT_LAYER_IDS }
     waitUntil(timeoutMillis = SETTLE_TIMEOUT_MILLIS) {
@@ -193,12 +197,14 @@ class MlnFfiStyleSwitchTest {
     }
     val state = runtime.createMapState(baseStyle = INITIAL_STYLE, styleComposition = composition)
 
-    setFfiTestMapContent(options) { MaplibreMap(state, Modifier) }
+    setFfiTestMapContent(options) {
+      MaplibreMap(modifier = Modifier, state = state)
+    }
 
     waitUntil(timeoutMillis = SETTLE_TIMEOUT_MILLIS) {
-      state.presentation != null && state.style.loadState == StyleLoadState.Ready
+      state.currentMapAttachment != null && state.style.loadState == StyleLoadState.Ready
     }
-    val session = requireNotNull(state.presentation).adapter as MlnFfiMapSession
+    val session = requireNotNull(state.currentMapAttachment).adapter as MlnFfiMapSession
 
     runOnUiThread {
       state.style.baseStyle = BaseStyle.Uri(B_STYLE_URL)

--- a/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/map/AndroidMapView.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/map/AndroidMapView.kt
@@ -23,7 +23,7 @@ internal actual fun ComposableMapView(
   onReset: () -> Unit,
   logger: Logger?,
   callbacks: MapAdapter.Callbacks,
-  options: MapPresentationOptions,
+  options: MapViewOptions,
 ) {
   AndroidMlnFfiPlatform.initialize(LocalContext.current)
   val runtimeBackends = remember { loadRuntimeBackends(logger) }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/Viewport.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/Viewport.kt
@@ -8,7 +8,7 @@ import org.maplibre.spatialk.geojson.BoundingBox
 /**
  * What the map shows right now: the size of the map composable and the visible area.
  *
- * Read a current instance from [org.maplibre.compose.map.MapPresentation.viewport]. A new immutable
+ * Read a current instance from [org.maplibre.compose.map.MapState.viewport]. A new immutable
  * instance replaces it when the map has adopted a new camera or size. A composition that reads any
  * property recomposes exactly when the value changes. All properties of one instance describe the
  * same rendered transform and are consistent with each other.

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/location/LocationPuck.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/location/LocationPuck.kt
@@ -175,7 +175,7 @@ private fun LocationPuckContent(
   onClick: LocationClickHandler?,
   onLongClick: LocationClickHandler?,
 ) {
-  val presentation = LocalMapState.current?.presentation
+  val mapState = LocalMapState.current
   val location = measurement?.location
   val bearing = measurement?.bearing
   val bearingAccuracy = measurement?.bearingAccuracy
@@ -193,7 +193,7 @@ private fun LocationPuckContent(
         condition(test = isOldLocation, output = const(0.dp)),
         fallback =
           (feature["accuracy"].asNumber() /
-              const((presentation?.viewport?.metersPerDpAtTarget ?: 0.0).toFloat()))
+              const((mapState?.viewport?.metersPerDpAtTarget ?: 0.0).toFloat()))
             .dp,
       ),
     color = const(colors.accuracyFillColor),

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/location/UpdateCamera.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/location/UpdateCamera.kt
@@ -2,7 +2,6 @@ package org.maplibre.compose.location
 
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
-import org.maplibre.compose.map.MapPresentation
 import org.maplibre.compose.map.MapState
 import org.maplibre.spatialk.units.Bearing
 import org.maplibre.spatialk.units.extensions.inDegrees
@@ -11,13 +10,12 @@ import org.maplibre.spatialk.units.extensions.inDegrees
  * Convenience method for keeping [mapState] in sync with the location change that triggered this
  * [LocationTrackingEffect] callback.
  *
- * @param animationDuration if `null`, updates the presentation directly without animation;
- *   otherwise, specifies the duration of the camera animation.
+ * @param animationDuration if `null`, updates the camera directly without animation; otherwise,
+ *   specifies the duration of the camera animation.
  * @param updateBearing determines how the bearing affects the camera state.
  */
 public suspend fun LocationChangeScope.updateCamera(
   mapState: MapState,
-  presentation: MapPresentation,
   animationDuration: Duration? = 300.milliseconds,
   updateBearing: BearingUpdate = BearingUpdate.TRACK_AUTOMATIC,
 ) {
@@ -42,8 +40,8 @@ public suspend fun LocationChangeScope.updateCamera(
         },
     )
 
-  if (animationDuration == null) presentation.setCameraPosition(newPosition)
-  else presentation.animateCameraPosition(newPosition, animationDuration)
+  if (animationDuration == null) mapState.setCameraPosition(newPosition)
+  else mapState.animateCameraPosition(newPosition, animationDuration)
 }
 
 /** How [updateCamera] updates camera bearing. */

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/CameraConstraints.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/CameraConstraints.kt
@@ -1,11 +1,14 @@
 package org.maplibre.compose.map
 
+import androidx.compose.runtime.Immutable
 import org.maplibre.spatialk.geojson.BoundingBox
 
-internal data class CameraConstraints(
-  val minZoom: Double,
-  val maxZoom: Double,
-  val minPitch: Double,
-  val maxPitch: Double,
-  val boundingBox: BoundingBox?,
+/** Limits the camera position that the map can display. */
+@Immutable
+public data class CameraConstraints(
+  public val minZoom: Double = 0.0,
+  public val maxZoom: Double = 20.0,
+  public val minPitch: Double = 0.0,
+  public val maxPitch: Double = 60.0,
+  public val boundingBox: BoundingBox? = null,
 )

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/ComposableMapView.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/ComposableMapView.kt
@@ -17,5 +17,5 @@ internal expect fun ComposableMapView(
   onReset: () -> Unit,
   logger: Logger?,
   callbacks: MapAdapter.Callbacks,
-  options: MapPresentationOptions,
+  options: MapViewOptions,
 )

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleAuthority.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleAuthority.kt
@@ -191,7 +191,6 @@ internal class MapLifecycleAuthority(
   fun publishPresentation(
     token: MapPresentationToken,
     adapter: MapAdapter,
-    options: MapPresentationOptions,
   ) {
     val retainedToReplace = serialized {
       if (closed) return
@@ -200,10 +199,7 @@ internal class MapLifecycleAuthority(
       check(current?.token == token && !current.releasing) {
         "The map presentation reservation is no longer current"
       }
-      if (current.adapter === adapter && owner.presentation?.adapter === adapter) {
-        owner.presentation?.updateOptions(options)
-        return
-      }
+      if (current.adapter === adapter && owner.currentMapAttachment?.adapter === adapter) return
       selectAdapterLocked(current, adapter)
       retainedAdapter?.takeUnless { retained ->
         retained === adapter || !adapter.retainsEngineBetweenPresentations
@@ -228,7 +224,6 @@ internal class MapLifecycleAuthority(
       owner.commitPresentation(
         token = token,
         adapter = adapter,
-        options = options,
       )
       retainedToReplace
     }
@@ -334,7 +329,7 @@ internal class MapLifecycleAuthority(
     requireOpen()
     val adapter = attachment?.adapter
     check(adapter != null && acceptsPresentationLocked(adapter)) {
-      "Platform map access requires a current Web presentation"
+      "Platform map access requires an attached Web map surface"
     }
     adapter
   }
@@ -351,7 +346,7 @@ internal class MapLifecycleAuthority(
     !closed &&
       attachment?.token == token &&
       attachment?.adapter === adapter &&
-      owner.presentation?.let { it.token == token && it.adapter === adapter } == true
+      owner.currentMapAttachment?.let { it.token == token && it.adapter === adapter } == true
   }
 
   fun bind(adapter: MapLifecyclePlatformAdapter): MapLifecycleBinding {
@@ -415,7 +410,7 @@ internal class MapLifecycleAuthority(
   }
 
   private fun acceptsPresentationLocked(adapter: MapAdapter): Boolean =
-    !closed && attachment?.adapter === adapter && owner.presentation?.adapter === adapter
+    !closed && attachment?.adapter === adapter && owner.currentMapAttachment?.adapter === adapter
 
   private fun acceptPlatformAccess(accepts: () -> Boolean, event: () -> Unit): Boolean {
     var commitDeferredClose = false

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapOptions.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapOptions.kt
@@ -3,32 +3,13 @@ package org.maplibre.compose.map
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.unit.dp
-import org.maplibre.compose.util.ClickResult
-import org.maplibre.compose.util.MapClickHandler
-import org.maplibre.spatialk.geojson.BoundingBox
 
-/**
- * Configures one temporary map presentation.
- *
- * Each field's companion object provides presets. [GestureOptions] is the same on every platform.
- * [RenderOptions] and [TileLodOptions] still differ by backend, so a custom configuration of those
- * two is written in expect/actual code.
- */
+/** Collects the map configuration that the platform view receives as one internal value. */
 @Immutable
-public data class MapPresentationOptions(
+internal data class MapViewOptions(
   val cameraPadding: PaddingValues = PaddingValues(0.dp),
-  val zoomRange: ClosedRange<Float> = 0f..20f,
-  val pitchRange: ClosedRange<Float> = 0f..60f,
-  val boundingBox: BoundingBox? = null,
+  val cameraConstraints: CameraConstraints = CameraConstraints(),
   val renderOptions: RenderOptions = RenderOptions.Standard,
   val gestureOptions: GestureOptions = GestureOptions.Standard,
   val tileLodOptions: TileLodOptions = TileLodOptions.Standard,
-)
-
-/** Callbacks from one temporary map presentation. */
-@Immutable
-public data class MapPresentationCallbacks(
-  val onClick: MapClickHandler = { _, _ -> ClickResult.Pass },
-  val onLongClick: MapClickHandler = { _, _ -> ClickResult.Pass },
-  val onFrame: (framesPerSecond: Double) -> Unit = {},
 )

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
@@ -265,7 +265,6 @@ internal constructor(
   internal val adapter: MapAdapter,
 ) {
   private val invalidated = CompletableDeferred<Unit>()
-  private val cameraMutation = MutatorMutex()
   private var validState: Boolean by mutableStateOf(true)
   private var viewportState: Viewport? by mutableStateOf(null)
   private val firstViewport = CompletableDeferred<Viewport>()
@@ -296,11 +295,7 @@ internal constructor(
   suspend fun animateCameraPosition(
     position: CameraPosition,
     duration: Duration = 300.milliseconds,
-  ) {
-    cameraMutation.mutate {
-      runLeaseBound { adapter.animateCameraPosition(position, duration) }
-    }
-  }
+  ): Unit = runLeaseBound { adapter.animateCameraPosition(position, duration) }
 
   suspend fun animateCameraPosition(
     boundingBox: BoundingBox,
@@ -308,13 +303,9 @@ internal constructor(
     tilt: Double = 0.0,
     padding: PaddingValues = PaddingValues(0.dp),
     duration: Duration = 300.milliseconds,
-  ) {
-    cameraMutation.mutate {
-      runLeaseBound {
-        awaitViewportState()
-        adapter.animateCameraPosition(boundingBox, bearing, tilt, padding, duration)
-      }
-    }
+  ): Unit = runLeaseBound {
+    awaitViewportState()
+    adapter.animateCameraPosition(boundingBox, bearing, tilt, padding, duration)
   }
 
   fun getVisibleRegion(): VisibleRegion? = withViewport { it.getVisibleRegion() }
@@ -457,6 +448,7 @@ internal constructor(
     internal set
 
   private var nextMapAttachment = CompletableDeferred<MapAttachment>()
+  private val cameraMutation = MutatorMutex()
 
   /** Contains the current rendered viewport, or null while no viewport is available. */
   public val viewport: Viewport?
@@ -498,28 +490,38 @@ internal constructor(
     applyAttachmentCameraCommand(command.attachment, command.command)
   }
 
-  /** Fits [boundingBox] in the current viewport without animation. */
+  /** Waits for a viewport, then fits [boundingBox] without animation. */
   public suspend fun setCameraPosition(
     boundingBox: BoundingBox,
     bearing: Double = 0.0,
     tilt: Double = 0.0,
     padding: PaddingValues = PaddingValues(0.dp),
-  ): Unit = requireAttachment().setCameraPosition(boundingBox, bearing, tilt, padding)
+  ): Unit = retryAcrossAttachments {
+    it.setCameraPosition(boundingBox, bearing, tilt, padding)
+  }
 
-  /** Animates the camera to [position]. A new camera animation replaces the previous one. */
+  /** Waits for an attached map, then animates to [position]. A new animation replaces this one. */
   public suspend fun animateCameraPosition(
     position: CameraPosition,
     duration: Duration = 300.milliseconds,
-  ): Unit = requireAttachment().animateCameraPosition(position, duration)
+  ): Unit = cameraMutation.mutate {
+    retryAcrossAttachments { it.animateCameraPosition(position, duration) }
+  }
 
-  /** Animates the camera to fit [boundingBox]. A new camera animation replaces the previous one. */
+  /**
+   * Waits for a viewport, then animates to fit [boundingBox]. A new animation replaces this one.
+   */
   public suspend fun animateCameraPosition(
     boundingBox: BoundingBox,
     bearing: Double = 0.0,
     tilt: Double = 0.0,
     padding: PaddingValues = PaddingValues(0.dp),
     duration: Duration = 300.milliseconds,
-  ): Unit = requireAttachment().animateCameraPosition(boundingBox, bearing, tilt, padding, duration)
+  ): Unit = cameraMutation.mutate {
+    retryAcrossAttachments {
+      it.animateCameraPosition(boundingBox, bearing, tilt, padding, duration)
+    }
+  }
 
   /** Returns the visible region, or null while no viewport is available. */
   public fun getVisibleRegion(): VisibleRegion? =
@@ -561,10 +563,13 @@ internal constructor(
     requireAttachment().queryRenderedFeatures(rect, layerIds, predicate)
 
   /** Waits for the first viewport from the current or a future map attachment. */
-  public suspend fun awaitViewport(): Viewport {
+  public suspend fun awaitViewport(): Viewport =
+    retryAcrossAttachments(MapAttachment::awaitViewport)
+
+  private suspend fun <T> retryAcrossAttachments(operation: suspend (MapAttachment) -> T): T {
     while (true) {
       try {
-        return awaitAttachment().awaitViewport()
+        return operation(awaitAttachment())
       } catch (_: MapNotAttachedException) {
         // A replacement surface can attach after this lease ends.
       }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
@@ -129,22 +129,22 @@ public class MapRuntimeClosedException : IllegalStateException("The map runtime 
 /** Thrown when an operation targets a closed logical map. */
 public class MapStateClosedException : IllegalStateException("The map state is closed")
 
-/** Thrown when an operation targets a presentation whose render lease has ended. */
-public class MapPresentationDetachedException :
-  IllegalStateException("The map presentation lease has ended")
+/** Thrown when an operation requires a map that is attached to a UI surface. */
+public class MapNotAttachedException :
+  IllegalStateException("The map is not attached to a UI surface")
 
 /** Reports the load state for the desired base style of one logical map. */
 public sealed interface StyleLoadState {
-  /** No presentation can currently load the desired style. */
+  /** No map surface can currently load the desired style. */
   public data object Pending : StyleLoadState
 
-  /** Indicates that the current presentation is loading the desired style. */
+  /** Indicates that the current map surface is loading the desired style. */
   public data object Loading : StyleLoadState
 
-  /** Indicates that the current presentation loaded the desired style. */
+  /** Indicates that the current map surface loaded the desired style. */
   public data object Ready : StyleLoadState
 
-  /** Indicates that the current presentation failed to load the desired style. */
+  /** Indicates that the current map surface failed to load the desired style. */
   public data class Failed(public val reason: String?) : StyleLoadState
 }
 
@@ -257,13 +257,12 @@ public class MapStyleState internal constructor(initialBaseStyle: BaseStyle) {
     }
 }
 
-/** Represents a temporary connection between a [MapState] and a map surface. */
-public class MapPresentation
+/** Connects a [MapState] to one map surface for the lifetime of one render lease. */
+internal class MapAttachment
 internal constructor(
   private val owner: MapState,
   internal val token: MapPresentationToken,
   internal val adapter: MapAdapter,
-  initialOptions: MapPresentationOptions = MapPresentationOptions(),
 ) {
   private val invalidated = CompletableDeferred<Unit>()
   private val cameraMutation = MutatorMutex()
@@ -272,36 +271,19 @@ internal constructor(
   private val firstViewport = CompletableDeferred<Viewport>()
   private var cameraMovingState: Boolean by mutableStateOf(false)
   private var moveReasonState: CameraMoveReason by mutableStateOf(CameraMoveReason.NONE)
-  private var optionsState: MapPresentationOptions by
-    mutableStateOf(initialOptions, structuralEqualityPolicy())
-
-  /** Returns true while this presentation is the current connection. */
-  public val isValid: Boolean
+  val isValid: Boolean
     get() = validState
 
-  /** Contains the current viewport, or null before the first rendered viewport. */
-  public val viewport: Viewport?
+  val viewport: Viewport?
     get() = viewportState
 
-  /** Returns true while a camera mutation is in progress. */
-  public val isCameraMoving: Boolean
+  val isCameraMoving: Boolean
     get() = cameraMovingState
 
-  /** Contains the reason for the current or most recent camera mutation. */
-  public val cameraMoveReason: CameraMoveReason
+  val cameraMoveReason: CameraMoveReason
     get() = moveReasonState
 
-  /** Contains the settings that the current [MaplibreMap] call applies to this render lease. */
-  public val options: MapPresentationOptions
-    get() = optionsState
-
-  /** Sets the camera for this presentation, or fails if its render lease has ended. */
-  public fun setCameraPosition(position: CameraPosition) {
-    owner.setCameraPosition(this, position)
-  }
-
-  /** Fits [boundingBox] in the current viewport and keeps the presentation camera padding. */
-  public suspend fun setCameraPosition(
+  suspend fun setCameraPosition(
     boundingBox: BoundingBox,
     bearing: Double = 0.0,
     tilt: Double = 0.0,
@@ -311,8 +293,7 @@ internal constructor(
     adapter.setCameraPosition(boundingBox, bearing, tilt, padding)
   }
 
-  /** Animates the camera to [position]. A new camera animation replaces the previous one. */
-  public suspend fun animateCameraPosition(
+  suspend fun animateCameraPosition(
     position: CameraPosition,
     duration: Duration = 300.milliseconds,
   ) {
@@ -321,8 +302,7 @@ internal constructor(
     }
   }
 
-  /** Animates the camera to fit [boundingBox]. A new camera animation replaces the previous one. */
-  public suspend fun animateCameraPosition(
+  suspend fun animateCameraPosition(
     boundingBox: BoundingBox,
     bearing: Double = 0.0,
     tilt: Double = 0.0,
@@ -337,29 +317,23 @@ internal constructor(
     }
   }
 
-  /** Returns the visible region, or null before this presentation has a viewport. */
-  public fun getVisibleRegion(): VisibleRegion? = withViewport { it.getVisibleRegion() }
+  fun getVisibleRegion(): VisibleRegion? = withViewport { it.getVisibleRegion() }
 
-  /** Returns the visible axis-aligned bounds, or null before this presentation has a viewport. */
-  public fun getVisibleBoundingBox(): BoundingBox? = withViewport { it.getVisibleBoundingBox() }
+  fun getVisibleBoundingBox(): BoundingBox? = withViewport { it.getVisibleBoundingBox() }
 
-  /** Projects [position] into a logical-pixel offset in this presentation. */
-  public fun screenLocationFromPosition(position: Position): DpOffset? = withViewport {
+  fun screenLocationFromPosition(position: Position): DpOffset? = withViewport {
     it.screenLocationFromPosition(position)
   }
 
-  /** Unprojects a logical-pixel [offset] into a geographic position. */
-  public fun positionFromScreenLocation(offset: DpOffset): Position? = withViewport {
+  fun positionFromScreenLocation(offset: DpOffset): Position? = withViewport {
     it.positionFromScreenLocation(offset)
   }
 
-  /** Returns the ground distance per dp, or null before this presentation has a viewport. */
-  public fun metersPerDpAtLatitude(latitude: Double): Double? = withViewport {
+  fun metersPerDpAtLatitude(latitude: Double): Double? = withViewport {
     it.metersPerDpAtLatitude(latitude)
   }
 
-  /** Queries rendered features at [offset] in front-to-back render order. */
-  public suspend fun queryRenderedFeatures(
+  suspend fun queryRenderedFeatures(
     offset: DpOffset,
     layerIds: Set<String>? = null,
     predicate: Expression<BooleanValue> = const(true),
@@ -368,8 +342,7 @@ internal constructor(
     adapter.queryRenderedFeatures(offset, layerIds, predicate.compileOrNull())
   }
 
-  /** Queries rendered features that intersect [rect] in front-to-back render order. */
-  public suspend fun queryRenderedFeatures(
+  suspend fun queryRenderedFeatures(
     rect: DpRect,
     layerIds: Set<String>? = null,
     predicate: Expression<BooleanValue> = const(true),
@@ -378,8 +351,7 @@ internal constructor(
     adapter.queryRenderedFeatures(rect, layerIds, predicate.compileOrNull())
   }
 
-  /** Suspends until this presentation has rendered its first viewport. */
-  public suspend fun awaitViewport(): Viewport = runLeaseBound { awaitViewportState() }
+  suspend fun awaitViewport(): Viewport = runLeaseBound { awaitViewportState() }
 
   internal fun updateViewport(value: Viewport?) {
     viewportState = value
@@ -399,10 +371,6 @@ internal constructor(
     cameraMovingState = false
   }
 
-  internal fun updateOptions(value: MapPresentationOptions) {
-    optionsState = value
-  }
-
   internal fun invalidate() {
     validState = false
     invalidated.complete(Unit)
@@ -419,23 +387,24 @@ internal constructor(
   private suspend fun awaitViewportState(): Viewport = firstViewport.await()
 
   private suspend fun <T> runLeaseBound(block: suspend () -> T): T = coroutineScope {
-    owner.requireCurrent(this@MapPresentation)
+    owner.requireCurrent(this@MapAttachment)
     val operation =
       async(start = CoroutineStart.UNDISPATCHED) {
-        owner.requireCurrent(this@MapPresentation)
+        owner.requireCurrent(this@MapAttachment)
         block()
       }
     select {
       operation.onAwait { it }
       invalidated.onAwait {
         operation.cancelAndJoin()
-        throw MapPresentationDetachedException()
+        throw MapNotAttachedException()
       }
     }
   }
 }
 
-/** Represents a logical map and its style independently from a temporary UI presentation. */
+/** Holds the observable style, camera, and map operations for one logical map. */
+@Stable
 public class MapState
 internal constructor(
   internal val runtime: RuntimeImplementation,
@@ -484,17 +453,123 @@ internal constructor(
   public val cameraPosition: CameraPosition
     get() = cameraPositionState
 
-  public var presentation: MapPresentation? by mutableStateOf(null)
+  internal var currentMapAttachment: MapAttachment? by mutableStateOf(null)
     internal set
+
+  private var nextMapAttachment = CompletableDeferred<MapAttachment>()
+
+  /** Contains the current rendered viewport, or null while no viewport is available. */
+  public val viewport: Viewport?
+    get() = currentMapAttachment?.viewport
+
+  /** Returns true while the current map surface is moving its camera. */
+  public val isCameraMoving: Boolean
+    get() = currentMapAttachment?.isCameraMoving == true
+
+  /**
+   * Contains the reason for the current camera movement, or [CameraMoveReason.NONE] while detached.
+   */
+  public val cameraMoveReason: CameraMoveReason
+    get() = currentMapAttachment?.cameraMoveReason ?: CameraMoveReason.NONE
 
   public val isClosed: Boolean
     get() = closedState
 
-  /** Marks this state as closed and starts cleanup of the current presentation. */
+  /** Marks this state as closed and starts cleanup of the current map surface. */
   public fun close(): Unit = lifecycle.close()
 
-  /** Waits until presentation cleanup has completed. */
+  /** Waits until map-surface cleanup has completed. */
   public suspend fun awaitClosed(): Unit = lifecycle.awaitClosed()
+
+  /**
+   * Sets the durable camera position and applies it to the current surface when one is attached.
+   */
+  public fun setCameraPosition(position: CameraPosition) {
+    val command = lifecycle.serialized {
+      requireOpenLocked()
+      cameraPositionState = position
+      cameraCommandRevision++
+      val attachment = currentMapAttachment ?: return
+      AttachmentCameraCommand(
+        attachment = attachment,
+        command = CameraCommand(attachment.adapter, position, cameraCommandRevision),
+      )
+    }
+    applyAttachmentCameraCommand(command.attachment, command.command)
+  }
+
+  /** Fits [boundingBox] in the current viewport without animation. */
+  public suspend fun setCameraPosition(
+    boundingBox: BoundingBox,
+    bearing: Double = 0.0,
+    tilt: Double = 0.0,
+    padding: PaddingValues = PaddingValues(0.dp),
+  ): Unit = requireAttachment().setCameraPosition(boundingBox, bearing, tilt, padding)
+
+  /** Animates the camera to [position]. A new camera animation replaces the previous one. */
+  public suspend fun animateCameraPosition(
+    position: CameraPosition,
+    duration: Duration = 300.milliseconds,
+  ): Unit = requireAttachment().animateCameraPosition(position, duration)
+
+  /** Animates the camera to fit [boundingBox]. A new camera animation replaces the previous one. */
+  public suspend fun animateCameraPosition(
+    boundingBox: BoundingBox,
+    bearing: Double = 0.0,
+    tilt: Double = 0.0,
+    padding: PaddingValues = PaddingValues(0.dp),
+    duration: Duration = 300.milliseconds,
+  ): Unit = requireAttachment().animateCameraPosition(boundingBox, bearing, tilt, padding, duration)
+
+  /** Returns the visible region, or null while no viewport is available. */
+  public fun getVisibleRegion(): VisibleRegion? =
+    withAttachmentRead(MapAttachment::getVisibleRegion)
+
+  /** Returns the visible axis-aligned bounds, or null while no viewport is available. */
+  public fun getVisibleBoundingBox(): BoundingBox? =
+    withAttachmentRead(MapAttachment::getVisibleBoundingBox)
+
+  /** Projects [position] into a logical-pixel offset, or returns null without a viewport. */
+  public fun screenLocationFromPosition(position: Position): DpOffset? = withAttachmentRead {
+    it.screenLocationFromPosition(position)
+  }
+
+  /** Unprojects [offset] into a geographic position, or returns null without a viewport. */
+  public fun positionFromScreenLocation(offset: DpOffset): Position? = withAttachmentRead {
+    it.positionFromScreenLocation(offset)
+  }
+
+  /** Returns the ground distance per dp, or null while no viewport is available. */
+  public fun metersPerDpAtLatitude(latitude: Double): Double? = withAttachmentRead {
+    it.metersPerDpAtLatitude(latitude)
+  }
+
+  /** Queries rendered features at [offset] in front-to-back render order. */
+  public suspend fun queryRenderedFeatures(
+    offset: DpOffset,
+    layerIds: Set<String>? = null,
+    predicate: Expression<BooleanValue> = const(true),
+  ): List<Feature<Geometry, JsonObject?>> =
+    requireAttachment().queryRenderedFeatures(offset, layerIds, predicate)
+
+  /** Queries rendered features that intersect [rect] in front-to-back render order. */
+  public suspend fun queryRenderedFeatures(
+    rect: DpRect,
+    layerIds: Set<String>? = null,
+    predicate: Expression<BooleanValue> = const(true),
+  ): List<Feature<Geometry, JsonObject?>> =
+    requireAttachment().queryRenderedFeatures(rect, layerIds, predicate)
+
+  /** Waits for the first viewport from the current or a future map attachment. */
+  public suspend fun awaitViewport(): Viewport {
+    while (true) {
+      try {
+        return awaitAttachment().awaitViewport()
+      } catch (_: MapNotAttachedException) {
+        // A replacement surface can attach after this lease ends.
+      }
+    }
+  }
 
   internal fun reservePresentation(
     owner: MapPresentationOwnerToken = MapPresentationOwnerToken()
@@ -503,8 +578,7 @@ internal constructor(
   internal fun publishPresentation(
     token: MapPresentationToken,
     adapter: MapAdapter,
-    options: MapPresentationOptions = MapPresentationOptions(),
-  ) = lifecycle.publishPresentation(token, adapter, options)
+  ) = lifecycle.publishPresentation(token, adapter)
 
   internal fun releasePresentation(token: MapPresentationToken, adapter: MapAdapter? = null) =
     lifecycle.releasePresentation(token, adapter)
@@ -658,42 +732,35 @@ internal constructor(
     }
   }
 
-  internal fun setCameraPosition(candidate: MapPresentation, position: CameraPosition) {
-    val command = lifecycle.serialized {
-      requireCurrentLocked(candidate)
-      cameraPositionState = position
-      CameraCommand(candidate.adapter, position, ++cameraCommandRevision)
-    }
-    applyPresentationCameraCommand(candidate, command)
-  }
-
-  internal fun synchronizeCamera(adapter: MapAdapter): MapPresentation? {
+  internal fun synchronizeCamera(adapter: MapAdapter): MapAttachment? {
     if (!lifecycle.acceptsPresentation(adapter)) return null
     val cameraPosition = adapter.getCameraPosition()
     val viewport = adapter.getViewport() ?: return null
     return lifecycle.serialized {
       if (!lifecycle.acceptsPresentation(adapter)) return@serialized null
       cameraPositionState = cameraPosition
-      val current = presentation ?: return@serialized null
+      val current = currentMapAttachment ?: return@serialized null
       current.cameraMoved(viewport)
       current
     }
   }
 
-  internal fun requireCurrent(candidate: MapPresentation) {
+  internal fun requireCurrent(candidate: MapAttachment) {
     lifecycle.serialized { requireCurrentLocked(candidate) }
   }
 
-  internal fun <T> withCurrent(candidate: MapPresentation, block: () -> T): T {
+  internal fun <T> withCurrent(candidate: MapAttachment, block: () -> T): T {
     lifecycle.serialized { requireCurrentLocked(candidate) }
     val result = block()
     lifecycle.serialized { requireCurrentLocked(candidate) }
     return result
   }
 
-  private fun requireCurrentLocked(candidate: MapPresentation) {
-    if (presentation !== candidate || !lifecycle.isCurrent(candidate.token, candidate.adapter)) {
-      throw MapPresentationDetachedException()
+  private fun requireCurrentLocked(candidate: MapAttachment) {
+    if (
+      currentMapAttachment !== candidate || !lifecycle.isCurrent(candidate.token, candidate.adapter)
+    ) {
+      throw MapNotAttachedException()
     }
   }
 
@@ -706,15 +773,17 @@ internal constructor(
     style.invalidateLoadedStyle()
     Snapshot.withMutableSnapshot {
       closedState = true
-      presentation?.invalidate()
-      presentation = null
+      currentMapAttachment?.invalidate()
+      currentMapAttachment = null
+      nextMapAttachment.completeExceptionally(MapStateClosedException())
     }
   }
 
   internal fun invalidatePresentation(adapter: MapAdapter?) {
     Snapshot.withMutableSnapshot {
-      presentation?.invalidate()
-      presentation = null
+      currentMapAttachment?.invalidate()
+      currentMapAttachment = null
+      prepareForNextAttachment()
       if (adapter?.retainsEngineBetweenPresentations != true) {
         style.loadState = StyleLoadState.Pending
       }
@@ -726,9 +795,10 @@ internal constructor(
       styleHandleEpoch++
       style.invalidateLoadedStyle()
       style.loadState = StyleLoadState.Pending
-      if (presentation?.adapter === adapter) {
-        presentation?.invalidate()
-        presentation = null
+      if (currentMapAttachment?.adapter === adapter) {
+        currentMapAttachment?.invalidate()
+        currentMapAttachment = null
+        prepareForNextAttachment()
       }
     }
   }
@@ -755,7 +825,7 @@ internal constructor(
   internal fun seedPresentationViewport(token: MapPresentationToken, adapter: MapAdapter) {
     val viewport = adapter.getViewport() ?: return
     lifecycle.serialized {
-      val current = presentation ?: return@serialized
+      val current = currentMapAttachment ?: return@serialized
       if (current.token != token || current.adapter !== adapter || current.viewport != null) return
       current.updateViewport(viewport)
     }
@@ -787,16 +857,16 @@ internal constructor(
     }
   }
 
-  private fun applyPresentationCameraCommand(
-    presentation: MapPresentation,
+  private fun applyAttachmentCameraCommand(
+    attachment: MapAttachment,
     initial: CameraCommand,
   ) {
     var command = initial
     while (true) {
-      if (!lifecycle.isCurrent(presentation.token, command.adapter)) return
+      if (!lifecycle.isCurrent(attachment.token, command.adapter)) return
       command.adapter.setCameraPosition(command.value)
       command = lifecycle.serialized {
-        if (!lifecycle.isCurrent(presentation.token, command.adapter)) return
+        if (!lifecycle.isCurrent(attachment.token, command.adapter)) return
         if (cameraCommandRevision == command.revision) return
         CameraCommand(command.adapter, cameraPositionState, cameraCommandRevision)
       }
@@ -806,9 +876,37 @@ internal constructor(
   internal fun commitPresentation(
     token: MapPresentationToken,
     adapter: MapAdapter,
-    options: MapPresentationOptions,
   ) {
-    presentation = MapPresentation(this, token, adapter, options)
+    val attachment = MapAttachment(this, token, adapter)
+    currentMapAttachment = attachment
+    nextMapAttachment.complete(attachment)
+  }
+
+  private fun requireAttachment(): MapAttachment =
+    currentMapAttachment ?: throw MapNotAttachedException()
+
+  private suspend fun awaitAttachment(): MapAttachment {
+    val pending = lifecycle.serialized {
+      requireOpenLocked()
+      currentMapAttachment?.let {
+        return it
+      }
+      nextMapAttachment
+    }
+    return pending.await()
+  }
+
+  private fun prepareForNextAttachment() {
+    if (nextMapAttachment.isCompleted) nextMapAttachment = CompletableDeferred()
+  }
+
+  private inline fun <T> withAttachmentRead(block: (MapAttachment) -> T?): T? {
+    val attachment = currentMapAttachment ?: return null
+    return try {
+      block(attachment)
+    } catch (_: MapNotAttachedException) {
+      null
+    }
   }
 
   private data class PresentationConfiguration(
@@ -820,6 +918,11 @@ internal constructor(
     val adapter: MapAdapter,
     val value: CameraPosition,
     val revision: Long,
+  )
+
+  private data class AttachmentCameraCommand(
+    val attachment: MapAttachment,
+    val command: CameraCommand,
   )
 
   private data class BaseStyleCommand(

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MaplibreMap.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MaplibreMap.kt
@@ -2,6 +2,7 @@ package org.maplibre.compose.map
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.safeDrawing
@@ -19,6 +20,7 @@ import androidx.compose.ui.UiComposable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 import org.maplibre.compose.camera.CameraMoveReason
@@ -30,6 +32,7 @@ import org.maplibre.compose.style.DesiredStyleLayer
 import org.maplibre.compose.style.DesiredStyleRevision
 import org.maplibre.compose.style.StyleBinding
 import org.maplibre.compose.style.rememberStyleComposition
+import org.maplibre.compose.util.ClickResult
 import org.maplibre.compose.util.FeaturesClickHandler
 import org.maplibre.compose.util.MapClickHandler
 import org.maplibre.spatialk.geojson.Position
@@ -38,12 +41,12 @@ private class MapStateAttachment(
   val state: MapState,
   private val token: MapPresentationToken,
 ) {
-  fun publish(map: MapAdapter, options: MapPresentationOptions) {
-    state.publishPresentation(token, map, options)
+  fun publish(map: MapAdapter) {
+    state.publishPresentation(token, map)
   }
 
-  fun currentPresentation(map: MapAdapter): MapPresentation? =
-    state.presentation?.takeIf { it.adapter === map }
+  fun currentAttachment(map: MapAdapter): MapAttachment? =
+    state.currentMapAttachment?.takeIf { it.adapter === map }
 
   fun release(map: MapAdapter? = null) {
     state.releasePresentation(token, map)
@@ -68,18 +71,24 @@ private class MapStateAttachment(
 }
 
 /**
- * Displays [state] through one temporary presentation.
+ * Displays [state] on a map surface.
  *
- * The caller controls the lifetime of [state]. This composable creates the current presentation and
- * releases it when the call leaves composition. [overlay] draws Compose UI over the map. The
- * default draws [MapOverlay.Default]. A supplied block replaces the default.
+ * The caller controls the lifetime of [state]. This composable attaches the map surface while the
+ * call remains in composition. [overlay] draws Compose UI over the map. The default draws
+ * [MapOverlay.Default]. A supplied block replaces the default.
  */
 @Composable
 public fun MaplibreMap(
-  state: MapState = rememberMapState(),
   modifier: Modifier = Modifier,
-  presentationOptions: MapPresentationOptions = MapPresentationOptions(),
-  callbacks: MapPresentationCallbacks = MapPresentationCallbacks(),
+  state: MapState = rememberMapState(),
+  cameraPadding: PaddingValues = PaddingValues(0.dp),
+  cameraConstraints: CameraConstraints = CameraConstraints(),
+  renderOptions: RenderOptions = RenderOptions.Standard,
+  gestureOptions: GestureOptions = GestureOptions.Standard,
+  tileLodOptions: TileLodOptions = TileLodOptions.Standard,
+  onClick: MapClickHandler = { _, _ -> ClickResult.Pass },
+  onLongClick: MapClickHandler = { _, _ -> ClickResult.Pass },
+  onFrame: (framesPerSecond: Double) -> Unit = {},
   contentWindowInsets: WindowInsets = WindowInsets.safeDrawing,
   overlay: @Composable @UiComposable MapOverlayScope.() -> Unit = {
     include(MapOverlay.Default)
@@ -92,13 +101,23 @@ public fun MaplibreMap(
 
   val presentationHostIdentity = mapPresentationHostIdentity()
   val presentationOwner = remember(state) { MapPresentationOwnerToken() }
+  val mapViewOptions =
+    MapViewOptions(
+      cameraPadding = cameraPadding,
+      cameraConstraints = cameraConstraints,
+      renderOptions = renderOptions,
+      gestureOptions = gestureOptions,
+      tileLodOptions = tileLodOptions,
+    )
   key(state, presentationHostIdentity) {
     PresentedMaplibreMap(
       state = state,
       presentationOwner = presentationOwner,
       modifier = modifier,
-      presentationOptions = presentationOptions,
-      callbacks = callbacks,
+      mapViewOptions = mapViewOptions,
+      onClick = onClick,
+      onLongClick = onLongClick,
+      onFrame = onFrame,
       contentWindowInsets = contentWindowInsets,
       overlay = overlay,
     )
@@ -110,8 +129,10 @@ private fun PresentedMaplibreMap(
   state: MapState,
   presentationOwner: MapPresentationOwnerToken,
   modifier: Modifier,
-  presentationOptions: MapPresentationOptions,
-  callbacks: MapPresentationCallbacks,
+  mapViewOptions: MapViewOptions,
+  onClick: MapClickHandler,
+  onLongClick: MapClickHandler,
+  onFrame: (Double) -> Unit,
   contentWindowInsets: WindowInsets,
   overlay: @Composable @UiComposable MapOverlayScope.() -> Unit,
 ) {
@@ -122,8 +143,10 @@ private fun PresentedMaplibreMap(
     state = state,
     attachment = attachment,
     modifier = modifier,
-    presentationOptions = presentationOptions,
-    callbacks = callbacks,
+    mapViewOptions = mapViewOptions,
+    onClick = onClick,
+    onLongClick = onLongClick,
+    onFrame = onFrame,
     contentWindowInsets = contentWindowInsets,
     overlay = overlay,
   )
@@ -134,8 +157,10 @@ private fun MaplibreMapPresentation(
   state: MapState,
   attachment: MapStateAttachment,
   modifier: Modifier,
-  presentationOptions: MapPresentationOptions,
-  callbacks: MapPresentationCallbacks,
+  mapViewOptions: MapViewOptions,
+  onClick: MapClickHandler,
+  onLongClick: MapClickHandler,
+  onFrame: (Double) -> Unit,
   contentWindowInsets: WindowInsets,
   overlay: @Composable @UiComposable MapOverlayScope.() -> Unit,
 ) {
@@ -152,11 +177,11 @@ private fun MaplibreMapPresentation(
         },
     )
   val mapClickScope = rememberCoroutineScope()
-  val presentation = state.presentation
-  var retainedRevisionReplayed by remember(rememberedStyle, presentation) { mutableStateOf(false) }
+  val mapAttachment = state.currentMapAttachment
+  var retainedRevisionReplayed by remember(rememberedStyle, mapAttachment) { mutableStateOf(false) }
 
-  LaunchedEffect(rememberedStyle, presentation, attachment) {
-    val map = presentation?.adapter ?: return@LaunchedEffect
+  LaunchedEffect(rememberedStyle, mapAttachment, attachment) {
+    val map = mapAttachment?.adapter ?: return@LaunchedEffect
     if (rememberedStyle == null) return@LaunchedEffect
     try {
       map.replayStyleRevision(state.desiredStyleRevision)
@@ -169,9 +194,9 @@ private fun MaplibreMapPresentation(
     }
   }
 
-  LaunchedEffect(rememberedStyle, desiredRevision, presentation, retainedRevisionReplayed) {
+  LaunchedEffect(rememberedStyle, desiredRevision, mapAttachment, retainedRevisionReplayed) {
     if (!retainedRevisionReplayed) return@LaunchedEffect
-    val map = presentation?.adapter ?: return@LaunchedEffect
+    val map = mapAttachment?.adapter ?: return@LaunchedEffect
     val revision = desiredRevision ?: return@LaunchedEffect
     attachment.reconcileStyleRevision(map, revision)
   }
@@ -181,15 +206,16 @@ private fun MaplibreMapPresentation(
       desiredRevision,
       mapClickScope,
       attachment,
-      presentation,
-      presentationOptions,
-      callbacks,
+      mapAttachment,
+      onClick,
+      onLongClick,
+      onFrame,
     ) {
       object : MapAdapter.Callbacks {
-        private fun currentPresentation(map: MapAdapter): MapPresentation? =
-          attachment.currentPresentation(map)
+        private fun currentAttachment(map: MapAdapter): MapAttachment? =
+          attachment.currentAttachment(map)
 
-        private fun synchronizeCamera(map: MapAdapter): MapPresentation? {
+        private fun synchronizeCamera(map: MapAdapter): MapAttachment? {
           return state.synchronizeCamera(map)
         }
 
@@ -212,7 +238,7 @@ private fun MaplibreMapPresentation(
         }
 
         override fun onCameraMoveStarted(map: MapAdapter, reason: CameraMoveReason) {
-          currentPresentation(map)?.cameraMoveStarted(reason)
+          currentAttachment(map)?.cameraMoveStarted(reason)
         }
 
         override fun onCameraMoved(map: MapAdapter) {
@@ -236,7 +262,7 @@ private fun MaplibreMapPresentation(
           mapHandler: MapClickHandler,
           layerHandler: (DesiredStyleLayer) -> FeaturesClickHandler?,
         ) {
-          if (currentPresentation(map) == null) return
+          if (currentAttachment(map) == null) return
           if (mapHandler(latLng, offset).consumed) return
           mapClickScope.launch {
             for (node in layerNodesInOrder()) {
@@ -260,21 +286,21 @@ private fun MaplibreMapPresentation(
         }
 
         override fun onClick(map: MapAdapter, latLng: Position, offset: DpOffset) =
-          dispatchPointerEvent(map, latLng, offset, callbacks.onClick, DesiredStyleLayer::onClick)
+          dispatchPointerEvent(map, latLng, offset, onClick, DesiredStyleLayer::onClick)
 
         override fun onLongClick(map: MapAdapter, latLng: Position, offset: DpOffset) =
           dispatchPointerEvent(
             map,
             latLng,
             offset,
-            callbacks.onLongClick,
+            onLongClick,
             DesiredStyleLayer::onLongClick,
           )
 
         override fun onFrame(fps: Double) {
-          val map = state.presentation?.adapter ?: return
+          val map = state.currentMapAttachment?.adapter ?: return
           synchronizeCamera(map)
-          callbacks.onFrame(fps)
+          onFrame(fps)
         }
       }
     }
@@ -286,20 +312,12 @@ private fun MaplibreMapPresentation(
       style = state.style.baseStyle,
       update = update@{ map ->
           if (state.isClosed) return@update
-          map.setCameraPadding(presentationOptions.cameraPadding)
-          map.setCameraConstraints(
-            CameraConstraints(
-              minZoom = presentationOptions.zoomRange.start.toDouble(),
-              maxZoom = presentationOptions.zoomRange.endInclusive.toDouble(),
-              minPitch = presentationOptions.pitchRange.start.toDouble(),
-              maxPitch = presentationOptions.pitchRange.endInclusive.toDouble(),
-              boundingBox = presentationOptions.boundingBox,
-            )
-          )
-          map.setRenderSettings(presentationOptions.renderOptions)
-          map.setGestureSettings(presentationOptions.gestureOptions)
-          map.setTileLodSettings(presentationOptions.tileLodOptions)
-          attachment.publish(map, presentationOptions)
+          map.setCameraPadding(mapViewOptions.cameraPadding)
+          map.setCameraConstraints(mapViewOptions.cameraConstraints)
+          map.setRenderSettings(mapViewOptions.renderOptions)
+          map.setGestureSettings(mapViewOptions.gestureOptions)
+          map.setTileLodSettings(mapViewOptions.tileLodOptions)
+          attachment.publish(map)
         },
       onReset = {
         attachment.release()
@@ -307,7 +325,7 @@ private fun MaplibreMapPresentation(
       },
       logger = state.runtime.logger,
       callbacks = adapterCallbacks,
-      options = presentationOptions,
+      options = mapViewOptions,
     )
 
     MapOverlayHost(

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/PlatformMapAccess.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/PlatformMapAccess.kt
@@ -26,9 +26,9 @@ public annotation class DelicateMapApi
  * The platform map is borrowed for [block]. Use the raw handle only during [block]. Kotlin cannot
  * prevent retention. A long-running block stops the map from processing other work.
  *
- * Native platforms create the engine map when necessary and permit access without a presentation.
- * Web requires a current presentation. The call fails without running [block] if the map closes or
- * the engine changes before execution. On Web, the call also fails if the current presentation
+ * Native platforms create the engine map when necessary and permit access without an attached UI
+ * surface. Web requires an attached surface. The call fails without running [block] if the map
+ * closes or the engine changes before execution. On Web, the call also fails if the current surface
  * detaches before execution. Cancelling while the invocation is queued prevents [block] from
  * running. Once execution starts, cancellation does not interrupt [block], but its result is
  * discarded.

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/Attribution.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/Attribution.kt
@@ -100,13 +100,12 @@ public fun MapOverlayScope.ExpandingAttributionButton(
   collapse: (Alignment) -> ExitTransition = AttributionDefaults.collapse,
 ) {
   var expanded by remember { mutableStateOf(true) }
-  val currentPresentation = presentation
+  val currentMapState = mapState
 
   // dismiss on any map gesture
-  LaunchedEffect(currentPresentation?.isCameraMoving, currentPresentation?.cameraMoveReason) {
+  LaunchedEffect(currentMapState.isCameraMoving, currentMapState.cameraMoveReason) {
     if (
-      currentPresentation?.isCameraMoving == true &&
-        currentPresentation.cameraMoveReason == CameraMoveReason.GESTURE
+      currentMapState.isCameraMoving && currentMapState.cameraMoveReason == CameraMoveReason.GESTURE
     ) {
       expanded = false
     }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/CompassButton.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/CompassButton.kt
@@ -78,7 +78,6 @@ public fun MapOverlayScope.CompassButton(
   getHomePosition: (CameraPosition) -> CameraPosition = { it.copy(bearing = 0.0, tilt = 0.0) },
 ) {
   val currentMapState = mapState
-  val currentPresentation = presentation
   val coroutineScope = rememberCoroutineScope()
   val interactionSource = remember { MutableInteractionSource() }
   val hovered by interactionSource.collectIsHoveredAsState()
@@ -97,10 +96,8 @@ public fun MapOverlayScope.CompassButton(
         indication = LocalIndication.current,
         role = Role.Button,
       ) {
-        currentPresentation?.let { current ->
-          coroutineScope.launch {
-            current.animateCameraPosition(getHomePosition(currentMapState.cameraPosition))
-          }
+        coroutineScope.launch {
+          currentMapState.animateCameraPosition(getHomePosition(currentMapState.cameraPosition))
         }
         onClick()
       }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/MapOverlay.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/MapOverlay.kt
@@ -27,7 +27,6 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import kotlin.math.PI
-import org.maplibre.compose.map.MapPresentation
 import org.maplibre.compose.map.MapState
 import org.maplibre.compose.map.MapStyleState
 import org.maplibre.spatialk.geojson.Position
@@ -46,10 +45,6 @@ import org.maplibre.spatialk.geojson.Position
 public interface MapOverlayScope {
   /** The logical map that this overlay belongs to. */
   public val mapState: MapState
-
-  /** The map's current presentation, or null while the surface is attaching. */
-  public val presentation: MapPresentation?
-    get() = mapState.presentation
 
   /** The style state of the map that this overlay belongs to. */
   public val style: MapStyleState
@@ -148,7 +143,7 @@ public class MapOverlay(
      */
     public val Default: MapOverlay = MapOverlay {
       DisappearingScaleBar(
-        metersPerDp = presentation?.viewport?.metersPerDpAtTarget ?: 0.0,
+        metersPerDp = mapState.viewport?.metersPerDpAtTarget ?: 0.0,
         zoom = mapState.cameraPosition.zoom,
         modifier = Modifier.align(Alignment.TopStart),
       )
@@ -211,15 +206,14 @@ internal fun MapOverlayHost(
       // Aligned children stay put when the camera moves. Reading the viewport here would
       // invalidate this layout on every frame of a camera ease, so it is read only when a child
       // needs placing; the read is also what re-runs this layout when the transform changes.
-      val presentation = if (hasPlacedAt) mapState.presentation else null
-      val viewport = presentation?.viewport
+      val viewport = if (hasPlacedAt) mapState.viewport else null
       measurables.forEachIndexed { index, measurable ->
         val placeable = placeables[index]
         when (val child = measurable.parentData as? OverlayChildData) {
           is OverlayChildData.PlacedAt -> {
             if (viewport == null || width == 0 || height == 0) return@forEachIndexed
             val screen =
-              presentation.screenLocationFromPosition(child.position) ?: return@forEachIndexed
+              mapState.screenLocationFromPosition(child.position) ?: return@forEachIndexed
             val aligned =
               child.alignment.align(
                 size = IntSize(placeable.width, placeable.height),
@@ -239,7 +233,7 @@ internal fun MapOverlayHost(
             val intersection =
               if (viewport == null || innerWidth == 0 || innerHeight == 0) null
               else {
-                presentation.screenLocationFromPosition(child.position)?.let { screen ->
+                mapState.screenLocationFromPosition(child.position)?.let { screen ->
                   findEllipseIntersection(
                     area =
                       Rect(

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
@@ -99,14 +99,14 @@ class MapPresentationTest {
     session.lifecycle.attach()
     val token = state.reservePresentation()
     state.publishPresentation(token, session)
-    assertSame(session, state.presentation?.adapter)
+    assertSame(session, state.currentMapAttachment?.adapter)
     assertTrue(state.updateLoadedStyle(session, RecordingStyleBinding()))
     assertTrue(state.markStyleReady(session))
     assertEquals(StyleLoadState.Ready, state.style.loadState)
 
     session.close()
 
-    assertNull(state.presentation)
+    assertNull(state.currentMapAttachment)
     assertNull(state.retainedAdapter(session.presentationCompatibilityKey))
     assertFalse(state.acceptsPresentationEvent(session))
     assertEquals(StyleLoadState.Pending, state.style.loadState)
@@ -121,7 +121,7 @@ class MapPresentationTest {
     val replacement = PresentationTestAdapter()
     val replacementToken = state.reservePresentation()
     state.publishPresentation(replacementToken, replacement)
-    assertSame(replacement, state.presentation?.adapter)
+    assertSame(replacement, state.currentMapAttachment?.adapter)
 
     state.close()
     val failure = assertFailsWith<MapStateCleanupException> { state.awaitClosed() }
@@ -147,7 +147,7 @@ class MapPresentationTest {
 
     state.releasePresentation(token, session)
     testScheduler.runCurrent()
-    assertNull(state.presentation)
+    assertNull(state.currentMapAttachment)
     assertSame(session, state.retainedAdapter(session.presentationCompatibilityKey))
     assertEquals(StyleLoadState.Ready, state.style.loadState)
 
@@ -173,16 +173,16 @@ class MapPresentationTest {
 
     state.releasePresentation(firstToken, first)
     first.detachStarted.await()
-    assertNull(state.presentation)
+    assertNull(state.currentMapAttachment)
 
     val replacement = PresentationTestAdapter()
     val replacementToken = state.reservePresentation(MapPresentationOwnerToken())
     state.publishPresentation(replacementToken, replacement)
-    assertSame(replacement, state.presentation?.adapter)
+    assertSame(replacement, state.currentMapAttachment?.adapter)
 
     first.finishDetach.complete(Unit)
     testScheduler.runCurrent()
-    assertSame(replacement, state.presentation?.adapter)
+    assertSame(replacement, state.currentMapAttachment?.adapter)
     state.close()
     state.awaitClosed()
     runtime.close()
@@ -275,7 +275,7 @@ class MapPresentationTest {
     state.publishPresentation(token, adapter)
 
     assertTrue(state.isClosed)
-    assertNull(state.presentation)
+    assertNull(state.currentMapAttachment)
     state.awaitClosed()
     runtime.close()
   }
@@ -307,7 +307,7 @@ class MapPresentationTest {
 
     state.publishPresentation(token, adapter)
 
-    assertSame(adapter, state.presentation?.adapter)
+    assertSame(adapter, state.currentMapAttachment?.adapter)
     val failure = assertIs<StyleLoadState.Failed>(state.style.loadState)
     assertEquals("style rejected", failure.reason)
     state.close()
@@ -339,7 +339,7 @@ class MapPresentationTest {
     val fixture = presentationFixture()
     val position = CameraPosition(target = Position(12.0, 34.0), zoom = 8.0)
 
-    fixture.presentation.setCameraPosition(position)
+    fixture.state.setCameraPosition(position)
 
     assertEquals(position, fixture.state.cameraPosition)
     assertEquals(position, fixture.adapter.lastCameraPosition)
@@ -355,43 +355,51 @@ class MapPresentationTest {
       state.releasePresentation(token, map)
     }
     state.publishPresentation(token, adapter)
-    val presentation = requireNotNull(state.presentation)
+    val presentation = requireNotNull(state.currentMapAttachment)
     val position = CameraPosition(target = Position(12.0, 34.0), zoom = 8.0)
     adapter.releaseOnNextCameraSet = true
 
-    presentation.setCameraPosition(position)
+    state.setCameraPosition(position)
 
     assertEquals(position, state.cameraPosition)
     assertFalse(presentation.isValid)
-    assertNull(state.presentation)
+    assertNull(state.currentMapAttachment)
     state.close()
     runtime.close()
   }
 
   @Test
-  fun a_departed_presentation_rejects_cached_operations_and_delayed_camera_events() {
+  fun a_detached_map_keeps_durable_camera_commands_and_rejects_surface_operations() = runTest {
     val fixture = presentationFixture()
     fixture.state.releasePresentation(fixture.token, fixture.adapter)
+    val position = CameraPosition(zoom = 4.0)
 
-    assertFailsWith<MapPresentationDetachedException> {
-      fixture.presentation.setCameraPosition(CameraPosition(zoom = 4.0))
+    fixture.state.setCameraPosition(position)
+    assertEquals(position, fixture.state.cameraPosition)
+    assertEquals(CameraPosition(), fixture.adapter.lastCameraPosition)
+    assertFailsWith<MapNotAttachedException> {
+      fixture.state.queryRenderedFeatures(DpOffset.Zero)
     }
     val viewportReads = fixture.adapter.viewportReads
     fixture.adapter.lastCameraPosition = CameraPosition(zoom = 7.0)
     assertNull(fixture.state.synchronizeCamera(fixture.adapter))
     assertEquals(viewportReads, fixture.adapter.viewportReads)
-    assertEquals(CameraPosition(), fixture.state.cameraPosition)
+    assertEquals(position, fixture.state.cameraPosition)
     fixture.close()
   }
 
   @Test
-  fun presentation_options_update_only_the_current_lease() {
+  fun a_camera_set_while_detached_applies_to_the_next_attachment() {
     val fixture = presentationFixture()
-    val options = MapPresentationOptions(zoomRange = 2f..18f, pitchRange = 3f..45f)
+    fixture.state.releasePresentation(fixture.token, fixture.adapter)
+    val position = CameraPosition(target = Position(12.0, 34.0), zoom = 8.0)
+    fixture.state.setCameraPosition(position)
+    val replacement = PresentationTestAdapter()
+    val token = fixture.state.reservePresentation()
 
-    fixture.state.publishPresentation(fixture.token, fixture.adapter, options)
+    fixture.state.publishPresentation(token, replacement)
 
-    assertEquals(options, fixture.presentation.options)
+    assertEquals(position, replacement.lastCameraPosition)
     fixture.close()
   }
 
@@ -403,7 +411,7 @@ class MapPresentationTest {
     fixture.state.publishPresentation(fixture.token, fixture.adapter)
 
     assertTrue(fixture.state.isClosed)
-    assertNull(fixture.state.presentation)
+    assertNull(fixture.state.currentMapAttachment)
     fixture.runtime.close()
   }
 
@@ -669,13 +677,13 @@ class MapPresentationTest {
     val initialCamera = CameraPosition(target = Position(12.0, 34.0), zoom = 8.0)
     val state = runtime.createMapState(initialCameraPosition = initialCamera)
     val token = state.reservePresentation()
-    val adapter = PresentationTestAdapter { state.presentation }
+    val adapter = PresentationTestAdapter { state.currentMapAttachment }
 
     state.publishPresentation(token, adapter)
 
     assertFalse(adapter.presentationWasVisibleWhileConfiguring)
     assertEquals(initialCamera, adapter.lastCameraPosition)
-    assertTrue(state.presentation != null)
+    assertTrue(state.currentMapAttachment != null)
     state.close()
     runtime.close()
   }
@@ -684,9 +692,9 @@ class MapPresentationTest {
   fun viewport_observations_are_null_before_the_first_viewport() {
     val fixture = presentationFixture()
 
-    assertNull(fixture.presentation.getVisibleRegion())
-    assertNull(fixture.presentation.getVisibleBoundingBox())
-    assertNull(fixture.presentation.metersPerDpAtLatitude(0.0))
+    assertNull(fixture.state.getVisibleRegion())
+    assertNull(fixture.state.getVisibleBoundingBox())
+    assertNull(fixture.state.metersPerDpAtLatitude(0.0))
     fixture.close()
   }
 
@@ -700,8 +708,29 @@ class MapPresentationTest {
 
     state.publishPresentation(token, adapter)
 
-    assertEquals(viewport, state.presentation?.viewport)
+    assertEquals(viewport, state.viewport)
     state.close()
+    runtime.close()
+  }
+
+  @Test
+  fun await_viewport_waits_for_the_next_attachment() = runTest {
+    val runtime = mapRuntimeForTest(physicalScope = backgroundScope)
+    val state = runtime.createMapState()
+    val viewport = testViewport()
+    val waiting = async { state.awaitViewport() }
+    testScheduler.runCurrent()
+
+    assertFalse(waiting.isCompleted)
+    val token = state.reservePresentation()
+    state.publishPresentation(
+      token,
+      PresentationTestAdapter().apply { currentViewport = viewport },
+    )
+
+    assertEquals(viewport, waiting.await())
+    state.close()
+    state.awaitClosed()
     runtime.close()
   }
 
@@ -713,13 +742,13 @@ class MapPresentationTest {
     val adapter = PresentationTestAdapter()
 
     state.publishPresentation(token, adapter)
-    assertNull(state.presentation?.viewport)
+    assertNull(state.currentMapAttachment?.viewport)
 
     val viewport = testViewport()
     adapter.currentViewport = viewport
     state.lifecycle.seedCurrentPresentationViewport(adapter)
 
-    assertEquals(viewport, state.presentation?.viewport)
+    assertEquals(viewport, state.viewport)
     state.close()
     runtime.close()
   }
@@ -728,12 +757,12 @@ class MapPresentationTest {
   fun a_bounds_set_waits_for_this_presentations_viewport() = runTest {
     val fixture = presentationFixture()
     val operation = async {
-      fixture.presentation.setCameraPosition(BoundingBox(Position(-1.0, -1.0), Position(1.0, 1.0)))
+      fixture.state.setCameraPosition(BoundingBox(Position(-1.0, -1.0), Position(1.0, 1.0)))
     }
     testScheduler.runCurrent()
 
     assertFalse(fixture.adapter.boundsSet.isCompleted)
-    fixture.presentation.updateViewport(testViewport())
+    fixture.attachment.updateViewport(testViewport())
     operation.await()
     assertTrue(fixture.adapter.boundsSet.isCompleted)
     fixture.close()
@@ -743,16 +772,16 @@ class MapPresentationTest {
   fun a_rendered_query_waits_for_the_first_viewport() = runTest {
     val fixture = presentationFixture()
     supervisorScope {
-      val query = async { fixture.presentation.queryRenderedFeatures(DpOffset.Zero) }
+      val query = async { fixture.state.queryRenderedFeatures(DpOffset.Zero) }
       testScheduler.runCurrent()
 
       assertFalse(fixture.adapter.queryStarted.isCompleted)
 
-      fixture.presentation.updateViewport(testViewport())
+      fixture.attachment.updateViewport(testViewport())
       fixture.adapter.queryStarted.await()
       fixture.state.releasePresentation(fixture.token, fixture.adapter)
 
-      assertFailsWith<MapPresentationDetachedException> { query.await() }
+      assertFailsWith<MapNotAttachedException> { query.await() }
     }
     fixture.close()
   }
@@ -760,14 +789,14 @@ class MapPresentationTest {
   @Test
   fun detachment_fails_an_active_query_instead_of_targeting_another_presentation() = runTest {
     val fixture = presentationFixture()
-    fixture.presentation.updateViewport(testViewport())
+    fixture.attachment.updateViewport(testViewport())
     supervisorScope {
-      val query = async { fixture.presentation.queryRenderedFeatures(DpOffset.Zero) }
+      val query = async { fixture.state.queryRenderedFeatures(DpOffset.Zero) }
       fixture.adapter.queryStarted.await()
 
       fixture.state.releasePresentation(fixture.token, fixture.adapter)
 
-      assertFailsWith<MapPresentationDetachedException> { query.await() }
+      assertFailsWith<MapNotAttachedException> { query.await() }
     }
     fixture.close()
   }
@@ -776,17 +805,17 @@ class MapPresentationTest {
   fun a_replacement_animation_cancels_only_the_previous_camera_mutation() = runTest {
     val fixture = presentationFixture()
     val first = async {
-      fixture.presentation.animateCameraPosition(CameraPosition(zoom = 2.0), 1.seconds)
+      fixture.state.animateCameraPosition(CameraPosition(zoom = 2.0), 1.seconds)
     }
     fixture.adapter.animationStarted.await()
     val second = async {
-      fixture.presentation.animateCameraPosition(CameraPosition(zoom = 3.0), 1.seconds)
+      fixture.state.animateCameraPosition(CameraPosition(zoom = 3.0), 1.seconds)
     }
     testScheduler.runCurrent()
 
     assertTrue(first.isCancelled)
     assertFalse(second.isCompleted)
-    assertTrue(fixture.presentation.isValid)
+    assertTrue(fixture.attachment.isValid)
 
     fixture.adapter.finishAnimation.complete(Unit)
     second.await()
@@ -806,7 +835,7 @@ private data class PresentationFixture(
   val state: MapState,
   val token: MapPresentationToken,
   val adapter: PresentationTestAdapter,
-  val presentation: MapPresentation,
+  val attachment: MapAttachment,
 ) {
   fun close() {
     state.close()
@@ -820,7 +849,13 @@ private fun presentationFixture(): PresentationFixture {
   val token = state.reservePresentation()
   val adapter = PresentationTestAdapter()
   state.publishPresentation(token, adapter)
-  return PresentationFixture(runtime, state, token, adapter, requireNotNull(state.presentation))
+  return PresentationFixture(
+    runtime,
+    state,
+    token,
+    adapter,
+    requireNotNull(state.currentMapAttachment),
+  )
 }
 
 private class RetainedAdapter(private val failOnClose: Boolean) : PresentationTestAdapter() {
@@ -935,7 +970,7 @@ private class ReleasingCameraAdapter(private val release: (MapAdapter) -> Unit) 
 }
 
 internal open class PresentationTestAdapter(
-  private val currentPresentation: () -> MapPresentation? = { null }
+  private val currentAttachment: () -> MapAttachment? = { null }
 ) : MapAdapter {
   var lastCameraPosition = CameraPosition()
   var presentationWasVisibleWhileConfiguring = false
@@ -965,7 +1000,7 @@ internal open class PresentationTestAdapter(
 
   override fun setBaseStyle(style: BaseStyle) {
     presentationWasVisibleWhileConfiguring =
-      presentationWasVisibleWhileConfiguring || currentPresentation() != null
+      presentationWasVisibleWhileConfiguring || currentAttachment() != null
   }
 
   override suspend fun reconcileStyleRevision(revision: DesiredStyleRevision): Boolean = true
@@ -976,7 +1011,7 @@ internal open class PresentationTestAdapter(
 
   override fun setCameraPosition(cameraPosition: CameraPosition) {
     presentationWasVisibleWhileConfiguring =
-      presentationWasVisibleWhileConfiguring || currentPresentation() != null
+      presentationWasVisibleWhileConfiguring || currentAttachment() != null
     lastCameraPosition = cameraPosition
   }
 

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
@@ -754,18 +754,27 @@ class MapPresentationTest {
   }
 
   @Test
-  fun a_bounds_set_waits_for_this_presentations_viewport() = runTest {
-    val fixture = presentationFixture()
+  fun a_bounds_set_waits_for_an_attachment_and_its_viewport() = runTest {
+    val runtime = mapRuntimeForTest(physicalScope = backgroundScope)
+    val state = runtime.createMapState()
     val operation = async {
-      fixture.state.setCameraPosition(BoundingBox(Position(-1.0, -1.0), Position(1.0, 1.0)))
+      state.setCameraPosition(BoundingBox(Position(-1.0, -1.0), Position(1.0, 1.0)))
     }
     testScheduler.runCurrent()
+    assertFalse(operation.isCompleted)
 
-    assertFalse(fixture.adapter.boundsSet.isCompleted)
-    fixture.attachment.updateViewport(testViewport())
+    val token = state.reservePresentation()
+    val adapter = PresentationTestAdapter()
+    state.publishPresentation(token, adapter)
+    testScheduler.runCurrent()
+    assertFalse(operation.isCompleted)
+
+    requireNotNull(state.currentMapAttachment).updateViewport(testViewport())
     operation.await()
-    assertTrue(fixture.adapter.boundsSet.isCompleted)
-    fixture.close()
+    assertTrue(adapter.boundsSet.isCompleted)
+    state.close()
+    state.awaitClosed()
+    runtime.close()
   }
 
   @Test
@@ -820,6 +829,60 @@ class MapPresentationTest {
     fixture.adapter.finishAnimation.complete(Unit)
     second.await()
     fixture.close()
+  }
+
+  @Test
+  fun the_latest_camera_animation_waits_for_attachment_and_restarts_on_replacement() = runTest {
+    val runtime = mapRuntimeForTest(physicalScope = backgroundScope)
+    val state = runtime.createMapState()
+    val superseded = async {
+      state.animateCameraPosition(CameraPosition(zoom = 2.0), 1.seconds)
+    }
+    testScheduler.runCurrent()
+    val animation = async {
+      state.animateCameraPosition(CameraPosition(zoom = 4.0), 1.seconds)
+    }
+    testScheduler.runCurrent()
+    assertTrue(superseded.isCancelled)
+    assertFalse(animation.isCompleted)
+
+    val firstToken = state.reservePresentation()
+    val first = PresentationTestAdapter()
+    state.publishPresentation(firstToken, first)
+    first.animationStarted.await()
+
+    state.releasePresentation(firstToken, first)
+    testScheduler.runCurrent()
+    assertFalse(animation.isCompleted)
+
+    val replacementToken = state.reservePresentation()
+    val replacement = PresentationTestAdapter()
+    state.publishPresentation(replacementToken, replacement)
+    replacement.animationStarted.await()
+    replacement.finishAnimation.complete(Unit)
+
+    animation.await()
+    state.close()
+    state.awaitClosed()
+    runtime.close()
+  }
+
+  @Test
+  fun closing_a_map_fails_a_camera_animation_waiting_for_attachment() = runTest {
+    val runtime = mapRuntimeForTest(physicalScope = backgroundScope)
+    val state = runtime.createMapState()
+    supervisorScope {
+      val animation = async {
+        state.animateCameraPosition(CameraPosition(zoom = 4.0), 1.seconds)
+      }
+      testScheduler.runCurrent()
+
+      state.close()
+
+      assertFailsWith<MapStateClosedException> { animation.await() }
+    }
+    state.awaitClosed()
+    runtime.close()
   }
 }
 

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapRuntimeTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapRuntimeTest.kt
@@ -87,7 +87,7 @@ class MapRuntimeTest {
 
     assertTrue(state.cameraPosition == camera)
     assertTrue(state.style.baseStyle == BaseStyle.Empty)
-    assertTrue(state.presentation == null)
+    assertTrue(state.currentMapAttachment == null)
     state.close()
     runtime.close()
   }

--- a/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/map/IosMapView.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/map/IosMapView.kt
@@ -19,7 +19,7 @@ internal actual fun ComposableMapView(
   onReset: () -> Unit,
   logger: Logger?,
   callbacks: MapAdapter.Callbacks,
-  options: MapPresentationOptions,
+  options: MapViewOptions,
 ) {
   val runtimeBackends = remember { loadRuntimeBackends(logger) }
   MlnFfiMapView(

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/JsMapView.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/JsMapView.kt
@@ -27,7 +27,7 @@ internal actual fun ComposableMapView(
   onReset: () -> Unit,
   logger: Logger?,
   callbacks: MapAdapter.Callbacks,
-  options: MapPresentationOptions,
+  options: MapViewOptions,
 ) {
   val density = LocalDensity.current
   val layoutDirection = LocalLayoutDirection.current

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserMapLifecycleTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserMapLifecycleTest.kt
@@ -78,22 +78,22 @@ class BrowserMapLifecycleTest {
         )
       val presented = mutableStateOf(true)
 
-      setBrowserMapContent { if (presented.value) MaplibreMap(state) }
+      setBrowserMapContent { if (presented.value) MaplibreMap(state = state) }
       waitUntilMap("the first Web presentation to become ready") {
-        state.presentation != null && state.style.loadState == StyleLoadState.Ready
+        state.currentMapAttachment != null && state.style.loadState == StyleLoadState.Ready
       }
-      val firstPresentation = requireNotNull(state.presentation)
+      val firstPresentation = requireNotNull(state.currentMapAttachment)
       val firstSession = firstPresentation.adapter as GlJsMapSession
       val firstEngine = requireNotNull(firstSession.engineMapForTest())
 
-      firstPresentation.setCameraPosition(replayedCamera)
+      state.setCameraPosition(replayedCamera)
       waitUntilMap("the logical map to accept the camera") {
         state.cameraPosition.isNear(replayedCamera)
       }
 
       runOnIdle { presented.value = false }
       waitUntilMap("the departed GL JS map to be destroyed") {
-        state.presentation == null && firstSession.engineMapForTest() == null
+        state.currentMapAttachment == null && firstSession.engineMapForTest() == null
       }
 
       assertTrue(!firstPresentation.isValid)
@@ -105,9 +105,10 @@ class BrowserMapLifecycleTest {
         state.style.baseStyle = REPLAY_STYLE
         runOnIdle { presented.value = true }
         waitUntilMap("the replacement Web map to request its retained style") {
-          state.presentation != null && deferredStyle.isStyleRequested()
+          state.currentMapAttachment != null && deferredStyle.isStyleRequested()
         }
-        val replacementSession = requireNotNull(state.presentation).adapter as GlJsMapSession
+        val replacementSession =
+          requireNotNull(state.currentMapAttachment).adapter as GlJsMapSession
 
         assertNotSame(firstSession, replacementSession)
         assertNotSame(firstEngine, replacementSession.engineMapForTest())
@@ -125,7 +126,7 @@ class BrowserMapLifecycleTest {
 
         deferredStyle.resolveSource()
         waitUntilMap("the replacement Web presentation to replay the logical map") {
-          state.presentation != null &&
+          state.currentMapAttachment != null &&
             state.style.loadState == StyleLoadState.Ready &&
             state.cameraPosition.isNear(replayedCamera)
         }

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserMapStyleStateTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserMapStyleStateTest.kt
@@ -134,18 +134,20 @@ class BrowserMapStyleStateTest {
       }
       val state = runtime.createMapState(baseStyle = STYLE_A, styleComposition = composition)
 
-      setBrowserMapContent { if (presented.value) MaplibreMap(state) }
-      waitUntilMap("style A to become ready") {
-        state.presentation != null && state.style.loadState == StyleLoadState.Ready
+      setBrowserMapContent {
+        if (presented.value) MaplibreMap(state = state)
       }
-      val initialSession = requireNotNull(state.presentation).adapter as GlJsMapSession
+      waitUntilMap("style A to become ready") {
+        state.currentMapAttachment != null && state.style.loadState == StyleLoadState.Ready
+      }
+      val initialSession = requireNotNull(state.currentMapAttachment).adapter as GlJsMapSession
       assertTrue(
         initialSession.engineMapForTest()?.getStyle()?.layers?.any { it.id == "initial-overlay" } ==
           true
       )
 
       runOnIdle { presented.value = false }
-      waitUntilMap("the Web map to detach") { state.presentation == null }
+      waitUntilMap("the Web map to detach") { state.currentMapAttachment == null }
       runOnIdle {
         useLatestRevision.value = true
         state.style.baseStyle = STYLE_B
@@ -170,9 +172,9 @@ class BrowserMapStyleStateTest {
       try {
         runOnIdle { presented.value = true }
         waitUntilMap("style B to load on the replacement map") {
-          state.presentation != null && state.style.loadState == StyleLoadState.Ready
+          state.currentMapAttachment != null && state.style.loadState == StyleLoadState.Ready
         }
-        val session = requireNotNull(state.presentation).adapter as GlJsMapSession
+        val session = requireNotNull(state.currentMapAttachment).adapter as GlJsMapSession
 
         assertTrue(layerAdditions.indexOf("initial-overlay") >= 0)
         assertTrue(
@@ -202,18 +204,18 @@ class BrowserMapStyleStateTest {
       val state = runtime.createMapState(baseStyle = STYLE_A)
       val size = mutableStateOf(0.dp)
 
-      setBrowserMapContent { MaplibreMap(state, modifier = Modifier.size(size.value)) }
+      setBrowserMapContent { MaplibreMap(state = state, modifier = Modifier.size(size.value)) }
       waitForIdle()
 
-      assertNull(state.presentation)
+      assertNull(state.currentMapAttachment)
       assertEquals(StyleLoadState.Pending, state.style.loadState)
 
       runOnIdle { size.value = 128.dp }
       waitUntilMap("the attached style to become ready") {
-        state.presentation != null && state.style.loadState == StyleLoadState.Ready
+        state.currentMapAttachment != null && state.style.loadState == StyleLoadState.Ready
       }
-      val presentation = requireNotNull(state.presentation)
-      val session = requireNotNull(state.presentation).adapter as GlJsMapSession
+      val presentation = requireNotNull(state.currentMapAttachment)
+      val session = requireNotNull(state.currentMapAttachment).adapter as GlJsMapSession
 
       assertNotNull(session.engineMapForTest())
       assertTrue(session.canPresentFrames)
@@ -223,7 +225,7 @@ class BrowserMapStyleStateTest {
         state.style.loadState is StyleLoadState.Failed
       }
 
-      assertTrue(state.presentation === presentation)
+      assertTrue(state.currentMapAttachment === presentation)
       assertTrue(presentation.isValid)
       assertFalse(session.canPresentFrames, "the failed map surface must remain hidden")
 

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserCameraTransitionLifecycleTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserCameraTransitionLifecycleTest.kt
@@ -5,7 +5,6 @@ import androidx.compose.ui.test.ExperimentalTestApi
 import js.objects.unsafeJso
 import kotlin.js.Promise
 import kotlin.test.Test
-import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
@@ -78,22 +77,19 @@ class BrowserCameraTransitionLifecycleTest {
       val state = runtime.createMapState(initialCameraPosition = CURRENT_CAMERA, baseStyle = STYLE)
       val presented = mutableStateOf(true)
 
-      setBrowserMapContent { if (presented.value) MaplibreMap(state) }
+      setBrowserMapContent { if (presented.value) MaplibreMap(state = state) }
       waitUntilMap("the Web presentation to become ready") {
-        state.presentation != null && state.style.loadState == StyleLoadState.Ready
+        state.currentMapAttachment != null && state.style.loadState == StyleLoadState.Ready
       }
-      val departedPresentation = requireNotNull(state.presentation)
+      val departedPresentation = requireNotNull(state.currentMapAttachment)
       val departedSession = departedPresentation.adapter as GlJsMapSession
       val departedEngine = requireNotNull(departedSession.engineMapForTest())
 
       runOnIdle { presented.value = false }
       waitUntilMap("the GL JS map to be destroyed") {
-        state.presentation == null && departedSession.engineMapForTest() == null
+        state.currentMapAttachment == null && departedSession.engineMapForTest() == null
       }
 
-      assertFailsWith<IllegalStateException> {
-        departedPresentation.setCameraPosition(STALE_CAMERA)
-      }
       departedSession.setCameraPosition(STALE_CAMERA)
       departedEngine.fire("move", unsafeJso<MapEvent>())
       waitForIdle()

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserMapSnapshotterTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserMapSnapshotterTest.kt
@@ -95,11 +95,11 @@ class BrowserMapSnapshotterTest {
       val state = runtime.createMapState(baseStyle = BASE_STYLE, styleComposition = composition)
       val snapshotter = runtime.createSnapshotter(BASE_STYLE, composition)
       try {
-        setBrowserMapContent(size = SIZE) { MaplibreMap(state) }
+        setBrowserMapContent(size = SIZE) { MaplibreMap(state = state) }
         waitUntilMap("the interactive map to become ready") {
-          state.presentation != null && state.style.loadState == StyleLoadState.Ready
+          state.currentMapAttachment != null && state.style.loadState == StyleLoadState.Ready
         }
-        val presentation = assertNotNull(state.presentation)
+        val presentation = assertNotNull(state.currentMapAttachment)
         val session = presentation.adapter as GlJsMapSession
         val interactiveEngine = assertNotNull(session.engineMapForTest())
 
@@ -115,11 +115,11 @@ class BrowserMapSnapshotterTest {
 
         assertEquals(GREEN, image.readPixel(SIZE / 2, SIZE / 2))
         assertEquals(2, evaluatorIdentities.size)
-        assertSame(presentation, state.presentation)
+        assertSame(presentation, state.currentMapAttachment)
         assertSame(interactiveEngine, session.engineMapForTest())
         snapshotter.close()
         snapshotter.awaitClosed()
-        assertSame(presentation, state.presentation)
+        assertSame(presentation, state.currentMapAttachment)
         assertSame(interactiveEngine, session.engineMapForTest())
         assertEquals(StyleLoadState.Ready, state.style.loadState)
       } finally {

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserMapStateTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserMapStateTest.kt
@@ -54,27 +54,27 @@ class BrowserMapStateTest {
       val includeRival = mutableStateOf(false)
 
       setBrowserMapContent {
-        MaplibreMap(state)
-        if (includeRival.value) MaplibreMap(state)
+        MaplibreMap(state = state)
+        if (includeRival.value) MaplibreMap(state = state)
       }
       waitUntilMap("the logical map presentation to load") {
-        state.presentation != null && state.style.loadState == StyleLoadState.Ready
+        state.currentMapAttachment != null && state.style.loadState == StyleLoadState.Ready
       }
 
-      assertNotNull(state.presentation)
-      val presentation = state.presentation!!
+      assertNotNull(state.currentMapAttachment)
+      val presentation = state.currentMapAttachment!!
       assertTrue(presentation.isValid)
       val createdSessions = GlJsMapSession.createdCount
 
       runOnIdle { includeRival.value = true }
       assertFailsWith<IllegalStateException> { waitForIdle() }
       assertEquals(createdSessions, GlJsMapSession.createdCount)
-      assertSame(presentation, state.presentation)
+      assertSame(presentation, state.currentMapAttachment)
       assertTrue(presentation.isValid)
 
       setContent {}
-      waitUntilMap("the presentation to detach") { state.presentation == null }
-      assertNull(state.presentation)
+      waitUntilMap("the presentation to detach") { state.currentMapAttachment == null }
+      assertNull(state.currentMapAttachment)
       assertFalse(state.isClosed)
 
       runtime.close()

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserPlatformMapAccessTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserPlatformMapAccessTest.kt
@@ -23,8 +23,8 @@ class BrowserPlatformMapAccessTest {
 
     val failure = assertFailsWith<IllegalStateException> { state.withPlatformMap { map.getZoom() } }
 
-    assertEquals("Platform map access requires a current Web presentation", failure.message)
-    assertNull(state.presentation)
+    assertEquals("Platform map access requires an attached Web map surface", failure.message)
+    assertNull(state.currentMapAttachment)
     runtime.close()
     runtime.awaitClosed()
   }
@@ -38,7 +38,7 @@ class BrowserPlatformMapAccessTest {
       val zoom = fixture.state.withPlatformMap { map.getZoom() }
 
       assertEquals(0.0, zoom)
-      assertTrue(fixture.state.presentation?.isValid == true)
+      assertTrue(fixture.state.currentMapAttachment?.isValid == true)
     } finally {
       fixture.close()
     }

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/testing/GlJsMapFixture.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/testing/GlJsMapFixture.kt
@@ -21,7 +21,6 @@ import org.maplibre.compose.map.GestureTarget
 import org.maplibre.compose.map.GlJsMapSession
 import org.maplibre.compose.map.MapAdapter
 import org.maplibre.compose.map.MapExtent
-import org.maplibre.compose.map.MapPresentation
 import org.maplibre.compose.map.mapRuntimeForTest
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.compose.style.DesiredStyleRevision
@@ -43,9 +42,6 @@ internal class GlJsMapFixture(private val extent: MapExtent) : MapFixture {
 
   override val session: MapAdapter
     get() = glJsSession
-
-  override val presentation: MapPresentation
-    get() = requireNotNull(state.presentation)
 
   override val gestures: GestureTarget
     get() = glJsSession
@@ -75,7 +71,7 @@ internal class GlJsMapFixture(private val extent: MapExtent) : MapFixture {
       }
     )
     state.publishPresentation(token, glJsSession)
-    recorder.presentation = requireNotNull(state.presentation)
+    recorder.attachment = requireNotNull(state.currentMapAttachment)
   }
 
   private fun frame(): Boolean {

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/map/DesktopMapView.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/map/DesktopMapView.kt
@@ -28,7 +28,7 @@ internal actual fun ComposableMapView(
   onReset: () -> Unit,
   logger: Logger?,
   callbacks: MapAdapter.Callbacks,
-  options: MapPresentationOptions,
+  options: MapViewOptions,
 ) {
   val hostFactory =
     LocalMlnFfiMapHostFactory.current

--- a/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/map/DesktopPresentationHostLifetimeTest.kt
+++ b/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/map/DesktopPresentationHostLifetimeTest.kt
@@ -47,21 +47,21 @@ class DesktopPresentationHostLifetimeTest {
 
       setContent {
         ProvideMapPresentationHost(host) {
-          MaplibreMap(state)
+          MaplibreMap(state = state)
         }
       }
-      waitUntil(timeoutMillis = 10_000) { state.presentation != null }
-      val firstPresentation = requireNotNull(state.presentation)
+      waitUntil(timeoutMillis = 10_000) { state.currentMapAttachment != null }
+      val firstPresentation = requireNotNull(state.currentMapAttachment)
       val engine = firstPresentation.adapter
 
       runOnIdle { host = ContextlessPresentationHost("second", equalityKey = "same") }
       waitUntil(timeoutMillis = 10_000) {
-        state.presentation != null && state.presentation !== firstPresentation
+        state.currentMapAttachment != null && state.currentMapAttachment !== firstPresentation
       }
 
       assertTrue(!firstPresentation.isValid)
-      assertNotSame(firstPresentation, state.presentation)
-      assertSame(engine, requireNotNull(state.presentation).adapter)
+      assertNotSame(firstPresentation, state.currentMapAttachment)
+      assertSame(engine, requireNotNull(state.currentMapAttachment).adapter)
       assertSame(runtime, state.runtime)
       assertTrue(!runtime.isClosed)
       assertTrue(!state.isClosed)
@@ -76,11 +76,11 @@ class DesktopPresentationHostLifetimeTest {
     val state = runtime.createMapState(baseStyle = BaseStyle.Empty)
 
     setContent {
-      CompositionLocalProvider(LocalInspectionMode provides true) { MaplibreMap(state) }
+      CompositionLocalProvider(LocalInspectionMode provides true) { MaplibreMap(state = state) }
     }
 
     waitForIdle()
-    assertTrue(state.presentation == null)
+    assertTrue(state.currentMapAttachment == null)
     runtime.close()
     runtime.awaitClosed()
   }

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/CameraMoveReportingTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/CameraMoveReportingTest.kt
@@ -25,15 +25,15 @@ class CameraMoveReportingTest {
       repeat(DRAG_SAMPLES) { sample ->
         it.gestures.moveBy(DRAG_STEP_DP, DRAG_STEP_DP, gestureToken = token)
         it.pump(FRAMES_PER_SAMPLE)
-        assertTrue(it.presentation.isCameraMoving, "the drag ended at sample $sample")
-        assertEquals(CameraMoveReason.GESTURE, it.presentation.cameraMoveReason)
+        assertTrue(it.state.isCameraMoving, "the drag ended at sample $sample")
+        assertEquals(CameraMoveReason.GESTURE, it.state.cameraMoveReason)
       }
       it.settle()
       it.gestures.onGestureEnded(token)
       it.pump(FRAMES_PER_SAMPLE)
 
-      assertFalse(it.presentation.isCameraMoving)
-      assertEquals(CameraMoveReason.GESTURE, it.presentation.cameraMoveReason)
+      assertFalse(it.state.isCameraMoving)
+      assertEquals(CameraMoveReason.GESTURE, it.state.cameraMoveReason)
     }
   }
 
@@ -45,8 +45,8 @@ class CameraMoveReportingTest {
       it.gestures.moveBy(DRAG_STEP_DP, DRAG_STEP_DP)
       it.pump(FRAMES_PER_SAMPLE)
 
-      assertFalse(it.presentation.isCameraMoving)
-      assertEquals(CameraMoveReason.PROGRAMMATIC, it.presentation.cameraMoveReason)
+      assertFalse(it.state.isCameraMoving)
+      assertEquals(CameraMoveReason.PROGRAMMATIC, it.state.cameraMoveReason)
     }
   }
 
@@ -54,7 +54,7 @@ class CameraMoveReportingTest {
   fun a_scale_changes_the_native_zoom(): MapTestResult = runMapTest {
     createMapFixture().use {
       it.startAtRest()
-      it.presentation.setCameraPosition(START)
+      it.state.setCameraPosition(START)
       it.pumpUntil("the camera to adopt the start zoom") {
         abs(it.session.getCameraPosition().zoom - START.zoom) < ZOOM_TOLERANCE
       }
@@ -70,7 +70,7 @@ class CameraMoveReportingTest {
   fun a_rotate_and_pitch_changes_the_native_camera(): MapTestResult = runMapTest {
     createMapFixture().use {
       it.startAtRest()
-      it.presentation.setCameraPosition(START)
+      it.state.setCameraPosition(START)
       it.pumpUntil("the camera to adopt the start pose") {
         abs(it.session.getCameraPosition().zoom - START.zoom) < ZOOM_TOLERANCE
       }

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/MapCameraTransitionTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/MapCameraTransitionTest.kt
@@ -31,13 +31,13 @@ class MapCameraTransitionTest {
     createMapFixture().use {
       it.loadStyle(BaseStyle.Empty)
       it.session.setCameraPadding(CAMERA_PADDING)
-      it.presentation.setCameraPosition(START)
+      it.state.setCameraPosition(START)
       it.awaitMapReady()
       it.pumpUntil("the camera padding to be applied") {
         it.cameraTargetMatches(START, CAMERA_PADDING)
       }
 
-      it.presentation.setCameraPosition(BOUNDS, 0.0, 0.0, FIT_PADDING)
+      it.state.setCameraPosition(BOUNDS, 0.0, 0.0, FIT_PADDING)
       it.pumpUntil("the bounds fit to be applied") {
         abs(it.session.getCameraPosition().zoom - START.zoom) > 0.1
       }
@@ -45,7 +45,7 @@ class MapCameraTransitionTest {
       it.assertCameraTarget(fitAfterPadding, CAMERA_PADDING)
       it.assertBoundsInside(CAMERA_PADDING + FIT_PADDING)
 
-      it.presentation.setCameraPosition(BOUNDS, 0.0, 0.0, FIT_PADDING)
+      it.state.setCameraPosition(BOUNDS, 0.0, 0.0, FIT_PADDING)
       it.pump(frames = 2)
       val repeatedFit = it.session.getCameraPosition()
       assertSameFit(fitAfterPadding, repeatedFit, "repeating the bounds fit changed its camera")
@@ -62,7 +62,7 @@ class MapCameraTransitionTest {
     createMapFixture().use {
       it.startAtOrigin()
 
-      it.presentation.setCameraPosition(ANTIMERIDIAN_BOUNDS, 0.0, 0.0, PaddingValues(0.dp))
+      it.state.setCameraPosition(ANTIMERIDIAN_BOUNDS, 0.0, 0.0, PaddingValues(0.dp))
       it.pumpUntil("the antimeridian bounds fit to be applied") {
         val camera = it.session.getCameraPosition()
         abs(abs(camera.target.longitude) - 180.0) < 1.0 && camera.zoom > START.zoom
@@ -75,14 +75,14 @@ class MapCameraTransitionTest {
     createMapFixture().use {
       it.loadStyle(BaseStyle.Empty)
       it.session.setCameraPadding(CAMERA_PADDING)
-      it.presentation.setCameraPosition(START)
+      it.state.setCameraPosition(START)
       it.awaitMapReady()
       it.pumpUntil("the camera padding to be applied") {
         it.cameraTargetMatches(START, CAMERA_PADDING)
       }
 
       it.awaitWhileRendering("the bounds animation to complete") {
-        it.presentation.animateCameraPosition(BOUNDS, 0.0, 0.0, FIT_PADDING, 200.milliseconds)
+        it.state.animateCameraPosition(BOUNDS, 0.0, 0.0, FIT_PADDING, 200.milliseconds)
       }
 
       val firstFit = it.session.getCameraPosition()
@@ -90,7 +90,7 @@ class MapCameraTransitionTest {
       it.assertBoundsInside(CAMERA_PADDING + FIT_PADDING)
 
       it.awaitWhileRendering("the repeated bounds animation to complete") {
-        it.presentation.animateCameraPosition(BOUNDS, 0.0, 0.0, FIT_PADDING, 200.milliseconds)
+        it.state.animateCameraPosition(BOUNDS, 0.0, 0.0, FIT_PADDING, 200.milliseconds)
       }
 
       assertSameFit(
@@ -107,7 +107,7 @@ class MapCameraTransitionTest {
       it.startAtOrigin()
 
       it.awaitWhileRendering("the animation to complete") {
-        it.presentation.animateCameraPosition(TARGET, 200.milliseconds)
+        it.state.animateCameraPosition(TARGET, 200.milliseconds)
       }
 
       assertNear(
@@ -128,7 +128,7 @@ class MapCameraTransitionTest {
 
         val animation =
           CoroutineScope(Dispatchers.Default).launch {
-            it.presentation.animateCameraPosition(TARGET, 2.seconds)
+            it.state.animateCameraPosition(TARGET, 2.seconds)
           }
         it.awaitCameraMoving()
         it.session.applyTestConstraints()
@@ -166,7 +166,7 @@ class MapCameraTransitionTest {
       it.startAtOrigin()
 
       it.awaitWhileRendering("the instant animation to complete") {
-        it.presentation.animateCameraPosition(TARGET, 0.milliseconds)
+        it.state.animateCameraPosition(TARGET, 0.milliseconds)
       }
     }
   }
@@ -181,13 +181,13 @@ class MapCameraTransitionTest {
 
       val superseded =
         CoroutineScope(Dispatchers.Default).launch {
-          it.presentation.animateCameraPosition(TARGET, 10.seconds)
+          it.state.animateCameraPosition(TARGET, 10.seconds)
         }
       it.awaitCameraMoving()
 
       val replacement =
         CoroutineScope(Dispatchers.Default).launch {
-          it.presentation.animateCameraPosition(MIDPOINT, 2.seconds)
+          it.state.animateCameraPosition(MIDPOINT, 2.seconds)
         }
       it.pumpUntil("the superseded animation to cancel") { superseded.isCompleted }
 
@@ -216,7 +216,7 @@ class MapCameraTransitionTest {
 
         val animation =
           CoroutineScope(Dispatchers.Default).launch {
-            it.presentation.animateCameraPosition(TARGET, 30.seconds)
+            it.state.animateCameraPosition(TARGET, 30.seconds)
           }
         it.awaitCameraMoving()
         animation.cancel()
@@ -229,7 +229,7 @@ class MapCameraTransitionTest {
         )
 
         it.awaitWhileRendering("a later animation to complete") {
-          it.presentation.animateCameraPosition(TARGET, 200.milliseconds)
+          it.state.animateCameraPosition(TARGET, 200.milliseconds)
         }
         assertNear(
           TARGET.zoom,
@@ -242,7 +242,7 @@ class MapCameraTransitionTest {
   private suspend fun MapFixture.startAtOrigin() {
     // GL JS renders nothing without a style.
     loadStyle(BaseStyle.Empty)
-    presentation.setCameraPosition(START)
+    state.setCameraPosition(START)
     // Render first: before the map exists, a camera read echoes back whatever was last set.
     awaitMapReady()
     pumpUntil("the map to reach its starting camera") {

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/MapQueryTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/MapQueryTest.kt
@@ -40,7 +40,7 @@ class MapQueryTest {
       // Rendering, not loading, is what populates the queryable set.
       it.pump(frames = 30)
 
-      val features = it.presentation.queryRenderedFeatures(offset = CENTER)
+      val features = it.state.queryRenderedFeatures(offset = CENTER)
 
       assertTrue(features.isNotEmpty(), "Expected a hit at the map center. Errors: ${it.errors}")
       val feature = features.first()
@@ -54,7 +54,7 @@ class MapQueryTest {
       it.loadStyle(BaseStyle.Json(COLLIDING_PROPERTIES_STYLE))
       it.pump(frames = 30)
 
-      val feature = it.presentation.queryRenderedFeatures(offset = CENTER).first()
+      val feature = it.state.queryRenderedFeatures(offset = CENTER).first()
 
       assertEquals("original-source", feature.properties?.get("\$source")?.jsonPrimitive?.content)
       assertEquals(
@@ -72,7 +72,7 @@ class MapQueryTest {
       it.pump(frames = 30)
 
       val features =
-        it.presentation.queryRenderedFeatures(
+        it.state.queryRenderedFeatures(
           offset = CENTER,
           layerIds = setOf("no-such-layer"),
         )
@@ -89,7 +89,7 @@ class MapQueryTest {
 
       // Not awaited: the query below must land inside the loading window.
       it.session.setBaseStyle(BaseStyle.Json(EMPTY_STYLE))
-      it.presentation.queryRenderedFeatures(
+      it.state.queryRenderedFeatures(
         offset = CENTER,
         layerIds = setOf("no-such-layer"),
       )
@@ -110,7 +110,7 @@ class MapQueryTest {
       it.pump(frames = 30)
 
       val features =
-        it.presentation.queryRenderedFeatures(
+        it.state.queryRenderedFeatures(
           rect = DpRect(left = 0.dp, top = 0.dp, right = 512.dp, bottom = 512.dp)
         )
 
@@ -124,7 +124,7 @@ class MapQueryTest {
       coroutineScope {
         val query =
           async(start = CoroutineStart.UNDISPATCHED) {
-            fixture.presentation.queryRenderedFeatures(offset = CENTER)
+            fixture.state.queryRenderedFeatures(offset = CENTER)
           }
 
         assertFalse(query.isCompleted)
@@ -144,11 +144,11 @@ class MapQueryTest {
       val matching = Feature["name"].cast<StringValue>() eq const("world")
       val misses = Feature["name"].cast<StringValue>() eq const("other")
 
-      val kept = it.presentation.queryRenderedFeatures(offset = CENTER, predicate = matching)
+      val kept = it.state.queryRenderedFeatures(offset = CENTER, predicate = matching)
       assertTrue(kept.isNotEmpty(), "Expected the matching predicate to keep the feature")
       assertEquals("world", kept.first().properties?.get("name")?.jsonPrimitive?.content)
 
-      val dropped = it.presentation.queryRenderedFeatures(offset = CENTER, predicate = misses)
+      val dropped = it.state.queryRenderedFeatures(offset = CENTER, predicate = misses)
       assertTrue(dropped.isEmpty(), "Expected the non-matching predicate to drop the feature")
     }
   }
@@ -159,7 +159,7 @@ class MapQueryTest {
       it.loadStyle(BaseStyle.Json(OVERLAPPING_FILL_STYLE))
       it.pump(frames = 30)
 
-      val features = it.presentation.queryRenderedFeatures(offset = CENTER)
+      val features = it.state.queryRenderedFeatures(offset = CENTER)
       val names = features.map { feature ->
         feature.properties?.get("name")?.jsonPrimitive?.content
       }
@@ -181,13 +181,13 @@ class MapQueryTest {
     createMapFixture().use {
       it.loadStyle(BaseStyle.Json(TWO_HALVES_STYLE))
       // Zoom 0 keeps ±90 inside the 512 px viewport.
-      it.presentation.setCameraPosition(CameraPosition(target = Position(0.0, 0.0), zoom = 0.0))
+      it.state.setCameraPosition(CameraPosition(target = Position(0.0, 0.0), zoom = 0.0))
       it.pump(frames = 30)
 
-      val westAt = assertNotNull(it.presentation.screenLocationFromPosition(WEST_POINT))
-      val eastAt = assertNotNull(it.presentation.screenLocationFromPosition(EAST_POINT))
-      val westHits = it.presentation.queryRenderedFeatures(offset = westAt)
-      val eastHits = it.presentation.queryRenderedFeatures(offset = eastAt)
+      val westAt = assertNotNull(it.state.screenLocationFromPosition(WEST_POINT))
+      val eastAt = assertNotNull(it.state.screenLocationFromPosition(EAST_POINT))
+      val westHits = it.state.queryRenderedFeatures(offset = westAt)
+      val eastHits = it.state.queryRenderedFeatures(offset = eastAt)
 
       assertEquals(
         setOf("west"),
@@ -208,7 +208,7 @@ class MapQueryTest {
       it.loadStyle(BaseStyle.Json(WORLD_POLYGON_STYLE))
       it.pump(frames = 30)
 
-      val feature = it.presentation.queryRenderedFeatures(offset = CENTER).first()
+      val feature = it.state.queryRenderedFeatures(offset = CENTER).first()
       val id = assertIs<JsonPrimitive>(feature.id)
       assertFalse(id.isString, "Expected the GeoJSON id to stay a number, not a string")
       assertEquals("42", id.content)

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/MapVisibleAreaTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/MapVisibleAreaTest.kt
@@ -24,10 +24,10 @@ class MapVisibleAreaTest {
     createMapFixture().use {
       it.loadStyle(BaseStyle.Empty)
       it.awaitMapReady()
-      it.presentation.setCameraPosition(CAMERA)
+      it.state.setCameraPosition(CAMERA)
       it.pumpUntil("the camera to apply") { it.session.hasNativeCamera(CAMERA) }
 
-      val box = assertNotNull(it.presentation.getVisibleBoundingBox())
+      val box = assertNotNull(it.state.getVisibleBoundingBox())
       assertContains(box, CAMERA.target, "the camera target")
       assertTrue(box.northeast.latitude > box.southwest.latitude, "the box should span latitude")
       assertTrue(box.northeast.longitude > box.southwest.longitude, "the box should span longitude")
@@ -40,11 +40,11 @@ class MapVisibleAreaTest {
       createMapFixture().use {
         it.loadStyle(BaseStyle.Empty)
         it.awaitMapReady()
-        it.presentation.setCameraPosition(ROTATED_CAMERA)
+        it.state.setCameraPosition(ROTATED_CAMERA)
         it.pumpUntil("the camera to rotate") { it.session.hasNativeCamera(ROTATED_CAMERA) }
 
-        val region = assertNotNull(it.presentation.getVisibleRegion())
-        val box = assertNotNull(it.presentation.getVisibleBoundingBox())
+        val region = assertNotNull(it.state.getVisibleRegion())
+        val box = assertNotNull(it.state.getVisibleBoundingBox())
         assertContains(box, region.farLeft, "the far left corner")
         assertContains(box, region.farRight, "the far right corner")
         assertContains(box, region.nearLeft, "the near left corner")
@@ -58,10 +58,10 @@ class MapVisibleAreaTest {
       createMapFixture().use {
         it.loadStyle(BaseStyle.Empty)
         it.awaitMapReady()
-        it.presentation.setCameraPosition(ROTATED_CAMERA)
+        it.state.setCameraPosition(ROTATED_CAMERA)
         it.pumpUntil("the camera to rotate") { it.session.hasNativeCamera(ROTATED_CAMERA) }
 
-        val region = assertNotNull(it.presentation.getVisibleRegion())
+        val region = assertNotNull(it.state.getVisibleRegion())
         val corners = region.corners()
         assertTrue(
           corners.distinct().size == 4,
@@ -80,10 +80,10 @@ class MapVisibleAreaTest {
     createMapFixture().use {
       it.loadStyle(BaseStyle.Empty)
       it.awaitMapReady()
-      it.presentation.setCameraPosition(ANTIMERIDIAN_CAMERA)
+      it.state.setCameraPosition(ANTIMERIDIAN_CAMERA)
       it.pumpUntil("the camera to apply") { it.session.hasNativeCamera(ANTIMERIDIAN_CAMERA) }
 
-      val box = assertNotNull(it.presentation.getVisibleBoundingBox())
+      val box = assertNotNull(it.state.getVisibleBoundingBox())
       // A wrapped hull would span nearly the whole world instead of the short interval, which may
       // extend past ±180.
       assertTrue(

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/sources/FeatureStateTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/sources/FeatureStateTest.kt
@@ -37,9 +37,7 @@ class FeatureStateTest {
   fun a_geojson_handle_updates_feature_state_and_the_rendered_style(): MapTestResult = runMapTest {
     createMapFixture().use { fixture ->
       fixture.loadStyle(BLACK_STYLE)
-      fixture.presentation.setCameraPosition(
-        CameraPosition(target = Position(0.0, 0.0), zoom = 1.0)
-      )
+      fixture.state.setCameraPosition(CameraPosition(target = Position(0.0, 0.0), zoom = 1.0))
       val binding = checkNotNull(fixture.style)
       val source =
         GeoJsonSource(

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/sources/GeoJsonClusterTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/sources/GeoJsonClusterTest.kt
@@ -28,9 +28,7 @@ class GeoJsonClusterTest {
   fun a_geojson_handle_answers_cluster_queries(): MapTestResult = runMapTest {
     createMapFixture().use { fixture ->
       fixture.loadStyle(BaseStyle.Empty)
-      fixture.presentation.setCameraPosition(
-        CameraPosition(target = Position(0.0, 0.0), zoom = ZOOM)
-      )
+      fixture.state.setCameraPosition(CameraPosition(target = Position(0.0, 0.0), zoom = ZOOM))
       val binding = checkNotNull(fixture.style)
       val source =
         GeoJsonSource(
@@ -43,7 +41,7 @@ class GeoJsonClusterTest {
       val handle = assertIs<GeoJsonSourceHandle>(fixture.state.style.source("points"))
 
       suspend fun rendered(): List<Feature<Geometry, JsonObject?>> =
-        fixture.presentation.queryRenderedFeatures(
+        fixture.state.queryRenderedFeatures(
           DpRect(0.dp, 0.dp, 512.dp, 512.dp),
           layerIds = null,
         )

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/testing/MapFixture.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/testing/MapFixture.kt
@@ -9,8 +9,8 @@ import kotlin.time.TimeSource
 import org.maplibre.compose.camera.CameraMoveReason
 import org.maplibre.compose.map.GestureTarget
 import org.maplibre.compose.map.MapAdapter
+import org.maplibre.compose.map.MapAttachment
 import org.maplibre.compose.map.MapExtent
-import org.maplibre.compose.map.MapPresentation
 import org.maplibre.compose.map.MapState
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.compose.style.StyleBinding
@@ -26,9 +26,6 @@ internal interface MapFixture : AutoCloseable {
 
   /** Public logical-map surface exercised by style-handle tests. */
   val state: MapState
-
-  /** Public lease surface exercised by viewport-bound tests. */
-  val presentation: MapPresentation
 
   val gestures: GestureTarget
 
@@ -133,7 +130,7 @@ internal expect fun runMapTest(block: suspend () -> Unit): MapTestResult
 
 internal class RecordingMapCallbacks : MapAdapter.Callbacks {
 
-  var presentation: MapPresentation? = null
+  var attachment: MapAttachment? = null
 
   val events: MutableList<String> = RecordingList()
 
@@ -146,7 +143,7 @@ internal class RecordingMapCallbacks : MapAdapter.Callbacks {
 
   override fun onStyleChanged(map: MapAdapter, style: StyleBinding?) {
     this.style = style
-    presentation?.updateViewport(map.getViewport())
+    attachment?.updateViewport(map.getViewport())
     events += if (style == null) "styleChanged(null)" else MapFixture.STYLE_LOADED
   }
 
@@ -163,17 +160,17 @@ internal class RecordingMapCallbacks : MapAdapter.Callbacks {
   }
 
   override fun onCameraMoveStarted(map: MapAdapter, reason: CameraMoveReason) {
-    presentation?.cameraMoveStarted(reason)
+    attachment?.cameraMoveStarted(reason)
     events += "cameraMoveStarted($reason)"
   }
 
   override fun onCameraMoved(map: MapAdapter) {
-    presentation?.cameraMoved(map.getViewport())
+    attachment?.cameraMoved(map.getViewport())
     events += "cameraMoved"
   }
 
   override fun onCameraMoveEnded(map: MapAdapter) {
-    presentation?.let {
+    attachment?.let {
       it.cameraMoved(map.getViewport())
       it.cameraMoveEnded()
     }
@@ -189,6 +186,6 @@ internal class RecordingMapCallbacks : MapAdapter.Callbacks {
   }
 
   override fun onFrame(fps: Double) {
-    presentation?.let { it.cameraMoved(it.adapter.getViewport()) }
+    attachment?.let { it.cameraMoved(it.adapter.getViewport()) }
   }
 }

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -1262,13 +1262,13 @@ internal class MlnFfiMapSession(
 
   /**
    * A resize changes the projection without a camera event, so Compose overlays that read
-   * [MapPresentation.viewport] would keep the previous screen locations unless this reports the new
+   * [MapState.viewport] would keep the previous screen locations unless this reports the new
    * snapshot.
    */
   private fun snapshotViewportAndNotify(map: MapHandle) {
     snapshotViewport(map)
     // The first attach snapshot can land before the lease is Attached. Seed from the snapshot
-    // itself so a dropped camera callback cannot leave MapPresentation.viewport null.
+    // itself so a dropped camera callback cannot leave MapState.viewport null.
     lifecycleAuthority.seedCurrentPresentationViewport(this)
     withLifecyclePresentation { engine, lease ->
       lifecycleCallbacks.onCameraMoved(engine, lease, this)
@@ -1364,7 +1364,7 @@ internal class MlnFfiMapSession(
       map.jumpTo(cameraForBounds(map, boundingBox, bearing, tilt, padding))
       snapshotViewport(map)
     }
-    // MapPresentation waits for the current lease's viewport before it calls this adapter.
+    // MapState waits for the current attachment's viewport before it calls this adapter.
     val hasViewport = stateLock.withLock {
       hasAttachedViewport && lifecycle.acceptsWork && loop != null
     }
@@ -1724,7 +1724,7 @@ internal class MlnFfiMapSession(
           session
             .queryRenderedFeatures(geometry, renderedQueryOptions(layerIds, predicate))
             .toGeoJsonFeatures()
-            // Native walks style layers from the bottom. MapPresentation and GL JS put the
+            // Native walks style layers from the bottom. MapState and GL JS put the
             // feature in front first.
             .asReversed()
         }

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapView.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapView.kt
@@ -43,7 +43,7 @@ internal fun MlnFfiMapView(
   onReset: () -> Unit,
   logger: Logger?,
   callbacks: MapAdapter.Callbacks,
-  options: MapPresentationOptions,
+  options: MapViewOptions,
 ) {
   val density = LocalDensity.current
 
@@ -87,7 +87,7 @@ internal fun MlnFfiMapView(
   onReset: () -> Unit,
   logger: Logger?,
   callbacks: MapAdapter.Callbacks,
-  options: MapPresentationOptions,
+  options: MapViewOptions,
 ) {
   val applicationOptions = state.runtime.nativeRuntimeOptions
   val layoutDirection = LocalLayoutDirection.current
@@ -136,7 +136,7 @@ internal fun MlnFfiMapView(
       session.attachPresentation()
       if (!session.isPresentationPublished) {
         currentUpdate.value(session)
-        if (state.presentation?.adapter !== session) return@LaunchedEffect
+        if (state.currentMapAttachment?.adapter !== session) return@LaunchedEffect
       }
       session.publishRetainedStyle()
     } catch (error: CancellationException) {

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/PlatformMapAccessTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/PlatformMapAccessTest.kt
@@ -41,7 +41,7 @@ class PlatformMapAccessTest {
 
       assertEquals("maplibre-compose-map", callbackThread)
       assertTrue(callbackThread != callerThread)
-      assertNull(state.presentation)
+      assertNull(state.currentMapAttachment)
     }
   }
 

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/mlnffi/BridgeMapFixture.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/mlnffi/BridgeMapFixture.kt
@@ -11,8 +11,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
 import kotlinx.io.files.Path
+import org.maplibre.compose.map.MapAttachment
 import org.maplibre.compose.map.MapExtent
-import org.maplibre.compose.map.MapPresentation
 import org.maplibre.compose.map.MlnFfiMapSession
 import org.maplibre.compose.map.mapRuntimeForTest
 import org.maplibre.compose.style.BaseStyle
@@ -63,8 +63,8 @@ private constructor(
       cacheFile = cacheFile,
     )
 
-  fun bindPresentation(presentation: MapPresentation) {
-    recorder.presentation = presentation
+  fun bindAttachment(attachment: MapAttachment) {
+    recorder.attachment = attachment
   }
 
   private val hostSession =

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/sources/CustomGeometrySourceTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/sources/CustomGeometrySourceTest.kt
@@ -181,8 +181,7 @@ class CustomGeometrySourceTest {
   private suspend fun BridgeMapFixture.queryCenter() =
     session.queryRenderedFeatures(offset = CENTER, layerIds = null, predicate = null)
 
-  private suspend fun MlnFfiMapFixture.queryCenter() =
-    presentation.queryRenderedFeatures(offset = CENTER)
+  private suspend fun MlnFfiMapFixture.queryCenter() = state.queryRenderedFeatures(offset = CENTER)
 
   private fun BridgeMapFixture.awaitCustomFeatures() {
     pumpUntil("the custom geometry source to request a tile") { requests.isNotEmpty() }

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/sources/GeoJsonSourceUpdateTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/sources/GeoJsonSourceUpdateTest.kt
@@ -31,7 +31,7 @@ class GeoJsonSourceUpdateTest {
     runMapTest {
       createMapFixture().use { fixture ->
         fixture.loadStyle(STYLE)
-        fixture.presentation.setCameraPosition(CameraPosition(target = ORIGIN, zoom = 14.0))
+        fixture.state.setCameraPosition(CameraPosition(target = ORIGIN, zoom = 14.0))
         val style = checkNotNull(fixture.style) { "Errors: ${fixture.errors}" }
         val source =
           GeoJsonSource(
@@ -70,7 +70,7 @@ class GeoJsonSourceUpdateTest {
     runMapTest {
       createMapFixture().use { fixture ->
         fixture.loadStyle(CLUSTERED_STYLE)
-        fixture.presentation.setCameraPosition(CameraPosition(target = ORIGIN, zoom = 14.0))
+        fixture.state.setCameraPosition(CameraPosition(target = ORIGIN, zoom = 14.0))
         val handle = assertIs<GeoJsonSourceHandle>(fixture.state.style.source(SOURCE_ID))
         fixture.pumpUntil("the base-style point to render") {
           fixture.readPixel(256, 256).isNear(CIRCLE)
@@ -88,7 +88,7 @@ class GeoJsonSourceUpdateTest {
   fun a_base_style_update_preserves_the_loaded_sources_minimum_zoom(): MapTestResult = runMapTest {
     createMapFixture().use { fixture ->
       fixture.loadStyle(MIN_ZOOM_STYLE)
-      fixture.presentation.setCameraPosition(CameraPosition(target = ORIGIN, zoom = 6.0))
+      fixture.state.setCameraPosition(CameraPosition(target = ORIGIN, zoom = 6.0))
       val handle = assertIs<GeoJsonSourceHandle>(fixture.state.style.source(SOURCE_ID))
       fixture.pumpUntil("the source to stay hidden below its minimum zoom") {
         fixture.readPixel(256, 256).isNear(BACKGROUND)

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/testing/MlnFfiMapFixture.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/testing/MlnFfiMapFixture.kt
@@ -6,7 +6,6 @@ import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.map.GestureTarget
 import org.maplibre.compose.map.MapAdapter
 import org.maplibre.compose.map.MapExtent
-import org.maplibre.compose.map.MapPresentation
 import org.maplibre.compose.map.mapRuntimeForTest
 import org.maplibre.compose.mlnffi.BridgeMapFixture
 import org.maplibre.compose.style.BaseStyle
@@ -27,14 +26,11 @@ internal class MlnFfiMapFixture(val bridge: BridgeMapFixture, private val extent
 
   init {
     state.publishPresentation(token, bridge.session)
-    bridge.bindPresentation(requireNotNull(state.presentation))
+    bridge.bindAttachment(requireNotNull(state.currentMapAttachment))
   }
 
   override val session: MapAdapter
     get() = bridge.session
-
-  override val presentation: MapPresentation
-    get() = requireNotNull(state.presentation)
 
   override val gestures: GestureTarget
     get() = bridge.session


### PR DESCRIPTION
## Description

Move viewport-bound operations onto `MapState`, flatten `MaplibreMap` configuration and callbacks, expose `CameraConstraints`, and keep surface attachment leases internal.

## Validation

Ran `mise run test:android`, `mise run test:android:device 36`, `mise run test:desktop`, `mise run test:js`, `mise run test:ios`, `mise run check`, and `mise run build:docs`.

## AI assistance

Used OpenAI Codex to design, implement, migrate, rebase, and validate the change.
