### PR TITLE
Name camera bounds operations explicitly

### DIFF
--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoMap.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoMap.kt
@@ -57,7 +57,7 @@ internal suspend fun MapState.flyTo(destination: DemoDestination) {
         duration = DemoFlightDuration,
       )
     is DemoDestination.FitBounds ->
-      animateCameraPosition(
+      animateCameraToBounds(
         boundingBox = destination.bounds,
         padding = DemoBoundsPadding,
         duration = DemoFlightDuration,

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/TransitNetworkDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/TransitNetworkDemo.kt
@@ -364,7 +364,7 @@ object TransitNetworkDemo : Demo {
 
     LaunchedEffect(selected, mapState) {
       val route = network.routes.find { it.id == selected } ?: return@LaunchedEffect
-      mapState.animateCameraPosition(
+      mapState.animateCameraToBounds(
         boundingBox = route.bounds,
         padding = RouteFitPadding,
         duration = 1.seconds,

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Camera.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Camera.kt
@@ -38,7 +38,7 @@ fun Camera() {
 
   // #region fit-bounds
   LaunchedEffect(mapState) {
-    mapState.animateCameraPosition(
+    mapState.animateCameraToBounds(
       boundingBox = BoundingBox(west = -123.0, south = 47.0, east = -122.0, north = 48.0),
       padding = PaddingValues(32.dp),
     )

--- a/docs/src/content/docs/camera.mdx
+++ b/docs/src/content/docs/camera.mdx
@@ -30,13 +30,13 @@ there.
 
 ## Fit a bounding box
 
-An `animateCameraPosition` overload accepts a `BoundingBox` and fits it in the
-current viewport. Padding adds space between the box and the map edges:
+<Api of="MapState.animateCameraToBounds" /> fits a `BoundingBox` in the current
+viewport. Padding adds space between the box and the map edges:
 
 <Code code={region(camera, "fit-bounds")} lang="kotlin" title="App.kt" />
 
-The `setCameraPosition` overload fits the same bounding box without an
-animation.
+Use <Api of="MapState.fitCameraToBounds" /> to fit the same bounding box without
+an animation.
 
 ## Read the visible area
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapAdapter.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapAdapter.kt
@@ -43,7 +43,7 @@ internal interface MapAdapter {
 
   suspend fun animateCameraPosition(finalPosition: CameraPosition, duration: Duration)
 
-  suspend fun animateCameraPosition(
+  suspend fun animateCameraToBounds(
     boundingBox: BoundingBox,
     bearing: Double,
     tilt: Double,
@@ -65,7 +65,7 @@ internal interface MapAdapter {
 
   fun setCameraPadding(padding: PaddingValues)
 
-  fun setCameraPosition(
+  fun fitCameraToBounds(
     boundingBox: BoundingBox,
     bearing: Double,
     tilt: Double,

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
@@ -282,14 +282,14 @@ internal constructor(
   val cameraMoveReason: CameraMoveReason
     get() = moveReasonState
 
-  suspend fun setCameraPosition(
+  suspend fun fitCameraToBounds(
     boundingBox: BoundingBox,
     bearing: Double = 0.0,
     tilt: Double = 0.0,
     padding: PaddingValues = PaddingValues(0.dp),
   ): Unit = runLeaseBound {
     awaitViewportState()
-    adapter.setCameraPosition(boundingBox, bearing, tilt, padding)
+    adapter.fitCameraToBounds(boundingBox, bearing, tilt, padding)
   }
 
   suspend fun animateCameraPosition(
@@ -297,7 +297,7 @@ internal constructor(
     duration: Duration = 300.milliseconds,
   ): Unit = runLeaseBound { adapter.animateCameraPosition(position, duration) }
 
-  suspend fun animateCameraPosition(
+  suspend fun animateCameraToBounds(
     boundingBox: BoundingBox,
     bearing: Double = 0.0,
     tilt: Double = 0.0,
@@ -305,7 +305,7 @@ internal constructor(
     duration: Duration = 300.milliseconds,
   ): Unit = runLeaseBound {
     awaitViewportState()
-    adapter.animateCameraPosition(boundingBox, bearing, tilt, padding, duration)
+    adapter.animateCameraToBounds(boundingBox, bearing, tilt, padding, duration)
   }
 
   fun getVisibleRegion(): VisibleRegion? = withViewport { it.getVisibleRegion() }
@@ -491,13 +491,13 @@ internal constructor(
   }
 
   /** Waits for a viewport, then fits [boundingBox] without animation. */
-  public suspend fun setCameraPosition(
+  public suspend fun fitCameraToBounds(
     boundingBox: BoundingBox,
     bearing: Double = 0.0,
     tilt: Double = 0.0,
     padding: PaddingValues = PaddingValues(0.dp),
   ): Unit = retryAcrossAttachments {
-    it.setCameraPosition(boundingBox, bearing, tilt, padding)
+    it.fitCameraToBounds(boundingBox, bearing, tilt, padding)
   }
 
   /** Waits for an attached map, then animates to [position]. A new animation replaces this one. */
@@ -511,7 +511,7 @@ internal constructor(
   /**
    * Waits for a viewport, then animates to fit [boundingBox]. A new animation replaces this one.
    */
-  public suspend fun animateCameraPosition(
+  public suspend fun animateCameraToBounds(
     boundingBox: BoundingBox,
     bearing: Double = 0.0,
     tilt: Double = 0.0,
@@ -519,7 +519,7 @@ internal constructor(
     duration: Duration = 300.milliseconds,
   ): Unit = cameraMutation.mutate {
     retryAcrossAttachments {
-      it.animateCameraPosition(boundingBox, bearing, tilt, padding, duration)
+      it.animateCameraToBounds(boundingBox, bearing, tilt, padding, duration)
     }
   }
 

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
@@ -758,11 +758,11 @@ class MapPresentationTest {
   }
 
   @Test
-  fun a_bounds_set_waits_for_an_attachment_and_its_viewport() = runTest {
+  fun a_bounds_fit_waits_for_an_attachment_and_its_viewport() = runTest {
     val runtime = mapRuntimeForTest(physicalScope = backgroundScope)
     val state = runtime.createMapState(BaseStyle.Demo)
     val operation = async {
-      state.setCameraPosition(BoundingBox(Position(-1.0, -1.0), Position(1.0, 1.0)))
+      state.fitCameraToBounds(BoundingBox(Position(-1.0, -1.0), Position(1.0, 1.0)))
     }
     testScheduler.runCurrent()
     assertFalse(operation.isCompleted)
@@ -775,7 +775,7 @@ class MapPresentationTest {
 
     requireNotNull(state.currentMapAttachment).updateViewport(testViewport())
     operation.await()
-    assertTrue(adapter.boundsSet.isCompleted)
+    assertTrue(adapter.boundsFit.isCompleted)
     state.close()
     state.awaitClosed()
     runtime.close()
@@ -1043,7 +1043,7 @@ internal open class PresentationTestAdapter(
   var presentationWasVisibleWhileConfiguring = false
   var viewportReads = 0
   var currentViewport: Viewport? = null
-  val boundsSet = CompletableDeferred<Unit>()
+  val boundsFit = CompletableDeferred<Unit>()
   val queryStarted = CompletableDeferred<Unit>()
   val animationStarted = CompletableDeferred<Unit>()
   val finishAnimation = CompletableDeferred<Unit>()
@@ -1057,7 +1057,7 @@ internal open class PresentationTestAdapter(
     finishAnimation.await()
   }
 
-  override suspend fun animateCameraPosition(
+  override suspend fun animateCameraToBounds(
     boundingBox: BoundingBox,
     bearing: Double,
     tilt: Double,
@@ -1084,13 +1084,13 @@ internal open class PresentationTestAdapter(
 
   override fun setCameraPadding(padding: PaddingValues) = Unit
 
-  override fun setCameraPosition(
+  override fun fitCameraToBounds(
     boundingBox: BoundingBox,
     bearing: Double,
     tilt: Double,
     padding: PaddingValues,
   ) {
-    boundsSet.complete(Unit)
+    boundsFit.complete(Unit)
   }
 
   override fun setCameraConstraints(value: CameraConstraints) = Unit

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
@@ -852,7 +852,7 @@ internal class GlJsMapSession(
     onMap { map -> map.jumpTo(unsafeJso<JumpToOptions> { this.padding = resolved }) }
   }
 
-  override fun setCameraPosition(
+  override fun fitCameraToBounds(
     boundingBox: BoundingBox,
     bearing: Double,
     tilt: Double,
@@ -880,7 +880,7 @@ internal class GlJsMapSession(
     }
   }
 
-  override suspend fun animateCameraPosition(
+  override suspend fun animateCameraToBounds(
     boundingBox: BoundingBox,
     bearing: Double,
     tilt: Double,

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/MapCameraTransitionTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/MapCameraTransitionTest.kt
@@ -37,7 +37,7 @@ class MapCameraTransitionTest {
         it.cameraTargetMatches(START, CAMERA_PADDING)
       }
 
-      it.state.setCameraPosition(BOUNDS, 0.0, 0.0, FIT_PADDING)
+      it.state.fitCameraToBounds(BOUNDS, 0.0, 0.0, FIT_PADDING)
       it.pumpUntil("the bounds fit to be applied") {
         abs(it.session.getCameraPosition().zoom - START.zoom) > 0.1
       }
@@ -45,7 +45,7 @@ class MapCameraTransitionTest {
       it.assertCameraTarget(fitAfterPadding, CAMERA_PADDING)
       it.assertBoundsInside(CAMERA_PADDING + FIT_PADDING)
 
-      it.state.setCameraPosition(BOUNDS, 0.0, 0.0, FIT_PADDING)
+      it.state.fitCameraToBounds(BOUNDS, 0.0, 0.0, FIT_PADDING)
       it.pump(frames = 2)
       val repeatedFit = it.session.getCameraPosition()
       assertSameFit(fitAfterPadding, repeatedFit, "repeating the bounds fit changed its camera")
@@ -62,7 +62,7 @@ class MapCameraTransitionTest {
     createMapFixture().use {
       it.startAtOrigin()
 
-      it.state.setCameraPosition(ANTIMERIDIAN_BOUNDS, 0.0, 0.0, PaddingValues(0.dp))
+      it.state.fitCameraToBounds(ANTIMERIDIAN_BOUNDS, 0.0, 0.0, PaddingValues(0.dp))
       it.pumpUntil("the antimeridian bounds fit to be applied") {
         val camera = it.session.getCameraPosition()
         abs(abs(camera.target.longitude) - 180.0) < 1.0 && camera.zoom > START.zoom
@@ -82,7 +82,7 @@ class MapCameraTransitionTest {
       }
 
       it.awaitWhileRendering("the bounds animation to complete") {
-        it.state.animateCameraPosition(BOUNDS, 0.0, 0.0, FIT_PADDING, 200.milliseconds)
+        it.state.animateCameraToBounds(BOUNDS, 0.0, 0.0, FIT_PADDING, 200.milliseconds)
       }
 
       val firstFit = it.session.getCameraPosition()
@@ -90,7 +90,7 @@ class MapCameraTransitionTest {
       it.assertBoundsInside(CAMERA_PADDING + FIT_PADDING)
 
       it.awaitWhileRendering("the repeated bounds animation to complete") {
-        it.state.animateCameraPosition(BOUNDS, 0.0, 0.0, FIT_PADDING, 200.milliseconds)
+        it.state.animateCameraToBounds(BOUNDS, 0.0, 0.0, FIT_PADDING, 200.milliseconds)
       }
 
       assertSameFit(

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -1355,7 +1355,7 @@ internal class MlnFfiMapSession(
     }
   }
 
-  override fun setCameraPosition(
+  override fun fitCameraToBounds(
     boundingBox: BoundingBox,
     bearing: Double,
     tilt: Double,
@@ -1426,7 +1426,7 @@ internal class MlnFfiMapSession(
     }
   }
 
-  override suspend fun animateCameraPosition(
+  override suspend fun animateCameraToBounds(
     boundingBox: BoundingBox,
     bearing: Double,
     tilt: Double,


### PR DESCRIPTION
## Description

Rename bounding-box camera operations to `fitCameraToBounds` and `animateCameraToBounds`, migrate all callers, and keep exact-position setters distinct from viewport-dependent work.

## Validation

Validated with `mise run check`, `mise run test:android`, `mise run test:desktop`, `caffeinate -dimsu mise run test:js`, and `mise run build:docs`.

## AI assistance

OpenAI Codex desktop with GPT-5 audited, implemented, migrated, and validated this change.