### PR TITLE
Report resource provider outcomes

### DIFF
--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Requests.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Requests.kt
@@ -8,6 +8,9 @@ import org.maplibre.compose.map.MaplibreMap
 import org.maplibre.compose.map.rememberDefaultMapRuntime
 import org.maplibre.compose.map.rememberMapState
 import org.maplibre.compose.resource.MapRequestTransform
+import org.maplibre.compose.resource.MapResourceError
+import org.maplibre.compose.resource.MapResourceKind
+import org.maplibre.compose.resource.MapResourceLoad
 import org.maplibre.compose.resource.MapResourceProvider
 
 @Composable
@@ -34,5 +37,27 @@ fun assetProvider(): MapResourceProvider {
   // #region provider
   val provider = MapResourceProvider(scheme = "app") { request -> readAsset(request.url) }
   // #endregion provider
+  return provider
+}
+
+@Suppress("UNUSED_PARAMETER") suspend fun readTile(url: String): ByteArray? = null
+
+fun tileProvider(): MapResourceProvider {
+  // #region outcomes
+  val provider =
+    MapResourceProvider(
+      accepts = { request -> request.kind == MapResourceKind.Tile },
+      load = { request ->
+        try {
+          when (val bytes = readTile(request.url)) {
+            null -> MapResourceLoad.NoContent()
+            else -> MapResourceLoad.Bytes(bytes)
+          }
+        } catch (error: Exception) {
+          MapResourceLoad.Failed(MapResourceError.Server, error.message ?: "tile read failed")
+        }
+      },
+    )
+  // #endregion outcomes
   return provider
 }

--- a/docs/src/content/docs/requests.mdx
+++ b/docs/src/content/docs/requests.mdx
@@ -35,3 +35,13 @@ options when you call <Api of="createMapRuntime" />. The scheme factory
 accepts every URL with that scheme:
 
 <Code code={region(requests, "provider")} lang="kotlin" title="App.kt" />
+
+### Choose an outcome
+
+A load returns a <Api of="MapResourceLoad" />. Each case corresponds to one
+HTTP response. Return `Bytes` with the body. Return `NoContent` for a tile
+outside the data set, and the map renders an empty tile without an error.
+Return `Failed` with a <Api of="MapResourceError" /> for an error. A provider
+that reads tiles from local storage uses all three:
+
+<Code code={region(requests, "outcomes")} lang="kotlin" title="App.kt" />

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/resource/MapResourceRequests.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/resource/MapResourceRequests.kt
@@ -1,5 +1,7 @@
 package org.maplibre.compose.resource
 
+import kotlin.time.Instant
+
 /**
  * The kind of resource MapLibre is about to fetch.
  *
@@ -47,49 +49,163 @@ public fun interface MapRequestInterceptor {
   public fun intercept(request: MapResourceRequest): MapRequestTransform
 }
 
-/** Bytes or a failure for a request that [MapResourceProvider.accepts] returned true for. */
+/**
+ * One resource that a [MapResourceProvider] loads.
+ *
+ * [url] is the URL after the engine resolves tile-server aliases. [requestedUrl] is the URL in the
+ * style. The prior fields are the validators and the body of the cached copy. A provider uses them
+ * to revalidate. The browser has no ambient cache, so it passes the default for every field after
+ * [kind].
+ */
+public class MapResourceLoadRequest(
+  public val url: String,
+  public val kind: MapResourceKind,
+  public val requestedUrl: String = url,
+  public val loadingMethod: LoadingMethod = LoadingMethod.All,
+  public val priority: Priority = Priority.Regular,
+  public val usage: Usage = Usage.Online,
+  public val storagePolicy: StoragePolicy = StoragePolicy.Permanent,
+  /** The inclusive byte range to load, or null for the whole resource. */
+  public val range: LongRange? = null,
+  public val priorEtag: String? = null,
+  public val priorModified: Instant? = null,
+  public val priorExpires: Instant? = null,
+  /** The cached body, or null when the cache has no body for this resource. */
+  public val priorData: ByteArray? = null,
+) {
+  /** Limits the load to the cache or to the network. [All] allows both. */
+  public enum class LoadingMethod {
+    All,
+    CacheOnly,
+    NetworkOnly,
+  }
+
+  /** The priority of the load. */
+  public enum class Priority {
+    Regular,
+    Low,
+  }
+
+  /** The consumer of the resource: a map, or an offline pack download. */
+  public enum class Usage {
+    Online,
+    Offline,
+  }
+
+  /** The cache retention policy for the resource. */
+  public enum class StoragePolicy {
+    Permanent,
+    Volatile,
+  }
+
+  override fun toString(): String = "MapResourceLoadRequest(url=$url, kind=$kind)"
+}
+
+/** The cause of a failed resource load. Each reason corresponds to an HTTP status. */
+public enum class MapResourceError {
+  /** A 404. */
+  NotFound,
+
+  /** A 5xx. */
+  Server,
+
+  /** A transport failure. */
+  Connection,
+
+  /** A 429. */
+  RateLimit,
+  Other,
+}
+
+/**
+ * The result of [MapResourceProvider.load].
+ *
+ * Each case corresponds to one HTTP response, and the engine handles the case as it handles that
+ * response. [modified] and [expires] are cache metadata that every case can include.
+ */
 public sealed interface MapResourceLoad {
+  public val modified: Instant?
+  public val expires: Instant?
+
   /**
-   * A successful body for the request.
+   * A 200: the body of the resource.
    *
-   * [etag] and [mustRevalidate] are optional cache validators. Native applies them to the ambient
-   * cache; the browser ignores them.
+   * [etag] and [mustRevalidate] are validators for the ambient cache.
    */
   public class Bytes(
     public val bytes: ByteArray,
     public val etag: String? = null,
     public val mustRevalidate: Boolean = false,
+    override val modified: Instant? = null,
+    override val expires: Instant? = null,
   ) : MapResourceLoad
 
-  /** A failure that MapLibre should treat as a failed fetch. */
-  public data class Failed(public val message: String) : MapResourceLoad
+  /**
+   * A 204: the resource exists and is empty.
+   *
+   * Return this for a tile outside the data set. The engine renders an empty tile and reports no
+   * error.
+   */
+  public class NoContent(
+    override val modified: Instant? = null,
+    override val expires: Instant? = null,
+  ) : MapResourceLoad
+
+  /**
+   * A 304: the cached body in the request is current.
+   *
+   * Valid only when the request has a [MapResourceLoadRequest.priorEtag] or a
+   * [MapResourceLoadRequest.priorModified]. The browser has neither, so it reports this result as
+   * an error.
+   */
+  public class NotModified(
+    override val modified: Instant? = null,
+    override val expires: Instant? = null,
+  ) : MapResourceLoad
+
+  /**
+   * A failed load.
+   *
+   * [reason] is the HTTP status that the engine handles. MapLibre Native reports a tile error for a
+   * [MapResourceError.NotFound] tile, and the browser skips the tile. Return [NoContent] for a tile
+   * outside the data set.
+   */
+  public class Failed(
+    public val reason: MapResourceError,
+    public val message: String,
+    public val retryAfter: Instant? = null,
+    override val modified: Instant? = null,
+    override val expires: Instant? = null,
+  ) : MapResourceLoad
 }
 
 /**
- * Serves resource bytes for requests the application accepts.
+ * Loads resources for the requests that the application accepts.
  *
- * [accepts] runs on a network thread and must return quickly. Return true only for requests this
- * provider will load. [load] may suspend; cancellation means the engine no longer needs the
- * resource.
+ * [accepts] runs on a network thread and must return quickly. Return true only for requests that
+ * this provider loads. [load] may suspend; cancellation means that the engine no longer needs the
+ * resource. An exception from [load] becomes a [MapResourceLoad.Failed] with reason
+ * [MapResourceError.Other].
  *
- * A true [accepts] result skips the engine HTTP client for that request, including its cache and
- * retry.
+ * A true [accepts] result replaces the engine HTTP client for that request. MapLibre Native stores
+ * the result in its ambient cache. After the cached entry expires, the engine requests the resource
+ * again with the prior validators set on the request.
  */
 public interface MapResourceProvider {
   public fun accepts(request: MapResourceRequest): Boolean
 
-  public suspend fun load(request: MapResourceRequest): MapResourceLoad
+  public suspend fun load(request: MapResourceLoadRequest): MapResourceLoad
 }
 
 /** Returns a provider that calls [accepts] and [load]. */
 public fun MapResourceProvider(
   accepts: (MapResourceRequest) -> Boolean,
-  load: suspend (MapResourceRequest) -> MapResourceLoad,
+  load: suspend (MapResourceLoadRequest) -> MapResourceLoad,
 ): MapResourceProvider =
   object : MapResourceProvider {
     override fun accepts(request: MapResourceRequest): Boolean = accepts(request)
 
-    override suspend fun load(request: MapResourceRequest): MapResourceLoad = load(request)
+    override suspend fun load(request: MapResourceLoadRequest): MapResourceLoad = load(request)
   }
 
 /**
@@ -99,7 +215,7 @@ public fun MapResourceProvider(
  */
 public fun MapResourceProvider(
   scheme: String,
-  load: suspend (MapResourceRequest) -> ByteArray,
+  load: suspend (MapResourceLoadRequest) -> ByteArray,
 ): MapResourceProvider {
   val prefix = "${scheme.trimEnd(':')}:"
   return MapResourceProvider(

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/resource/MapRequestInterceptorTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/resource/MapRequestInterceptorTest.kt
@@ -93,7 +93,7 @@ class MapRequestInterceptorTest {
     assertFalse(
       provider.accepts(MapResourceRequest("https://example.test/style.json", MapResourceKind.Style))
     )
-    val load = provider.load(MapResourceRequest("app://style.json", MapResourceKind.Style))
+    val load = provider.load(MapResourceLoadRequest("app://style.json", MapResourceKind.Style))
     val bytes = load as MapResourceLoad.Bytes
     assertEquals("body", bytes.bytes.decodeToString())
   }

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsTypes.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsTypes.kt
@@ -2,6 +2,7 @@ package org.maplibre.compose.gljs
 
 import js.buffer.ArrayBuffer
 import js.typedarrays.Uint8Array
+import kotlin.js.Date
 import kotlin.js.Promise
 import web.html.HTMLElement
 
@@ -64,6 +65,7 @@ internal external interface RequestParameters {
 
 internal external interface ProtocolResponse {
   var data: ArrayBuffer
+  var expires: Date?
 }
 
 internal external interface FilterSpecification

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/resource/GlJsRequestController.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/resource/GlJsRequestController.kt
@@ -3,6 +3,7 @@ package org.maplibre.compose.resource
 import js.buffer.ArrayBuffer
 import js.objects.unsafeJso
 import js.typedarrays.Uint8Array
+import kotlin.js.Date
 import kotlin.js.Promise
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
@@ -44,7 +45,7 @@ internal class GlJsRequestController(private val config: MapResourceConfig) : Au
     )
   }
 
-  private fun loadProtocol(
+  internal fun loadProtocol(
     request: RequestParameters,
     abortController: Any,
   ): Promise<ProtocolResponse> {
@@ -52,10 +53,9 @@ internal class GlJsRequestController(private val config: MapResourceConfig) : Au
     val work = scope.async {
       val provider =
         config.provider ?: throw IllegalStateException("No resource provider is installed")
-      when (val result = provider.load(MapResourceRequest(parsed.url, parsed.kind))) {
-        is MapResourceLoad.Bytes -> result.bytes.toProtocolResponse()
-        is MapResourceLoad.Failed -> throw IllegalStateException(result.message)
-      }
+      // MapLibre GL JS passes only the URL and the kind, so every other field is the default.
+      val result = provider.load(MapResourceLoadRequest(parsed.url, parsed.kind))
+      result.toProtocolResponse(parsed.url)
     }
     val signal = abortController.asDynamic().signal
     val abort: () -> Unit = { work.cancel() }
@@ -145,8 +145,48 @@ private fun requestParameters(url: String, headers: Map<String, String>): Any {
   return params
 }
 
-private fun ByteArray.toProtocolResponse(): ProtocolResponse {
+/**
+ * The HTTP status that MapLibre GL JS reads from a rejected protocol promise, or null for a reason
+ * with no status. Only 404 changes its behavior: it skips a tile with that status.
+ */
+internal fun MapResourceError.httpStatus(): Int? =
+  when (this) {
+    MapResourceError.NotFound -> 404
+    MapResourceError.Server -> 500
+    MapResourceError.RateLimit -> 429
+    MapResourceError.Connection,
+    MapResourceError.Other -> null
+  }
+
+/**
+ * The rejection of a protocol load. [status] is set on the JS object for MapLibre GL JS to read.
+ */
+internal class ResourceLoadError(message: String, val status: Int?) : Exception(message) {
+  init {
+    if (status != null) asDynamic().status = status
+  }
+}
+
+/** Converts a load result to the protocol promise outcome of the corresponding HTTP response. */
+private fun MapResourceLoad.toProtocolResponse(url: String): ProtocolResponse {
+  val expires = expires?.let { Date(it.toEpochMilliseconds().toDouble()) }
+  return when (this) {
+    is MapResourceLoad.Bytes -> bytes.toProtocolResponse(expires)
+    is MapResourceLoad.NoContent -> ByteArray(0).toProtocolResponse(expires)
+    is MapResourceLoad.NotModified ->
+      throw ResourceLoadError(
+        "Resource provider returned NotModified for $url, but the browser sends no validators",
+        status = null,
+      )
+    is MapResourceLoad.Failed -> throw ResourceLoadError(message, reason.httpStatus())
+  }
+}
+
+private fun ByteArray.toProtocolResponse(expires: Date?): ProtocolResponse {
   val bytes = Uint8Array<ArrayBuffer>(size)
   forEachIndexed { index, byte -> bytes.asDynamic()[index] = byte.toInt() and 0xFF }
-  return unsafeJso { data = bytes.buffer }
+  return unsafeJso {
+    data = bytes.buffer
+    if (expires != null) this.expires = expires
+  }
 }

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/resource/GlJsRequestControllerTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/resource/GlJsRequestControllerTest.kt
@@ -1,11 +1,18 @@
 package org.maplibre.compose.resource
 
+import js.buffer.ArrayBuffer
+import kotlin.js.Promise
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlin.time.Instant
+import kotlinx.coroutines.await
+import kotlinx.coroutines.test.runTest
+import org.maplibre.compose.gljs.ProtocolResponse
+import org.maplibre.compose.gljs.RequestParameters
 
 class GlJsRequestControllerTest {
 
@@ -126,6 +133,66 @@ class GlJsRequestControllerTest {
     assertNull(controller.transformRequest("https://tiles.example.com/style.json", "Tile"))
     controller.close()
   }
+
+  @Test
+  fun bytes_resolve_with_the_body_and_expiry() = runTest {
+    val expires = Instant.fromEpochMilliseconds(1_000)
+    val response =
+      load(MapResourceLoad.Bytes("body".encodeToByteArray(), expires = expires)).await()
+    assertEquals("body", response.data.decodeToString())
+    assertEquals(1_000.0, response.expires?.getTime())
+  }
+
+  @Test
+  fun no_content_resolves_with_an_empty_body() = runTest {
+    val response = load(MapResourceLoad.NoContent()).await()
+    assertEquals(0, response.data.byteLength)
+    assertNull(response.expires)
+  }
+
+  @Test
+  fun not_found_rejects_with_status_404() = runTest {
+    val error = rejection(MapResourceLoad.Failed(MapResourceError.NotFound, "no tile"))
+    assertEquals(404, error.asDynamic().status as Int)
+    assertEquals("no tile", error.message)
+  }
+
+  @Test
+  fun a_reason_without_a_status_rejects_without_one() = runTest {
+    val error = rejection(MapResourceLoad.Failed(MapResourceError.Connection, "offline"))
+    assertEquals(null, error.asDynamic().status)
+  }
+
+  @Test
+  fun not_modified_rejects_as_a_provider_error() = runTest {
+    val error = rejection(MapResourceLoad.NotModified())
+    assertEquals(null, error.asDynamic().status)
+    assertTrue(error.message.orEmpty().contains("NotModified"))
+  }
+
+  private fun load(result: MapResourceLoad): Promise<ProtocolResponse> {
+    val controller =
+      GlJsRequestController(
+        MapResourceConfig(provider = MapResourceProvider(accepts = { true }, load = { result }))
+      )
+    val protocolUrl = controller.protocolUrl("app://tile", MapResourceKind.Tile)
+    val request = js("({})").unsafeCast<RequestParameters>()
+    request.asDynamic().url = protocolUrl
+    return controller.loadProtocol(request, js("new AbortController()")).also {
+      it.then({ controller.close() }, { controller.close() })
+    }
+  }
+
+  private suspend fun rejection(result: MapResourceLoad): Throwable =
+    try {
+      load(result).await()
+      error("expected the protocol promise to reject")
+    } catch (error: Throwable) {
+      error
+    }
+
+  private fun ArrayBuffer.decodeToString(): String =
+    js("new TextDecoder()").decode(this).unsafeCast<String>()
 
   private companion object {
     val SCHEME = Regex("^mlc-res-[0-9a-f]{32}$")

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/resource/MlnFfiResourceProvider.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/resource/MlnFfiResourceProvider.kt
@@ -4,6 +4,7 @@ import co.touchlab.kermit.Logger
 import kotlin.concurrent.Volatile
 import kotlin.concurrent.atomics.AtomicBoolean
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
+import kotlin.time.Instant
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
@@ -17,12 +18,16 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.maplibre.compose.util.rethrowIfFatal
 import org.maplibre.nativeffi.resource.ResourceErrorReason
+import org.maplibre.nativeffi.resource.ResourceLoadingMethod
+import org.maplibre.nativeffi.resource.ResourcePriority
 import org.maplibre.nativeffi.resource.ResourceProviderCallback
 import org.maplibre.nativeffi.resource.ResourceProviderDecision
 import org.maplibre.nativeffi.resource.ResourceRequest
 import org.maplibre.nativeffi.resource.ResourceRequestHandle
 import org.maplibre.nativeffi.resource.ResourceResponse
 import org.maplibre.nativeffi.resource.ResourceResponseStatus
+import org.maplibre.nativeffi.resource.ResourceStoragePolicy
+import org.maplibre.nativeffi.resource.ResourceUsage
 
 /**
  * URI schemes MapLibre's own loader handles; everything else is ours. Its network stack rejects a
@@ -77,7 +82,7 @@ internal class MlnFfiResourceProvider(
     val mapRequest = MapResourceRequest(url, request.kind.toCommon())
     val user = userProvider
     if (user != null && user.acceptsOrDeclines(mapRequest)) {
-      takeUser(FfiResourceRequest(handle), mapRequest, url, request.requestedUrl)
+      takeUser(FfiResourceRequest(handle), request.toLoadRequest())
       return ResourceProviderDecision.HANDLE
     }
     if (passThroughNetwork && isMapLibresToFetch(url)) {
@@ -90,12 +95,9 @@ internal class MlnFfiResourceProvider(
     return ResourceProviderDecision.HANDLE
   }
 
-  internal fun takeUser(
-    request: TakenResourceRequest,
-    mapRequest: MapResourceRequest,
-    url: String,
-    requestedUrl: String,
-  ) {
+  internal fun takeUser(request: TakenResourceRequest, load: MapResourceLoadRequest) {
+    val url = load.url
+    val requestedUrl = load.requestedUrl
     if (!accepting.load()) {
       refuse(request, url, requestedUrl)
       return
@@ -108,7 +110,7 @@ internal class MlnFfiResourceProvider(
     var started = false
     userScope.launch(start = CoroutineStart.UNDISPATCHED) {
       started = true
-      serveUser(request, provider, mapRequest, url, requestedUrl)
+      serveUser(request, provider, load)
     }
     if (!started) refuse(request, url, requestedUrl)
   }
@@ -116,16 +118,16 @@ internal class MlnFfiResourceProvider(
   private suspend fun serveUser(
     request: TakenResourceRequest,
     provider: MapResourceProvider,
-    mapRequest: MapResourceRequest,
-    url: String,
-    requestedUrl: String,
+    load: MapResourceLoadRequest,
   ) {
+    val url = load.url
+    val requestedUrl = load.requestedUrl
     try {
       request.use { open ->
         if (open.isCancelled()) return
         val response =
           try {
-            loadWhileRequestOpen(open, provider, mapRequest)
+            loadWhileRequestOpen(open, provider, load)
           } catch (error: CancellationException) {
             if (open.isCancelled()) return
             failure(
@@ -228,9 +230,9 @@ internal class MlnFfiResourceProvider(
   private suspend fun loadWhileRequestOpen(
     request: TakenResourceRequest,
     provider: MapResourceProvider,
-    mapRequest: MapResourceRequest,
+    resource: MapResourceLoadRequest,
   ): ResourceResponse = coroutineScope {
-    val load = async { provider.load(mapRequest).toResourceResponse() }
+    val load = async { provider.load(resource).toResourceResponse() }
     val watch = launch {
       while (load.isActive) {
         if (request.isCancelled()) {
@@ -359,17 +361,69 @@ private fun Char.isAsciiLetter(): Boolean = this in 'a'..'z' || this in 'A'..'Z'
 
 private fun Char.isAsciiDigit(): Boolean = this in '0'..'9'
 
-private fun MapResourceLoad.toResourceResponse(): ResourceResponse =
+/** Copies the FFI request into the request a [MapResourceProvider] loads, field for field. */
+internal fun ResourceRequest.toLoadRequest(): MapResourceLoadRequest =
+  MapResourceLoadRequest(
+    url = resolvedUrl,
+    kind = kind.toCommon(),
+    requestedUrl = requestedUrl,
+    loadingMethod =
+      when (loadingMethod) {
+        ResourceLoadingMethod.CACHE_ONLY -> MapResourceLoadRequest.LoadingMethod.CacheOnly
+        ResourceLoadingMethod.NETWORK_ONLY -> MapResourceLoadRequest.LoadingMethod.NetworkOnly
+        else -> MapResourceLoadRequest.LoadingMethod.All
+      },
+    priority =
+      when (priority) {
+        ResourcePriority.LOW -> MapResourceLoadRequest.Priority.Low
+        else -> MapResourceLoadRequest.Priority.Regular
+      },
+    usage =
+      when (usage) {
+        ResourceUsage.OFFLINE -> MapResourceLoadRequest.Usage.Offline
+        else -> MapResourceLoadRequest.Usage.Online
+      },
+    storagePolicy =
+      when (storagePolicy) {
+        ResourceStoragePolicy.VOLATILE -> MapResourceLoadRequest.StoragePolicy.Volatile
+        else -> MapResourceLoadRequest.StoragePolicy.Permanent
+      },
+    range = range?.let { it.start..it.end },
+    priorEtag = priorEtag,
+    priorModified = priorModifiedUnixMs?.let(Instant::fromEpochMilliseconds),
+    priorExpires = priorExpiresUnixMs?.let(Instant::fromEpochMilliseconds),
+    priorData = priorData.takeIf { it.isNotEmpty() },
+  )
+
+/** Copies a load result to the FFI response, field for field. */
+internal fun MapResourceLoad.toResourceResponse(): ResourceResponse {
+  val response =
+    when (this) {
+      is MapResourceLoad.Bytes ->
+        ResourceResponse(ResourceResponseStatus.OK).also {
+          it.bytes = bytes
+          it.etag = etag
+          it.mustRevalidate = mustRevalidate
+        }
+      is MapResourceLoad.NoContent -> ResourceResponse(ResourceResponseStatus.NO_CONTENT)
+      is MapResourceLoad.NotModified -> ResourceResponse(ResourceResponseStatus.NOT_MODIFIED)
+      is MapResourceLoad.Failed ->
+        ResourceResponse(ResourceResponseStatus.ERROR).also {
+          it.errorReason = reason.toFfi()
+          it.errorMessage = message
+          it.retryAfterUnixMs = retryAfter?.toEpochMilliseconds()
+        }
+    }
+  response.modifiedUnixMs = modified?.toEpochMilliseconds()
+  response.expiresUnixMs = expires?.toEpochMilliseconds()
+  return response
+}
+
+private fun MapResourceError.toFfi(): ResourceErrorReason =
   when (this) {
-    is MapResourceLoad.Bytes ->
-      ResourceResponse(ResourceResponseStatus.OK).also {
-        it.bytes = bytes
-        it.etag = etag
-        it.mustRevalidate = mustRevalidate
-      }
-    is MapResourceLoad.Failed ->
-      ResourceResponse(ResourceResponseStatus.ERROR).also {
-        it.errorReason = ResourceErrorReason.OTHER
-        it.errorMessage = message
-      }
+    MapResourceError.NotFound -> ResourceErrorReason.NOT_FOUND
+    MapResourceError.Server -> ResourceErrorReason.SERVER
+    MapResourceError.Connection -> ResourceErrorReason.CONNECTION
+    MapResourceError.RateLimit -> ResourceErrorReason.RATE_LIMIT
+    MapResourceError.Other -> ResourceErrorReason.OTHER
   }

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/resource/MlnFfiResourceRequestTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/resource/MlnFfiResourceRequestTest.kt
@@ -12,6 +12,7 @@ import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Instant
 import kotlin.time.TimeSource
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -22,8 +23,14 @@ import org.maplibre.compose.mlnffi.launchTestTask
 import org.maplibre.compose.mlnffi.parkForTest
 import org.maplibre.compose.testing.RecordingList
 import org.maplibre.nativeffi.resource.ResourceErrorReason
+import org.maplibre.nativeffi.resource.ResourceKind
+import org.maplibre.nativeffi.resource.ResourceLoadingMethod
+import org.maplibre.nativeffi.resource.ResourcePriority
+import org.maplibre.nativeffi.resource.ResourceRequest
 import org.maplibre.nativeffi.resource.ResourceResponse
 import org.maplibre.nativeffi.resource.ResourceResponseStatus
+import org.maplibre.nativeffi.resource.ResourceStoragePolicy
+import org.maplibre.nativeffi.resource.ResourceUsage
 
 /** Long enough that a wait failing here means the thing waited for is not going to happen. */
 private const val WAIT_SECONDS = 10L
@@ -89,7 +96,7 @@ class MlnFfiResourceRequestTest {
     provider.userProvider =
       MapResourceProvider(accepts = { true }, load = { MapResourceLoad.Bytes(ByteArray(0)) })
     val request = RecordedRequest()
-    provider.takeUser(request, MapResourceRequest(URL, MapResourceKind.Style), URL, URL)
+    provider.takeUser(request, MapResourceLoadRequest(URL, MapResourceKind.Style))
     request.awaitClose()
     assertEquals(1, request.closes)
     assertEquals(1, request.completions)
@@ -106,7 +113,7 @@ class MlnFfiResourceRequestTest {
       MapResourceProvider(accepts = { true }, load = { MapResourceLoad.Bytes(ByteArray(0)) })
     provider.close()
     val request = RecordedRequest()
-    provider.takeUser(request, MapResourceRequest(URL, MapResourceKind.Style), URL, URL)
+    provider.takeUser(request, MapResourceLoadRequest(URL, MapResourceKind.Style))
     assertEquals(1, request.completions)
     assertEquals(ResourceResponseStatus.ERROR, request.response.status)
     assertContains(request.response.errorMessage.orEmpty(), "shut down")
@@ -132,7 +139,7 @@ class MlnFfiResourceRequestTest {
         },
       )
     val request = RecordedRequest()
-    provider.takeUser(request, MapResourceRequest(URL, MapResourceKind.Style), URL, URL)
+    provider.takeUser(request, MapResourceLoadRequest(URL, MapResourceKind.Style))
     assertTrue(loading.await(WAIT_SECONDS * 1_000), "the user load never started")
 
     request.cancel()
@@ -154,10 +161,103 @@ class MlnFfiResourceRequestTest {
         load = { throw CancellationException("timeout") },
       )
     val request = RecordedRequest()
-    provider.takeUser(request, MapResourceRequest(URL, MapResourceKind.Style), URL, URL)
+    provider.takeUser(request, MapResourceLoadRequest(URL, MapResourceKind.Style))
     request.awaitAnswer()
     assertEquals(ResourceResponseStatus.ERROR, request.response.status)
     assertContains(request.response.errorMessage.orEmpty(), "cancelled")
+    request.awaitClose()
+  }
+
+  @Test
+  fun bytes_complete_as_ok_with_validators() {
+    val response =
+      MapResourceLoad.Bytes(
+          "body".encodeToByteArray(),
+          etag = "v1",
+          mustRevalidate = true,
+          modified = Instant.fromEpochMilliseconds(10),
+          expires = Instant.fromEpochMilliseconds(20),
+        )
+        .toResourceResponse()
+    assertEquals(ResourceResponseStatus.OK, response.status)
+    assertEquals("body", response.bytes.decodeToString())
+    assertEquals("v1", response.etag)
+    assertTrue(response.mustRevalidate)
+    assertEquals(10, response.modifiedUnixMs)
+    assertEquals(20, response.expiresUnixMs)
+  }
+
+  @Test
+  fun no_content_and_not_modified_complete_with_their_status() {
+    val noContent =
+      MapResourceLoad.NoContent(expires = Instant.fromEpochMilliseconds(20)).toResourceResponse()
+    assertEquals(ResourceResponseStatus.NO_CONTENT, noContent.status)
+    assertEquals(20, noContent.expiresUnixMs)
+    val notModified =
+      MapResourceLoad.NotModified(modified = Instant.fromEpochMilliseconds(10)).toResourceResponse()
+    assertEquals(ResourceResponseStatus.NOT_MODIFIED, notModified.status)
+    assertEquals(10, notModified.modifiedUnixMs)
+  }
+
+  @Test
+  fun a_failure_keeps_its_reason_and_retry_time() {
+    val response =
+      MapResourceLoad.Failed(
+          MapResourceError.RateLimit,
+          "slow down",
+          retryAfter = Instant.fromEpochMilliseconds(30),
+        )
+        .toResourceResponse()
+    assertEquals(ResourceResponseStatus.ERROR, response.status)
+    assertEquals(ResourceErrorReason.RATE_LIMIT, response.errorReason)
+    assertEquals("slow down", response.errorMessage)
+    assertEquals(30, response.retryAfterUnixMs)
+  }
+
+  @Test
+  fun the_ffi_request_copies_into_the_load_request() {
+    val ffi =
+      ResourceRequest(
+        requestedUrl = "maplibre://tiles/1/2/3",
+        resolvedUrl = "https://tiles.example.com/1/2/3.pbf",
+        kind = ResourceKind.TILE,
+        loadingMethod = ResourceLoadingMethod.CACHE_ONLY,
+        priority = ResourcePriority.LOW,
+        usage = ResourceUsage.OFFLINE,
+        storagePolicy = ResourceStoragePolicy.VOLATILE,
+        range = ResourceRequest.ByteRange(0, 9),
+        priorModifiedUnixMs = 10,
+        priorExpiresUnixMs = 20,
+        priorEtag = "v1",
+        priorData = "old".encodeToByteArray(),
+      )
+    val load = ffi.toLoadRequest()
+    assertEquals("https://tiles.example.com/1/2/3.pbf", load.url)
+    assertEquals("maplibre://tiles/1/2/3", load.requestedUrl)
+    assertEquals(MapResourceKind.Tile, load.kind)
+    assertEquals(MapResourceLoadRequest.LoadingMethod.CacheOnly, load.loadingMethod)
+    assertEquals(MapResourceLoadRequest.Priority.Low, load.priority)
+    assertEquals(MapResourceLoadRequest.Usage.Offline, load.usage)
+    assertEquals(MapResourceLoadRequest.StoragePolicy.Volatile, load.storagePolicy)
+    assertEquals(0L..9L, load.range)
+    assertEquals(Instant.fromEpochMilliseconds(10), load.priorModified)
+    assertEquals(Instant.fromEpochMilliseconds(20), load.priorExpires)
+    assertEquals("v1", load.priorEtag)
+    assertEquals("old", load.priorData?.decodeToString())
+  }
+
+  @Test
+  fun a_user_load_reaches_the_request_as_the_ffi_response() {
+    val provider =
+      MlnFfiResourceProvider(getLogger = { null }, passThroughNetwork = true).also {
+        providers += it
+      }
+    provider.userProvider =
+      MapResourceProvider(accepts = { true }, load = { MapResourceLoad.NoContent() })
+    val request = RecordedRequest()
+    provider.takeUser(request, MapResourceLoadRequest(URL, MapResourceKind.Tile))
+    request.awaitAnswer()
+    assertEquals(ResourceResponseStatus.NO_CONTENT, request.response.status)
     request.awaitClose()
   }
 


### PR DESCRIPTION
Resolve #1228 

## Description

`MapResourceLoad` gains `NoContent`, `NotModified`, and a reason on `Failed`, and `MapResourceProvider.load` receives a `MapResourceLoadRequest` that copies every field of the FFI resource request, so each outcome behaves as the corresponding HTTP response does on each engine.

## Validation

JVM and browser resource tests pass, the iOS simulator target and the demo app compile, and `mise run fix` is clean.

## AI assistance

Claude Fable 5.1 in Claude Code.