### PR TITLE
Publish native style bindings before callbacks

### DIFF
--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleAuthority.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleAuthority.kt
@@ -531,13 +531,13 @@ internal class MapLifecycleBinding(
   fun claimStyleIdentity(
     engine: EngineMapIdentity,
     request: StyleRequestIdentity,
-    event: () -> Unit,
+    event: (StyleIdentity) -> Unit,
   ): StyleIdentity? = serialized {
     if (!acceptEngineIdentity(engine)) return@serialized null
     if (currentStyleRequest.load() != StyleRequestClaim(engine, request)) return@serialized null
     val identity = StyleIdentity(nextIdentity.incrementAndFetch())
     currentStyle.store(StyleClaim(engine, identity))
-    event()
+    event(identity)
     identity
   }
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleCallbacks.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleCallbacks.kt
@@ -22,8 +22,12 @@ internal class MapLifecycleCallbacks(
     request: StyleRequestIdentity,
     map: MapAdapter,
     style: StyleBinding,
+    beforeDelegate: (StyleIdentity) -> Unit = {},
   ): StyleIdentity? {
-    return lifecycle.claimStyleIdentity(engine, request) { delegate().onStyleChanged(map, style) }
+    return lifecycle.claimStyleIdentity(engine, request) { identity ->
+      beforeDelegate(identity)
+      delegate().onStyleChanged(map, style)
+    }
   }
 
   fun onMapFinishedLoading(engine: EngineMapIdentity, style: StyleIdentity, map: MapAdapter) =

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
@@ -720,7 +720,7 @@ class MapPresentationTest {
   @Test
   fun await_viewport_waits_for_the_next_attachment() = runTest {
     val runtime = mapRuntimeForTest(physicalScope = backgroundScope)
-    val state = runtime.createMapState()
+    val state = runtime.createMapState(BaseStyle.Demo)
     val viewport = testViewport()
     val waiting = async { state.awaitViewport() }
     testScheduler.runCurrent()
@@ -760,7 +760,7 @@ class MapPresentationTest {
   @Test
   fun a_bounds_set_waits_for_an_attachment_and_its_viewport() = runTest {
     val runtime = mapRuntimeForTest(physicalScope = backgroundScope)
-    val state = runtime.createMapState()
+    val state = runtime.createMapState(BaseStyle.Demo)
     val operation = async {
       state.setCameraPosition(BoundingBox(Position(-1.0, -1.0), Position(1.0, 1.0)))
     }
@@ -838,7 +838,7 @@ class MapPresentationTest {
   @Test
   fun the_latest_camera_animation_waits_for_attachment_and_restarts_on_replacement() = runTest {
     val runtime = mapRuntimeForTest(physicalScope = backgroundScope)
-    val state = runtime.createMapState()
+    val state = runtime.createMapState(BaseStyle.Demo)
     val superseded = async {
       state.animateCameraPosition(CameraPosition(zoom = 2.0), 1.seconds)
     }
@@ -874,7 +874,7 @@ class MapPresentationTest {
   @Test
   fun closing_a_map_fails_a_camera_animation_waiting_for_attachment() = runTest {
     val runtime = mapRuntimeForTest(physicalScope = backgroundScope)
-    val state = runtime.createMapState()
+    val state = runtime.createMapState(BaseStyle.Demo)
     supervisorScope {
       val animation = async {
         state.animateCameraPosition(CameraPosition(zoom = 4.0), 1.seconds)

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/testing/MapFixture.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/testing/MapFixture.kt
@@ -128,7 +128,9 @@ expect class MapTestResult
 
 internal expect fun runMapTest(block: suspend () -> Unit): MapTestResult
 
-internal class RecordingMapCallbacks : MapAdapter.Callbacks {
+internal class RecordingMapCallbacks(
+  private val beforeStyleChanged: (MapAdapter, StyleBinding?) -> Unit = { _, _ -> }
+) : MapAdapter.Callbacks {
 
   var attachment: MapAttachment? = null
 
@@ -142,6 +144,7 @@ internal class RecordingMapCallbacks : MapAdapter.Callbacks {
     private set
 
   override fun onStyleChanged(map: MapAdapter, style: StyleBinding?) {
+    beforeStyleChanged(map, style)
     this.style = style
     attachment?.updateViewport(map.getViewport())
     events += if (style == null) "styleChanged(null)" else MapFixture.STYLE_LOADED

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -818,18 +818,19 @@ internal class MlnFfiMapSession(
           return
         }
         val acceptedStyle =
-          lifecycleCallbacks.onStyleChanged(engine, producer.request, this, binding)
+          lifecycleCallbacks.onStyleChanged(engine, producer.request, this, binding) { identity ->
+            // Live handles from the previous binding must not write into a style that is gone.
+            styleBinding?.invalidate()
+            styleBinding = binding
+            featureStateReplayPending.store(true)
+            lifecycleStyleIdentity = identity
+            styleLoadUnreported = true
+            reportedUrlAttribution.clear()
+          }
         if (acceptedStyle == null) {
           binding.invalidate()
           return
         }
-        // Live handles from the previous binding must not write into a style that is gone.
-        styleBinding?.invalidate()
-        styleBinding = binding
-        featureStateReplayPending.store(true)
-        lifecycleStyleIdentity = acceptedStyle
-        styleLoadUnreported = true
-        reportedUrlAttribution.clear()
         // A producer frame that started before this callback can still hold the previous style.
         // requestRepaint dirties mbgl so the next renderUpdate draws instead of returning
         // NO_UPDATE; requestRender lets that draw through the session skip gate.

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/mlnffi/BridgeMapFixture.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/mlnffi/BridgeMapFixture.kt
@@ -1,7 +1,11 @@
+@file:OptIn(ExperimentalAtomicApi::class)
+
 package org.maplibre.compose.mlnffi
 
 import androidx.compose.ui.unit.LayoutDirection
 import co.touchlab.kermit.Logger
+import kotlin.concurrent.atomics.AtomicBoolean
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
@@ -32,7 +36,12 @@ private constructor(
   private val initialExtent: MapExtent,
 ) : AutoCloseable {
 
-  private val recorder = RecordingMapCallbacks()
+  private val stylePublishedBeforeSessionReady = AtomicBoolean(false)
+  private val recorder = RecordingMapCallbacks { map, style ->
+    if (style != null && (map as MlnFfiMapSession).loadedStyleIdentity !== style.identity) {
+      stylePublishedBeforeSessionReady.store(true)
+    }
+  }
 
   val events: MutableList<String>
     get() = recorder.events
@@ -247,6 +256,9 @@ private constructor(
         events.count { it == STYLE_LOADED } > styleLoadsBefore && this.style != null
       }
     }
+    check(!stylePublishedBeforeSessionReady.load()) {
+      "The loaded style callback ran before the native session stored its binding"
+    }
   }
 
   /**
@@ -261,6 +273,9 @@ private constructor(
         "Timed out waiting for style $style to load before rendering. Errors: $errors"
       }
       parkForTest(POLL_INTERVAL_MILLIS)
+    }
+    check(!stylePublishedBeforeSessionReady.load()) {
+      "The loaded style callback ran before the native session stored its binding"
     }
   }
 


### PR DESCRIPTION
## Description

Store each accepted native style binding before publishing its callback, enforce that ordering in the native fixture, and migrate four test callers missed when createMapState began requiring a base style in #1222.

## Validation

Validated with mise run check, mise run test:android, mise run test:android:device 36, mise run test:desktop, caffeinate -dimsu mise run test:js, mise run test:ios, and the focused replacing_the_style_cancels_an_mvt_provider_call JVM test.

## AI assistance

Implemented and validated with Codex using GPT-5.