### PR TITLE
Require a base style when creating map states

### DIFF
--- a/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MapLifecycleCallbackRaceTest.kt
+++ b/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MapLifecycleCallbackRaceTest.kt
@@ -20,7 +20,7 @@ class MapLifecycleCallbackRaceTest {
   @Test
   fun an_accepted_owner_callback_completes_while_style_sources_are_read() = runBlocking {
     val runtime = mapRuntimeForTest()
-    val state = runtime.createMapState()
+    val state = runtime.createMapState(BaseStyle.Demo)
     val adapter = PresentationTestAdapter()
     val token = state.reservePresentation()
     state.publishPresentation(token, adapter)
@@ -65,7 +65,7 @@ class MapLifecycleCallbackRaceTest {
   @Test
   fun accepted_callback_delivery_completes_before_closure_commits() = runBlocking {
     val runtime = mapRuntimeForTest()
-    val state = runtime.createMapState()
+    val state = runtime.createMapState(BaseStyle.Demo)
     val binding = state.lifecycle.bind(CallbackRacePlatformAdapter())
     binding.attach()
     val engine = requireNotNull(binding.engineIdentity)
@@ -104,7 +104,7 @@ class MapLifecycleCallbackRaceTest {
   @Test
   fun a_late_platform_style_write_replays_the_latest_durable_style() {
     val runtime = mapRuntimeForTest()
-    val state = runtime.createMapState()
+    val state = runtime.createMapState(BaseStyle.Demo)
     val firstStyle = BaseStyle.Json("first")
     val secondStyle = BaseStyle.Json("second")
     val adapter = BlockingStyleAdapter(firstStyle)
@@ -137,7 +137,7 @@ class MapLifecycleCallbackRaceTest {
   @Test
   fun a_late_camera_write_replays_the_latest_durable_camera() {
     val runtime = mapRuntimeForTest()
-    val state = runtime.createMapState()
+    val state = runtime.createMapState(BaseStyle.Demo)
     val adapter = BlockingCameraAdapter()
     val token = state.reservePresentation()
     state.publishPresentation(token, adapter)
@@ -164,7 +164,7 @@ class MapLifecycleCallbackRaceTest {
   @Test
   fun presentation_configuration_replays_a_newer_style_after_a_late_initial_write() {
     val runtime = mapRuntimeForTest()
-    val state = runtime.createMapState()
+    val state = runtime.createMapState(BaseStyle.Demo)
     val adapter = BlockingStyleAdapter(BaseStyle.Demo)
     val token = state.reservePresentation()
     val publicationFinished = CountDownLatch(1)
@@ -189,7 +189,7 @@ class MapLifecycleCallbackRaceTest {
   @Test
   fun departed_presentation_configuration_cannot_write_its_style() {
     val runtime = mapRuntimeForTest()
-    val state = runtime.createMapState()
+    val state = runtime.createMapState(BaseStyle.Demo)
     val owner = MapPresentationOwnerToken()
     val first = BlockingConfigurationAdapter()
     val firstToken = state.reservePresentation(owner)
@@ -216,7 +216,7 @@ class MapLifecycleCallbackRaceTest {
   @Test
   fun a_style_action_cannot_silently_target_the_replacement_style() {
     val runtime = mapRuntimeForTest()
-    val state = runtime.createMapState()
+    val state = runtime.createMapState(BaseStyle.Demo)
     val adapter = PresentationTestAdapter()
     val token = state.reservePresentation()
     state.publishPresentation(token, adapter)

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
@@ -99,7 +99,7 @@ public interface MapRuntime {
    * result.
    */
   public fun createMapState(
-    baseStyle: BaseStyle = BaseStyle.Demo,
+    baseStyle: BaseStyle,
     styleComposition: StyleComposition = StyleComposition.Empty,
     initialCameraPosition: CameraPosition = CameraPosition(),
   ): MapState

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapLifecycleBindingTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapLifecycleBindingTest.kt
@@ -12,12 +12,16 @@ import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
+import org.maplibre.compose.style.BaseStyle
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class MapLifecycleBindingTest {
 
   private fun TestScope.bindLifecycle(adapter: MapLifecyclePlatformAdapter): MapLifecycleBinding =
-    mapRuntimeForTest(physicalScope = backgroundScope).createMapState().lifecycle.bind(adapter)
+    mapRuntimeForTest(physicalScope = backgroundScope)
+      .createMapState(BaseStyle.Demo)
+      .lifecycle
+      .bind(adapter)
 
   @Test
   fun a_map_attaches_with_an_engine_identity_and_render_lease() = runTest {

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
@@ -57,7 +57,7 @@ class MapPresentationTest {
   @Test
   fun closing_map_state_closes_a_bound_session_before_it_is_published() = runTest {
     val runtime = mapRuntimeForTest(physicalScope = backgroundScope)
-    val state = runtime.createMapState()
+    val state = runtime.createMapState(BaseStyle.Demo)
     val session = BoundLifecycleSession()
     session.lifecycle = state.lifecycle.bind(session)
     session.lifecycle.attach()
@@ -75,7 +75,7 @@ class MapPresentationTest {
   @Test
   fun a_bound_but_unpublished_session_cannot_mutate_durable_style_state() = runTest {
     val runtime = mapRuntimeForTest(physicalScope = backgroundScope)
-    val state = runtime.createMapState()
+    val state = runtime.createMapState(BaseStyle.Demo)
     val session = BoundLifecycleSession()
     session.lifecycle = state.lifecycle.bind(session)
     session.lifecycle.attach()
@@ -92,7 +92,7 @@ class MapPresentationTest {
   @Test
   fun a_session_that_closes_itself_is_retired_and_its_failure_reaches_map_closure() = runTest {
     val runtime = mapRuntimeForTest(physicalScope = backgroundScope)
-    val state = runtime.createMapState()
+    val state = runtime.createMapState(BaseStyle.Demo)
     val finishCleanup = CompletableDeferred<Unit>()
     val session = BoundLifecycleSession(failOnClose = true, finishCleanup = finishCleanup)
     session.lifecycle = state.lifecycle.bind(session)
@@ -135,7 +135,7 @@ class MapPresentationTest {
   @Test
   fun a_detached_retained_session_that_closes_itself_invalidates_its_style() = runTest {
     val runtime = mapRuntimeForTest(physicalScope = backgroundScope)
-    val state = runtime.createMapState()
+    val state = runtime.createMapState(BaseStyle.Demo)
     val finishCleanup = CompletableDeferred<Unit>()
     val session = BoundLifecycleSession(finishCleanup = finishCleanup)
     session.lifecycle = state.lifecycle.bind(session)
@@ -166,7 +166,7 @@ class MapPresentationTest {
   @Test
   fun a_new_presentation_can_reserve_while_the_previous_one_is_still_detaching() = runTest {
     val runtime = mapRuntimeForTest(physicalScope = backgroundScope)
-    val state = runtime.createMapState()
+    val state = runtime.createMapState(BaseStyle.Demo)
     val first = BlockingDetachAdapter()
     val firstToken = state.reservePresentation(MapPresentationOwnerToken())
     state.publishPresentation(firstToken, first)
@@ -191,7 +191,7 @@ class MapPresentationTest {
   @Test
   fun closure_reports_a_superseded_presentations_in_flight_detach_failure() = runTest {
     val runtime = mapRuntimeForTest(physicalScope = backgroundScope)
-    val state = runtime.createMapState()
+    val state = runtime.createMapState(BaseStyle.Demo)
     val first = BlockingDetachAdapter(failOnDetach = true)
     val firstToken = state.reservePresentation(MapPresentationOwnerToken())
     state.publishPresentation(firstToken, first)
@@ -214,7 +214,7 @@ class MapPresentationTest {
   @Test
   fun closure_reports_an_in_flight_session_detach_failure_once() = runTest {
     val runtime = mapRuntimeForTest(physicalScope = backgroundScope)
-    val state = runtime.createMapState()
+    val state = runtime.createMapState(BaseStyle.Demo)
     val finishDetach = CompletableDeferred<Unit>()
     val detachStarted = CompletableDeferred<Unit>()
     val session =
@@ -242,7 +242,7 @@ class MapPresentationTest {
   @Test
   fun retained_engine_access_remains_valid_while_the_presentation_detaches() = runTest {
     val runtime = mapRuntimeForTest(physicalScope = backgroundScope)
-    val state = runtime.createMapState()
+    val state = runtime.createMapState(BaseStyle.Demo)
     val finishDetach = CompletableDeferred<Unit>()
     val detachStarted = CompletableDeferred<Unit>()
     val session = BoundLifecycleSession(finishDetach = finishDetach, detachStarted = detachStarted)
@@ -268,7 +268,7 @@ class MapPresentationTest {
   @Test
   fun closure_during_presentation_configuration_makes_publication_inert() = runTest {
     val runtime = mapRuntimeForTest(physicalScope = backgroundScope)
-    val state = runtime.createMapState()
+    val state = runtime.createMapState(BaseStyle.Demo)
     val token = state.reservePresentation()
     val adapter = ClosingDuringConfigurationAdapter(state::close)
 
@@ -283,7 +283,7 @@ class MapPresentationTest {
   @Test
   fun a_style_failure_before_publication_remains_the_durable_load_state() = runTest {
     val runtime = mapRuntimeForTest()
-    val state = runtime.createMapState()
+    val state = runtime.createMapState(BaseStyle.Demo)
     val callbacks = state.durableStyleCallbacks()
     val token = state.reservePresentation()
     val adapter = FailureDuringConfigurationAdapter { map ->
@@ -301,7 +301,7 @@ class MapPresentationTest {
   @Test
   fun a_configuration_error_publishes_the_presentation_with_failed_style_state() = runTest {
     val runtime = mapRuntimeForTest()
-    val state = runtime.createMapState()
+    val state = runtime.createMapState(BaseStyle.Demo)
     val token = state.reservePresentation()
     val adapter = ConfigurationErrorAdapter()
 
@@ -317,7 +317,7 @@ class MapPresentationTest {
   @Test
   fun style_events_before_publication_update_the_durable_style_state() = runTest {
     val runtime = mapRuntimeForTest()
-    val state = runtime.createMapState()
+    val state = runtime.createMapState(BaseStyle.Demo)
     val token = state.reservePresentation()
     val adapter = PresentationTestAdapter()
     val callbacks = state.durableStyleCallbacks()
@@ -349,7 +349,7 @@ class MapPresentationTest {
   @Test
   fun camera_intent_accepted_before_detachment_remains_durable() {
     val runtime = mapRuntimeForTest()
-    val state = runtime.createMapState()
+    val state = runtime.createMapState(BaseStyle.Demo)
     val token = state.reservePresentation()
     val adapter = ReleasingCameraAdapter { map ->
       state.releasePresentation(token, map)
@@ -410,7 +410,7 @@ class MapPresentationTest {
   @Test
   fun replacement_cleanup_failures_are_reported_on_close() = runTest {
     val runtime = mapRuntimeForTest()
-    val state = runtime.createMapState()
+    val state = runtime.createMapState(BaseStyle.Demo)
     val firstToken = state.reservePresentation()
     val first = RetainedAdapter(failOnClose = true)
     state.publishPresentation(firstToken, first)
@@ -431,7 +431,7 @@ class MapPresentationTest {
   @Test
   fun a_durable_callback_updates_style_load_state_after_the_presentation_leaves() = runTest {
     val runtime = mapRuntimeForTest()
-    val state = runtime.createMapState()
+    val state = runtime.createMapState(BaseStyle.Demo)
     val token = state.reservePresentation()
     val adapter = RetainedAdapter(failOnClose = false)
     state.publishPresentation(token, adapter)
@@ -448,7 +448,7 @@ class MapPresentationTest {
   @Test
   fun a_durable_source_change_refreshes_sources_after_the_presentation_leaves() = runTest {
     val runtime = mapRuntimeForTest()
-    val state = runtime.createMapState()
+    val state = runtime.createMapState(BaseStyle.Demo)
     val token = state.reservePresentation()
     val adapter = RetainedAdapter(failOnClose = false)
     state.publishPresentation(token, adapter)
@@ -596,7 +596,7 @@ class MapPresentationTest {
   @Test
   fun replacing_a_retained_engine_invalidates_its_style_handles_before_publication() = runTest {
     val runtime = mapRuntimeForTest()
-    val state = runtime.createMapState()
+    val state = runtime.createMapState(BaseStyle.Demo)
     val firstToken = state.reservePresentation()
     val first = RetainedAdapter(failOnClose = false)
     state.publishPresentation(firstToken, first)
@@ -667,7 +667,11 @@ class MapPresentationTest {
   fun publication_happens_after_the_adapter_accepts_initial_map_state() {
     val runtime = mapRuntimeForTest()
     val initialCamera = CameraPosition(target = Position(12.0, 34.0), zoom = 8.0)
-    val state = runtime.createMapState(initialCameraPosition = initialCamera)
+    val state =
+      runtime.createMapState(
+        baseStyle = BaseStyle.Demo,
+        initialCameraPosition = initialCamera,
+      )
     val token = state.reservePresentation()
     val adapter = PresentationTestAdapter { state.presentation }
 
@@ -693,7 +697,7 @@ class MapPresentationTest {
   @Test
   fun publication_uses_the_viewport_the_adapter_has_for_the_current_attachment() {
     val runtime = mapRuntimeForTest()
-    val state = runtime.createMapState()
+    val state = runtime.createMapState(BaseStyle.Demo)
     val token = state.reservePresentation()
     val viewport = testViewport()
     val adapter = PresentationTestAdapter().apply { currentViewport = viewport }
@@ -708,7 +712,7 @@ class MapPresentationTest {
   @Test
   fun a_viewport_that_arrives_after_publication_still_seeds_the_presentation() {
     val runtime = mapRuntimeForTest()
-    val state = runtime.createMapState()
+    val state = runtime.createMapState(BaseStyle.Demo)
     val token = state.reservePresentation()
     val adapter = PresentationTestAdapter()
 
@@ -816,7 +820,7 @@ private data class PresentationFixture(
 
 private fun presentationFixture(): PresentationFixture {
   val runtime = mapRuntimeForTest()
-  val state = runtime.createMapState()
+  val state = runtime.createMapState(BaseStyle.Demo)
   val token = state.reservePresentation()
   val adapter = PresentationTestAdapter()
   state.publishPresentation(token, adapter)

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapRuntimeTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapRuntimeTest.kt
@@ -24,14 +24,14 @@ class MapRuntimeTest {
       assertTrue(second.isClosed)
       resourcesClosed = true
     }
-    first = runtime.createMapState()
-    second = runtime.createMapState()
+    first = runtime.createMapState(BaseStyle.Demo)
+    second = runtime.createMapState(BaseStyle.Demo)
 
     runtime.close()
 
     assertTrue(first.isClosed)
     assertTrue(second.isClosed)
-    assertFailsWith<MapRuntimeClosedException> { runtime.createMapState() }
+    assertFailsWith<MapRuntimeClosedException> { runtime.createMapState(BaseStyle.Demo) }
     runtime.awaitClosed()
     assertTrue(resourcesClosed)
   }
@@ -39,14 +39,14 @@ class MapRuntimeTest {
   @Test
   fun child_closure_does_not_close_its_runtime() = runTest {
     val runtime = mapRuntimeForTest()
-    val first = runtime.createMapState()
+    val first = runtime.createMapState(BaseStyle.Demo)
 
     first.close()
     first.awaitClosed()
 
     assertTrue(first.isClosed)
     assertFalse(runtime.isClosed)
-    val second = runtime.createMapState()
+    val second = runtime.createMapState(BaseStyle.Demo)
     assertNotSame(first, second)
     runtime.close()
     runtime.awaitClosed()
@@ -58,7 +58,7 @@ class MapRuntimeTest {
     var secondResourcesClosed = false
     val first = mapRuntimeForTest { firstResourcesClosed = true }
     val second = mapRuntimeForTest { secondResourcesClosed = true }
-    val secondState = second.createMapState()
+    val secondState = second.createMapState(BaseStyle.Demo)
 
     first.close()
     first.awaitClosed()
@@ -66,7 +66,7 @@ class MapRuntimeTest {
     assertTrue(firstResourcesClosed)
     assertFalse(secondResourcesClosed)
     assertFalse(secondState.isClosed)
-    second.createMapState().close()
+    second.createMapState(BaseStyle.Demo).close()
     second.close()
     second.awaitClosed()
     assertTrue(secondResourcesClosed)

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/CompositedMap.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/CompositedMap.kt
@@ -27,7 +27,7 @@ internal class CompositedMap(style: BaseStyle, private val scaleFactor: Double =
   private var styleLoaded = false
   private val scope = MainScope()
   private val runtime = mapRuntimeForTest()
-  private val state = runtime.createMapState()
+  private val state = runtime.createMapState(BaseStyle.Demo)
 
   var frameRequests: Int = 0
     private set

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserOfflineManagerTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserOfflineManagerTest.kt
@@ -28,7 +28,7 @@ class BrowserOfflineManagerTest {
     }
     assertFailsWith<UnsupportedOperationException> { manager.clearAmbientCache() }
 
-    val state = runtime.createMapState()
+    val state = runtime.createMapState(BaseStyle.Demo)
     val snapshotter = runtime.createSnapshotter(BaseStyle.Empty)
     assertFalse(state.isClosed)
     assertEquals(BaseStyle.Empty, snapshotter.style.baseStyle)

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserPlatformMapAccessTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserPlatformMapAccessTest.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.async
 import kotlinx.coroutines.supervisorScope
 import org.maplibre.compose.gljs.runBrowserMapTest
+import org.maplibre.compose.style.BaseStyle
 import org.maplibre.compose.testing.GlJsMapFixture
 
 @OptIn(DelicateMapApi::class, ExperimentalTestApi::class)
@@ -19,7 +20,7 @@ class BrowserPlatformMapAccessTest {
   @Test
   fun web_access_requires_a_current_presentation() = runBrowserMapTest {
     val runtime = createMapRuntime(MapRuntimeOptions())
-    val state = runtime.createMapState()
+    val state = runtime.createMapState(BaseStyle.Demo)
 
     val failure = assertFailsWith<IllegalStateException> { state.withPlatformMap { map.getZoom() } }
 

--- a/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/desktop/DesktopRuntimeConfigurationTest.kt
+++ b/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/desktop/DesktopRuntimeConfigurationTest.kt
@@ -11,6 +11,7 @@ import kotlin.test.assertTrue
 import kotlinx.coroutines.test.runTest
 import org.maplibre.compose.map.MapRuntimeOptions
 import org.maplibre.compose.map.createMapRuntime
+import org.maplibre.compose.style.BaseStyle
 
 class DesktopRuntimeConfigurationTest {
 
@@ -49,8 +50,8 @@ class DesktopRuntimeConfigurationTest {
     val first = createMapRuntime(MapRuntimeOptions("com.example.first"))
     val second =
       createMapRuntime(MapRuntimeOptions("com.example.second", maximumCacheSizeBytes = 2_000))
-    val firstState = first.createMapState()
-    val secondState = second.createMapState()
+    val firstState = first.createMapState(BaseStyle.Demo)
+    val secondState = second.createMapState(BaseStyle.Demo)
 
     assertNotSame(first.offlineManager, second.offlineManager)
 
@@ -59,7 +60,7 @@ class DesktopRuntimeConfigurationTest {
 
     assertTrue(firstState.isClosed)
     assertTrue(!secondState.isClosed)
-    second.createMapState().close()
+    second.createMapState(BaseStyle.Demo).close()
     second.close()
     second.awaitClosed()
   }

--- a/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/desktop/bridge/LinuxVulkanOpenGlInteropTest.kt
+++ b/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/desktop/bridge/LinuxVulkanOpenGlInteropTest.kt
@@ -273,7 +273,7 @@ class LinuxVulkanOpenGlInteropTest {
       }
 
     private val runtime = mapRuntimeForTest()
-    private val state = runtime.createMapState()
+    private val state = runtime.createMapState(BaseStyle.Demo)
     private val renderer =
       MlnFfiMapSession(
         lifecycleAuthority = state.lifecycle,

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/DefaultMapRuntimeTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/DefaultMapRuntimeTest.kt
@@ -8,6 +8,7 @@ import kotlin.test.assertTrue
 import kotlinx.coroutines.test.runTest
 import org.maplibre.compose.mlnffi.FfiTestPlatform
 import org.maplibre.compose.mlnffi.MlnFfiRuntimeOptions
+import org.maplibre.compose.style.BaseStyle
 
 class DefaultMapRuntimeTest {
   @Test
@@ -29,7 +30,7 @@ class DefaultMapRuntimeTest {
       assertSame(first, second)
       assertFalse(createdReplacement)
       assertTrue(second.isClosed)
-      assertFailsWith<MapRuntimeClosedException> { second.createMapState() }
+      assertFailsWith<MapRuntimeClosedException> { second.createMapState(BaseStyle.Demo) }
     } finally {
       DefaultMapRuntime.resetForTest()
       FfiTestPlatform.deleteCacheFile(cacheFile)

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/mlnffi/BridgeMapFixture.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/mlnffi/BridgeMapFixture.kt
@@ -50,7 +50,7 @@ private constructor(
   private var frameId = 0L
   private var frameRequested = true
   private val runtime = mapRuntimeForTest()
-  private val state = runtime.createMapState()
+  private val state = runtime.createMapState(BaseStyle.Demo)
 
   val session: MlnFfiMapSession =
     MlnFfiMapSession(


### PR DESCRIPTION
## Description

Require callers of MapRuntime.createMapState to provide a BaseStyle, matching createSnapshotter, while rememberMapState keeps its demo default.

## Validation

Validated on macOS with mise run check, mise run test:android, mise run test:desktop, and caffeinate -dimsu mise run test:js.

## AI assistance

OpenAI Codex desktop with GPT-5 implemented, validated, and prepared this change.