### PR TITLE
Add loaded style resource registries and commands

### DIFF
--- a/.agents/docs/STYLE_RESOURCES.md
+++ b/.agents/docs/STYLE_RESOURCES.md
@@ -1,0 +1,238 @@
+# Loaded style resources
+
+`MapStyleState` groups loaded sources, layers, and style images by resource
+kind. Each resource kind exposes only the operations that its MapLibre object
+supports.
+
+This API replaces `MapStyleState.sources`, `MapStyleState.source(id)`, and
+`MapStyleState.layer(id)`. The migration adds no compatibility aliases.
+
+## Public API
+
+`MapStyleState` exposes three stable objects:
+
+```kotlin
+public class MapStyleState internal constructor(...) {
+  public val sources: StyleSources
+  public val layers: StyleLayers
+  public val images: StyleImages
+}
+```
+
+The objects belong to `org.maplibre.compose.map`. Their constructors are
+internal.
+
+### Sources
+
+`StyleSources` provides lookup, ordered iteration, and structural commands:
+
+```kotlin
+public class StyleSources internal constructor(...) : Iterable<SourceHandle> {
+  public operator fun get(id: String): SourceHandle?
+
+  public fun add(source: Source): SourceHandle
+
+  public fun remove(id: String): Boolean
+
+  override fun iterator(): Iterator<SourceHandle>
+}
+```
+
+`get` returns a generation-bound handle for the loaded source. It returns null
+while the style is not ready or when the ID is absent.
+
+Iteration contains every source in the current loaded style. The order matches
+the engine style order. Iteration is empty while the style is not ready.
+
+`add` adds the source to the current loaded style and returns its handle. The
+command fails when the style already contains the source ID.
+
+`remove` removes a source from the current loaded style. It returns false when
+the ID is absent. MapLibre can refuse removal when a layer still references the
+source.
+
+Source handles retain their current commands. These commands include GeoJSON
+data updates, feature state, source queries, cluster queries, and custom-source
+invalidation.
+
+### Layers
+
+`StyleLayers` provides lookup and ordered iteration:
+
+```kotlin
+public class StyleLayers internal constructor(...) : Iterable<LayerHandle> {
+  public operator fun get(id: String): LayerHandle?
+
+  override fun iterator(): Iterator<LayerHandle>
+}
+```
+
+`get` returns a generation-bound handle for the loaded layer. It returns null
+while the style is not ready or when the ID is absent.
+
+Iteration contains every layer in the current loaded style, from bottom to top.
+Iteration is empty while the style is not ready.
+
+`LayerHandle` retains imperative property reads and writes. This API does not
+add, remove, or move layers imperatively. Declarative layer operations require
+the ordering and replacement rules in `StyleComposition`.
+
+### Images
+
+`StyleImages` provides structural commands only:
+
+```kotlin
+public class StyleImages internal constructor(...) {
+  public fun add(
+    id: String,
+    image: ImageBitmap,
+    sdf: Boolean = false,
+    stretch: ImageStretch? = null,
+  )
+
+  public fun remove(id: String): Boolean
+}
+```
+
+`add` installs a style image in the current loaded style. The command fails when
+the style already contains the image ID.
+
+`remove` removes a style image from the current loaded style. It returns false
+when the ID is absent.
+
+A style image has no handle or public inspection API. Style images support icon
+and pattern lookup by the renderer, but they expose no commands comparable to
+source data updates or layer property writes. An `ImageSourceHandle` remains a
+source handle. It controls the bitmap, URI, and geographic bounds of an image
+source.
+
+## Loaded-style lifetime
+
+The three resource objects remain attached to one `MapStyleState`. Their
+contents and commands target the current ready loaded-style generation.
+
+A source or layer handle belongs to the generation that created it. A base style
+reload or an engine replacement invalidates the handle. A later resource with
+the same ID does not make the old handle valid again.
+
+Imperative source and image additions belong to the current generation. The
+library does not replay them into a replacement generation. A retained engine
+keeps the additions while the presentation is detached because the loaded-style
+generation remains the same.
+
+`StyleComposition` remains the only API for sources, layers, and images that
+must survive a generation replacement.
+
+## Ownership and reconciliation
+
+Each loaded resource ID has one structural owner. The base style,
+`StyleComposition`, or an imperative command can own the ID.
+
+An imperative command cannot remove a source or image that the current
+`StyleComposition` revision owns. The command fails before it changes the
+engine. The reconciler tracks installed declarative resources and would
+otherwise retain stale installation state.
+
+An imperative addition cannot use an ID that the base style or the current
+`StyleComposition` revision already uses. A later declarative revision cannot
+claim an ID that an imperative addition uses in the current generation. The
+revision fails with a duplicate-ID error instead of replacing either resource.
+
+`MapState` and `MapSnapshotter` own the imperative resource records for their
+current loaded-style generation. `StyleReconciler` remains the owner of
+declarative installation records. Both paths check resource ownership before a
+structural mutation reaches `StyleBinding`.
+
+## Source metadata and attribution
+
+`StyleSources` is the public registry for loaded source handles. It includes
+base-style sources, declarative sources, and imperative sources.
+
+The registry refreshes when a style becomes ready, after a successful source
+addition or removal, and when an engine source-metadata event arrives. A stale
+metadata event cannot replace the registry for a newer generation.
+
+Attribution remains a derived operation over the general source registry:
+
+```kotlin
+public fun MapStyleState.attributions(): List<String> =
+  sources
+    .map(SourceHandle::attributionHtml)
+    .filter(String::isNotEmpty)
+    .distinct()
+```
+
+The attribution extension keeps no separate source collection or cache.
+
+## Command results and failures
+
+Structural commands require `StyleLoadState.Ready`. A command fails with an
+`IllegalStateException` when no ready loaded-style generation exists or when the
+generation changes during the command.
+
+A command fails with `StyleHandleException` when an ID conflicts with another
+owner or when MapLibre refuses the mutation. A failed command leaves the public
+resource registry unchanged.
+
+A successful command updates the public registry before it returns and requests
+a render. A later engine metadata event can replace source metadata without
+changing source order.
+
+## Implementation requirements
+
+`MapStyleState` creates each resource object once. The objects read current
+handles from state-backed snapshots and send structural commands through their
+attached owner.
+
+The owner performs each command in this order:
+
+1. Require a ready current `StyleBinding`.
+2. Check the resource ID and its structural owner.
+3. Apply the mutation through `StyleBinding`.
+4. Confirm that the loaded-style generation is unchanged.
+5. Update the public resource snapshot.
+6. Request a render.
+
+The common `StyleBinding` boundary gains point lookup for style-image IDs so
+that `add` can reject duplicates and `remove` can report absence. The public API
+does not expose that lookup.
+
+Source and layer snapshots use the complete engine reads that already produce
+`SourceHandle` and `LayerHandle` values. Snapshot publication preserves engine
+order and uses the existing generation checks around source refreshes.
+
+## Validation
+
+Common tests cover these contracts:
+
+- lookup and iteration before readiness, after readiness, and after invalidation
+- source and layer iteration order
+- source addition, removal, duplicate IDs, and engine refusal
+- image addition, removal, and duplicate IDs
+- rejection of mutations against declaratively owned resources
+- duplicate ownership introduced by a later declarative revision
+- stale handles after a base-style reload and an engine replacement
+- retained-generation behavior while a presentation is detached
+- attribution from base-style, declarative, and imperative sources
+- stale source-metadata events after a generation replacement
+- registry publication and render requests after successful commands
+
+Platform tests cover one successful source mutation and one successful image
+mutation on MapLibre Native FFI and MapLibre GL JS. Existing live-map tests
+continue to cover the commands on each source and layer handle type.
+
+Run the normal focused validation through mise tasks. The implementation must
+pass `mise run check`, `mise run test:android`, `mise run test:desktop`,
+`mise run test:ios`, and `caffeinate -dimsu mise run test:js`.
+
+## Excluded API
+
+This design adds no mutable `Map` implementation. A `Map` would expose generic
+mutation methods that cannot enforce resource ownership or generation checks.
+
+This design adds no image enumeration or `StyleImageHandle`. Image commands do
+not need either API.
+
+This design adds no imperative layer insertion, removal, or movement. Those
+operations require declarative anchor, replacement, click-handler, and source
+dependency state.

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/LayerHandle.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/LayerHandle.kt
@@ -15,6 +15,7 @@ internal constructor(
   public val id: String,
   public val type: String,
   private val style: StyleBinding,
+  private val isCurrentResource: () -> Boolean,
   private val operations: StyleHandleOperationGuard,
 ) {
   private val identity: StyleIdentity = style.identity
@@ -55,6 +56,7 @@ internal constructor(
 
   private fun requireCurrent() {
     style.requireCurrent(identity)
+    check(isCurrentResource()) { "Layer '$id' is no longer owned by this handle" }
     val currentType = style.getLayer(id)?.definition()?.type
     check(currentType == type) { "Layer '$id' is no longer the $type layer owned by this handle" }
   }
@@ -78,9 +80,10 @@ internal constructor(
 
 internal fun StyleBinding.layerHandle(
   id: String,
+  isCurrentResource: () -> Boolean,
   operations: StyleHandleOperationGuard,
 ): LayerHandle? {
   requireCurrent()
   val layer = getLayer(id) ?: return null
-  return LayerHandle(id, layer.definition().type, this, operations)
+  return LayerHandle(id, layer.definition().type, this, isCurrentResource, operations)
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.runtime.structuralEqualityPolicy
+import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.DpRect
 import androidx.compose.ui.unit.dp
@@ -54,14 +55,19 @@ import org.maplibre.compose.offline.RuntimeBoundOfflineManager
 import org.maplibre.compose.offline.UnsupportedOfflineManager
 import org.maplibre.compose.resource.MapRequestInterceptor
 import org.maplibre.compose.resource.MapResourceConfig
+import org.maplibre.compose.sources.Source
 import org.maplibre.compose.sources.SourceHandle
 import org.maplibre.compose.sources.sourceHandle
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.compose.style.DesiredStyleRevision
 import org.maplibre.compose.style.LocalMapState
+import org.maplibre.compose.style.SourceDefinition
 import org.maplibre.compose.style.StyleBinding
 import org.maplibre.compose.style.StyleComposition
+import org.maplibre.compose.style.StyleHandleException
 import org.maplibre.compose.style.StyleHandleOperationGuard
+import org.maplibre.compose.style.StyleMutationException
+import org.maplibre.compose.util.ImageStretch
 import org.maplibre.compose.util.MaplibreComposable
 import org.maplibre.compose.util.VisibleRegion
 import org.maplibre.spatialk.geojson.BoundingBox
@@ -153,6 +159,16 @@ internal interface MapStyleStateOwner {
 
   fun desiredSourceDefinition(id: String): org.maplibre.compose.style.SourceDefinition?
 
+  fun sourceDefinitionToken(id: String): Any?
+
+  fun addStyleSource(source: Source): SourceHandle
+
+  fun removeStyleSource(id: String): Boolean
+
+  fun addStyleImage(id: String, image: ImageBitmap, sdf: Boolean, stretch: ImageStretch?)
+
+  fun removeStyleImage(id: String): Boolean
+
   fun readyLoadedStyle(): StyleBinding?
 
   fun <T> runStyleHandleOperation(binding: StyleBinding, action: () -> T): T
@@ -167,6 +183,7 @@ public class MapStyleState internal constructor(initialBaseStyle: BaseStyle) {
   private var owner: MapStyleStateOwner? = null
   private val loadedStyle = AtomicReference<StyleBinding?>(null)
   private var sourcesState: Map<String, SourceHandle> by mutableStateOf(emptyMap())
+  private var layersState: Map<String, LayerHandle> by mutableStateOf(emptyMap())
   private var baseStyleState: BaseStyle by
     mutableStateOf(initialBaseStyle, structuralEqualityPolicy())
 
@@ -179,28 +196,36 @@ public class MapStyleState internal constructor(initialBaseStyle: BaseStyle) {
   public var loadState: StyleLoadState by mutableStateOf(StyleLoadState.Pending)
     internal set
 
-  /** Contains the sources in the current loaded style, in style order. */
-  public val sources: Map<String, SourceHandle>
-    get() = if (readyLoadedStyle() == null) emptyMap() else sourcesState
+  /** Sources in the current loaded-style generation. */
+  public val sources: StyleSources = StyleSources(this)
 
-  /** Returns a generation-bound handle for [id], or null until the style is ready or if absent. */
-  public fun source(id: String): SourceHandle? {
-    val current = readyLoadedStyle() ?: return null
-    return sourceHandle(current, id)
+  /** Layers in the current loaded-style generation. */
+  public val layers: StyleLayers = StyleLayers(this)
+
+  /** Style-image commands for the current loaded-style generation. */
+  public val images: StyleImages = StyleImages(this)
+
+  internal fun sourceHandle(id: String): SourceHandle? {
+    if (readyLoadedStyle() == null) return null
+    return sourcesState[id]
   }
 
-  private fun sourceHandle(current: StyleBinding, id: String): SourceHandle? =
+  private fun sourceHandle(current: StyleBinding, id: String): SourceHandle? = owner.let { owner ->
+    val definition = owner?.desiredSourceDefinition(id)
+    val token = owner?.sourceDefinitionToken(id)
     current.sourceHandle(
       id = id,
-      definition = owner?.desiredSourceDefinition(id),
-      currentDefinition = { owner?.desiredSourceDefinition(id) },
+      definition = definition,
+      currentDefinition = {
+        owner?.desiredSourceDefinition(id)?.takeIf { owner.sourceDefinitionToken(id) === token }
+      },
       operations = operationGuard(current),
     )
+  }
 
-  /** Returns a generation-bound handle for [id], or null until the style is ready or if absent. */
-  public fun layer(id: String): LayerHandle? {
-    val current = readyLoadedStyle() ?: return null
-    return current.layerHandle(id, operationGuard(current))
+  internal fun layerHandle(id: String): LayerHandle? {
+    if (readyLoadedStyle() == null) return null
+    return layersState[id]
   }
 
   private fun readyLoadedStyle(): StyleBinding? =
@@ -210,6 +235,8 @@ public class MapStyleState internal constructor(initialBaseStyle: BaseStyle) {
     this.owner = owner
   }
 
+  internal fun requireOwner(): MapStyleStateOwner = checkNotNull(owner)
+
   internal fun setBaseStyleState(value: BaseStyle) {
     baseStyleState = value
   }
@@ -217,22 +244,31 @@ public class MapStyleState internal constructor(initialBaseStyle: BaseStyle) {
   internal fun updateLoadedStyle(style: StyleBinding?) {
     loadedStyle.store(style)
     sourcesState = emptyMap()
+    layersState = emptyMap()
   }
 
   internal fun invalidateLoadedStyle() {
     loadedStyle.exchange(null)?.invalidate()
     sourcesState = emptyMap()
+    layersState = emptyMap()
   }
 
   internal fun isCurrentLoadedStyle(style: StyleBinding): Boolean = loadedStyle.load() === style
 
   internal fun currentLoadedStyle(): StyleBinding? = loadedStyle.load()
 
-  internal fun refreshSources() {
+  internal fun refreshResources() {
     val current = loadedStyle.load()
-    sourcesState =
-      if (loadState != StyleLoadState.Ready || current == null) emptyMap() else readSources(current)
+    if (loadState != StyleLoadState.Ready || current == null) {
+      sourcesState = emptyMap()
+      layersState = emptyMap()
+    } else {
+      updateResources(readResources(current))
+    }
   }
+
+  internal fun readResources(current: StyleBinding): LoadedStyleResources =
+    LoadedStyleResources(readSources(current), readLayers(current))
 
   internal fun readSources(current: StyleBinding): Map<String, SourceHandle> =
     current
@@ -243,6 +279,25 @@ public class MapStyleState internal constructor(initialBaseStyle: BaseStyle) {
   internal fun updateSources(sources: Map<String, SourceHandle>) {
     sourcesState = sources
   }
+
+  internal fun readLayers(current: StyleBinding): Map<String, LayerHandle> =
+    current
+      .getLayers()
+      .mapNotNull { layer ->
+        current.layerHandle(layer.id, operationGuard(current))?.let { layer.id to it }
+      }
+      .toMap()
+
+  internal fun updateResources(resources: LoadedStyleResources) {
+    sourcesState = resources.sources
+    layersState = resources.layers
+  }
+
+  internal fun sourceHandles(): Map<String, SourceHandle> =
+    if (readyLoadedStyle() == null) emptyMap() else sourcesState
+
+  internal fun layerHandles(): Map<String, LayerHandle> =
+    if (readyLoadedStyle() == null) emptyMap() else layersState
 
   private fun operationGuard(style: StyleBinding): StyleHandleOperationGuard =
     object : StyleHandleOperationGuard {
@@ -256,6 +311,13 @@ public class MapStyleState internal constructor(initialBaseStyle: BaseStyle) {
       }
     }
 }
+
+internal data class LoadedStyleResources(
+  val sources: Map<String, SourceHandle>,
+  val layers: Map<String, LayerHandle>,
+)
+
+internal class ImperativeSourceRecord(val definition: SourceDefinition)
 
 /** Connects a [MapState] to one map surface for the lifetime of one render lease. */
 internal class MapAttachment
@@ -408,6 +470,8 @@ internal constructor(
   private var cameraCommandRevision = 0L
   private var styleHandleEpoch = 0L
   private var styleSourceChangeRevision = 0L
+  private val imperativeSources = mutableMapOf<String, ImperativeSourceRecord>()
+  private val imperativeImageIds = mutableSetOf<String>()
   private var closedState: Boolean by mutableStateOf(false)
   private var cameraPositionState: CameraPosition by
     mutableStateOf(initialCameraPosition, structuralEqualityPolicy())
@@ -422,6 +486,21 @@ internal constructor(
 
           override fun desiredSourceDefinition(id: String) =
             this@MapState.desiredSourceDefinition(id)
+
+          override fun sourceDefinitionToken(id: String) = this@MapState.sourceDefinitionToken(id)
+
+          override fun addStyleSource(source: Source) = this@MapState.addStyleSource(source)
+
+          override fun removeStyleSource(id: String) = this@MapState.removeStyleSource(id)
+
+          override fun addStyleImage(
+            id: String,
+            image: ImageBitmap,
+            sdf: Boolean,
+            stretch: ImageStretch?,
+          ) = this@MapState.addStyleImage(id, image, sdf, stretch)
+
+          override fun removeStyleImage(id: String) = this@MapState.removeStyleImage(id)
 
           override fun readyLoadedStyle() = this@MapState.readyLoadedStyle()
 
@@ -598,19 +677,19 @@ internal constructor(
       val read = lifecycle.serialized {
         if (!lifecycle.acceptsAdapter(adapter)) return false
         val binding = style.currentLoadedStyle() ?: return false
-        StyleSourceRead(binding, styleHandleEpoch, styleSourceChangeRevision)
+        StyleResourceRead(binding, styleHandleEpoch, styleSourceChangeRevision)
       }
-      val sources = runCatching { style.readSources(read.binding) }
-      if (sources.isFailure) {
-        val stillCurrent = lifecycle.serialized { isCurrentStyleSourceRead(adapter, read) }
+      val resources = runCatching { style.readResources(read.binding) }
+      if (resources.isFailure) {
+        val stillCurrent = lifecycle.serialized { isCurrentStyleResourceRead(adapter, read) }
         if (!stillCurrent) return false
-        throw requireNotNull(sources.exceptionOrNull())
+        throw requireNotNull(resources.exceptionOrNull())
       }
       val committed = lifecycle.serialized {
-        if (!isCurrentStyleSourceRead(adapter, read)) return false
+        if (!isCurrentStyleResourceRead(adapter, read)) return false
         if (style.loadState is StyleLoadState.Failed) return false
         if (styleSourceChangeRevision != read.sourceChangeRevision) return@serialized false
-        style.updateSources(sources.getOrThrow())
+        style.updateResources(resources.getOrThrow())
         style.loadState = StyleLoadState.Ready
         true
       }
@@ -627,16 +706,16 @@ internal constructor(
       val sourceChangeRevision = ++styleSourceChangeRevision
       if (style.loadState != StyleLoadState.Ready) return true
       val binding = style.currentLoadedStyle() ?: return true
-      StyleSourceRead(binding, styleHandleEpoch, sourceChangeRevision)
+      StyleResourceRead(binding, styleHandleEpoch, sourceChangeRevision)
     }
     val sources = runCatching { style.readSources(read.binding) }
     if (sources.isFailure) {
-      val stillCurrent = lifecycle.serialized { isCurrentStyleSourceRead(adapter, read) }
+      val stillCurrent = lifecycle.serialized { isCurrentStyleResourceRead(adapter, read) }
       if (!stillCurrent) return false
       throw requireNotNull(sources.exceptionOrNull())
     }
     return lifecycle.serialized {
-      if (!isCurrentStyleSourceRead(adapter, read)) return false
+      if (!isCurrentStyleResourceRead(adapter, read)) return false
       if (style.loadState != StyleLoadState.Ready) return false
       // A later callback performs its own complete read, preserving source order without allowing
       // this older result to overwrite it.
@@ -646,7 +725,7 @@ internal constructor(
     }
   }
 
-  private fun isCurrentStyleSourceRead(adapter: MapAdapter, read: StyleSourceRead): Boolean =
+  private fun isCurrentStyleResourceRead(adapter: MapAdapter, read: StyleResourceRead): Boolean =
     lifecycle.acceptsAdapter(adapter) &&
       styleHandleEpoch == read.styleHandleEpoch &&
       style.currentLoadedStyle() === read.binding
@@ -656,6 +735,8 @@ internal constructor(
       if (!lifecycle.acceptsAdapter(adapter)) return false
       if (style.currentLoadedStyle() === loadedStyle) return true
       styleHandleEpoch++
+      imperativeSources.clear()
+      imperativeImageIds.clear()
       style.loadState = StyleLoadState.Loading
       style.updateLoadedStyle(loadedStyle)
       true
@@ -676,6 +757,7 @@ internal constructor(
   internal fun beginStyleRevision(adapter: MapAdapter, revision: DesiredStyleRevision) {
     lifecycle.serialized {
       if (lifecycle.acceptsAdapter(adapter)) {
+        requireNoImperativeResourceConflicts(revision)
         styleHandleEpoch++
         desiredStyleRevision = revision
         style.loadState = StyleLoadState.Loading
@@ -688,6 +770,8 @@ internal constructor(
       requireOpenLocked()
       if (style.baseStyle == value) return
       styleHandleEpoch++
+      imperativeSources.clear()
+      imperativeImageIds.clear()
       style.setBaseStyleState(value)
       style.invalidateLoadedStyle()
       val adapter = lifecycle.currentAdapter()
@@ -704,7 +788,139 @@ internal constructor(
   }
 
   internal fun desiredSourceDefinition(id: String): org.maplibre.compose.style.SourceDefinition? =
-    desiredStyleRevision.sources.firstOrNull { it.id == id }
+    desiredStyleRevision.sources.firstOrNull { it.id == id } ?: imperativeSources[id]?.definition
+
+  internal fun sourceDefinitionToken(id: String): Any? = imperativeSources[id]
+
+  internal fun addStyleSource(source: Source): SourceHandle {
+    val binding = lifecycle.serialized {
+      requireOpenLocked()
+      requireNoDesiredSource(source.id)
+      checkNotNull(style.currentLoadedStyle()).also(::requireStyleHandleLocked)
+    }
+    val definition = source.definition()
+    if (binding.sourceExists(source.id) == true) {
+      throw StyleHandleException("Source ID '${source.id}' already exists in style")
+    }
+    val added =
+      try {
+        binding.addSource(definition)
+      } catch (error: StyleMutationException) {
+        throw StyleHandleException("Could not add source '${source.id}': ${error.message}", error)
+      }
+    if (!added) throw IllegalStateException("The loaded-style generation changed during add")
+    lifecycle.serialized {
+      requireStyleHandleLocked(binding)
+      imperativeSources[source.id] = ImperativeSourceRecord(definition)
+    }
+    return checkNotNull(refreshSourcesAfterCommand(binding)[source.id])
+  }
+
+  internal fun removeStyleSource(id: String): Boolean {
+    val binding = lifecycle.serialized {
+      requireOpenLocked()
+      requireNoDesiredSource(id)
+      checkNotNull(style.currentLoadedStyle()).also(::requireStyleHandleLocked)
+    }
+    if (binding.sourceExists(id) == false) return false
+    try {
+      binding.removeSource(id)
+    } catch (error: StyleMutationException) {
+      throw StyleHandleException("Could not remove source '$id': ${error.message}", error)
+    }
+    lifecycle.serialized {
+      requireStyleHandleLocked(binding)
+      imperativeSources.remove(id)
+    }
+    refreshSourcesAfterCommand(binding)
+    return true
+  }
+
+  internal fun addStyleImage(
+    id: String,
+    image: ImageBitmap,
+    sdf: Boolean,
+    stretch: ImageStretch?,
+  ) {
+    val binding = lifecycle.serialized {
+      requireOpenLocked()
+      requireNoDesiredImage(id)
+      checkNotNull(style.currentLoadedStyle()).also(::requireStyleHandleLocked)
+    }
+    if (binding.imageExists(id) == true) {
+      throw StyleHandleException("Image ID '$id' already exists in style")
+    }
+    try {
+      binding.addImage(id, image, sdf, stretch)
+    } catch (error: StyleMutationException) {
+      throw StyleHandleException("Could not add image '$id': ${error.message}", error)
+    }
+    lifecycle.serialized {
+      requireStyleHandleLocked(binding)
+      imperativeImageIds += id
+    }
+  }
+
+  internal fun removeStyleImage(id: String): Boolean {
+    val binding = lifecycle.serialized {
+      requireOpenLocked()
+      requireNoDesiredImage(id)
+      checkNotNull(style.currentLoadedStyle()).also(::requireStyleHandleLocked)
+    }
+    if (binding.imageExists(id) == false) return false
+    try {
+      binding.removeImage(id)
+    } catch (error: StyleMutationException) {
+      throw StyleHandleException("Could not remove image '$id': ${error.message}", error)
+    }
+    lifecycle.serialized {
+      requireStyleHandleLocked(binding)
+      imperativeImageIds -= id
+    }
+    return true
+  }
+
+  private fun refreshSourcesAfterCommand(binding: StyleBinding): Map<String, SourceHandle> {
+    while (true) {
+      val read = lifecycle.serialized {
+        requireStyleHandleLocked(binding)
+        StyleResourceRead(binding, styleHandleEpoch, ++styleSourceChangeRevision)
+      }
+      val sources = style.readSources(binding)
+      val committed = lifecycle.serialized {
+        requireStyleHandleLocked(binding)
+        if (styleSourceChangeRevision != read.sourceChangeRevision) return@serialized false
+        style.updateSources(sources)
+        true
+      }
+      if (committed) return sources
+    }
+  }
+
+  private fun requireNoDesiredSource(id: String) {
+    if (desiredStyleRevision.sources.any { it.id == id }) {
+      throw StyleHandleException("Source ID '$id' is owned by StyleComposition")
+    }
+  }
+
+  private fun requireNoDesiredImage(id: String) {
+    if (desiredStyleRevision.images.any { it.id == id }) {
+      throw StyleHandleException("Image ID '$id' is owned by StyleComposition")
+    }
+  }
+
+  private fun requireNoImperativeResourceConflicts(revision: DesiredStyleRevision) {
+    revision.sources
+      .firstOrNull { it.id in imperativeSources }
+      ?.let {
+        throw StyleHandleException("Source ID '${it.id}' is owned by an imperative addition")
+      }
+    revision.images
+      .firstOrNull { it.id in imperativeImageIds }
+      ?.let {
+        throw StyleHandleException("Image ID '${it.id}' is owned by an imperative addition")
+      }
+  }
 
   internal fun <T> runStyleHandleOperation(
     binding: StyleBinding,
@@ -936,7 +1152,7 @@ internal constructor(
     val revision: Long,
   )
 
-  private data class StyleSourceRead(
+  private data class StyleResourceRead(
     val binding: StyleBinding,
     val styleHandleEpoch: Long,
     val sourceChangeRevision: Long,

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
@@ -897,7 +897,9 @@ internal constructor(
   }
 
   internal fun desiredSourceDefinition(id: String): org.maplibre.compose.style.SourceDefinition? =
-    desiredStyleRevision.sources.firstOrNull { it.id == id } ?: imperativeSources[id]?.definition
+    lifecycle.serialized {
+      desiredStyleRevision.sources.firstOrNull { it.id == id } ?: imperativeSources[id]?.definition
+    }
 
   internal fun addStyleSource(source: Source): SourceHandle {
     val definition = source.definition()

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
@@ -67,6 +67,7 @@ import org.maplibre.compose.style.StyleComposition
 import org.maplibre.compose.style.StyleHandleException
 import org.maplibre.compose.style.StyleHandleOperationGuard
 import org.maplibre.compose.style.StyleMutationException
+import org.maplibre.compose.style.canUpdateTo
 import org.maplibre.compose.util.ImageStretch
 import org.maplibre.compose.util.MaplibreComposable
 import org.maplibre.compose.util.VisibleRegion
@@ -159,8 +160,6 @@ internal interface MapStyleStateOwner {
 
   fun desiredSourceDefinition(id: String): org.maplibre.compose.style.SourceDefinition?
 
-  fun sourceDefinitionToken(id: String): Any?
-
   fun addStyleSource(source: Source): SourceHandle
 
   fun removeStyleSource(id: String): Boolean
@@ -182,6 +181,8 @@ internal interface MapStyleStateOwner {
 public class MapStyleState internal constructor(initialBaseStyle: BaseStyle) {
   private var owner: MapStyleStateOwner? = null
   private val loadedStyle = AtomicReference<StyleBinding?>(null)
+  private val sourceIdentities = AtomicReference<Map<String, StyleResourceIdentity>>(emptyMap())
+  private val layerIdentities = AtomicReference<Map<String, StyleResourceIdentity>>(emptyMap())
   private var sourcesState: Map<String, SourceHandle> by mutableStateOf(emptyMap())
   private var layersState: Map<String, LayerHandle> by mutableStateOf(emptyMap())
   private var baseStyleState: BaseStyle by
@@ -212,13 +213,12 @@ public class MapStyleState internal constructor(initialBaseStyle: BaseStyle) {
 
   private fun sourceHandle(current: StyleBinding, id: String): SourceHandle? = owner.let { owner ->
     val definition = owner?.desiredSourceDefinition(id)
-    val token = owner?.sourceDefinitionToken(id)
+    val identity = sourceIdentity(id)
     current.sourceHandle(
       id = id,
       definition = definition,
-      currentDefinition = {
-        owner?.desiredSourceDefinition(id)?.takeIf { owner.sourceDefinitionToken(id) === token }
-      },
+      currentDefinition = { owner?.desiredSourceDefinition(id) },
+      isCurrentResource = { sourceIdentities.load()[id] === identity },
       operations = operationGuard(current),
     )
   }
@@ -243,12 +243,16 @@ public class MapStyleState internal constructor(initialBaseStyle: BaseStyle) {
 
   internal fun updateLoadedStyle(style: StyleBinding?) {
     loadedStyle.store(style)
+    sourceIdentities.store(emptyMap())
+    layerIdentities.store(emptyMap())
     sourcesState = emptyMap()
     layersState = emptyMap()
   }
 
   internal fun invalidateLoadedStyle() {
     loadedStyle.exchange(null)?.invalidate()
+    sourceIdentities.store(emptyMap())
+    layerIdentities.store(emptyMap())
     sourcesState = emptyMap()
     layersState = emptyMap()
   }
@@ -270,23 +274,40 @@ public class MapStyleState internal constructor(initialBaseStyle: BaseStyle) {
   internal fun readResources(current: StyleBinding): LoadedStyleResources =
     LoadedStyleResources(readSources(current), readLayers(current))
 
-  internal fun readSources(current: StyleBinding): Map<String, SourceHandle> =
-    current
-      .getSources()
-      .mapNotNull { source -> sourceHandle(current, source.id)?.let { source.id to it } }
-      .toMap()
+  internal fun readSources(current: StyleBinding): Map<String, SourceHandle> {
+    val ids = current.getSources().mapTo(linkedSetOf()) { it.id }
+    retainResourceIdentities(sourceIdentities, ids)
+    return ids.mapNotNull { id -> sourceHandle(current, id)?.let { id to it } }.toMap()
+  }
 
   internal fun updateSources(sources: Map<String, SourceHandle>) {
     sourcesState = sources
   }
 
-  internal fun readLayers(current: StyleBinding): Map<String, LayerHandle> =
-    current
-      .getLayers()
-      .mapNotNull { layer ->
-        current.layerHandle(layer.id, operationGuard(current))?.let { layer.id to it }
+  internal fun readLayers(current: StyleBinding): Map<String, LayerHandle> {
+    val ids = current.getLayers().mapTo(linkedSetOf()) { it.id }
+    retainResourceIdentities(layerIdentities, ids)
+    return ids
+      .mapNotNull { id ->
+        val identity = layerIdentity(id)
+        current
+          .layerHandle(
+            id,
+            isCurrentResource = { layerIdentities.load()[id] === identity },
+            operations = operationGuard(current),
+          )
+          ?.let { id to it }
       }
       .toMap()
+  }
+
+  internal fun invalidateSourceIdentities(ids: Set<String>) {
+    removeResourceIdentities(sourceIdentities, ids)
+  }
+
+  internal fun invalidateLayerIdentities(ids: Set<String>) {
+    removeResourceIdentities(layerIdentities, ids)
+  }
 
   internal fun updateResources(resources: LoadedStyleResources) {
     sourcesState = resources.sources
@@ -310,6 +331,51 @@ public class MapStyleState internal constructor(initialBaseStyle: BaseStyle) {
         owner?.requireStyleHandleUnchanged(style, checkpoint)
       }
     }
+
+  private fun sourceIdentity(id: String): StyleResourceIdentity =
+    resourceIdentity(sourceIdentities, id)
+
+  private fun layerIdentity(id: String): StyleResourceIdentity =
+    resourceIdentity(layerIdentities, id)
+}
+
+private class StyleResourceIdentity
+
+private fun resourceIdentity(
+  identities: AtomicReference<Map<String, StyleResourceIdentity>>,
+  id: String,
+): StyleResourceIdentity {
+  while (true) {
+    val current = identities.load()
+    current[id]?.let {
+      return it
+    }
+    val identity = StyleResourceIdentity()
+    if (identities.compareAndSet(current, current + (id to identity))) return identity
+  }
+}
+
+private fun retainResourceIdentities(
+  identities: AtomicReference<Map<String, StyleResourceIdentity>>,
+  ids: Set<String>,
+) {
+  while (true) {
+    val current = identities.load()
+    val retained = current.filterKeys { it in ids }
+    if (retained.size == current.size || identities.compareAndSet(current, retained)) return
+  }
+}
+
+private fun removeResourceIdentities(
+  identities: AtomicReference<Map<String, StyleResourceIdentity>>,
+  ids: Set<String>,
+) {
+  if (ids.isEmpty()) return
+  while (true) {
+    val current = identities.load()
+    val remaining = current - ids
+    if (remaining.size == current.size || identities.compareAndSet(current, remaining)) return
+  }
 }
 
 internal data class LoadedStyleResources(
@@ -318,6 +384,12 @@ internal data class LoadedStyleResources(
 )
 
 internal class ImperativeSourceRecord(val definition: SourceDefinition)
+
+internal class ImperativeImageRecord
+
+internal class StyleMutationReservation {
+  val completion = CompletableDeferred<Unit>()
+}
 
 /** Connects a [MapState] to one map surface for the lifetime of one render lease. */
 internal class MapAttachment
@@ -471,7 +543,8 @@ internal constructor(
   private var styleHandleEpoch = 0L
   private var styleSourceChangeRevision = 0L
   private val imperativeSources = mutableMapOf<String, ImperativeSourceRecord>()
-  private val imperativeImageIds = mutableSetOf<String>()
+  private val imperativeImages = mutableMapOf<String, ImperativeImageRecord>()
+  private var activeStyleMutation: StyleMutationReservation? = null
   private var closedState: Boolean by mutableStateOf(false)
   private var cameraPositionState: CameraPosition by
     mutableStateOf(initialCameraPosition, structuralEqualityPolicy())
@@ -486,8 +559,6 @@ internal constructor(
 
           override fun desiredSourceDefinition(id: String) =
             this@MapState.desiredSourceDefinition(id)
-
-          override fun sourceDefinitionToken(id: String) = this@MapState.sourceDefinitionToken(id)
 
           override fun addStyleSource(source: Source) = this@MapState.addStyleSource(source)
 
@@ -736,7 +807,7 @@ internal constructor(
       if (style.currentLoadedStyle() === loadedStyle) return true
       styleHandleEpoch++
       imperativeSources.clear()
-      imperativeImageIds.clear()
+      imperativeImages.clear()
       style.loadState = StyleLoadState.Loading
       style.updateLoadedStyle(loadedStyle)
       true
@@ -754,14 +825,21 @@ internal constructor(
     }
   }
 
-  internal fun beginStyleRevision(adapter: MapAdapter, revision: DesiredStyleRevision) {
-    lifecycle.serialized {
-      if (lifecycle.acceptsAdapter(adapter)) {
-        requireNoImperativeResourceConflicts(revision)
-        styleHandleEpoch++
-        desiredStyleRevision = revision
-        style.loadState = StyleLoadState.Loading
+  internal suspend fun beginStyleRevision(adapter: MapAdapter, revision: DesiredStyleRevision) {
+    while (true) {
+      val mutation = lifecycle.serialized {
+        if (!lifecycle.acceptsAdapter(adapter)) return
+        activeStyleMutation
+          ?: run {
+            requireNoImperativeResourceConflicts(revision)
+            invalidateStructurallyReplacedResources(desiredStyleRevision, revision)
+            styleHandleEpoch++
+            desiredStyleRevision = revision
+            style.loadState = StyleLoadState.Loading
+            return
+          }
       }
+      mutation.completion.await()
     }
   }
 
@@ -769,9 +847,10 @@ internal constructor(
     val command = lifecycle.serialized {
       requireOpenLocked()
       if (style.baseStyle == value) return
+      requireNoActiveStyleMutation()
       styleHandleEpoch++
       imperativeSources.clear()
-      imperativeImageIds.clear()
+      imperativeImages.clear()
       style.setBaseStyleState(value)
       style.invalidateLoadedStyle()
       val adapter = lifecycle.currentAdapter()
@@ -790,50 +869,70 @@ internal constructor(
   internal fun desiredSourceDefinition(id: String): org.maplibre.compose.style.SourceDefinition? =
     desiredStyleRevision.sources.firstOrNull { it.id == id } ?: imperativeSources[id]?.definition
 
-  internal fun sourceDefinitionToken(id: String): Any? = imperativeSources[id]
-
   internal fun addStyleSource(source: Source): SourceHandle {
+    val definition = source.definition()
+    val record = ImperativeSourceRecord(definition)
+    val reservation = StyleMutationReservation()
     val binding = lifecycle.serialized {
       requireOpenLocked()
       requireNoDesiredSource(source.id)
-      checkNotNull(style.currentLoadedStyle()).also(::requireStyleHandleLocked)
-    }
-    val definition = source.definition()
-    if (binding.sourceExists(source.id) == true) {
-      throw StyleHandleException("Source ID '${source.id}' already exists in style")
-    }
-    val added =
-      try {
-        binding.addSource(definition)
-      } catch (error: StyleMutationException) {
-        throw StyleHandleException("Could not add source '${source.id}': ${error.message}", error)
+      requireNoActiveStyleMutation()
+      if (source.id in imperativeSources) {
+        throw StyleHandleException("Source ID '${source.id}' already exists in style")
       }
-    if (!added) throw IllegalStateException("The loaded-style generation changed during add")
-    lifecycle.serialized {
-      requireStyleHandleLocked(binding)
-      imperativeSources[source.id] = ImperativeSourceRecord(definition)
+      checkNotNull(style.currentLoadedStyle()).also(::requireStyleHandleLocked).also {
+        imperativeSources[source.id] = record
+        activeStyleMutation = reservation
+      }
     }
-    return checkNotNull(refreshSourcesAfterCommand(binding)[source.id])
+    var committed = false
+    try {
+      if (binding.sourceExists(source.id) == true) {
+        throw StyleHandleException("Source ID '${source.id}' already exists in style")
+      }
+      val added = binding.addSource(definition)
+      if (!added) throw IllegalStateException("The loaded-style generation changed during add")
+      lifecycle.serialized { requireStyleHandleLocked(binding) }
+      val handle = checkNotNull(refreshSourcesAfterCommand(binding)[source.id])
+      committed = true
+      return handle
+    } catch (error: StyleMutationException) {
+      throw StyleHandleException("Could not add source '${source.id}': ${error.message}", error)
+    } finally {
+      lifecycle.serialized {
+        if (!committed && imperativeSources[source.id] === record) {
+          imperativeSources.remove(source.id)
+        }
+        completeStyleMutation(reservation)
+      }
+    }
   }
 
   internal fun removeStyleSource(id: String): Boolean {
+    val reservation = StyleMutationReservation()
     val binding = lifecycle.serialized {
       requireOpenLocked()
       requireNoDesiredSource(id)
-      checkNotNull(style.currentLoadedStyle()).also(::requireStyleHandleLocked)
+      requireNoActiveStyleMutation()
+      checkNotNull(style.currentLoadedStyle()).also(::requireStyleHandleLocked).also {
+        activeStyleMutation = reservation
+      }
     }
-    if (binding.sourceExists(id) == false) return false
     try {
+      if (binding.sourceExists(id) == false) return false
       binding.removeSource(id)
+      lifecycle.serialized {
+        requireStyleHandleLocked(binding)
+        imperativeSources.remove(id)
+        style.invalidateSourceIdentities(setOf(id))
+      }
+      refreshSourcesAfterCommand(binding)
+      return true
     } catch (error: StyleMutationException) {
       throw StyleHandleException("Could not remove source '$id': ${error.message}", error)
+    } finally {
+      lifecycle.serialized { completeStyleMutation(reservation) }
     }
-    lifecycle.serialized {
-      requireStyleHandleLocked(binding)
-      imperativeSources.remove(id)
-    }
-    refreshSourcesAfterCommand(binding)
-    return true
   }
 
   internal fun addStyleImage(
@@ -842,42 +941,61 @@ internal constructor(
     sdf: Boolean,
     stretch: ImageStretch?,
   ) {
+    val record = ImperativeImageRecord()
+    val reservation = StyleMutationReservation()
     val binding = lifecycle.serialized {
       requireOpenLocked()
       requireNoDesiredImage(id)
-      checkNotNull(style.currentLoadedStyle()).also(::requireStyleHandleLocked)
+      requireNoActiveStyleMutation()
+      if (id in imperativeImages) {
+        throw StyleHandleException("Image ID '$id' already exists in style")
+      }
+      checkNotNull(style.currentLoadedStyle()).also(::requireStyleHandleLocked).also {
+        imperativeImages[id] = record
+        activeStyleMutation = reservation
+      }
     }
-    if (binding.imageExists(id) == true) {
-      throw StyleHandleException("Image ID '$id' already exists in style")
-    }
+    var committed = false
     try {
+      if (binding.imageExists(id) == true) {
+        throw StyleHandleException("Image ID '$id' already exists in style")
+      }
       binding.addImage(id, image, sdf, stretch)
+      lifecycle.serialized { requireStyleHandleLocked(binding) }
+      committed = true
     } catch (error: StyleMutationException) {
       throw StyleHandleException("Could not add image '$id': ${error.message}", error)
-    }
-    lifecycle.serialized {
-      requireStyleHandleLocked(binding)
-      imperativeImageIds += id
+    } finally {
+      lifecycle.serialized {
+        if (!committed && imperativeImages[id] === record) imperativeImages.remove(id)
+        completeStyleMutation(reservation)
+      }
     }
   }
 
   internal fun removeStyleImage(id: String): Boolean {
+    val reservation = StyleMutationReservation()
     val binding = lifecycle.serialized {
       requireOpenLocked()
       requireNoDesiredImage(id)
-      checkNotNull(style.currentLoadedStyle()).also(::requireStyleHandleLocked)
+      requireNoActiveStyleMutation()
+      checkNotNull(style.currentLoadedStyle()).also(::requireStyleHandleLocked).also {
+        activeStyleMutation = reservation
+      }
     }
-    if (binding.imageExists(id) == false) return false
     try {
+      if (binding.imageExists(id) == false) return false
       binding.removeImage(id)
+      lifecycle.serialized {
+        requireStyleHandleLocked(binding)
+        imperativeImages.remove(id)
+      }
+      return true
     } catch (error: StyleMutationException) {
       throw StyleHandleException("Could not remove image '$id': ${error.message}", error)
+    } finally {
+      lifecycle.serialized { completeStyleMutation(reservation) }
     }
-    lifecycle.serialized {
-      requireStyleHandleLocked(binding)
-      imperativeImageIds -= id
-    }
-    return true
   }
 
   private fun refreshSourcesAfterCommand(binding: StyleBinding): Map<String, SourceHandle> {
@@ -916,10 +1034,51 @@ internal constructor(
         throw StyleHandleException("Source ID '${it.id}' is owned by an imperative addition")
       }
     revision.images
-      .firstOrNull { it.id in imperativeImageIds }
+      .firstOrNull { it.id in imperativeImages }
       ?.let {
         throw StyleHandleException("Image ID '${it.id}' is owned by an imperative addition")
       }
+  }
+
+  private fun requireNoActiveStyleMutation() {
+    if (activeStyleMutation != null) {
+      throw StyleHandleException("Another imperative style resource command is in progress")
+    }
+  }
+
+  private fun completeStyleMutation(reservation: StyleMutationReservation) {
+    if (activeStyleMutation === reservation) activeStyleMutation = null
+    reservation.completion.complete(Unit)
+  }
+
+  private fun invalidateStructurallyReplacedResources(
+    previous: DesiredStyleRevision,
+    next: DesiredStyleRevision,
+  ) {
+    val nextSources = next.sources.associateBy(SourceDefinition::id)
+    val replacedSourceIds =
+      previous.sources
+        .filter { previousSource ->
+          nextSources[previousSource.id]?.let(previousSource::canUpdateTo) != true
+        }
+        .mapTo(mutableSetOf(), SourceDefinition::id)
+    style.invalidateSourceIdentities(replacedSourceIds)
+
+    val nextLayers = next.layers.associateBy { it.definition.id }
+    val replacedLayerIds =
+      previous.layers
+        .filter { previousLayer ->
+          val nextLayer = nextLayers[previousLayer.definition.id]
+          nextLayer == null ||
+            nextLayer.anchor != previousLayer.anchor ||
+            nextLayer.definition.type != previousLayer.definition.type ||
+            nextLayer.definition.sourceId != previousLayer.definition.sourceId ||
+            nextLayer.definition.value["source-layer"] !=
+              previousLayer.definition.value["source-layer"] ||
+            previousLayer.definition.sourceId in replacedSourceIds
+        }
+        .mapTo(mutableSetOf()) { it.definition.id }
+    style.invalidateLayerIdentities(replacedLayerIds)
   }
 
   internal fun <T> runStyleHandleOperation(

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
@@ -309,6 +309,36 @@ public class MapStyleState internal constructor(initialBaseStyle: BaseStyle) {
     removeResourceIdentities(layerIdentities, ids)
   }
 
+  internal fun invalidateStructurallyReplacedResources(
+    previous: DesiredStyleRevision,
+    next: DesiredStyleRevision,
+  ) {
+    val nextSources = next.sources.associateBy(SourceDefinition::id)
+    val replacedSourceIds =
+      previous.sources
+        .filter { previousSource ->
+          nextSources[previousSource.id]?.let(previousSource::canUpdateTo) != true
+        }
+        .mapTo(mutableSetOf(), SourceDefinition::id)
+    invalidateSourceIdentities(replacedSourceIds)
+
+    val nextLayers = next.layers.associateBy { it.definition.id }
+    val replacedLayerIds =
+      previous.layers
+        .filter { previousLayer ->
+          val nextLayer = nextLayers[previousLayer.definition.id]
+          nextLayer == null ||
+            nextLayer.anchor != previousLayer.anchor ||
+            nextLayer.definition.type != previousLayer.definition.type ||
+            nextLayer.definition.sourceId != previousLayer.definition.sourceId ||
+            nextLayer.definition.value["source-layer"] !=
+              previousLayer.definition.value["source-layer"] ||
+            previousLayer.definition.sourceId in replacedSourceIds
+        }
+        .mapTo(mutableSetOf()) { it.definition.id }
+    invalidateLayerIdentities(replacedLayerIds)
+  }
+
   internal fun updateResources(resources: LoadedStyleResources) {
     sourcesState = resources.sources
     layersState = resources.layers
@@ -832,7 +862,7 @@ internal constructor(
         activeStyleMutation
           ?: run {
             requireNoImperativeResourceConflicts(revision)
-            invalidateStructurallyReplacedResources(desiredStyleRevision, revision)
+            style.invalidateStructurallyReplacedResources(desiredStyleRevision, revision)
             styleHandleEpoch++
             desiredStyleRevision = revision
             style.loadState = StyleLoadState.Loading
@@ -1049,36 +1079,6 @@ internal constructor(
   private fun completeStyleMutation(reservation: StyleMutationReservation) {
     if (activeStyleMutation === reservation) activeStyleMutation = null
     reservation.completion.complete(Unit)
-  }
-
-  private fun invalidateStructurallyReplacedResources(
-    previous: DesiredStyleRevision,
-    next: DesiredStyleRevision,
-  ) {
-    val nextSources = next.sources.associateBy(SourceDefinition::id)
-    val replacedSourceIds =
-      previous.sources
-        .filter { previousSource ->
-          nextSources[previousSource.id]?.let(previousSource::canUpdateTo) != true
-        }
-        .mapTo(mutableSetOf(), SourceDefinition::id)
-    style.invalidateSourceIdentities(replacedSourceIds)
-
-    val nextLayers = next.layers.associateBy { it.definition.id }
-    val replacedLayerIds =
-      previous.layers
-        .filter { previousLayer ->
-          val nextLayer = nextLayers[previousLayer.definition.id]
-          nextLayer == null ||
-            nextLayer.anchor != previousLayer.anchor ||
-            nextLayer.definition.type != previousLayer.definition.type ||
-            nextLayer.definition.sourceId != previousLayer.definition.sourceId ||
-            nextLayer.definition.value["source-layer"] !=
-              previousLayer.definition.value["source-layer"] ||
-            previousLayer.definition.sourceId in replacedSourceIds
-        }
-        .mapTo(mutableSetOf()) { it.definition.id }
-    style.invalidateLayerIdentities(replacedLayerIds)
   }
 
   internal fun <T> runStyleHandleOperation(

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapSnapshotter.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapSnapshotter.kt
@@ -354,36 +354,39 @@ internal class MapSnapshotterImplementation(
       launch(start = CoroutineStart.LAZY) {
         var claim: StyleClaim? = null
         var binding: StyleBinding? = null
-        try {
-          val currentClaim = claimStyle()
-          claim = currentClaim
-          val currentBinding =
-            platform.prepare(currentClaim.baseStyle, currentClaim.revision, capture.request)
-          binding = currentBinding
-          val request = capture.request
-          val evaluationOwnership = styleEvaluationOwnership(currentBinding, currentClaim.ownership)
-          val revision =
-            styleEvaluator.evaluate(
-              styleComposition,
-              currentBinding,
-              Density(request.density, request.fontScale),
-              request.layoutDirection,
-              evaluationOwnership,
-            )
-          requireNoImperativeResourceConflicts(currentBinding, revision)
-          recordStyleOwnership(currentClaim, revision)
-          val image = platform.capture(request, revision)
-          if (!publishStyle(capture, currentClaim, currentBinding, revision)) {
-            currentBinding.invalidate()
+        val result =
+          try {
+            val currentClaim = claimStyle()
+            claim = currentClaim
+            val currentBinding =
+              platform.prepare(currentClaim.baseStyle, currentClaim.revision, capture.request)
+            binding = currentBinding
+            val request = capture.request
+            val evaluationOwnership =
+              styleEvaluationOwnership(currentBinding, currentClaim.ownership)
+            val revision =
+              styleEvaluator.evaluate(
+                styleComposition,
+                currentBinding,
+                Density(request.density, request.fontScale),
+                request.layoutDirection,
+                evaluationOwnership,
+              )
+            requireNoImperativeResourceConflicts(currentBinding, revision)
+            recordStyleOwnership(currentClaim, revision)
+            val image = platform.capture(request, revision)
+            if (!publishStyle(capture, currentClaim, currentBinding, revision)) {
+              currentBinding.invalidate()
+            }
+            Result.success(image)
+          } catch (error: Throwable) {
+            if (error is CancellationException) binding?.invalidate()
+            else claim?.let { publishStyleFailure(it, error) }
+            Result.failure(error)
+          } finally {
+            claim?.let(::completeStyleClaim)
           }
-          capture.resume(image)
-        } catch (error: Throwable) {
-          if (error is CancellationException) binding?.invalidate()
-          else claim?.let { publishStyleFailure(it, error) }
-          capture.resumeFailure(error)
-        } finally {
-          claim?.let(::completeStyleClaim)
-        }
+        result.fold(capture::resume, capture::resumeFailure)
       }
     lock.withLock {
       capture.operation = operation

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapSnapshotter.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapSnapshotter.kt
@@ -748,12 +748,16 @@ internal class MapSnapshotterImplementation(
   ): Boolean = lock.withLock {
     if (closed || capture.abandoned || claim.revision != baseStyleRevision) return@withLock false
     styleHandleEpoch++
+    val reusesLoadedStyle = style.currentLoadedStyle() === binding
+    if (reusesLoadedStyle) {
+      style.invalidateStructurallyReplacedResources(desiredRevision, revision)
+    }
     desiredRevision = revision
-    if (style.currentLoadedStyle() !== binding) {
+    if (!reusesLoadedStyle) {
       imperativeSources.clear()
       imperativeImages.clear()
+      style.updateLoadedStyle(binding)
     }
-    style.updateLoadedStyle(binding)
     style.loadState = StyleLoadState.Ready
     style.refreshResources()
     true

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapSnapshotter.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapSnapshotter.kt
@@ -25,6 +25,8 @@ import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.yield
 import org.maplibre.compose.camera.CameraPosition
+import org.maplibre.compose.sources.Source
+import org.maplibre.compose.sources.SourceHandle
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.compose.style.DesiredStyleRevision
 import org.maplibre.compose.style.MapNodeApplier
@@ -32,7 +34,10 @@ import org.maplibre.compose.style.SourceDefinition
 import org.maplibre.compose.style.StyleBinding
 import org.maplibre.compose.style.StyleComposition
 import org.maplibre.compose.style.StyleContent
+import org.maplibre.compose.style.StyleHandleException
+import org.maplibre.compose.style.StyleMutationException
 import org.maplibre.compose.style.StyleNode
+import org.maplibre.compose.util.ImageStretch
 
 /** Options that affect the pixels returned by a snapshot capture. */
 public data class MapSnapshotOutputOptions(
@@ -221,6 +226,8 @@ internal class MapSnapshotterImplementation(
   private var ownedBaseStyleRevision: Long? = null
   private val ownedSourceIds = mutableSetOf<String>()
   private val ownedLayerIds = mutableSetOf<String>()
+  private val imperativeSources = mutableMapOf<String, ImperativeSourceRecord>()
+  private val imperativeImageIds = mutableSetOf<String>()
   private var styleHandleEpoch = 0L
   private var desiredRevision = DesiredStyleRevision.Empty
 
@@ -233,6 +240,25 @@ internal class MapSnapshotterImplementation(
 
           override fun desiredSourceDefinition(id: String) =
             this@MapSnapshotterImplementation.desiredSourceDefinition(id)
+
+          override fun sourceDefinitionToken(id: String) =
+            this@MapSnapshotterImplementation.sourceDefinitionToken(id)
+
+          override fun addStyleSource(source: Source) =
+            this@MapSnapshotterImplementation.addStyleSource(source)
+
+          override fun removeStyleSource(id: String) =
+            this@MapSnapshotterImplementation.removeStyleSource(id)
+
+          override fun addStyleImage(
+            id: String,
+            image: ImageBitmap,
+            sdf: Boolean,
+            stretch: ImageStretch?,
+          ) = this@MapSnapshotterImplementation.addStyleImage(id, image, sdf, stretch)
+
+          override fun removeStyleImage(id: String) =
+            this@MapSnapshotterImplementation.removeStyleImage(id)
 
           override fun readyLoadedStyle() = this@MapSnapshotterImplementation.readyLoadedStyle()
 
@@ -336,14 +362,16 @@ internal class MapSnapshotterImplementation(
             platform.prepare(currentClaim.baseStyle, currentClaim.revision, capture.request)
           binding = currentBinding
           val request = capture.request
+          val evaluationOwnership = styleEvaluationOwnership(currentBinding, currentClaim.ownership)
           val revision =
             styleEvaluator.evaluate(
               styleComposition,
               currentBinding,
               Density(request.density, request.fontScale),
               request.layoutDirection,
-              currentClaim.ownership,
+              evaluationOwnership,
             )
+          requireNoImperativeResourceConflicts(currentBinding, revision)
           recordStyleOwnership(currentClaim, revision)
           val image = platform.capture(request, revision)
           if (!publishStyle(capture, currentClaim, currentBinding, revision)) {
@@ -401,6 +429,8 @@ internal class MapSnapshotterImplementation(
   private fun settleStyleAfterCancellation() {
     lock.withLock {
       styleHandleEpoch++
+      imperativeSources.clear()
+      imperativeImageIds.clear()
       style.invalidateLoadedStyle()
       if (!closed) style.loadState = StyleLoadState.Pending
     }
@@ -450,13 +480,145 @@ internal class MapSnapshotterImplementation(
       if (style.baseStyle == value) return
       styleHandleEpoch++
       baseStyleRevision++
+      imperativeSources.clear()
+      imperativeImageIds.clear()
       style.setBaseStyleState(value)
       style.loadState = StyleLoadState.Pending
     }
   }
 
   internal fun desiredSourceDefinition(id: String): SourceDefinition? = lock.withLock {
-    desiredRevision.sources.firstOrNull { it.id == id }
+    desiredRevision.sources.firstOrNull { it.id == id } ?: imperativeSources[id]?.definition
+  }
+
+  internal fun sourceDefinitionToken(id: String): Any? = lock.withLock { imperativeSources[id] }
+
+  internal fun addStyleSource(source: Source): SourceHandle {
+    val binding = lock.withLock {
+      requireOpenLocked()
+      requireNoDesiredSource(source.id)
+      checkNotNull(style.currentLoadedStyle()).also(::requireStyleHandleLocked)
+    }
+    val definition = source.definition()
+    if (binding.sourceExists(source.id) == true) {
+      throw StyleHandleException("Source ID '${source.id}' already exists in style")
+    }
+    val added =
+      try {
+        binding.addSource(definition)
+      } catch (error: StyleMutationException) {
+        throw StyleHandleException("Could not add source '${source.id}': ${error.message}", error)
+      }
+    if (!added) throw IllegalStateException("The loaded-style generation changed during add")
+    lock.withLock {
+      requireStyleHandleLocked(binding)
+      imperativeSources[source.id] = ImperativeSourceRecord(definition)
+    }
+    return checkNotNull(refreshSourcesAfterCommand(binding)[source.id])
+  }
+
+  internal fun removeStyleSource(id: String): Boolean {
+    val binding = lock.withLock {
+      requireOpenLocked()
+      requireNoDesiredSource(id)
+      checkNotNull(style.currentLoadedStyle()).also(::requireStyleHandleLocked)
+    }
+    if (binding.sourceExists(id) == false) return false
+    try {
+      binding.removeSource(id)
+    } catch (error: StyleMutationException) {
+      throw StyleHandleException("Could not remove source '$id': ${error.message}", error)
+    }
+    lock.withLock {
+      requireStyleHandleLocked(binding)
+      imperativeSources.remove(id)
+    }
+    refreshSourcesAfterCommand(binding)
+    return true
+  }
+
+  internal fun addStyleImage(
+    id: String,
+    image: ImageBitmap,
+    sdf: Boolean,
+    stretch: ImageStretch?,
+  ) {
+    val binding = lock.withLock {
+      requireOpenLocked()
+      requireNoDesiredImage(id)
+      checkNotNull(style.currentLoadedStyle()).also(::requireStyleHandleLocked)
+    }
+    if (binding.imageExists(id) == true) {
+      throw StyleHandleException("Image ID '$id' already exists in style")
+    }
+    try {
+      binding.addImage(id, image, sdf, stretch)
+    } catch (error: StyleMutationException) {
+      throw StyleHandleException("Could not add image '$id': ${error.message}", error)
+    }
+    lock.withLock {
+      requireStyleHandleLocked(binding)
+      imperativeImageIds += id
+    }
+  }
+
+  internal fun removeStyleImage(id: String): Boolean {
+    val binding = lock.withLock {
+      requireOpenLocked()
+      requireNoDesiredImage(id)
+      checkNotNull(style.currentLoadedStyle()).also(::requireStyleHandleLocked)
+    }
+    if (binding.imageExists(id) == false) return false
+    try {
+      binding.removeImage(id)
+    } catch (error: StyleMutationException) {
+      throw StyleHandleException("Could not remove image '$id': ${error.message}", error)
+    }
+    lock.withLock {
+      requireStyleHandleLocked(binding)
+      imperativeImageIds -= id
+    }
+    return true
+  }
+
+  private fun refreshSourcesAfterCommand(binding: StyleBinding): Map<String, SourceHandle> {
+    val sources = style.readSources(binding)
+    lock.withLock {
+      requireStyleHandleLocked(binding)
+      style.updateSources(sources)
+    }
+    return sources
+  }
+
+  private fun requireNoDesiredSource(id: String) {
+    if (desiredRevision.sources.any { it.id == id }) {
+      throw StyleHandleException("Source ID '$id' is owned by StyleComposition")
+    }
+  }
+
+  private fun requireNoDesiredImage(id: String) {
+    if (desiredRevision.images.any { it.id == id }) {
+      throw StyleHandleException("Image ID '$id' is owned by StyleComposition")
+    }
+  }
+
+  private fun requireNoImperativeResourceConflicts(
+    binding: StyleBinding,
+    revision: DesiredStyleRevision,
+  ) {
+    lock.withLock {
+      if (style.currentLoadedStyle() !== binding) return
+      revision.sources
+        .firstOrNull { it.id in imperativeSources }
+        ?.let {
+          throw StyleHandleException("Source ID '${it.id}' is owned by an imperative addition")
+        }
+      revision.images
+        .firstOrNull { it.id in imperativeImageIds }
+        ?.let {
+          throw StyleHandleException("Image ID '${it.id}' is owned by an imperative addition")
+        }
+    }
   }
 
   internal fun readyLoadedStyle(): StyleBinding? = lock.withLock {
@@ -505,6 +667,14 @@ internal class MapSnapshotterImplementation(
     )
   }
 
+  private fun styleEvaluationOwnership(
+    binding: StyleBinding,
+    ownership: SnapshotStyleOwnership,
+  ): SnapshotStyleOwnership = lock.withLock {
+    if (style.currentLoadedStyle() !== binding) return ownership
+    ownership.copy(sourceIds = ownership.sourceIds + imperativeSources.keys)
+  }
+
   private fun recordStyleOwnership(claim: StyleClaim, revision: DesiredStyleRevision) {
     lock.withLock {
       if (closed || claim.revision != baseStyleRevision) return
@@ -527,9 +697,13 @@ internal class MapSnapshotterImplementation(
     if (closed || capture.abandoned || claim.revision != baseStyleRevision) return@withLock false
     styleHandleEpoch++
     desiredRevision = revision
+    if (style.currentLoadedStyle() !== binding) {
+      imperativeSources.clear()
+      imperativeImageIds.clear()
+    }
     style.updateLoadedStyle(binding)
     style.loadState = StyleLoadState.Ready
-    style.refreshSources()
+    style.refreshResources()
     true
   }
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapSnapshotter.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapSnapshotter.kt
@@ -227,7 +227,9 @@ internal class MapSnapshotterImplementation(
   private val ownedSourceIds = mutableSetOf<String>()
   private val ownedLayerIds = mutableSetOf<String>()
   private val imperativeSources = mutableMapOf<String, ImperativeSourceRecord>()
-  private val imperativeImageIds = mutableSetOf<String>()
+  private val imperativeImages = mutableMapOf<String, ImperativeImageRecord>()
+  private var activeStyleMutation: StyleMutationReservation? = null
+  private var activeStyleClaim: StyleClaim? = null
   private var styleHandleEpoch = 0L
   private var desiredRevision = DesiredStyleRevision.Empty
 
@@ -240,9 +242,6 @@ internal class MapSnapshotterImplementation(
 
           override fun desiredSourceDefinition(id: String) =
             this@MapSnapshotterImplementation.desiredSourceDefinition(id)
-
-          override fun sourceDefinitionToken(id: String) =
-            this@MapSnapshotterImplementation.sourceDefinitionToken(id)
 
           override fun addStyleSource(source: Source) =
             this@MapSnapshotterImplementation.addStyleSource(source)
@@ -382,6 +381,8 @@ internal class MapSnapshotterImplementation(
           if (error is CancellationException) binding?.invalidate()
           else claim?.let { publishStyleFailure(it, error) }
           capture.resumeFailure(error)
+        } finally {
+          claim?.let(::completeStyleClaim)
         }
       }
     lock.withLock {
@@ -430,7 +431,7 @@ internal class MapSnapshotterImplementation(
     lock.withLock {
       styleHandleEpoch++
       imperativeSources.clear()
-      imperativeImageIds.clear()
+      imperativeImages.clear()
       style.invalidateLoadedStyle()
       if (!closed) style.loadState = StyleLoadState.Pending
     }
@@ -478,10 +479,11 @@ internal class MapSnapshotterImplementation(
     lock.withLock {
       requireOpenLocked()
       if (style.baseStyle == value) return
+      requireNoActiveStyleMutation()
       styleHandleEpoch++
       baseStyleRevision++
       imperativeSources.clear()
-      imperativeImageIds.clear()
+      imperativeImages.clear()
       style.setBaseStyleState(value)
       style.loadState = StyleLoadState.Pending
     }
@@ -491,50 +493,70 @@ internal class MapSnapshotterImplementation(
     desiredRevision.sources.firstOrNull { it.id == id } ?: imperativeSources[id]?.definition
   }
 
-  internal fun sourceDefinitionToken(id: String): Any? = lock.withLock { imperativeSources[id] }
-
   internal fun addStyleSource(source: Source): SourceHandle {
+    val definition = source.definition()
+    val record = ImperativeSourceRecord(definition)
+    val reservation = StyleMutationReservation()
     val binding = lock.withLock {
       requireOpenLocked()
       requireNoDesiredSource(source.id)
-      checkNotNull(style.currentLoadedStyle()).also(::requireStyleHandleLocked)
-    }
-    val definition = source.definition()
-    if (binding.sourceExists(source.id) == true) {
-      throw StyleHandleException("Source ID '${source.id}' already exists in style")
-    }
-    val added =
-      try {
-        binding.addSource(definition)
-      } catch (error: StyleMutationException) {
-        throw StyleHandleException("Could not add source '${source.id}': ${error.message}", error)
+      requireNoActiveStyleOperation()
+      if (source.id in imperativeSources) {
+        throw StyleHandleException("Source ID '${source.id}' already exists in style")
       }
-    if (!added) throw IllegalStateException("The loaded-style generation changed during add")
-    lock.withLock {
-      requireStyleHandleLocked(binding)
-      imperativeSources[source.id] = ImperativeSourceRecord(definition)
+      checkNotNull(style.currentLoadedStyle()).also(::requireStyleHandleLocked).also {
+        imperativeSources[source.id] = record
+        activeStyleMutation = reservation
+      }
     }
-    return checkNotNull(refreshSourcesAfterCommand(binding)[source.id])
+    var committed = false
+    try {
+      if (binding.sourceExists(source.id) == true) {
+        throw StyleHandleException("Source ID '${source.id}' already exists in style")
+      }
+      val added = binding.addSource(definition)
+      if (!added) throw IllegalStateException("The loaded-style generation changed during add")
+      lock.withLock { requireStyleHandleLocked(binding) }
+      val handle = checkNotNull(refreshSourcesAfterCommand(binding)[source.id])
+      committed = true
+      return handle
+    } catch (error: StyleMutationException) {
+      throw StyleHandleException("Could not add source '${source.id}': ${error.message}", error)
+    } finally {
+      lock.withLock {
+        if (!committed && imperativeSources[source.id] === record) {
+          imperativeSources.remove(source.id)
+        }
+        completeStyleMutation(reservation)
+      }
+    }
   }
 
   internal fun removeStyleSource(id: String): Boolean {
+    val reservation = StyleMutationReservation()
     val binding = lock.withLock {
       requireOpenLocked()
       requireNoDesiredSource(id)
-      checkNotNull(style.currentLoadedStyle()).also(::requireStyleHandleLocked)
+      requireNoActiveStyleOperation()
+      checkNotNull(style.currentLoadedStyle()).also(::requireStyleHandleLocked).also {
+        activeStyleMutation = reservation
+      }
     }
-    if (binding.sourceExists(id) == false) return false
     try {
+      if (binding.sourceExists(id) == false) return false
       binding.removeSource(id)
+      lock.withLock {
+        requireStyleHandleLocked(binding)
+        imperativeSources.remove(id)
+        style.invalidateSourceIdentities(setOf(id))
+      }
+      refreshSourcesAfterCommand(binding)
+      return true
     } catch (error: StyleMutationException) {
       throw StyleHandleException("Could not remove source '$id': ${error.message}", error)
+    } finally {
+      lock.withLock { completeStyleMutation(reservation) }
     }
-    lock.withLock {
-      requireStyleHandleLocked(binding)
-      imperativeSources.remove(id)
-    }
-    refreshSourcesAfterCommand(binding)
-    return true
   }
 
   internal fun addStyleImage(
@@ -543,42 +565,61 @@ internal class MapSnapshotterImplementation(
     sdf: Boolean,
     stretch: ImageStretch?,
   ) {
+    val record = ImperativeImageRecord()
+    val reservation = StyleMutationReservation()
     val binding = lock.withLock {
       requireOpenLocked()
       requireNoDesiredImage(id)
-      checkNotNull(style.currentLoadedStyle()).also(::requireStyleHandleLocked)
+      requireNoActiveStyleOperation()
+      if (id in imperativeImages) {
+        throw StyleHandleException("Image ID '$id' already exists in style")
+      }
+      checkNotNull(style.currentLoadedStyle()).also(::requireStyleHandleLocked).also {
+        imperativeImages[id] = record
+        activeStyleMutation = reservation
+      }
     }
-    if (binding.imageExists(id) == true) {
-      throw StyleHandleException("Image ID '$id' already exists in style")
-    }
+    var committed = false
     try {
+      if (binding.imageExists(id) == true) {
+        throw StyleHandleException("Image ID '$id' already exists in style")
+      }
       binding.addImage(id, image, sdf, stretch)
+      lock.withLock { requireStyleHandleLocked(binding) }
+      committed = true
     } catch (error: StyleMutationException) {
       throw StyleHandleException("Could not add image '$id': ${error.message}", error)
-    }
-    lock.withLock {
-      requireStyleHandleLocked(binding)
-      imperativeImageIds += id
+    } finally {
+      lock.withLock {
+        if (!committed && imperativeImages[id] === record) imperativeImages.remove(id)
+        completeStyleMutation(reservation)
+      }
     }
   }
 
   internal fun removeStyleImage(id: String): Boolean {
+    val reservation = StyleMutationReservation()
     val binding = lock.withLock {
       requireOpenLocked()
       requireNoDesiredImage(id)
-      checkNotNull(style.currentLoadedStyle()).also(::requireStyleHandleLocked)
+      requireNoActiveStyleOperation()
+      checkNotNull(style.currentLoadedStyle()).also(::requireStyleHandleLocked).also {
+        activeStyleMutation = reservation
+      }
     }
-    if (binding.imageExists(id) == false) return false
     try {
+      if (binding.imageExists(id) == false) return false
       binding.removeImage(id)
+      lock.withLock {
+        requireStyleHandleLocked(binding)
+        imperativeImages.remove(id)
+      }
+      return true
     } catch (error: StyleMutationException) {
       throw StyleHandleException("Could not remove image '$id': ${error.message}", error)
+    } finally {
+      lock.withLock { completeStyleMutation(reservation) }
     }
-    lock.withLock {
-      requireStyleHandleLocked(binding)
-      imperativeImageIds -= id
-    }
-    return true
   }
 
   private fun refreshSourcesAfterCommand(binding: StyleBinding): Map<String, SourceHandle> {
@@ -614,7 +655,7 @@ internal class MapSnapshotterImplementation(
           throw StyleHandleException("Source ID '${it.id}' is owned by an imperative addition")
         }
       revision.images
-        .firstOrNull { it.id in imperativeImageIds }
+        .firstOrNull { it.id in imperativeImages }
         ?.let {
           throw StyleHandleException("Image ID '${it.id}' is owned by an imperative addition")
         }
@@ -652,19 +693,30 @@ internal class MapSnapshotterImplementation(
     }
   }
 
-  private fun claimStyle(): StyleClaim = lock.withLock {
-    requireOpenLocked()
-    style.loadState = StyleLoadState.Loading
-    StyleClaim(
-      baseStyle = style.baseStyle,
-      revision = baseStyleRevision,
-      ownership =
-        if (ownedBaseStyleRevision == baseStyleRevision) {
-          SnapshotStyleOwnership(ownedSourceIds.toSet(), ownedLayerIds.toSet())
-        } else {
-          SnapshotStyleOwnership.Empty
-        },
-    )
+  private suspend fun claimStyle(): StyleClaim {
+    while (true) {
+      val result = lock.withLock {
+        requireOpenLocked()
+        activeStyleMutation
+          ?: StyleClaim(
+              baseStyle = style.baseStyle,
+              revision = baseStyleRevision,
+              ownership =
+                if (ownedBaseStyleRevision == baseStyleRevision) {
+                  SnapshotStyleOwnership(ownedSourceIds.toSet(), ownedLayerIds.toSet())
+                } else {
+                  SnapshotStyleOwnership.Empty
+                },
+            )
+            .also {
+              check(activeStyleClaim == null)
+              activeStyleClaim = it
+              style.loadState = StyleLoadState.Loading
+            }
+      }
+      if (result is StyleClaim) return result
+      (result as StyleMutationReservation).completion.await()
+    }
   }
 
   private fun styleEvaluationOwnership(
@@ -699,7 +751,7 @@ internal class MapSnapshotterImplementation(
     desiredRevision = revision
     if (style.currentLoadedStyle() !== binding) {
       imperativeSources.clear()
-      imperativeImageIds.clear()
+      imperativeImages.clear()
     }
     style.updateLoadedStyle(binding)
     style.loadState = StyleLoadState.Ready
@@ -712,6 +764,29 @@ internal class MapSnapshotterImplementation(
       if (!closed && claim.revision == baseStyleRevision) {
         style.loadState = StyleLoadState.Failed(error.message)
       }
+    }
+  }
+
+  private fun requireNoActiveStyleOperation() {
+    if (activeStyleMutation != null || activeStyleClaim != null) {
+      throw StyleHandleException("Another style operation is in progress")
+    }
+  }
+
+  private fun requireNoActiveStyleMutation() {
+    if (activeStyleMutation != null) {
+      throw StyleHandleException("Another imperative style resource command is in progress")
+    }
+  }
+
+  private fun completeStyleMutation(reservation: StyleMutationReservation) {
+    if (activeStyleMutation === reservation) activeStyleMutation = null
+    reservation.completion.complete(Unit)
+  }
+
+  private fun completeStyleClaim(claim: StyleClaim) {
+    lock.withLock {
+      if (activeStyleClaim === claim) activeStyleClaim = null
     }
   }
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapStyleResources.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapStyleResources.kt
@@ -1,0 +1,53 @@
+package org.maplibre.compose.map
+
+import androidx.compose.runtime.Stable
+import androidx.compose.ui.graphics.ImageBitmap
+import org.maplibre.compose.layers.LayerHandle
+import org.maplibre.compose.sources.Source
+import org.maplibre.compose.sources.SourceHandle
+import org.maplibre.compose.util.ImageStretch
+
+/** Provides lookup, iteration, and structural commands for the current loaded sources. */
+@Stable
+public class StyleSources internal constructor(private val style: MapStyleState) :
+  Iterable<SourceHandle> {
+  /** Returns the current generation's handle for [id], or null when unavailable or absent. */
+  public operator fun get(id: String): SourceHandle? = style.sourceHandle(id)
+
+  /** Adds [source] to the current loaded-style generation and returns its handle. */
+  public fun add(source: Source): SourceHandle = style.requireOwner().addStyleSource(source)
+
+  /** Removes [id] from the current loaded-style generation and reports whether it existed. */
+  public fun remove(id: String): Boolean = style.requireOwner().removeStyleSource(id)
+
+  /** Iterates over the current loaded sources in engine style order. */
+  override fun iterator(): Iterator<SourceHandle> = style.sourceHandles().values.iterator()
+}
+
+/** Provides lookup and iteration for the current loaded layers. */
+@Stable
+public class StyleLayers internal constructor(private val style: MapStyleState) :
+  Iterable<LayerHandle> {
+  /** Returns the current generation's handle for [id], or null when unavailable or absent. */
+  public operator fun get(id: String): LayerHandle? = style.layerHandle(id)
+
+  /** Iterates over the current loaded layers from bottom to top. */
+  override fun iterator(): Iterator<LayerHandle> = style.layerHandles().values.iterator()
+}
+
+/** Provides structural commands for style images in the current loaded-style generation. */
+@Stable
+public class StyleImages internal constructor(private val style: MapStyleState) {
+  /** Adds a style image. The command fails when [id] already exists. */
+  public fun add(
+    id: String,
+    image: ImageBitmap,
+    sdf: Boolean = false,
+    stretch: ImageStretch? = null,
+  ) {
+    style.requireOwner().addStyleImage(id, image, sdf, stretch)
+  }
+
+  /** Removes [id] and reports whether it existed. */
+  public fun remove(id: String): Boolean = style.requireOwner().removeStyleImage(id)
+}

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/Attribution.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/Attribution.kt
@@ -215,7 +215,7 @@ public fun AttributionLinks(
  * them. Sources that declare no attribution are skipped.
  */
 public fun MapStyleState.attributions(): List<String> =
-  sources.values.map { it.attributionHtml }.filter { it.isNotEmpty() }.distinct()
+  sources.map { it.attributionHtml }.filter { it.isNotEmpty() }.distinct()
 
 public object AttributionDefaults {
   /** Reads over both light and dark basemaps, in the absence of a theme to draw colors from. */

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/sources/SourceHandle.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/sources/SourceHandle.kt
@@ -333,13 +333,15 @@ internal fun StyleBinding.sourceHandle(
   id: String,
   definition: SourceDefinition?,
   currentDefinition: () -> SourceDefinition?,
+  isCurrentResource: () -> Boolean,
   operations: StyleHandleOperationGuard,
 ): SourceHandle? {
   requireCurrent()
   val source = getSource(id) ?: return null
   val kind = sourceKind(definition, source)
   val composed = definition != null
-  val currentKind = {
+  val currentKind = currentKind@{
+    if (!isCurrentResource()) return@currentKind null
     val current = currentDefinition()
     if (composed && current == null) null else sourceKind(current, getSource(id))
   }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleBinding.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleBinding.kt
@@ -62,6 +62,9 @@ internal interface StyleBinding {
 
   fun removeImage(id: String)
 
+  /** @return whether [id] exists, or null when the loaded style became unavailable. */
+  fun imageExists(id: String): Boolean?
+
   fun getSource(id: String): Source?
 
   fun getSources(): List<Source>

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleReconciler.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleReconciler.kt
@@ -190,18 +190,6 @@ internal class StyleReconciler {
     return getOrNull(index + 1).orEmpty()
   }
 
-  private fun SourceDefinition.canUpdateTo(next: SourceDefinition): Boolean =
-    when {
-      this is SourceDefinition.GeoJson && next is SourceDefinition.GeoJson ->
-        options == next.options
-      this is SourceDefinition.Image && next is SourceDefinition.Image -> true
-      this is SourceDefinition.CustomGeometry && next is SourceDefinition.CustomGeometry ->
-        options == next.options
-      this is SourceDefinition.CustomVector && next is SourceDefinition.CustomVector ->
-        options == next.options
-      else -> this == next
-    }
-
   private class AppliedSource(
     var definition: SourceDefinition,
     val installation: SourceInstallation,
@@ -213,3 +201,14 @@ internal class StyleReconciler {
     val installation: LayerInstallation,
   )
 }
+
+internal fun SourceDefinition.canUpdateTo(next: SourceDefinition): Boolean =
+  when {
+    this is SourceDefinition.GeoJson && next is SourceDefinition.GeoJson -> options == next.options
+    this is SourceDefinition.Image && next is SourceDefinition.Image -> true
+    this is SourceDefinition.CustomGeometry && next is SourceDefinition.CustomGeometry ->
+      options == next.options
+    this is SourceDefinition.CustomVector && next is SourceDefinition.CustomVector ->
+      options == next.options
+    else -> this == next
+  }

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
@@ -35,6 +35,7 @@ import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.camera.Viewport
 import org.maplibre.compose.expressions.ast.CompiledExpression
 import org.maplibre.compose.expressions.value.BooleanValue
+import org.maplibre.compose.layers.Anchor
 import org.maplibre.compose.layers.BackgroundLayer
 import org.maplibre.compose.layers.LayerHandle
 import org.maplibre.compose.overlay.attributions
@@ -45,6 +46,7 @@ import org.maplibre.compose.sources.GeoJsonSourceHandle
 import org.maplibre.compose.sources.TileSetOptions
 import org.maplibre.compose.sources.VectorSource
 import org.maplibre.compose.style.BaseStyle
+import org.maplibre.compose.style.DesiredStyleLayer
 import org.maplibre.compose.style.DesiredStyleRevision
 import org.maplibre.compose.style.ImageSnapshot
 import org.maplibre.compose.style.RecordingStyleBinding
@@ -537,7 +539,7 @@ class MapPresentationTest {
   }
 
   @Test
-  fun a_typed_source_handle_rejects_a_same_id_source_type_replacement() {
+  fun a_typed_source_handle_rejects_a_same_id_source_type_replacement() = runTest {
     val fixture = presentationFixture()
     val geoJson =
       GeoJsonSource(
@@ -575,6 +577,48 @@ class MapPresentationTest {
 
     assertFailsWith<IllegalStateException> { handle.getFeatureState("7") }
     assertEquals(JsonObject(emptyMap()), loadedStyle.featureState("shared", null, "7"))
+    fixture.close()
+  }
+
+  @Test
+  fun a_base_source_handle_does_not_revive_after_same_id_replacement() {
+    val fixture = presentationFixture()
+    val original = attributedVectorSource("shared", "original")
+    val binding = RecordingStyleBinding(sources = listOf(original))
+    fixture.state.durableStyleCallbacks().onStyleChanged(fixture.adapter, binding)
+    fixture.state.durableStyleCallbacks().onMapFinishedLoading(fixture.adapter)
+    val stale = checkNotNull(fixture.state.style.sources["shared"])
+
+    assertTrue(fixture.state.style.sources.remove("shared"))
+    val replacement =
+      fixture.state.style.sources.add(attributedVectorSource("shared", "replacement"))
+
+    assertEquals("replacement", replacement.attributionHtml)
+    assertFailsWith<IllegalStateException> { stale.attributionHtml }
+    fixture.close()
+  }
+
+  @Test
+  fun a_declarative_source_handle_does_not_revive_after_same_type_replacement() = runTest {
+    val fixture = presentationFixture()
+    val original = attributedVectorSource("shared", "original")
+    fixture.state.desiredStyleRevision =
+      DesiredStyleRevision(listOf(original.definition()), emptyList(), emptyList())
+    val binding = RecordingStyleBinding(sources = listOf(original))
+    fixture.state.durableStyleCallbacks().onStyleChanged(fixture.adapter, binding)
+    fixture.state.durableStyleCallbacks().onMapFinishedLoading(fixture.adapter)
+    val stale = checkNotNull(fixture.state.style.sources["shared"])
+    val replacement = attributedVectorSource("shared", "replacement")
+
+    fixture.state.beginStyleRevision(
+      fixture.adapter,
+      DesiredStyleRevision(listOf(replacement.definition()), emptyList(), emptyList()),
+    )
+    binding.replaceSource(replacement)
+    fixture.state.markStyleReady(fixture.adapter)
+
+    assertFailsWith<IllegalStateException> { stale.attributionHtml }
+    assertEquals("replacement", fixture.state.style.sources["shared"]?.attributionHtml)
     fixture.close()
   }
 
@@ -658,6 +702,29 @@ class MapPresentationTest {
 
     loadedStyle.invalidate()
     assertFailsWith<IllegalStateException> { handle.getProperty("background-opacity") }
+    fixture.close()
+  }
+
+  @Test
+  fun a_layer_handle_does_not_revive_after_structural_replacement() = runTest {
+    val fixture = presentationFixture()
+    val layer = BackgroundLayer("background")
+    val original = DesiredStyleLayer(layer.definition(), Anchor.Top, null, null)
+    fixture.state.desiredStyleRevision =
+      DesiredStyleRevision(emptyList(), listOf(original), emptyList())
+    val binding = RecordingStyleBinding(layers = listOf(layer))
+    fixture.state.durableStyleCallbacks().onStyleChanged(fixture.adapter, binding)
+    fixture.state.durableStyleCallbacks().onMapFinishedLoading(fixture.adapter)
+    val stale = checkNotNull(fixture.state.style.layers["background"])
+
+    fixture.state.beginStyleRevision(
+      fixture.adapter,
+      DesiredStyleRevision(emptyList(), listOf(original.copy(anchor = Anchor.Bottom)), emptyList()),
+    )
+    fixture.state.markStyleReady(fixture.adapter)
+
+    assertFailsWith<IllegalStateException> { stale.getProperty("background-opacity") }
+    assertTrue(fixture.state.style.layers["background"] != null)
     fixture.close()
   }
 
@@ -792,7 +859,7 @@ class MapPresentationTest {
   }
 
   @Test
-  fun a_declarative_revision_cannot_claim_an_imperative_resource_id() {
+  fun a_declarative_revision_cannot_claim_an_imperative_resource_id() = runTest {
     val fixture = presentationFixture()
     val binding = RecordingStyleBinding()
     val source = attributedVectorSource("shared", "shared attribution")
@@ -834,6 +901,29 @@ class MapPresentationTest {
         ),
       )
     }
+    assertEquals(StyleLoadState.Ready, fixture.state.style.loadState)
+    assertTrue(binding.imageExists("shared") == true)
+    fixture.close()
+  }
+
+  @Test
+  fun a_nested_imperative_command_cannot_cross_a_resource_reservation() {
+    val fixture = presentationFixture()
+    val image = FakeImageBitmap(1, 1)
+    var nestedFailure: Throwable? = null
+    val binding =
+      RecordingStyleBinding(
+        beforeAddImage = {
+          nestedFailure =
+            runCatching { fixture.state.style.images.add("shared", image) }.exceptionOrNull()
+        }
+      )
+    fixture.state.durableStyleCallbacks().onStyleChanged(fixture.adapter, binding)
+    fixture.state.durableStyleCallbacks().onMapFinishedLoading(fixture.adapter)
+
+    fixture.state.style.images.add("shared", image)
+
+    assertIs<StyleHandleException>(nestedFailure)
     assertEquals(StyleLoadState.Ready, fixture.state.style.loadState)
     assertTrue(binding.imageExists("shared") == true)
     fixture.close()

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
@@ -1,6 +1,10 @@
 package org.maplibre.compose.map
 
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.ImageBitmapConfig
+import androidx.compose.ui.graphics.colorspace.ColorSpace
+import androidx.compose.ui.graphics.colorspace.ColorSpaces
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.DpRect
 import androidx.compose.ui.unit.DpSize
@@ -33,6 +37,7 @@ import org.maplibre.compose.expressions.ast.CompiledExpression
 import org.maplibre.compose.expressions.value.BooleanValue
 import org.maplibre.compose.layers.BackgroundLayer
 import org.maplibre.compose.layers.LayerHandle
+import org.maplibre.compose.overlay.attributions
 import org.maplibre.compose.sources.GeoJsonData
 import org.maplibre.compose.sources.GeoJsonOptions
 import org.maplibre.compose.sources.GeoJsonSource
@@ -41,7 +46,10 @@ import org.maplibre.compose.sources.TileSetOptions
 import org.maplibre.compose.sources.VectorSource
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.compose.style.DesiredStyleRevision
+import org.maplibre.compose.style.ImageSnapshot
 import org.maplibre.compose.style.RecordingStyleBinding
+import org.maplibre.compose.style.StyleHandleException
+import org.maplibre.compose.style.StyleImageDefinition
 import org.maplibre.compose.util.VisibleRegion
 import org.maplibre.spatialk.geojson.BoundingBox
 import org.maplibre.spatialk.geojson.Feature
@@ -470,7 +478,7 @@ class MapPresentationTest {
     style.removeSource("tiles")
     callbacks.onSourceChanged(adapter, "tiles")
 
-    assertTrue(state.style.sources.isEmpty())
+    assertTrue(state.style.sources.none())
     state.close()
     runtime.close()
   }
@@ -490,13 +498,13 @@ class MapPresentationTest {
           )
       )
 
-    assertNull(fixture.state.style.source("points"))
+    assertNull(fixture.state.style.sources["points"])
     fixture.state.durableStyleCallbacks().onStyleChanged(fixture.adapter, firstStyle)
-    assertNull(fixture.state.style.source("points"))
+    assertNull(fixture.state.style.sources["points"])
     fixture.state.durableStyleCallbacks().onMapFinishedLoading(fixture.adapter)
 
-    val handle = assertIs<GeoJsonSourceHandle>(fixture.state.style.source("points"))
-    assertNull(fixture.state.style.source("missing"))
+    val handle = assertIs<GeoJsonSourceHandle>(fixture.state.style.sources["points"])
+    assertNull(fixture.state.style.sources["missing"])
     handle.setFeatureState("7", buildJsonObject { put("selected", true) })
     assertEquals(
       true,
@@ -546,7 +554,7 @@ class MapPresentationTest {
     val loadedStyle = RecordingStyleBinding(sources = listOf(geoJson))
     fixture.state.durableStyleCallbacks().onStyleChanged(fixture.adapter, loadedStyle)
     fixture.state.durableStyleCallbacks().onMapFinishedLoading(fixture.adapter)
-    val handle = assertIs<GeoJsonSourceHandle>(fixture.state.style.source("shared"))
+    val handle = assertIs<GeoJsonSourceHandle>(fixture.state.style.sources["shared"])
     val vector = VectorSource("shared", "https://example.com/tiles.json")
 
     fixture.state.beginStyleRevision(
@@ -586,7 +594,7 @@ class MapPresentationTest {
       )
     fixture.state.durableStyleCallbacks().onStyleChanged(fixture.adapter, loadedStyle)
     fixture.state.durableStyleCallbacks().onMapFinishedLoading(fixture.adapter)
-    val handle = assertIs<GeoJsonSourceHandle>(fixture.state.style.source("points"))
+    val handle = assertIs<GeoJsonSourceHandle>(fixture.state.style.sources["points"])
     val point =
       buildFeatureCollection<Geometry, JsonObject?> {
           addFeature(geometry = Point(Position(0.0, 0.0)))
@@ -621,7 +629,7 @@ class MapPresentationTest {
       )
     state.durableStyleCallbacks().onStyleChanged(first, firstStyle)
     state.durableStyleCallbacks().onMapFinishedLoading(first)
-    val handle = assertIs<GeoJsonSourceHandle>(state.style.source("points"))
+    val handle = assertIs<GeoJsonSourceHandle>(state.style.sources["points"])
     state.releasePresentation(firstToken, first)
     testScheduler.advanceUntilIdle()
 
@@ -643,8 +651,8 @@ class MapPresentationTest {
     fixture.state.durableStyleCallbacks().onStyleChanged(fixture.adapter, loadedStyle)
     fixture.state.durableStyleCallbacks().onMapFinishedLoading(fixture.adapter)
 
-    val handle = assertIs<LayerHandle>(fixture.state.style.layer("background"))
-    assertNull(fixture.state.style.layer("missing"))
+    val handle = assertIs<LayerHandle>(fixture.state.style.layers["background"])
+    assertNull(fixture.state.style.layers["missing"])
     handle.setPaintProperty("background-opacity", JsonPrimitive(0.5))
     assertEquals(JsonPrimitive(0.5), handle.getProperty("background-opacity"))
 
@@ -665,10 +673,223 @@ class MapPresentationTest {
     assertTrue(fixture.state.updateLoadedStyle(fixture.adapter, replacement))
 
     assertEquals(StyleLoadState.Loading, fixture.state.style.loadState)
-    assertNull(fixture.state.style.layer("anything"))
+    assertNull(fixture.state.style.layers["anything"])
     assertTrue(fixture.state.markStyleReady(fixture.adapter))
     assertEquals(StyleLoadState.Ready, fixture.state.style.loadState)
     fixture.close()
+  }
+
+  @Test
+  fun loaded_style_resource_objects_preserve_engine_order_and_empty_on_invalidation() {
+    val fixture = presentationFixture()
+    val sources =
+      listOf(
+        attributedVectorSource("bottom", "first"),
+        attributedVectorSource("top", "second"),
+      )
+    val layers = listOf(BackgroundLayer("bottom"), BackgroundLayer("top"))
+    val binding = RecordingStyleBinding(sources = sources, layers = layers)
+    val styleSources = fixture.state.style.sources
+    val styleLayers = fixture.state.style.layers
+    val styleImages = fixture.state.style.images
+
+    assertTrue(styleSources.none())
+    assertTrue(styleLayers.none())
+    assertFailsWith<IllegalStateException> {
+      styleSources.add(attributedVectorSource("unready", "unready"))
+    }
+    assertFailsWith<IllegalStateException> {
+      styleImages.add("unready", FakeImageBitmap(1, 1))
+    }
+    fixture.state.durableStyleCallbacks().onStyleChanged(fixture.adapter, binding)
+    fixture.state.durableStyleCallbacks().onMapFinishedLoading(fixture.adapter)
+
+    assertSame(styleSources, fixture.state.style.sources)
+    assertSame(styleLayers, fixture.state.style.layers)
+    assertSame(styleImages, fixture.state.style.images)
+    assertEquals(listOf("bottom", "top"), styleSources.map { it.id })
+    assertEquals(listOf("bottom", "top"), styleLayers.map { it.id })
+
+    fixture.state.style.baseStyle = BaseStyle.Json("replacement")
+    assertTrue(styleSources.none())
+    assertTrue(styleLayers.none())
+    fixture.close()
+  }
+
+  @Test
+  fun imperative_source_commands_publish_results_and_normalize_engine_refusal() {
+    val fixture = presentationFixture()
+    val binding = RecordingStyleBinding(refusedSourceRemovals = setOf("blocked"))
+    fixture.state.durableStyleCallbacks().onStyleChanged(fixture.adapter, binding)
+    fixture.state.durableStyleCallbacks().onMapFinishedLoading(fixture.adapter)
+    val added = attributedVectorSource("added", "added attribution")
+    val blocked = attributedVectorSource("blocked", "blocked attribution")
+
+    val firstHandle = fixture.state.style.sources.add(added)
+    assertEquals("added", firstHandle.id)
+    assertEquals("added", fixture.state.style.sources["added"]?.id)
+    fixture.state.style.sources.add(blocked)
+    assertFailsWith<StyleHandleException> { fixture.state.style.sources.add(added) }
+    assertFalse(fixture.state.style.sources.remove("missing"))
+    assertTrue(fixture.state.style.sources.remove("added"))
+    assertNull(fixture.state.style.sources["added"])
+    val replacementHandle = fixture.state.style.sources.add(added)
+    assertFailsWith<IllegalStateException> { firstHandle.attributionHtml }
+    assertEquals("added attribution", replacementHandle.attributionHtml)
+    assertTrue(fixture.state.style.sources.remove("added"))
+
+    assertFailsWith<StyleHandleException> { fixture.state.style.sources.remove("blocked") }
+    assertTrue("blocked" in binding.sources)
+    assertTrue(fixture.state.style.sources["blocked"] != null)
+    fixture.close()
+  }
+
+  @Test
+  fun imperative_image_commands_add_remove_and_reject_duplicates() {
+    val fixture = presentationFixture()
+    val binding = RecordingStyleBinding()
+    val image = FakeImageBitmap(1, 1)
+    fixture.state.durableStyleCallbacks().onStyleChanged(fixture.adapter, binding)
+    fixture.state.durableStyleCallbacks().onMapFinishedLoading(fixture.adapter)
+
+    fixture.state.style.images.add("marker", image)
+    assertEquals(setOf("marker"), binding.imageIds)
+    assertFailsWith<StyleHandleException> { fixture.state.style.images.add("marker", image) }
+    assertFalse(fixture.state.style.images.remove("missing"))
+    assertTrue(fixture.state.style.images.remove("marker"))
+    assertTrue(binding.imageIds.isEmpty())
+    fixture.close()
+  }
+
+  @Test
+  fun imperative_commands_cannot_mutate_composition_owned_resources() {
+    val fixture = presentationFixture()
+    val source = attributedVectorSource("owned", "owned attribution")
+    val image = FakeImageBitmap(1, 1)
+    fixture.state.desiredStyleRevision =
+      DesiredStyleRevision(
+        sources = listOf(source.definition()),
+        layers = emptyList(),
+        images =
+          listOf(
+            StyleImageDefinition(
+              "owned",
+              ImageSnapshot.capture(image),
+              sdf = false,
+              stretch = null,
+            )
+          ),
+      )
+    val binding = RecordingStyleBinding(images = listOf("owned" to image), sources = listOf(source))
+    fixture.state.durableStyleCallbacks().onStyleChanged(fixture.adapter, binding)
+    fixture.state.durableStyleCallbacks().onMapFinishedLoading(fixture.adapter)
+
+    assertFailsWith<StyleHandleException> { fixture.state.style.sources.remove("owned") }
+    assertFailsWith<StyleHandleException> { fixture.state.style.images.remove("owned") }
+    assertTrue(binding.sourceExists("owned") == true)
+    assertTrue(binding.imageExists("owned") == true)
+    fixture.close()
+  }
+
+  @Test
+  fun a_declarative_revision_cannot_claim_an_imperative_resource_id() {
+    val fixture = presentationFixture()
+    val binding = RecordingStyleBinding()
+    val source = attributedVectorSource("shared", "shared attribution")
+    val image = FakeImageBitmap(1, 1)
+    fixture.state.durableStyleCallbacks().onStyleChanged(fixture.adapter, binding)
+    fixture.state.durableStyleCallbacks().onMapFinishedLoading(fixture.adapter)
+    fixture.state.style.sources.add(source)
+
+    assertFailsWith<StyleHandleException> {
+      fixture.state.beginStyleRevision(
+        fixture.adapter,
+        DesiredStyleRevision(
+          sources = listOf(source.definition()),
+          layers = emptyList(),
+          images = emptyList(),
+        ),
+      )
+    }
+    assertEquals(StyleLoadState.Ready, fixture.state.style.loadState)
+    assertTrue(fixture.state.style.sources["shared"] != null)
+
+    assertTrue(fixture.state.style.sources.remove("shared"))
+    fixture.state.style.images.add("shared", image)
+    assertFailsWith<StyleHandleException> {
+      fixture.state.beginStyleRevision(
+        fixture.adapter,
+        DesiredStyleRevision(
+          sources = emptyList(),
+          layers = emptyList(),
+          images =
+            listOf(
+              StyleImageDefinition(
+                "shared",
+                ImageSnapshot.capture(image),
+                sdf = false,
+                stretch = null,
+              )
+            ),
+        ),
+      )
+    }
+    assertEquals(StyleLoadState.Ready, fixture.state.style.loadState)
+    assertTrue(binding.imageExists("shared") == true)
+    fixture.close()
+  }
+
+  @Test
+  fun attribution_derives_from_base_declarative_and_imperative_sources() {
+    val fixture = presentationFixture()
+    val base = attributedVectorSource("base", "base attribution")
+    val declarative = attributedVectorSource("declarative", "declarative attribution")
+    fixture.state.desiredStyleRevision =
+      DesiredStyleRevision(
+        sources = listOf(declarative.definition()),
+        layers = emptyList(),
+        images = emptyList(),
+      )
+    val binding = RecordingStyleBinding(sources = listOf(base, declarative))
+    fixture.state.durableStyleCallbacks().onStyleChanged(fixture.adapter, binding)
+    fixture.state.durableStyleCallbacks().onMapFinishedLoading(fixture.adapter)
+
+    fixture.state.style.sources.add(attributedVectorSource("imperative", "imperative attribution"))
+
+    assertEquals(
+      listOf("base attribution", "declarative attribution", "imperative attribution"),
+      fixture.state.style.attributions(),
+    )
+    fixture.close()
+  }
+
+  @Test
+  fun imperative_resources_survive_detachment_only_with_the_retained_generation() = runTest {
+    val runtime = mapRuntimeForTest()
+    val state = runtime.createMapState(BaseStyle.Empty)
+    val token = state.reservePresentation()
+    val adapter = RetainedAdapter(failOnClose = false)
+    val binding = RecordingStyleBinding()
+    state.publishPresentation(token, adapter)
+    state.durableStyleCallbacks().onStyleChanged(adapter, binding)
+    state.durableStyleCallbacks().onMapFinishedLoading(adapter)
+    state.style.sources.add(attributedVectorSource("retained", "retained attribution"))
+
+    state.releasePresentation(token, adapter)
+    testScheduler.advanceUntilIdle()
+
+    assertTrue(state.style.sources["retained"] != null)
+    assertTrue(state.style.sources.remove("retained"))
+
+    val replacement = RecordingStyleBinding()
+    val replacementToken = state.reservePresentation()
+    val replacementAdapter = RetainedAdapter(failOnClose = false)
+    state.publishPresentation(replacementToken, replacementAdapter)
+    state.durableStyleCallbacks().onStyleChanged(replacementAdapter, replacement)
+    state.durableStyleCallbacks().onMapFinishedLoading(replacementAdapter)
+    assertTrue(state.style.sources.none())
+    state.close()
+    runtime.close()
   }
 
   @Test
@@ -890,11 +1111,13 @@ class MapPresentationTest {
   }
 }
 
-private fun attributedVectorSource(): VectorSource =
+private fun attributedVectorSource(): VectorSource = attributedVectorSource("tiles", "attribution")
+
+private fun attributedVectorSource(id: String, attribution: String): VectorSource =
   VectorSource(
-    id = "tiles",
+    id = id,
     tiles = listOf("https://example.com/{z}/{x}/{y}.pbf"),
-    options = TileSetOptions(attributionHtml = "attribution"),
+    options = TileSetOptions(attributionHtml = attribution),
   )
 
 private data class PresentationFixture(
@@ -908,6 +1131,24 @@ private data class PresentationFixture(
     state.close()
     runtime.close()
   }
+}
+
+private class FakeImageBitmap(override val width: Int, override val height: Int) : ImageBitmap {
+  override val colorSpace: ColorSpace = ColorSpaces.Srgb
+  override val hasAlpha: Boolean = true
+  override val config: ImageBitmapConfig = ImageBitmapConfig.Argb8888
+
+  override fun readPixels(
+    buffer: IntArray,
+    startX: Int,
+    startY: Int,
+    width: Int,
+    height: Int,
+    bufferOffset: Int,
+    stride: Int,
+  ) = Unit
+
+  override fun prepareToDraw() = Unit
 }
 
 private fun presentationFixture(): PresentationFixture {

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapSnapshotterTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapSnapshotterTest.kt
@@ -9,6 +9,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.milliseconds
@@ -27,10 +28,13 @@ import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
+import org.maplibre.compose.layers.BackgroundLayer
 import org.maplibre.compose.sources.GeoJsonData
 import org.maplibre.compose.sources.GeoJsonOptions
 import org.maplibre.compose.sources.GeoJsonSource
 import org.maplibre.compose.sources.GeoJsonSourceHandle
+import org.maplibre.compose.sources.TileSetOptions
+import org.maplibre.compose.sources.VectorSource
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.compose.style.DesiredStyleRevision
 import org.maplibre.compose.style.RecordingStyleBinding
@@ -168,6 +172,73 @@ class MapSnapshotterTest {
     assertTrue(snapshotter.style.sources.remove("imperative"))
     assertTrue(snapshotter.style.sources.none())
 
+    close(snapshotter, runtime)
+  }
+
+  @Test
+  fun reused_snapshot_style_preserves_existing_resource_handles() = runTest {
+    val source =
+      GeoJsonSource(
+        id = "base-source",
+        data = GeoJsonData.JsonString("""{"type":"FeatureCollection","features":[]}"""),
+        options = GeoJsonOptions(),
+      )
+    val binding =
+      RecordingStyleBinding(
+        sources = listOf(source),
+        layers = listOf(BackgroundLayer("base-layer")),
+      )
+    val runtime =
+      mapRuntimeForTest(
+        snapshotterAdapterFactory =
+          SnapshotterAdapterFactory { FakeSnapshotterAdapter(prepare = { _, _ -> binding }) },
+        styleEvaluator = StyleCompositionEvaluator { _, _, _, _, _ -> DesiredStyleRevision.Empty },
+      )
+    val snapshotter = runtime.createSnapshotter(BaseStyle.Empty)
+    val request = MapSnapshotRequest(1, 1)
+    snapshotter.capture(request)
+    val sourceHandle = checkNotNull(snapshotter.style.sources["base-source"])
+    val layerHandle = checkNotNull(snapshotter.style.layers["base-layer"])
+
+    snapshotter.capture(request)
+
+    assertEquals("", sourceHandle.attributionHtml)
+    assertNull(layerHandle.getProperty("background-opacity"))
+    close(snapshotter, runtime)
+  }
+
+  @Test
+  fun reused_snapshot_style_invalidates_a_structurally_replaced_source() = runTest {
+    val original = attributedVectorSource("original")
+    val replacement = attributedVectorSource("replacement")
+    var desired = DesiredStyleRevision(listOf(original.definition()), emptyList(), emptyList())
+    val binding = RecordingStyleBinding(sources = listOf(original))
+    val runtime =
+      mapRuntimeForTest(
+        snapshotterAdapterFactory =
+          SnapshotterAdapterFactory {
+            FakeSnapshotterAdapter(
+              prepare = { _, _ -> binding },
+              capture = { request, _ ->
+                if (desired.sources.single() == replacement.definition()) {
+                  binding.replaceSource(replacement)
+                }
+                FakeImageBitmap(request.width, request.height)
+              },
+            )
+          },
+        styleEvaluator = StyleCompositionEvaluator { _, _, _, _, _ -> desired },
+      )
+    val snapshotter = runtime.createSnapshotter(BaseStyle.Empty)
+    val request = MapSnapshotRequest(1, 1)
+    snapshotter.capture(request)
+    val stale = checkNotNull(snapshotter.style.sources["shared"])
+
+    desired = DesiredStyleRevision(listOf(replacement.definition()), emptyList(), emptyList())
+    snapshotter.capture(request)
+
+    assertFailsWith<IllegalStateException> { stale.attributionHtml }
+    assertEquals("replacement", snapshotter.style.sources["shared"]?.attributionHtml)
     close(snapshotter, runtime)
   }
 
@@ -535,6 +606,13 @@ class MapSnapshotterTest {
     runtime.close()
     runtime.awaitClosed()
   }
+
+  private fun attributedVectorSource(attribution: String): VectorSource =
+    VectorSource(
+      id = "shared",
+      tiles = listOf("https://example.com/{z}/{x}/{y}.pbf"),
+      options = TileSetOptions(attributionHtml = attribution),
+    )
 
   private class FakeSnapshotterAdapter(
     private val prepare: suspend (BaseStyle, MapSnapshotRequest) -> StyleBinding = { _, _ ->

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapSnapshotterTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapSnapshotterTest.kt
@@ -156,7 +156,6 @@ class MapSnapshotterTest {
         styleEvaluator = StyleCompositionEvaluator { _, _, _, _, _ -> DesiredStyleRevision.Empty },
       )
     val snapshotter = runtime.createSnapshotter(BaseStyle.Empty)
-    snapshotter.capture(MapSnapshotRequest(1, 1))
     val source =
       GeoJsonSource(
         id = "imperative",
@@ -164,13 +163,16 @@ class MapSnapshotterTest {
         options = GeoJsonOptions(),
       )
 
-    assertTrue(snapshotter.style.sources.add(source) is GeoJsonSourceHandle)
-    assertTrue(snapshotter.style.sources["imperative"] is GeoJsonSourceHandle)
-    snapshotter.style.images.add("imperative", FakeImageBitmap(1, 1))
-    assertEquals(setOf("imperative"), binding.imageIds)
-    assertTrue(snapshotter.style.images.remove("imperative"))
-    assertTrue(snapshotter.style.sources.remove("imperative"))
-    assertTrue(snapshotter.style.sources.none())
+    withContext(Dispatchers.Unconfined) {
+      snapshotter.capture(MapSnapshotRequest(1, 1))
+      assertTrue(snapshotter.style.sources.add(source) is GeoJsonSourceHandle)
+      assertTrue(snapshotter.style.sources["imperative"] is GeoJsonSourceHandle)
+      snapshotter.style.images.add("imperative", FakeImageBitmap(1, 1))
+      assertEquals(setOf("imperative"), binding.imageIds)
+      assertTrue(snapshotter.style.images.remove("imperative"))
+      assertTrue(snapshotter.style.sources.remove("imperative"))
+      assertTrue(snapshotter.style.sources.none())
+    }
 
     close(snapshotter, runtime)
   }

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapSnapshotterTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapSnapshotterTest.kt
@@ -35,6 +35,7 @@ import org.maplibre.compose.style.BaseStyle
 import org.maplibre.compose.style.DesiredStyleRevision
 import org.maplibre.compose.style.RecordingStyleBinding
 import org.maplibre.compose.style.StyleBinding
+import org.maplibre.compose.style.StyleHandleException
 
 class MapSnapshotterTest {
 
@@ -167,6 +168,45 @@ class MapSnapshotterTest {
     assertTrue(snapshotter.style.sources.remove("imperative"))
     assertTrue(snapshotter.style.sources.none())
 
+    close(snapshotter, runtime)
+  }
+
+  @Test
+  fun imperative_commands_cannot_cross_an_active_snapshot_style_revision() = runTest {
+    val binding = RecordingStyleBinding()
+    val captureStarted = CompletableDeferred<Unit>()
+    val finishCapture = CompletableDeferred<Unit>()
+    var blockCapture = false
+    val runtime =
+      mapRuntimeForTest(
+        snapshotterAdapterFactory =
+          SnapshotterAdapterFactory {
+            FakeSnapshotterAdapter(
+              prepare = { _, _ -> binding },
+              capture = { _, _ ->
+                if (blockCapture) {
+                  captureStarted.complete(Unit)
+                  finishCapture.await()
+                }
+                FakeImageBitmap(1, 1)
+              },
+            )
+          },
+        styleEvaluator = StyleCompositionEvaluator { _, _, _, _, _ -> DesiredStyleRevision.Empty },
+      )
+    val snapshotter = runtime.createSnapshotter(BaseStyle.Empty)
+    snapshotter.capture(MapSnapshotRequest(1, 1))
+    blockCapture = true
+    val capture = async { snapshotter.capture(MapSnapshotRequest(1, 1)) }
+    captureStarted.await()
+
+    assertFailsWith<StyleHandleException> {
+      snapshotter.style.images.add("crossing", FakeImageBitmap(1, 1))
+    }
+
+    finishCapture.complete(Unit)
+    capture.await()
+    assertTrue(binding.imageIds.isEmpty())
     close(snapshotter, runtime)
   }
 

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapSnapshotterTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapSnapshotterTest.kt
@@ -27,6 +27,10 @@ import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
+import org.maplibre.compose.sources.GeoJsonData
+import org.maplibre.compose.sources.GeoJsonOptions
+import org.maplibre.compose.sources.GeoJsonSource
+import org.maplibre.compose.sources.GeoJsonSourceHandle
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.compose.style.DesiredStyleRevision
 import org.maplibre.compose.style.RecordingStyleBinding
@@ -135,6 +139,35 @@ class MapSnapshotterTest {
     snapshotter.awaitClosed()
     runtime.close()
     runtime.awaitClosed()
+  }
+
+  @Test
+  fun a_published_snapshot_style_accepts_imperative_source_and_image_commands() = runTest {
+    val binding = RecordingStyleBinding()
+    val runtime =
+      mapRuntimeForTest(
+        snapshotterAdapterFactory =
+          SnapshotterAdapterFactory { FakeSnapshotterAdapter(prepare = { _, _ -> binding }) },
+        styleEvaluator = StyleCompositionEvaluator { _, _, _, _, _ -> DesiredStyleRevision.Empty },
+      )
+    val snapshotter = runtime.createSnapshotter(BaseStyle.Empty)
+    snapshotter.capture(MapSnapshotRequest(1, 1))
+    val source =
+      GeoJsonSource(
+        id = "imperative",
+        data = GeoJsonData.JsonString("""{"type":"FeatureCollection","features":[]}"""),
+        options = GeoJsonOptions(),
+      )
+
+    assertTrue(snapshotter.style.sources.add(source) is GeoJsonSourceHandle)
+    assertTrue(snapshotter.style.sources["imperative"] is GeoJsonSourceHandle)
+    snapshotter.style.images.add("imperative", FakeImageBitmap(1, 1))
+    assertEquals(setOf("imperative"), binding.imageIds)
+    assertTrue(snapshotter.style.images.remove("imperative"))
+    assertTrue(snapshotter.style.sources.remove("imperative"))
+    assertTrue(snapshotter.style.sources.none())
+
+    close(snapshotter, runtime)
   }
 
   @Test

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/style/RecordingStyleBinding.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/style/RecordingStyleBinding.kt
@@ -30,6 +30,7 @@ internal class RecordingStyleBinding(
   override val supportsCustomDemEncoding: Boolean = false,
   override val supportsRasterDemScheme: Boolean = true,
   private val refusedSourceRemovals: Set<String> = emptySet(),
+  private val beforeAddImage: ((String) -> Unit)? = null,
 ) : StyleBinding {
 
   override val identity: StyleIdentity = StyleIdentity.create()
@@ -42,6 +43,7 @@ internal class RecordingStyleBinding(
   private val baseLayers = layers.associateBy { it.id }.toMutableMap()
   private val orderedLayerIds = mutableListOf<String>()
   private val featureStates = mutableMapOf<Triple<String, String?, String>, JsonObject>()
+  private var addImageHookInvoked = false
 
   override var isLoaded: Boolean = true
     private set
@@ -73,6 +75,10 @@ internal class RecordingStyleBinding(
   override val logger: Logger? = null
 
   override fun addImage(definition: StyleImageDefinition) {
+    if (!addImageHookInvoked) {
+      addImageHookInvoked = true
+      beforeAddImage?.invoke(definition.id)
+    }
     check(definition.id !in images) { "Image ID '${definition.id}' already exists in style" }
     images[definition.id] = definition.image
   }

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/style/RecordingStyleBinding.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/style/RecordingStyleBinding.kt
@@ -29,6 +29,7 @@ internal class RecordingStyleBinding(
   layers: List<Layer> = emptyList(),
   override val supportsCustomDemEncoding: Boolean = false,
   override val supportsRasterDemScheme: Boolean = true,
+  private val refusedSourceRemovals: Set<String> = emptySet(),
 ) : StyleBinding {
 
   override val identity: StyleIdentity = StyleIdentity.create()
@@ -50,6 +51,9 @@ internal class RecordingStyleBinding(
 
   val installedLayerIds: Set<String>
     get() = this.layers.keys - baseLayers.keys
+
+  val imageIds: Set<String>
+    get() = images.keys
 
   var customGeometryProvider: GeometryTileProvider? = null
     private set
@@ -77,6 +81,8 @@ internal class RecordingStyleBinding(
     check(images.remove(id) != null) { "Image ID '$id' not found in style" }
   }
 
+  override fun imageExists(id: String): Boolean = id in images
+
   override fun getSource(id: String): Source? =
     baseSources[id] ?: sources[id]?.let { UnknownSource(id, it) }
 
@@ -96,6 +102,9 @@ internal class RecordingStyleBinding(
   }
 
   override fun removeSource(sourceId: String) {
+    if (sourceId in refusedSourceRemovals) {
+      throw StyleMutationException("Source '$sourceId' is still in use", null)
+    }
     sources.remove(sourceId)
     baseSources.remove(sourceId)
   }

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/style/GlJsStyleBinding.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/style/GlJsStyleBinding.kt
@@ -129,13 +129,22 @@ internal class GlJsStyleBinding(
           }
         }
       }
-    if (map.hasImage(id)) map.removeImage(id)
-    map.addImage(id, pixels, metadata)
+    mutate("add image '$id'") {
+      if (map.hasImage(id)) map.removeImage(id)
+      map.addImage(id, pixels, metadata)
+    }
   }
 
   override fun removeImage(id: String) {
     requireLoaded()
-    if (map.hasImage(id)) map.removeImage(id)
+    mutate("remove image '$id'") {
+      if (map.hasImage(id)) map.removeImage(id)
+    }
+  }
+
+  override fun imageExists(id: String): Boolean {
+    requireLoaded()
+    return map.hasImage(id)
   }
 
   override fun getSource(id: String): Source? {
@@ -191,7 +200,7 @@ internal class GlJsStyleBinding(
 
   override fun removeSource(sourceId: String) {
     requireLoaded()
-    map.removeSource(sourceId)
+    mutate("remove source '$sourceId'") { map.removeSource(sourceId) }
     customVectorAttachments.remove(sourceId)?.close()
   }
 

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserMapStyleStateTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserMapStyleStateTest.kt
@@ -251,7 +251,7 @@ class BrowserMapStyleStateTest {
 
       assertEquals(
         listOf("fetched attribution"),
-        styleState?.sources?.values?.map { it.attributionHtml },
+        styleState?.sources?.map { it.attributionHtml },
         "loading is only finished once a source's TileJSON has arrived; the attribution UI reads " +
           "this the moment it is told",
       )
@@ -279,7 +279,7 @@ class BrowserMapStyleStateTest {
 
       current.value = tileJsonStyle
       waitUntilMap("the switched style's attribution to be reported") {
-        styleState?.sources?.values?.map { it.attributionHtml } == listOf("fetched attribution")
+        styleState?.sources?.map { it.attributionHtml } == listOf("fetched attribution")
       }
     } finally {
       restoreFetch()
@@ -312,16 +312,16 @@ class BrowserMapStyleStateTest {
 
         showLateSource.value = true
 
-        waitUntilMap("the late source's initial snapshot") { styleState?.sources?.size == 1 }
-        assertEquals(listOf(""), styleState?.sources?.values?.map { it.attributionHtml })
-        val initialSource = styleState?.sources?.values?.single()
+        waitUntilMap("the late source's initial snapshot") { styleState?.sources?.count() == 1 }
+        assertEquals(listOf(""), styleState?.sources?.map { it.attributionHtml })
+        val initialSource = styleState?.sources?.single()
 
         waitUntilMap("MapLibre to request the TileJSON") { tileJson.isRequested() }
         tileJson.resolve()
         waitUntilMap("the late source's attribution") {
-          styleState?.sources?.values?.map { it.attributionHtml } == listOf("fetched attribution")
+          styleState?.sources?.map { it.attributionHtml } == listOf("fetched attribution")
         }
-        assertNotSame(initialSource, styleState?.sources?.values?.single())
+        assertNotSame(initialSource, styleState?.sources?.single())
         assertEquals(
           StyleLoadState.Ready,
           mapState?.style?.loadState,
@@ -348,26 +348,25 @@ class BrowserMapStyleStateTest {
       MaplibreMap(state = logicalMap, modifier = Modifier)
     }
     waitUntilMap("the first style to load") {
-      mapState?.style?.loadState == StyleLoadState.Ready &&
-        styleState?.sources?.isNotEmpty() == true
+      mapState?.style?.loadState == StyleLoadState.Ready && styleState?.sources?.any() == true
     }
     val firstIdentity = identity
     assertEquals(
       listOf("first attribution"),
-      styleState?.sources?.values?.map { it.attributionHtml },
+      styleState?.sources?.map { it.attributionHtml },
     )
 
     val observed = mutableListOf<List<String>>()
     current.value = styleWith("second", "second-source")
     waitUntilMap("the second style's sources to be reported") {
-      styleState?.sources?.values?.map { it.attributionHtml }?.let { observed += it }
+      styleState?.sources?.map { it.attributionHtml }?.let { observed += it }
       mapState?.style?.loadState == StyleLoadState.Ready &&
-        styleState?.sources?.keys == setOf("second-source")
+        styleState?.sources?.map { it.id }?.toSet() == setOf("second-source")
     }
 
     assertEquals(
       listOf("second attribution"),
-      styleState?.sources?.values?.map { it.attributionHtml },
+      styleState?.sources?.map { it.attributionHtml },
     )
     assertNotSame(firstIdentity, identity)
     assertTrue(

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/layers/LayerHandlePropertyTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/layers/LayerHandlePropertyTest.kt
@@ -16,7 +16,7 @@ class LayerHandlePropertyTest {
   fun a_layer_handle_updates_and_reads_a_paint_property(): MapTestResult = runMapTest {
     createMapFixture().use { fixture ->
       fixture.loadStyle(STYLE)
-      val handle = assertNotNull(fixture.state.style.layer("background"))
+      val handle = assertNotNull(fixture.state.style.layers["background"])
 
       handle.setPaintProperty("background-opacity", JsonPrimitive(0.25))
 
@@ -28,7 +28,7 @@ class LayerHandlePropertyTest {
   fun a_rejected_layer_property_has_a_public_handle_error(): MapTestResult = runMapTest {
     createMapFixture().use { fixture ->
       fixture.loadStyle(STYLE)
-      val handle = assertNotNull(fixture.state.style.layer("background"))
+      val handle = assertNotNull(fixture.state.style.layers["background"])
 
       assertFailsWith<StyleHandleException> {
         handle.setPaintProperty("not-a-style-property", JsonPrimitive(0.25))
@@ -40,8 +40,8 @@ class LayerHandlePropertyTest {
   fun root_properties_are_readable_and_rejected_writes_throw(): MapTestResult = runMapTest {
     createMapFixture().use { fixture ->
       fixture.loadStyle(STYLE)
-      val handle = assertNotNull(fixture.state.style.layer("background"))
-      val circle = assertNotNull(fixture.state.style.layer("points"))
+      val handle = assertNotNull(fixture.state.style.layers["background"])
+      val circle = assertNotNull(fixture.state.style.layers["points"])
 
       assertEquals(JsonPrimitive("background"), handle.getProperty("id"))
       assertEquals(JsonPrimitive("background"), handle.getProperty("type"))

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/sources/FeatureStateTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/sources/FeatureStateTest.kt
@@ -50,7 +50,7 @@ class FeatureStateTest {
             ),
           options = GeoJsonOptions(),
         )
-      binding.install(source)
+      fixture.state.style.sources.add(source)
       val layer = CircleLayer("circles", source)
       layer.setCircleRadius(const(48.dp).compile(ExpressionContext.None))
       layer.setCircleColor(
@@ -64,7 +64,7 @@ class FeatureStateTest {
           .compile(ExpressionContext.None)
       )
       binding.install(layer)
-      val handle = assertIs<GeoJsonSourceHandle>(fixture.state.style.source("points"))
+      val handle = assertIs<GeoJsonSourceHandle>(fixture.state.style.sources["points"])
 
       fixture.pumpUntilPixel("the default circle", CENTER, CENTER, BLUE)
       handle.setFeatureState(

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/sources/GeoJsonClusterTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/sources/GeoJsonClusterTest.kt
@@ -36,9 +36,9 @@ class GeoJsonClusterTest {
           data = GeoJsonData.Features(nearbyPoints()),
           options = GeoJsonOptions(cluster = true, clusterRadius = 200, clusterMaxZoom = 14),
         )
-      binding.install(source)
+      fixture.state.style.sources.add(source)
       binding.install(CircleLayer("clusters", source))
-      val handle = assertIs<GeoJsonSourceHandle>(fixture.state.style.source("points"))
+      val handle = assertIs<GeoJsonSourceHandle>(fixture.state.style.sources["points"])
 
       suspend fun rendered(): List<Feature<Geometry, JsonObject?>> =
         fixture.state.queryRenderedFeatures(

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/style/BaseStyleSourceReadTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/style/BaseStyleSourceReadTest.kt
@@ -14,10 +14,10 @@ class BaseStyleSourceReadTest {
     createMapFixture().use { fixture ->
       fixture.loadStyle(ATTRIBUTED_STYLE)
 
-      val source = assertIs<GeoJsonSourceHandle>(fixture.state.style.source("attributed"))
+      val source = assertIs<GeoJsonSourceHandle>(fixture.state.style.sources["attributed"])
 
       assertEquals("inline attribution", source.attributionHtml)
-      assertEquals(listOf("attributed"), fixture.state.style.sources.keys.toList())
+      assertEquals(listOf("attributed"), fixture.state.style.sources.map { it.id })
     }
   }
 

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/style/LoadedStyleResourceMutationTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/style/LoadedStyleResourceMutationTest.kt
@@ -1,0 +1,42 @@
+package org.maplibre.compose.style
+
+import androidx.compose.ui.graphics.ImageBitmap
+import kotlin.test.Test
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import org.maplibre.compose.sources.GeoJsonData
+import org.maplibre.compose.sources.GeoJsonOptions
+import org.maplibre.compose.sources.GeoJsonSource
+import org.maplibre.compose.sources.GeoJsonSourceHandle
+import org.maplibre.compose.testing.MapTestResult
+import org.maplibre.compose.testing.createMapFixture
+import org.maplibre.compose.testing.runMapTest
+
+class LoadedStyleResourceMutationTest {
+  @Test
+  fun public_commands_mutate_a_live_source_and_style_image(): MapTestResult = runMapTest {
+    createMapFixture().use { fixture ->
+      fixture.loadStyle(EMPTY_STYLE)
+      val source =
+        GeoJsonSource(
+          id = "imperative",
+          data = GeoJsonData.JsonString("""{"type":"FeatureCollection","features":[]}"""),
+          options = GeoJsonOptions(),
+        )
+
+      assertIs<GeoJsonSourceHandle>(fixture.state.style.sources.add(source))
+      assertIs<GeoJsonSourceHandle>(fixture.state.style.sources["imperative"])
+      fixture.state.style.images.add("imperative", ImageBitmap(1, 1))
+      fixture.settle()
+
+      assertTrue(fixture.state.style.images.remove("imperative"))
+      assertTrue(fixture.state.style.sources.remove("imperative"))
+      assertNull(fixture.state.style.sources["imperative"])
+    }
+  }
+
+  private companion object {
+    val EMPTY_STYLE = BaseStyle.Json("""{"version":8,"sources":{},"layers":[]}""")
+  }
+}

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/style/MlnFfiStyleBinding.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/style/MlnFfiStyleBinding.kt
@@ -113,26 +113,30 @@ internal open class MlnFfiStyleBinding(
     val pixels = image.toPremultipliedRgba8()
     val stretchPx = stretch?.resolve(image.width, image.height, scale)
     mutateMap { map ->
-      map.setStyleImage(
-        imageId = id,
-        image = pixels,
-        options =
-          StyleImageOptions().also { options ->
-            options.sdf = sdf
-            options.pixelRatio = scale
-            stretchPx?.let { px ->
-              if (px.stretchX.isNotEmpty()) {
-                options.stretchX = px.stretchX.map { (start, end) -> FfiImageStretch(start, end) }
+      try {
+        map.setStyleImage(
+          imageId = id,
+          image = pixels,
+          options =
+            StyleImageOptions().also { options ->
+              options.sdf = sdf
+              options.pixelRatio = scale
+              stretchPx?.let { px ->
+                if (px.stretchX.isNotEmpty()) {
+                  options.stretchX = px.stretchX.map { (start, end) -> FfiImageStretch(start, end) }
+                }
+                if (px.stretchY.isNotEmpty()) {
+                  options.stretchY = px.stretchY.map { (start, end) -> FfiImageStretch(start, end) }
+                }
+                px.content?.let { box ->
+                  options.content = ImageContent(box.left, box.top, box.right, box.bottom)
+                }
               }
-              if (px.stretchY.isNotEmpty()) {
-                options.stretchY = px.stretchY.map { (start, end) -> FfiImageStretch(start, end) }
-              }
-              px.content?.let { box ->
-                options.content = ImageContent(box.left, box.top, box.right, box.bottom)
-              }
-            }
-          },
-      )
+            },
+        )
+      } catch (error: MaplibreException) {
+        throw StyleMutationException(error.message, error)
+      }
     }
   }
 
@@ -142,8 +146,16 @@ internal open class MlnFfiStyleBinding(
     }
 
   override fun removeImage(id: String) {
-    mutateMap { it.removeStyleImage(id) }
+    mutateMap {
+      try {
+        it.removeStyleImage(id)
+      } catch (error: MaplibreException) {
+        throw StyleMutationException(error.message, error)
+      }
+    }
   }
+
+  override fun imageExists(id: String): Boolean? = readMap { it.styleImageInfo(id) != null }
 
   override fun getSource(id: String): Source? = readMap { map ->
     if (!isStyleSource(map, id)) null else reconstructSource(map, id)
@@ -335,7 +347,11 @@ internal open class MlnFfiStyleBinding(
 
   override fun removeSource(sourceId: String) {
     mutateMap { map ->
-      map.removeStyleSource(sourceId)
+      try {
+        map.removeStyleSource(sourceId)
+      } catch (error: MaplibreException) {
+        throw StyleMutationException(error.message, error)
+      }
       forgetFeatureStates(sourceId)
       reportSourceChanged(sourceId)
     }

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/sources/CustomGeometrySourceTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/sources/CustomGeometrySourceTest.kt
@@ -171,11 +171,11 @@ class CustomGeometrySourceTest {
         requests += tile
         cover(tile.bounds, featureName)
       }
-    binding.install(source)
+    val handle = state.style.sources.add(source)
     binding.install(FillLayer(id = "custom-fill", source = source))
     state.desiredStyleRevision =
       DesiredStyleRevision(listOf(source.definition()), emptyList(), emptyList())
-    return assertIs<CustomGeometrySourceHandle>(state.style.source(SOURCE_ID))
+    return assertIs<CustomGeometrySourceHandle>(handle)
   }
 
   private suspend fun BridgeMapFixture.queryCenter() =

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/sources/CustomVectorSourceNativeTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/sources/CustomVectorSourceNativeTest.kt
@@ -34,7 +34,7 @@ class CustomVectorSourceNativeTest {
         }
       val layer = CircleLayer("empty-points", source)
       layer.sourceLayer = "points"
-      style.install(source)
+      fixture.state.style.sources.add(source)
       style.install(layer)
 
       fixture.pumpUntil("the empty custom MVT tile to be requested") { requests.isNotEmpty() }
@@ -47,7 +47,7 @@ class CustomVectorSourceNativeTest {
 
       fixture.state.desiredStyleRevision =
         DesiredStyleRevision(listOf(source.definition()), emptyList(), emptyList())
-      val handle = assertIs<CustomVectorSourceHandle>(fixture.state.style.source("empty"))
+      val handle = assertIs<CustomVectorSourceHandle>(fixture.state.style.sources["empty"])
       assertTrue(handle.querySourceFeatures(setOf("points")).isEmpty())
       val answered = requests.size
 

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/sources/GeoJsonSourceStyleReloadTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/sources/GeoJsonSourceStyleReloadTest.kt
@@ -5,7 +5,6 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
 import kotlinx.serialization.json.JsonObject
 import org.maplibre.compose.style.BaseStyle
-import org.maplibre.compose.style.install
 import org.maplibre.compose.testing.MapTestResult
 import org.maplibre.compose.testing.createMapFixture
 import org.maplibre.compose.testing.runMapTest
@@ -23,8 +22,7 @@ class GeoJsonSourceStyleReloadTest {
           data = GeoJsonData.Features(FeatureCollection<Geometry, JsonObject?>(emptyList())),
           options = GeoJsonOptions(),
         )
-      checkNotNull(fixture.style).install(source)
-      val handle = assertIs<GeoJsonSourceHandle>(fixture.state.style.source("points"))
+      val handle = assertIs<GeoJsonSourceHandle>(fixture.state.style.sources.add(source))
 
       fixture.loadStyle(REPLACEMENT_STYLE)
 

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/sources/GeoJsonSourceUpdateTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/sources/GeoJsonSourceUpdateTest.kt
@@ -39,13 +39,13 @@ class GeoJsonSourceUpdateTest {
             GeoJsonData.Features(pointAt(ORIGIN)),
             GeoJsonOptions(),
           )
-        style.install(source)
+        fixture.state.style.sources.add(source)
         val layer = CircleLayer(LAYER_ID, source)
         layer.setCircleRadius(const(16.dp).compile(ExpressionContext.None))
         layer.setCircleColor(const(Color.Black))
         layer.setCircleOpacity(const(1.0f))
         style.install(layer)
-        val sourceHandle = assertIs<GeoJsonSourceHandle>(fixture.state.style.source(SOURCE_ID))
+        val sourceHandle = assertIs<GeoJsonSourceHandle>(fixture.state.style.sources[SOURCE_ID])
 
         val centerX = 256
         val centerY = 256
@@ -71,7 +71,7 @@ class GeoJsonSourceUpdateTest {
       createMapFixture().use { fixture ->
         fixture.loadStyle(CLUSTERED_STYLE)
         fixture.state.setCameraPosition(CameraPosition(target = ORIGIN, zoom = 14.0))
-        val handle = assertIs<GeoJsonSourceHandle>(fixture.state.style.source(SOURCE_ID))
+        val handle = assertIs<GeoJsonSourceHandle>(fixture.state.style.sources[SOURCE_ID])
         fixture.pumpUntil("the base-style point to render") {
           fixture.readPixel(256, 256).isNear(CIRCLE)
         }
@@ -89,7 +89,7 @@ class GeoJsonSourceUpdateTest {
     createMapFixture().use { fixture ->
       fixture.loadStyle(MIN_ZOOM_STYLE)
       fixture.state.setCameraPosition(CameraPosition(target = ORIGIN, zoom = 6.0))
-      val handle = assertIs<GeoJsonSourceHandle>(fixture.state.style.source(SOURCE_ID))
+      val handle = assertIs<GeoJsonSourceHandle>(fixture.state.style.sources[SOURCE_ID])
       fixture.pumpUntil("the source to stay hidden below its minimum zoom") {
         fixture.readPixel(256, 256).isNear(BACKGROUND)
       }
@@ -108,14 +108,14 @@ class GeoJsonSourceUpdateTest {
       createMapFixture().use { fixture ->
         fixture.loadStyle(STYLE)
         val style = checkNotNull(fixture.style)
-        style.install(
+        fixture.state.style.sources.add(
           GeoJsonSource(
             SOURCE_ID,
             GeoJsonData.Features(pointAt(ORIGIN)),
             GeoJsonOptions(),
           )
         )
-        val handle = assertIs<GeoJsonSourceHandle>(fixture.state.style.source(SOURCE_ID))
+        val handle = assertIs<GeoJsonSourceHandle>(fixture.state.style.sources[SOURCE_ID])
         style.removeSource(SOURCE_ID)
         style.install(
           GeoJsonSource(

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/sources/VectorSourceQueryTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/sources/VectorSourceQueryTest.kt
@@ -13,7 +13,7 @@ class VectorSourceQueryTest {
   fun a_vector_handle_queries_the_loaded_source(): MapTestResult = runMapTest {
     createMapFixture().use { fixture ->
       fixture.loadStyle(VECTOR_STYLE)
-      val handle = assertIs<VectorSourceHandle>(fixture.state.style.source("vector"))
+      val handle = assertIs<VectorSourceHandle>(fixture.state.style.sources["vector"])
 
       assertTrue(handle.querySourceFeatures(setOf("places")).isEmpty())
     }


### PR DESCRIPTION
## Description

Adds stable loaded-style source and layer registries, imperative source and image commands with generation and ownership checks, and attribution derived from the source registry.

## Validation

`mise run check`, `mise run test:android`, `mise run test:desktop`, `mise run test:ios`, and `caffeinate -dimsu mise run test:js` pass locally.

## AI assistance

Codex with GPT-5 implemented, tested, and documented this change under user direction.
