### PR TITLE
Replace Kermit with a process-global map logger

### DIFF
--- a/.agents/docs/LOGGING.md
+++ b/.agents/docs/LOGGING.md
@@ -71,12 +71,13 @@ The library installs each engine's log seam once and forwards to the current
 ### MapLibre Native
 
 `Maplibre.setLogCallback` is the one seam. The library installs the callback
-when the first native runtime is created, after the platform initialization that
-loads the native library. The callback reads `MapLogging.logger` at call time.
-It maps `LogSeverity` to `MapLogLevel`, sets the source to `NativeEngine`, and
-puts the `LogEvent` name in `category`. The callback consumes every record. The
-engine's own fall-through sink is stderr on every platform this build targets,
-so leaving records to it loses them on Android
+when the first native runtime is created. `setLogCallback` loads the native
+library itself, so no other initialization has to run first. The callback reads
+`MapLogging.logger` at call time. It maps `LogSeverity` to `MapLogLevel`, sets
+the source to `NativeEngine`, and puts the `LogEvent` name in `category`. The
+callback consumes every record. The engine's own fall-through sink is stderr on
+every platform this build targets, so leaving records to it loses them on
+Android
 ([maplibre-native-ffi#679](https://github.com/maplibre/maplibre-native-ffi/issues/679)).
 
 The library changes no async severity mask. The engine's default delivers info
@@ -99,11 +100,11 @@ web in the same way that logcat is on Android.
 
 ## Inside the library
 
-Library code logs through an internal `MapLog` helper with the same call shape
+Library code logs through an internal `MapLog` object with the same call shape
 as the previous Kermit logger: a level method, an optional throwable, and a lazy
-message. The helper checks `minLevel` before it builds the message. Sessions and
-bindings take an optional `MapLog` so tests inject a recorder without touching
-the global.
+message. It reads `MapLogging.logger` at each call and checks `minLevel` before
+it builds the message. Sessions and bindings take a nullable `MapLog` so a test
+can disable logging. A test that asserts on records installs its own logger.
 
 The library's own records use the source `Library` and no category. The previous
 verbose level collapsed into `Debug`.
@@ -112,6 +113,6 @@ verbose level collapsed into `Debug`.
 
 The default logger writes at the matching level to `android.util.Log` on
 Android, `NSLog` on iOS, standard error on the JVM, and the matching `console`
-method in the browser. The tag is `maplibre-compose`. This reproduces the output
-that the Kermit default produced, so an application that configures nothing sees
-the same log.
+method in the browser. The tag is `maplibre-compose`. Standard error, rather
+than Kermit's standard output, keeps diagnostics apart from program output. An
+application that configures nothing sees its platform log, as before.

--- a/.agents/docs/LOGGING.md
+++ b/.agents/docs/LOGGING.md
@@ -1,0 +1,117 @@
+# Logging
+
+How MapLibre Compose delivers diagnostics, and how an application routes them
+into its own logging library.
+
+## The contract
+
+The library owns a small logging contract in `org.maplibre.compose.logging` and
+depends on no logging library. An application adapts the contract to the library
+that it uses, in a few lines.
+
+```kotlin
+public enum class MapLogLevel { Debug, Info, Warning, Error }
+
+public enum class MapLogSource { Library, NativeEngine, WebEngine }
+
+public class MapLogRecord(
+  public val level: MapLogLevel,
+  public val source: MapLogSource,
+  /** The engine's category when it reports one: a native event name, or a GL JS source or layer id. */
+  public val category: String?,
+  public val message: String,
+  public val throwable: Throwable?,
+)
+
+public fun interface MapLogger {
+  /** Records below this level are dropped before their message is built. */
+  public val minLevel: MapLogLevel get() = MapLogLevel.Debug
+  public fun log(record: MapLogRecord)
+}
+
+public object MapLogging {
+  /** The sink for every record. Null drops every record. Defaults to [platformLogger]. */
+  public var logger: MapLogger?
+  /** Writes to the platform log: logcat, NSLog, stderr, or the browser console. */
+  public val platformLogger: MapLogger
+}
+```
+
+`MapLogger.log` runs on any thread, including engine worker threads, and may run
+while the native engine holds its logging lock. An implementation returns
+quickly and calls no map API.
+
+A single record parameter keeps the interface evolvable. A field added to
+`MapLogRecord` breaks no implementer.
+
+Four levels match the levels that both engines and the browser console
+distinguish. MapLibre Native compiles debug records out of release builds and
+never delivers them to a callback.
+
+## Configuration is process-global
+
+`MapLogging.logger` is the only configuration point. The runtime options carry
+no logger.
+
+- The native log callback is process-global, and its records name no runtime.
+- The browser console is process-global.
+- The default runtime from `rememberDefaultMapRuntime` takes no options, so a
+  per-runtime setting misses the common case.
+- Every logging library that an application would plug in is itself a process
+  singleton.
+
+Tests that assert on log output install a recording logger and restore the
+previous one. Each platform test process runs without parallel forks.
+
+## Engine bridges
+
+The library installs each engine's log seam once and forwards to the current
+`MapLogging.logger`. Changing the logger later reinstalls nothing.
+
+### MapLibre Native
+
+`Maplibre.setLogCallback` is the one seam. The library installs the callback
+when the first native runtime is created, after the platform initialization that
+loads the native library. The callback reads `MapLogging.logger` at call time.
+It maps `LogSeverity` to `MapLogLevel`, sets the source to `NativeEngine`, and
+puts the `LogEvent` name in `category`. The callback consumes every record. The
+engine's own fall-through sink is stderr on every platform this build targets,
+so leaving records to it loses them on Android
+([maplibre-native-ffi#679](https://github.com/maplibre/maplibre-native-ffi/issues/679)).
+
+The library changes no async severity mask. The engine's default delivers info
+and warning records asynchronously and error records synchronously.
+
+Structured runtime events such as a failed style load or a render error stay on
+their existing paths: the lifecycle callbacks first, then the library log.
+
+### MapLibre GL JS
+
+The `error` event on the map is the one seam. The library's existing listener
+forwards each event at `Error` level with the source `WebEngine` and the event's
+source or layer id as `category`. Attaching that listener is also what silences
+the browser's own `console.error` fallback, so `Error` is the honest level.
+
+GL JS writes warnings, including style validation warnings, to `console.warn`
+directly, and its workers write to their own consoles. Neither is redirectable.
+The library leaves them in the browser console, which is the platform log on the
+web in the same way that logcat is on Android.
+
+## Inside the library
+
+Library code logs through an internal `MapLog` helper with the same call shape
+as the previous Kermit logger: a level method, an optional throwable, and a lazy
+message. The helper checks `minLevel` before it builds the message. Sessions and
+bindings take an optional `MapLog` so tests inject a recorder without touching
+the global.
+
+The library's own records use the source `Library` and no category. The previous
+verbose level collapsed into `Debug`.
+
+## Platform sinks
+
+The default logger writes at the matching level to `android.util.Log` on
+Android, `NSLog` on iOS, standard error on the JVM, and the matching `console`
+method in the browser. The tag is `maplibre-compose`. This reproduces the output
+that the Kermit default produced, so an application that configures nothing sees
+the same log.

--- a/demo-app/common/build.gradle.kts
+++ b/demo-app/common/build.gradle.kts
@@ -75,6 +75,7 @@ kotlin {
       implementation(libs.androidx.navigation.compose)
       implementation(libs.kotlin.dsv)
       implementation(libs.kotlinx.serialization.json)
+      implementation(libs.kermit)
       implementation(libs.ktor.client.core)
       implementation(libs.mobilityData.gtfsSchedule)
       implementation(libs.spatialk.geojson)

--- a/lib/maplibre-compose/build.gradle.kts
+++ b/lib/maplibre-compose/build.gradle.kts
@@ -58,7 +58,6 @@ kotlin {
       implementation(libs.jetbrains.compose.components.resources)
       implementation(libs.htmlConverterCompose)
       api(libs.lifecycle.runtime.compose)
-      api(libs.kermit)
       implementation(libs.kotlinx.coroutines.core)
       implementation(libs.kotlinx.atomicfu)
       api(libs.kotlinx.io.core)

--- a/lib/maplibre-compose/src/androidDeviceTest/kotlin/org/maplibre/compose/map/AndroidExplicitRuntimeTest.kt
+++ b/lib/maplibre-compose/src/androidDeviceTest/kotlin/org/maplibre/compose/map/AndroidExplicitRuntimeTest.kt
@@ -21,7 +21,6 @@ class AndroidExplicitRuntimeTest {
         MapRuntimeOptions(
           context = context,
           cacheFile = cacheDirectory.resolve("cache.db"),
-          logger = null,
         )
       )
     val state = runtime.createMapState(baseStyle = BaseStyle.Empty)

--- a/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/logging/PlatformMapLogger.android.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/logging/PlatformMapLogger.android.kt
@@ -1,0 +1,15 @@
+package org.maplibre.compose.logging
+
+import android.util.Log
+
+internal actual fun platformMapLogger(): MapLogger = MapLogger { record ->
+  val priority =
+    when (record.level) {
+      MapLogLevel.Debug -> Log.DEBUG
+      MapLogLevel.Info -> Log.INFO
+      MapLogLevel.Warning -> Log.WARN
+      MapLogLevel.Error -> Log.ERROR
+    }
+  val trace = record.throwable?.let { "\n" + Log.getStackTraceString(it) }.orEmpty()
+  Log.println(priority, MAP_LOG_TAG, record.toPlatformLine() + trace)
+}

--- a/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/logging/PlatformMapLogger.android.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/logging/PlatformMapLogger.android.kt
@@ -11,5 +11,5 @@ internal actual fun platformMapLogger(): MapLogger = MapLogger { record ->
       MapLogLevel.Error -> Log.ERROR
     }
   val trace = record.throwable?.let { "\n" + Log.getStackTraceString(it) }.orEmpty()
-  Log.println(priority, MAP_LOG_TAG, record.toPlatformLine() + trace)
+  Log.println(priority, MAP_LOG_TAG, record.categorizedMessage() + trace)
 }

--- a/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/map/AndroidMapView.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/map/AndroidMapView.kt
@@ -5,7 +5,7 @@ import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import co.touchlab.kermit.Logger
+import org.maplibre.compose.logging.MapLog
 import org.maplibre.compose.mlnffi.AndroidMapSurfaceKind
 import org.maplibre.compose.mlnffi.AndroidMlnFfiPlatform
 import org.maplibre.compose.mlnffi.AndroidMlnFfiSurface
@@ -21,7 +21,7 @@ internal actual fun ComposableMapView(
   style: BaseStyle,
   update: (map: MapAdapter) -> Unit,
   onReset: () -> Unit,
-  logger: Logger?,
+  logger: MapLog?,
   callbacks: MapAdapter.Callbacks,
   options: MapViewOptions,
 ) {

--- a/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/map/MapRuntime.android.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/map/MapRuntime.android.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.platform.LocalContext
-import co.touchlab.kermit.Logger
 import java.io.File
 import kotlinx.io.files.Path
 import org.maplibre.compose.mlnffi.AndroidMlnFfiPlatform
@@ -21,8 +20,6 @@ public actual data class MapRuntimeOptions(
   public val cacheFile: File = context.applicationContext.cacheDir.resolve("maplibre-cache.db"),
   /** Maximum ambient cache size in bytes, or null for MapLibre's own default. */
   public val maximumCacheSizeBytes: Long? = null,
-  /** Receives diagnostic messages from maps and shared runtime resources. */
-  public val logger: Logger? = Logger.withTag("maplibre-compose"),
   /** Rewrites URLs and headers for every resource this runtime fetches. */
   public val requestInterceptor: MapRequestInterceptor? = null,
   /** Serves bytes for resource URLs this provider accepts. */
@@ -31,11 +28,10 @@ public actual data class MapRuntimeOptions(
 
 internal fun MapRuntimeOptions.toMlnFfiRuntimeOptions(): MlnFfiRuntimeOptions =
   MlnFfiRuntimeOptions(
-    Path(cacheFile.absolutePath),
-    maximumCacheSizeBytes,
-    logger,
-    requestInterceptor,
-    resourceProvider,
+    cacheFile = Path(cacheFile.absolutePath),
+    maximumCacheSizeBytes = maximumCacheSizeBytes,
+    requestInterceptor = requestInterceptor,
+    resourceProvider = resourceProvider,
   )
 
 public actual fun createMapRuntime(options: MapRuntimeOptions): MapRuntime {

--- a/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/mlnffi/AndroidMlnFfiSurface.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/mlnffi/AndroidMlnFfiSurface.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
-import co.touchlab.kermit.Logger
+import org.maplibre.compose.logging.MapLog
 import org.maplibre.compose.map.mlnFfiArchitecture
 import org.maplibre.compose.map.mlnFfiOperatingSystem
 
@@ -28,7 +28,7 @@ internal fun AndroidMlnFfiSurface(
   kind: AndroidMapSurfaceKind,
   maximumFps: Int? = null,
   modifier: Modifier,
-  logger: Logger?,
+  logger: MapLog?,
   presentWindow: Boolean = true,
 ) {
   val density = LocalDensity.current.density.toDouble()

--- a/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/mlnffi/AndroidMlnFfiSurfaceController.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/mlnffi/AndroidMlnFfiSurfaceController.kt
@@ -5,8 +5,8 @@ import android.os.HandlerThread
 import android.os.Looper
 import android.os.SystemClock
 import android.view.Surface
-import co.touchlab.kermit.Logger
 import java.util.concurrent.FutureTask
+import org.maplibre.compose.logging.MapLog
 import org.maplibre.compose.map.MapExtent
 
 /**
@@ -25,7 +25,7 @@ import org.maplibre.compose.map.MapExtent
 internal class AndroidMlnFfiSurfaceController(
   private val renderer: MlnFfiMapRenderer,
   private val backend: MapRenderBackend,
-  private val logger: Logger?,
+  private val logger: MapLog?,
   maximumFps: Int? = null,
 ) : MlnFfiMapHostSession, AutoCloseable {
   override val backends = RenderBackendPair(backend, ComposeRenderBackend.OPENGL)

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/logging/MapLog.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/logging/MapLog.kt
@@ -1,0 +1,35 @@
+package org.maplibre.compose.logging
+
+/**
+ * Library-side log entry point with lazy messages.
+ *
+ * The default instance reads [MapLogging.logger] at each call, so a logger installed later receives
+ * the records. A test passes its own [MapLogger] to record without touching the global.
+ */
+internal class MapLog(private val sink: () -> MapLogger? = { MapLogging.logger }) {
+  constructor(logger: MapLogger) : this({ logger })
+
+  fun d(throwable: Throwable? = null, message: () -> String) =
+    log(MapLogLevel.Debug, throwable, message)
+
+  fun i(throwable: Throwable? = null, message: () -> String) =
+    log(MapLogLevel.Info, throwable, message)
+
+  fun w(throwable: Throwable? = null, message: () -> String) =
+    log(MapLogLevel.Warning, throwable, message)
+
+  fun e(throwable: Throwable? = null, message: () -> String) =
+    log(MapLogLevel.Error, throwable, message)
+
+  fun log(
+    level: MapLogLevel,
+    throwable: Throwable?,
+    message: () -> String,
+    source: MapLogSource = MapLogSource.Library,
+    category: String? = null,
+  ) {
+    val logger = sink() ?: return
+    if (level < logger.minLevel) return
+    logger.log(MapLogRecord(level, source, category, message(), throwable))
+  }
+}

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/logging/MapLog.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/logging/MapLog.kt
@@ -1,14 +1,10 @@
 package org.maplibre.compose.logging
 
 /**
- * Library-side log entry point with lazy messages.
- *
- * The default instance reads [MapLogging.logger] at each call, so a logger installed later receives
- * the records. A test passes its own [MapLogger] to record without touching the global.
+ * Library-side log entry point with lazy messages. Reads [MapLogging.logger] at each call, so a
+ * logger installed later receives the records. A null [MapLog] reference disables logging.
  */
-internal class MapLog(private val sink: () -> MapLogger? = { MapLogging.logger }) {
-  constructor(logger: MapLogger) : this({ logger })
-
+internal object MapLog {
   fun d(throwable: Throwable? = null, message: () -> String) =
     log(MapLogLevel.Debug, throwable, message)
 
@@ -28,7 +24,7 @@ internal class MapLog(private val sink: () -> MapLogger? = { MapLogging.logger }
     source: MapLogSource = MapLogSource.Library,
     category: String? = null,
   ) {
-    val logger = sink() ?: return
+    val logger = MapLogging.logger ?: return
     if (level < logger.minLevel) return
     logger.log(MapLogRecord(level, source, category, message(), throwable))
   }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/logging/MapLogLevel.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/logging/MapLogLevel.kt
@@ -1,0 +1,9 @@
+package org.maplibre.compose.logging
+
+/** Severity of a [MapLogRecord], in ascending order. */
+public enum class MapLogLevel {
+  Debug,
+  Info,
+  Warning,
+  Error,
+}

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/logging/MapLogRecord.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/logging/MapLogRecord.kt
@@ -8,9 +8,9 @@ public class MapLogRecord(
    * The engine's category when it reports one: a MapLibre Native event name such as `HttpRequest`,
    * or the MapLibre GL JS source or layer id that an error concerns.
    */
-  public val category: String?,
+  public val category: String? = null,
   public val message: String,
-  public val throwable: Throwable?,
+  public val throwable: Throwable? = null,
 ) {
   override fun toString(): String =
     "MapLogRecord(level=$level, source=$source, category=$category, message=$message, throwable=$throwable)"

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/logging/MapLogRecord.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/logging/MapLogRecord.kt
@@ -1,0 +1,17 @@
+package org.maplibre.compose.logging
+
+/** One diagnostic message from the library or a map engine. */
+public class MapLogRecord(
+  public val level: MapLogLevel,
+  public val source: MapLogSource,
+  /**
+   * The engine's category when it reports one: a MapLibre Native event name such as `HttpRequest`,
+   * or the MapLibre GL JS source or layer id that an error concerns.
+   */
+  public val category: String?,
+  public val message: String,
+  public val throwable: Throwable?,
+) {
+  override fun toString(): String =
+    "MapLogRecord(level=$level, source=$source, category=$category, message=$message, throwable=$throwable)"
+}

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/logging/MapLogSource.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/logging/MapLogSource.kt
@@ -1,0 +1,11 @@
+package org.maplibre.compose.logging
+
+/** The component that produced a [MapLogRecord]. */
+public enum class MapLogSource {
+  /** MapLibre Compose itself. */
+  Library,
+  /** MapLibre Native, on Android, iOS, and desktop. */
+  NativeEngine,
+  /** MapLibre GL JS, in the browser. */
+  WebEngine,
+}

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/logging/MapLogger.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/logging/MapLogger.kt
@@ -1,0 +1,15 @@
+package org.maplibre.compose.logging
+
+/**
+ * Receives every diagnostic from the library and the map engines.
+ *
+ * [log] runs on any thread, including engine worker threads, and may run while the native engine
+ * holds its logging lock. Return quickly and call no map API from it.
+ */
+public fun interface MapLogger {
+  /** Records below this level are dropped before their message is built. */
+  public val minLevel: MapLogLevel
+    get() = MapLogLevel.Debug
+
+  public fun log(record: MapLogRecord)
+}

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/logging/MapLogger.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/logging/MapLogger.kt
@@ -4,10 +4,10 @@ package org.maplibre.compose.logging
  * Receives every diagnostic from the library and the map engines.
  *
  * [log] runs on any thread, including engine worker threads, and may run while the native engine
- * holds its logging lock. Return quickly and call no map API from it.
+ * holds its logging lock. An implementation returns quickly and calls no map API.
  */
 public fun interface MapLogger {
-  /** Records below this level are dropped before their message is built. */
+  /** The library drops records below this level before it builds their message. */
   public val minLevel: MapLogLevel
     get() = MapLogLevel.Debug
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/logging/MapLogging.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/logging/MapLogging.kt
@@ -1,0 +1,25 @@
+package org.maplibre.compose.logging
+
+import kotlin.concurrent.Volatile
+
+/** Process-wide logging configuration for every map runtime. */
+public object MapLogging {
+  /**
+   * Writes each record to the platform log: logcat, NSLog, standard error, or the browser console.
+   */
+  public val platformLogger: MapLogger = platformMapLogger()
+
+  /** The sink for every record. Null drops every record. Defaults to [platformLogger]. */
+  @Volatile public var logger: MapLogger? = platformLogger
+}
+
+internal expect fun platformMapLogger(): MapLogger
+
+internal const val MAP_LOG_TAG: String = "maplibre-compose"
+
+/** The platform log line: the tag, the category when present, and the message. */
+internal fun MapLogRecord.toPlatformLine(): String = buildString {
+  append(MAP_LOG_TAG)
+  category?.let { append(" [").append(it).append(']') }
+  append(": ").append(message)
+}

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/logging/MapLogging.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/logging/MapLogging.kt
@@ -17,9 +17,9 @@ internal expect fun platformMapLogger(): MapLogger
 
 internal const val MAP_LOG_TAG: String = "maplibre-compose"
 
-/** The platform log line: the tag, the category when present, and the message. */
-internal fun MapLogRecord.toPlatformLine(): String = buildString {
-  append(MAP_LOG_TAG)
-  category?.let { append(" [").append(it).append(']') }
-  append(": ").append(message)
-}
+/** The message, prefixed with the category when the engine reported one. */
+internal fun MapLogRecord.categorizedMessage(): String =
+  if (category == null) message else "[$category] $message"
+
+/** The platform log line: the tag and the categorized message. */
+internal fun MapLogRecord.toPlatformLine(): String = "$MAP_LOG_TAG: ${categorizedMessage()}"

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/ComposableMapView.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/ComposableMapView.kt
@@ -2,7 +2,7 @@ package org.maplibre.compose.map
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import co.touchlab.kermit.Logger
+import org.maplibre.compose.logging.MapLog
 import org.maplibre.compose.style.BaseStyle
 
 /** Identifies the platform presentation host that owns the current UI surface. */
@@ -15,7 +15,7 @@ internal expect fun ComposableMapView(
   style: BaseStyle,
   update: (map: MapAdapter) -> Unit,
   onReset: () -> Unit,
-  logger: Logger?,
+  logger: MapLog?,
   callbacks: MapAdapter.Callbacks,
   options: MapViewOptions,
 )

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
@@ -21,7 +21,6 @@ import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.DpRect
 import androidx.compose.ui.unit.dp
-import co.touchlab.kermit.Logger
 import kotlin.concurrent.atomics.AtomicReference
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.jvm.JvmInline
@@ -50,6 +49,7 @@ import org.maplibre.compose.expressions.dsl.const
 import org.maplibre.compose.expressions.value.BooleanValue
 import org.maplibre.compose.layers.LayerHandle
 import org.maplibre.compose.layers.layerHandle
+import org.maplibre.compose.logging.MapLog
 import org.maplibre.compose.offline.OfflineManager
 import org.maplibre.compose.offline.RuntimeBoundOfflineManager
 import org.maplibre.compose.offline.UnsupportedOfflineManager
@@ -1438,7 +1438,7 @@ internal fun interface MapRuntimeResources {
 internal class RuntimeImplementation(
   internal val platformOptions: Any?,
   private val resources: MapRuntimeResources,
-  internal val logger: Logger?,
+  internal val logger: MapLog?,
   offlineManagerBackend: OfflineManager = UnsupportedOfflineManager,
   internal val physicalScope: CoroutineScope =
     CoroutineScope(SupervisorJob() + Dispatchers.Default),

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleBinding.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleBinding.kt
@@ -1,12 +1,12 @@
 package org.maplibre.compose.style
 
 import androidx.compose.ui.graphics.ImageBitmap
-import co.touchlab.kermit.Logger
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import org.maplibre.compose.layers.Layer
+import org.maplibre.compose.logging.MapLog
 import org.maplibre.compose.sources.CustomGeometrySourceOptions
 import org.maplibre.compose.sources.CustomVectorSourceOptions
 import org.maplibre.compose.sources.GeoJsonData
@@ -52,7 +52,7 @@ internal interface StyleBinding {
     }
   }
 
-  val logger: Logger?
+  val logger: MapLog?
 
   fun addImage(definition: StyleImageDefinition)
 

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/style/RecordingStyleBinding.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/style/RecordingStyleBinding.kt
@@ -1,12 +1,12 @@
 package org.maplibre.compose.style
 
 import androidx.compose.ui.graphics.ImageBitmap
-import co.touchlab.kermit.Logger
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import org.maplibre.compose.layers.Layer
 import org.maplibre.compose.layers.UnknownLayer
+import org.maplibre.compose.logging.MapLog
 import org.maplibre.compose.sources.CustomGeometrySourceOptions
 import org.maplibre.compose.sources.CustomVectorSourceOptions
 import org.maplibre.compose.sources.GeoJsonData
@@ -72,7 +72,7 @@ internal class RecordingStyleBinding(
     isLoaded = false
   }
 
-  override val logger: Logger? = null
+  override val logger: MapLog? = null
 
   override fun addImage(definition: StyleImageDefinition) {
     if (!addImageHookInvoked) {

--- a/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/logging/PlatformMapLogger.ios.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/logging/PlatformMapLogger.ios.kt
@@ -1,0 +1,8 @@
+package org.maplibre.compose.logging
+
+import platform.Foundation.NSLog
+
+internal actual fun platformMapLogger(): MapLogger = MapLogger { record ->
+  val trace = record.throwable?.let { "\n" + it.stackTraceToString() }.orEmpty()
+  NSLog("%s", "[${record.level}] ${record.toPlatformLine()}$trace")
+}

--- a/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/logging/PlatformMapLogger.ios.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/logging/PlatformMapLogger.ios.kt
@@ -4,5 +4,5 @@ import platform.Foundation.NSLog
 
 internal actual fun platformMapLogger(): MapLogger = MapLogger { record ->
   val trace = record.throwable?.let { "\n" + it.stackTraceToString() }.orEmpty()
-  NSLog("%s", "[${record.level}] ${record.toPlatformLine()}$trace")
+  NSLog("%@", "[${record.level}] ${record.toPlatformLine()}$trace")
 }

--- a/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/map/IosMapView.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/map/IosMapView.kt
@@ -3,7 +3,7 @@ package org.maplibre.compose.map
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import co.touchlab.kermit.Logger
+import org.maplibre.compose.logging.MapLog
 import org.maplibre.compose.mlnffi.IosMlnFfiSurface
 import org.maplibre.compose.mlnffi.MapRenderBackend
 import org.maplibre.compose.style.BaseStyle
@@ -17,7 +17,7 @@ internal actual fun ComposableMapView(
   style: BaseStyle,
   update: (map: MapAdapter) -> Unit,
   onReset: () -> Unit,
-  logger: Logger?,
+  logger: MapLog?,
   callbacks: MapAdapter.Callbacks,
   options: MapViewOptions,
 ) {

--- a/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/map/MapRuntime.ios.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/map/MapRuntime.ios.kt
@@ -2,7 +2,6 @@ package org.maplibre.compose.map
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
-import co.touchlab.kermit.Logger
 import kotlinx.io.files.Path
 import org.maplibre.compose.ios.iosCacheFile
 import org.maplibre.compose.mlnffi.MlnFfiRuntimeOptions
@@ -16,8 +15,6 @@ public actual data class MapRuntimeOptions(
   public val cacheFile: String = iosCacheFile(),
   /** Maximum ambient cache size in bytes, or null for MapLibre's own default. */
   public val maximumCacheSizeBytes: Long? = null,
-  /** Receives diagnostic messages from maps and shared runtime resources. */
-  public val logger: Logger? = Logger.withTag("maplibre-compose"),
   /** Rewrites URLs and headers for every resource this runtime fetches. */
   public val requestInterceptor: MapRequestInterceptor? = null,
   /** Serves bytes for resource URLs this provider accepts. */
@@ -26,11 +23,10 @@ public actual data class MapRuntimeOptions(
 
 internal fun MapRuntimeOptions.toMlnFfiRuntimeOptions(): MlnFfiRuntimeOptions =
   MlnFfiRuntimeOptions(
-    Path(cacheFile),
-    maximumCacheSizeBytes,
-    logger,
-    requestInterceptor,
-    resourceProvider,
+    cacheFile = Path(cacheFile),
+    maximumCacheSizeBytes = maximumCacheSizeBytes,
+    requestInterceptor = requestInterceptor,
+    resourceProvider = resourceProvider,
   )
 
 public actual fun createMapRuntime(options: MapRuntimeOptions): MapRuntime =

--- a/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/mlnffi/IosMlnFfiSurface.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/mlnffi/IosMlnFfiSurface.kt
@@ -11,13 +11,13 @@ import androidx.compose.ui.viewinterop.UIKitView
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
-import co.touchlab.kermit.Logger
 import kotlinx.cinterop.BetaInteropApi
 import kotlinx.cinterop.CValue
 import kotlinx.cinterop.ObjCClass
 import kotlinx.cinterop.objcPtr
 import kotlinx.cinterop.toLong
 import kotlinx.cinterop.useContents
+import org.maplibre.compose.logging.MapLog
 import org.maplibre.compose.map.MapExtent
 import platform.CoreGraphics.CGRect
 import platform.CoreGraphics.CGRectMake
@@ -34,7 +34,7 @@ internal fun IosMlnFfiSurface(
   runtimeBackends: Set<MapRenderBackend>,
   maximumFps: Int? = null,
   modifier: Modifier,
-  logger: Logger?,
+  logger: MapLog?,
   presentWindow: Boolean = true,
 ) {
   val lifecycleOwner = LocalLifecycleOwner.current

--- a/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/mlnffi/IosMlnFfiSurfaceController.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/mlnffi/IosMlnFfiSurfaceController.kt
@@ -1,9 +1,9 @@
 package org.maplibre.compose.mlnffi
 
-import co.touchlab.kermit.Logger
 import kotlin.concurrent.Volatile
 import kotlinx.cinterop.BetaInteropApi
 import kotlinx.cinterop.autoreleasepool
+import org.maplibre.compose.logging.MapLog
 import org.maplibre.compose.map.MapExtent
 import org.maplibre.compose.util.rethrowIfFatal
 import platform.Foundation.NSCondition
@@ -24,7 +24,7 @@ import platform.Foundation.dateWithTimeIntervalSinceNow
  */
 internal class IosMlnFfiSurfaceController(
   private val renderer: MlnFfiMapRenderer,
-  private val logger: Logger?,
+  private val logger: MapLog?,
   maximumFps: Int? = null,
 ) : MlnFfiMapHostSession, AutoCloseable {
   override val backends = RenderBackendPair(MapRenderBackend.METAL, ComposeRenderBackend.METAL)

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsCompositor.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsCompositor.kt
@@ -1,7 +1,7 @@
 package org.maplibre.compose.gljs
 
 import androidx.compose.runtime.staticCompositionLocalOf
-import co.touchlab.kermit.Logger
+import org.maplibre.compose.logging.MapLog
 import org.maplibre.compose.map.MapExtent
 
 /** What a map should render into for one frame. */
@@ -22,12 +22,12 @@ internal interface GlJsCompositor : AutoCloseable {
 
 /** A seam for tests that run against a raster surface with no WebGL context. */
 internal val LocalGlJsCompositor =
-  staticCompositionLocalOf<(Logger?) -> GlJsCompositor> {
+  staticCompositionLocalOf<(MapLog?) -> GlJsCompositor> {
     { logger -> ComposeGlJsCompositor(logger) }
   }
 
 /** A target is never resized in place: WebGL cannot resize a texture. */
-internal class ComposeGlJsCompositor(private val logger: Logger?) : GlJsCompositor {
+internal class ComposeGlJsCompositor(private val logger: MapLog?) : GlJsCompositor {
 
   private var target: GlJsRenderTarget? = null
   private var generation = 0L

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsMapSurface.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsMapSurface.kt
@@ -17,11 +17,11 @@ import androidx.compose.ui.graphics.skiaCanvas
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.IntSize
-import co.touchlab.kermit.Logger
 import kotlin.math.abs
 import kotlin.math.roundToInt
 import org.jetbrains.skia.Rect
 import org.jetbrains.skia.SamplingMode
+import org.maplibre.compose.logging.MapLog
 import org.maplibre.compose.map.MapExtent
 
 /** Hosts [renderer] on a Compose drawing surface. Compose owns the frame loop. */
@@ -29,7 +29,7 @@ import org.maplibre.compose.map.MapExtent
 internal fun GlJsMapSurface(
   renderer: GlJsMapRenderer,
   modifier: Modifier,
-  logger: Logger?,
+  logger: MapLog?,
   presentFrames: Boolean,
 ) {
   val density = LocalDensity.current.density.toDouble()

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/logging/PlatformMapLogger.js.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/logging/PlatformMapLogger.js.kt
@@ -2,13 +2,11 @@ package org.maplibre.compose.logging
 
 internal actual fun platformMapLogger(): MapLogger = MapLogger { record ->
   val line = record.toPlatformLine()
-  val throwable = record.throwable
+  val args = if (record.throwable == null) arrayOf<Any?>(line) else arrayOf(line, record.throwable)
   when (record.level) {
-    MapLogLevel.Debug -> if (throwable == null) console.log(line) else console.log(line, throwable)
-    MapLogLevel.Info -> if (throwable == null) console.info(line) else console.info(line, throwable)
-    MapLogLevel.Warning ->
-      if (throwable == null) console.warn(line) else console.warn(line, throwable)
-    MapLogLevel.Error ->
-      if (throwable == null) console.error(line) else console.error(line, throwable)
+    MapLogLevel.Debug -> console.log(*args)
+    MapLogLevel.Info -> console.info(*args)
+    MapLogLevel.Warning -> console.warn(*args)
+    MapLogLevel.Error -> console.error(*args)
   }
 }

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/logging/PlatformMapLogger.js.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/logging/PlatformMapLogger.js.kt
@@ -1,0 +1,14 @@
+package org.maplibre.compose.logging
+
+internal actual fun platformMapLogger(): MapLogger = MapLogger { record ->
+  val line = record.toPlatformLine()
+  val throwable = record.throwable
+  when (record.level) {
+    MapLogLevel.Debug -> if (throwable == null) console.log(line) else console.log(line, throwable)
+    MapLogLevel.Info -> if (throwable == null) console.info(line) else console.info(line, throwable)
+    MapLogLevel.Warning ->
+      if (throwable == null) console.warn(line) else console.warn(line, throwable)
+    MapLogLevel.Error ->
+      if (throwable == null) console.error(line) else console.error(line, throwable)
+  }
+}

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
@@ -9,7 +9,6 @@ import androidx.compose.ui.unit.DpRect
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
-import co.touchlab.kermit.Logger
 import js.objects.unsafeJso
 import kotlin.coroutines.resume
 import kotlin.math.log2
@@ -51,6 +50,9 @@ import org.maplibre.compose.gljs.queryPoint
 import org.maplibre.compose.gljs.styleJson
 import org.maplibre.compose.gljs.styleUrl
 import org.maplibre.compose.gljs.subscribe
+import org.maplibre.compose.logging.MapLog
+import org.maplibre.compose.logging.MapLogLevel
+import org.maplibre.compose.logging.MapLogSource
 import org.maplibre.compose.resource.GlJsRequestController
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.compose.style.DesiredStyleRevision
@@ -90,7 +92,7 @@ private const val FRAME_INTERVAL_SLACK = 0.1
 internal class GlJsMapSession(
   private val lifecycleAuthority: MapLifecycleAuthority,
   callbacks: MapAdapter.Callbacks,
-  internal var logger: Logger?,
+  internal var logger: MapLog?,
   internal var layoutDirection: LayoutDirection,
   private val requests: GlJsRequestController? = null,
 ) : MapLifecycleSession, GlJsMapRenderer, GestureTarget {
@@ -528,8 +530,15 @@ internal class GlJsMapSession(
     map.subscribe("error") { event ->
       val reason = event.error?.message ?: "MapLibre failed to load the map"
       if (!styleLoadPending) {
-        // Tile and sprite failures land here too, and are not the map failing to load.
-        logger?.w { "MapLibre reported an error: $reason" }
+        // Tile and sprite failures land here too, and are not the map failing to load. Listening
+        // is what silences the browser's own console.error fallback, so this is the only outlet.
+        logger?.log(
+          MapLogLevel.Error,
+          throwable = null,
+          message = { reason },
+          source = MapLogSource.WebEngine,
+          category = event.sourceId ?: event.asDynamic().layer?.id as? String,
+        )
       }
     }
 

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
@@ -531,7 +531,8 @@ internal class GlJsMapSession(
       val reason = event.error?.message ?: "MapLibre failed to load the map"
       if (!styleLoadPending) {
         // Tile and sprite failures land here too, and are not the map failing to load. Listening
-        // is what silences the browser's own console.error fallback, so this is the only outlet.
+        // is what silences the browser's own console.error fallback, so the record reaches the
+        // logger only through this listener.
         logger?.log(
           MapLogLevel.Error,
           throwable = null,

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsSnapshotterAdapter.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsSnapshotterAdapter.kt
@@ -1,7 +1,6 @@
 package org.maplibre.compose.map
 
 import androidx.compose.ui.graphics.ImageBitmap
-import co.touchlab.kermit.Logger
 import js.objects.unsafeJso
 import kotlin.coroutines.resume
 import kotlinx.coroutines.CancellationException
@@ -19,6 +18,7 @@ import org.maplibre.compose.gljs.isTerminalStyleLoadFailure
 import org.maplibre.compose.gljs.styleJson
 import org.maplibre.compose.gljs.styleUrl
 import org.maplibre.compose.gljs.subscribe
+import org.maplibre.compose.logging.MapLog
 import org.maplibre.compose.resource.GlJsRequestController
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.compose.style.DesiredStyleRevision
@@ -32,7 +32,7 @@ import web.html.HTMLCanvasElement
 import web.html.HTMLElement
 
 internal class GlJsSnapshotterAdapterFactory(
-  private val logger: Logger?,
+  private val logger: MapLog?,
   private val requests: GlJsRequestController? = null,
 ) : SnapshotterAdapterFactory {
   override fun create(): SnapshotterAdapter = GlJsSnapshotterAdapter(logger, requests)
@@ -40,7 +40,7 @@ internal class GlJsSnapshotterAdapterFactory(
 
 /** One private GL JS map and DOM target for a Web snapshotter. */
 private class GlJsSnapshotterAdapter(
-  private val logger: Logger?,
+  private val logger: MapLog?,
   private val requests: GlJsRequestController?,
 ) : SnapshotterAdapter {
   private var open = true

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/JsMapView.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/JsMapView.kt
@@ -12,8 +12,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
-import co.touchlab.kermit.Logger
 import org.maplibre.compose.gljs.GlJsMapSurface
+import org.maplibre.compose.logging.MapLog
 import org.maplibre.compose.style.BaseStyle
 
 @Composable internal actual fun mapPresentationHostIdentity(): Any = Unit
@@ -25,7 +25,7 @@ internal actual fun ComposableMapView(
   style: BaseStyle,
   update: (map: MapAdapter) -> Unit,
   onReset: () -> Unit,
-  logger: Logger?,
+  logger: MapLog?,
   callbacks: MapAdapter.Callbacks,
   options: MapViewOptions,
 ) {

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/MapRuntime.js.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/MapRuntime.js.kt
@@ -24,7 +24,7 @@ internal class JsRuntimePlatform(
 public actual fun createMapRuntime(options: MapRuntimeOptions): MapRuntime {
   val resourceConfig = MapResourceConfig(options.requestInterceptor, options.resourceProvider)
   val requests = GlJsRequestController(resourceConfig)
-  val logger = MapLog()
+  val logger = MapLog
   return RuntimeImplementation(
     platformOptions = JsRuntimePlatform(options, requests),
     resources = MapRuntimeResources { requests.close() },

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/MapRuntime.js.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/MapRuntime.js.kt
@@ -1,7 +1,7 @@
 package org.maplibre.compose.map
 
 import androidx.compose.runtime.Composable
-import co.touchlab.kermit.Logger
+import org.maplibre.compose.logging.MapLog
 import org.maplibre.compose.offline.UnsupportedOfflineManager
 import org.maplibre.compose.resource.GlJsRequestController
 import org.maplibre.compose.resource.MapRequestInterceptor
@@ -10,7 +10,6 @@ import org.maplibre.compose.resource.MapResourceProvider
 
 /** Browser runtime configuration. */
 public actual data class MapRuntimeOptions(
-  public val logger: Logger? = Logger.withTag("maplibre-compose"),
   /** Rewrites URLs and headers for every resource this runtime fetches. */
   public val requestInterceptor: MapRequestInterceptor? = null,
   /** Serves bytes for resource URLs this provider accepts. */
@@ -25,12 +24,13 @@ internal class JsRuntimePlatform(
 public actual fun createMapRuntime(options: MapRuntimeOptions): MapRuntime {
   val resourceConfig = MapResourceConfig(options.requestInterceptor, options.resourceProvider)
   val requests = GlJsRequestController(resourceConfig)
+  val logger = MapLog()
   return RuntimeImplementation(
     platformOptions = JsRuntimePlatform(options, requests),
     resources = MapRuntimeResources { requests.close() },
-    logger = options.logger,
+    logger = logger,
     offlineManagerBackend = UnsupportedOfflineManager,
-    snapshotterAdapterFactory = GlJsSnapshotterAdapterFactory(options.logger, requests),
+    snapshotterAdapterFactory = GlJsSnapshotterAdapterFactory(logger, requests),
     resourceConfig = resourceConfig,
   )
 }

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/style/GlJsStyleBinding.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/style/GlJsStyleBinding.kt
@@ -1,7 +1,6 @@
 package org.maplibre.compose.style
 
 import androidx.compose.ui.graphics.ImageBitmap
-import co.touchlab.kermit.Logger
 import js.objects.unsafeJso
 import kotlinx.coroutines.await
 import kotlinx.serialization.json.JsonElement
@@ -30,6 +29,7 @@ import org.maplibre.compose.gljs.keys
 import org.maplibre.compose.gljs.subscribe
 import org.maplibre.compose.layers.Layer
 import org.maplibre.compose.layers.UnknownLayer
+import org.maplibre.compose.logging.MapLog
 import org.maplibre.compose.sources.CLUSTER_ID_PROPERTY
 import org.maplibre.compose.sources.CustomGeometrySourceOptions
 import org.maplibre.compose.sources.CustomVectorSourceOptions
@@ -58,7 +58,7 @@ import org.maplibre.spatialk.geojson.Position
 /** [StyleBinding] for one loaded style in a MapLibre GL JS map. */
 internal class GlJsStyleBinding(
   private val map: MaplibreMap,
-  override val logger: Logger?,
+  override val logger: MapLog?,
   private val getScale: () -> Float,
 ) : StyleBinding {
 

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/testing/GlJsMapFixture.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/testing/GlJsMapFixture.kt
@@ -36,7 +36,7 @@ internal class GlJsMapFixture(private val extent: MapExtent) : MapFixture {
       initialCameraPosition = CameraPosition(zoom = 0.0),
       baseStyle = BaseStyle.Empty,
     )
-  private val glJsSession = GlJsMapSession(state.lifecycle, recorder, MapLog(), LayoutDirection.Ltr)
+  private val glJsSession = GlJsMapSession(state.lifecycle, recorder, MapLog, LayoutDirection.Ltr)
   private val token = state.reservePresentation()
 
   override val session: MapAdapter

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/testing/GlJsMapFixture.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/testing/GlJsMapFixture.kt
@@ -1,7 +1,6 @@
 package org.maplibre.compose.testing
 
 import androidx.compose.ui.unit.LayoutDirection
-import co.touchlab.kermit.Logger
 import kotlin.js.Date
 import kotlin.time.Duration
 import kotlinx.coroutines.CoroutineScope
@@ -17,6 +16,7 @@ import org.maplibre.compose.gljs.GlJsRuntime
 import org.maplibre.compose.gljs.GlJsSurfaceSession
 import org.maplibre.compose.gljs.LOCAL_WORKER_URL
 import org.maplibre.compose.gljs.yieldToBrowser
+import org.maplibre.compose.logging.MapLog
 import org.maplibre.compose.map.GestureTarget
 import org.maplibre.compose.map.GlJsMapSession
 import org.maplibre.compose.map.MapAdapter
@@ -36,8 +36,7 @@ internal class GlJsMapFixture(private val extent: MapExtent) : MapFixture {
       initialCameraPosition = CameraPosition(zoom = 0.0),
       baseStyle = BaseStyle.Empty,
     )
-  private val glJsSession =
-    GlJsMapSession(state.lifecycle, recorder, Logger.withTag("gljs-map"), LayoutDirection.Ltr)
+  private val glJsSession = GlJsMapSession(state.lifecycle, recorder, MapLog(), LayoutDirection.Ltr)
   private val token = state.reservePresentation()
 
   override val session: MapAdapter

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/DesktopCache.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/DesktopCache.kt
@@ -1,6 +1,5 @@
 package org.maplibre.compose.desktop
 
-import co.touchlab.kermit.Logger
 import java.nio.file.Path
 import java.nio.file.Paths
 import org.maplibre.compose.mlnffi.MlnFfiRuntimeOptions
@@ -10,7 +9,6 @@ import org.maplibre.compose.resource.MapResourceProvider
 internal fun desktopRuntimeOptions(
   applicationId: String = inferredApplicationId(),
   maximumCacheSizeBytes: Long? = null,
-  logger: Logger? = Logger.withTag("maplibre-compose"),
   requestInterceptor: MapRequestInterceptor? = null,
   resourceProvider: MapResourceProvider? = null,
 ): MlnFfiRuntimeOptions {
@@ -19,11 +17,10 @@ internal fun desktopRuntimeOptions(
   }
   val cachePath = desktopCachePath(applicationId)
   return MlnFfiRuntimeOptions(
-    kotlinx.io.files.Path(cachePath.toString()),
-    maximumCacheSizeBytes,
-    logger,
-    requestInterceptor,
-    resourceProvider,
+    cacheFile = kotlinx.io.files.Path(cachePath.toString()),
+    maximumCacheSizeBytes = maximumCacheSizeBytes,
+    requestInterceptor = requestInterceptor,
+    resourceProvider = resourceProvider,
   )
 }
 

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/skiko/SkikoReflection.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/skiko/SkikoReflection.kt
@@ -1,6 +1,5 @@
 package org.maplibre.compose.desktop.skiko
 
-import co.touchlab.kermit.Logger
 import java.awt.Component
 import java.awt.Container
 import java.awt.Window
@@ -10,6 +9,7 @@ import java.lang.reflect.Field
 import java.lang.reflect.Method
 import java.util.concurrent.atomic.AtomicBoolean
 import javax.swing.SwingUtilities
+import org.maplibre.compose.logging.MapLog
 import org.maplibre.compose.mlnffi.MlnFfiHostException
 
 /**
@@ -228,7 +228,7 @@ internal object SkikoDirect3DDeviceLayout {
   const val READ_SIZE: Long = DEVICE_OFFSET + Long.SIZE_BYTES
 
   private val warnedAboutSkikoVersion = AtomicBoolean(false)
-  private val logger = Logger.withTag("maplibre-compose")
+  private val logger = MapLog()
 
   /**
    * Skiko's own version string from `org.jetbrains.skiko.Version`, or null if it is unavailable.

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/skiko/SkikoReflection.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/skiko/SkikoReflection.kt
@@ -228,7 +228,7 @@ internal object SkikoDirect3DDeviceLayout {
   const val READ_SIZE: Long = DEVICE_OFFSET + Long.SIZE_BYTES
 
   private val warnedAboutSkikoVersion = AtomicBoolean(false)
-  private val logger = MapLog()
+  private val logger = MapLog
 
   /**
    * Skiko's own version string from `org.jetbrains.skiko.Version`, or null if it is unavailable.

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/logging/PlatformMapLogger.desktop.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/logging/PlatformMapLogger.desktop.kt
@@ -1,0 +1,6 @@
+package org.maplibre.compose.logging
+
+internal actual fun platformMapLogger(): MapLogger = MapLogger { record ->
+  System.err.println("[${record.level}] ${record.toPlatformLine()}")
+  record.throwable?.printStackTrace()
+}

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/map/DesktopMapView.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/map/DesktopMapView.kt
@@ -3,9 +3,9 @@ package org.maplibre.compose.map
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import co.touchlab.kermit.Logger
 import org.maplibre.compose.desktop.LocalComposeMapPresentationHost
 import org.maplibre.compose.desktop.bridge.ComposeMapPresentationHostFactory
+import org.maplibre.compose.logging.MapLog
 import org.maplibre.compose.style.BaseStyle
 
 /** Gives Compose value-based keys reference-identity semantics for physical host resources. */
@@ -26,7 +26,7 @@ internal actual fun ComposableMapView(
   style: BaseStyle,
   update: (map: MapAdapter) -> Unit,
   onReset: () -> Unit,
-  logger: Logger?,
+  logger: MapLog?,
   callbacks: MapAdapter.Callbacks,
   options: MapViewOptions,
 ) {

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/map/MapRuntime.desktop.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/map/MapRuntime.desktop.kt
@@ -1,7 +1,6 @@
 package org.maplibre.compose.map
 
 import androidx.compose.runtime.Composable
-import co.touchlab.kermit.Logger
 import org.maplibre.compose.desktop.desktopRuntimeOptions
 import org.maplibre.compose.desktop.inferredApplicationId
 import org.maplibre.compose.resource.MapRequestInterceptor
@@ -13,8 +12,6 @@ public actual data class MapRuntimeOptions(
   public val applicationId: String = inferredApplicationId(),
   /** Ambient cache size in bytes, or null for MapLibre's default. */
   public val maximumCacheSizeBytes: Long? = null,
-  /** Receives diagnostic messages from maps and shared runtime resources. */
-  public val logger: Logger? = Logger.withTag("maplibre-compose"),
   /** Rewrites URLs and headers for every resource this runtime fetches. */
   public val requestInterceptor: MapRequestInterceptor? = null,
   /** Serves bytes for resource URLs this provider accepts. */
@@ -25,7 +22,6 @@ internal fun MapRuntimeOptions.toMlnFfiRuntimeOptions() =
   desktopRuntimeOptions(
     applicationId,
     maximumCacheSizeBytes,
-    logger,
     requestInterceptor,
     resourceProvider,
   )

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapRuntimeLoop.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapRuntimeLoop.kt
@@ -1,8 +1,8 @@
 package org.maplibre.compose.map
 
-import co.touchlab.kermit.Logger
 import kotlin.concurrent.Volatile
 import kotlinx.io.files.Path
+import org.maplibre.compose.logging.MapLog
 import org.maplibre.compose.mlnffi.MlnFfiGate
 import org.maplibre.compose.mlnffi.MlnFfiOwnerLock
 import org.maplibre.compose.mlnffi.MlnFfiOwnerThread
@@ -49,7 +49,7 @@ internal class MlnFfiMapRuntimeLoop(
   /** The extent the map is created with. Its scale factor is fixed for the map's lifetime. */
   private val extent: MapExtent,
   private val cacheFile: Path,
-  private val getLogger: () -> Logger?,
+  private val getLogger: () -> MapLog?,
   private val resourceProviderFactory: MlnFfiResourceProviderFactory = ::MlnFfiResourceProvider,
   private val resourceConfig: MapResourceConfig = MapResourceConfig(),
   /** Runs on the owner thread once the map exists, before it is published. */
@@ -69,7 +69,7 @@ internal class MlnFfiMapRuntimeLoop(
   private val onFailure: (Throwable) -> Unit = {},
 ) : AutoCloseable {
 
-  private val logger: Logger?
+  private val logger: MapLog?
     get() = getLogger()
 
   /** Work for the owner thread; [OwnerTask.abandon] runs instead if it never gets to run. */

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -11,7 +11,6 @@ import androidx.compose.ui.unit.DpRect
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
-import co.touchlab.kermit.Logger
 import kotlin.concurrent.Volatile
 import kotlin.concurrent.atomics.AtomicBoolean
 import kotlin.concurrent.atomics.AtomicLong
@@ -35,6 +34,7 @@ import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.camera.Viewport
 import org.maplibre.compose.expressions.ast.CompiledExpression
 import org.maplibre.compose.expressions.value.BooleanValue
+import org.maplibre.compose.logging.MapLog
 import org.maplibre.compose.mlnffi.EglContextHandles
 import org.maplibre.compose.mlnffi.MapRenderBackend
 import org.maplibre.compose.mlnffi.MetalSurfaceTarget
@@ -153,7 +153,7 @@ internal data class NativeEngineCompatibility(
 internal class MlnFfiMapSession(
   private val lifecycleAuthority: MapLifecycleAuthority,
   callbacks: MapAdapter.Callbacks,
-  @Volatile internal var logger: Logger?,
+  @Volatile internal var logger: MapLog?,
   renderBackend: MapRenderBackend,
   scaleFactor: Double = 1.0,
   @Volatile internal var layoutDirection: LayoutDirection,
@@ -912,7 +912,7 @@ internal class MlnFfiMapSession(
           val waiter = transitionWaiters.remove(id)
           if (waiter == null) {
             // Expected after a cancellation: the caller withdrew before native finished.
-            logger?.v { "Ignoring the end of unknown camera transition $id" }
+            logger?.d { "Ignoring the end of unknown camera transition $id" }
           } else {
             // Resumed after the drain: this event is queued immediately before the transition's
             // MAP_CAMERA_DID_CHANGE, so resuming now would read the camera too early.
@@ -930,7 +930,7 @@ internal class MlnFfiMapSession(
 
       // Event types are value classes over Int, so an FFI upgrade can add one this build has never
       // seen. Types this session does not select are never queued.
-      else -> logger?.v { "Unrecognized MapLibre event type ${event.type}" }
+      else -> logger?.d { "Unrecognized MapLibre event type ${event.type}" }
     }
   }
 

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapView.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapView.kt
@@ -14,8 +14,8 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.testTag
-import co.touchlab.kermit.Logger
 import kotlinx.coroutines.CancellationException
+import org.maplibre.compose.logging.MapLog
 import org.maplibre.compose.mlnffi.MapRenderBackend
 import org.maplibre.compose.mlnffi.MlnFfiMapHostFactory
 import org.maplibre.compose.mlnffi.MlnFfiMapHostResult
@@ -41,7 +41,7 @@ internal fun MlnFfiMapView(
   style: BaseStyle,
   update: (map: MapAdapter) -> Unit,
   onReset: () -> Unit,
-  logger: Logger?,
+  logger: MapLog?,
   callbacks: MapAdapter.Callbacks,
   options: MapViewOptions,
 ) {
@@ -79,13 +79,13 @@ internal fun MlnFfiMapView(
 @Composable
 internal fun MlnFfiMapView(
   renderBackend: MapRenderBackend,
-  surface: @Composable (MlnFfiMapRenderer, Modifier, Logger?, Boolean) -> Unit,
+  surface: @Composable (MlnFfiMapRenderer, Modifier, MapLog?, Boolean) -> Unit,
   modifier: Modifier,
   state: MapState,
   style: BaseStyle,
   update: (map: MapAdapter) -> Unit,
   onReset: () -> Unit,
-  logger: Logger?,
+  logger: MapLog?,
   callbacks: MapAdapter.Callbacks,
   options: MapViewOptions,
 ) {
@@ -223,7 +223,7 @@ private fun selectHost(
  * Reports which backends the packaged MapLibre Native FFI runtime was built with. Empty rather than
  * throwing when no runtime is on the classpath; negotiation reports that as a diagnostic.
  */
-internal fun loadRuntimeBackends(logger: Logger?): Set<MapRenderBackend> =
+internal fun loadRuntimeBackends(logger: MapLog?): Set<MapRenderBackend> =
   try {
     Maplibre.loadNativeLibrary()
     Maplibre.supportedRenderBackends().mapNotNullTo(mutableSetOf()) { it.toComposeBackend() }

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/mlnffi/MlnFfiLogBridge.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/mlnffi/MlnFfiLogBridge.kt
@@ -13,10 +13,10 @@ import org.maplibre.nativeffi.log.LogSeverity
 /**
  * Forwards MapLibre Native's process-global log stream to [MapLogging.logger].
  *
- * Installed once, after the native library is loaded. The callback reads the current logger at each
- * record, so replacing the logger never reinstalls the callback. Every record is consumed: the
- * engine's own fall-through sink is stderr on every platform this build targets
- * (maplibre/maplibre-native-ffi#679).
+ * Installed once, when the first native runtime is created; `setLogCallback` loads the native
+ * library itself. The callback reads the current logger at each record, so replacing the logger
+ * never reinstalls the callback. Every record is consumed: the engine's own fall-through sink is
+ * stderr on every platform this build targets (maplibre/maplibre-native-ffi#679).
  */
 internal object MlnFfiLogBridge {
   private val lock = MlnFfiLock()

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/mlnffi/MlnFfiLogBridge.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/mlnffi/MlnFfiLogBridge.kt
@@ -1,0 +1,74 @@
+package org.maplibre.compose.mlnffi
+
+import org.maplibre.compose.logging.MapLogLevel
+import org.maplibre.compose.logging.MapLogRecord
+import org.maplibre.compose.logging.MapLogSource
+import org.maplibre.compose.logging.MapLogging
+import org.maplibre.nativeffi.Maplibre
+import org.maplibre.nativeffi.log.LogCallback
+import org.maplibre.nativeffi.log.LogEvent
+import org.maplibre.nativeffi.log.LogRecord
+import org.maplibre.nativeffi.log.LogSeverity
+
+/**
+ * Forwards MapLibre Native's process-global log stream to [MapLogging.logger].
+ *
+ * Installed once, after the native library is loaded. The callback reads the current logger at each
+ * record, so replacing the logger never reinstalls the callback. Every record is consumed: the
+ * engine's own fall-through sink is stderr on every platform this build targets
+ * (maplibre/maplibre-native-ffi#679).
+ */
+internal object MlnFfiLogBridge {
+  private val lock = MlnFfiLock()
+  private var installed = false
+
+  fun ensureInstalled() {
+    lock.withLock {
+      if (installed) return
+      Maplibre.setLogCallback(LogCallback(::forward))
+      installed = true
+    }
+  }
+
+  private fun forward(record: LogRecord): Boolean {
+    val logger = MapLogging.logger ?: return true
+    val level = record.severity.toMapLogLevel()
+    if (level < logger.minLevel) return true
+    val message =
+      if (record.code >= 0) "${record.message} (code ${record.code})" else record.message
+    logger.log(
+      MapLogRecord(level, MapLogSource.NativeEngine, record.event.categoryName(), message, null)
+    )
+    return true
+  }
+}
+
+private fun LogSeverity.toMapLogLevel(): MapLogLevel =
+  when (this) {
+    LogSeverity.INFO -> MapLogLevel.Info
+    LogSeverity.WARNING -> MapLogLevel.Warning
+    LogSeverity.ERROR -> MapLogLevel.Error
+    else -> MapLogLevel.Warning
+  }
+
+private fun LogEvent.categoryName(): String =
+  when (this) {
+    LogEvent.GENERAL -> "General"
+    LogEvent.SETUP -> "Setup"
+    LogEvent.SHADER -> "Shader"
+    LogEvent.PARSE_STYLE -> "ParseStyle"
+    LogEvent.PARSE_TILE -> "ParseTile"
+    LogEvent.RENDER -> "Render"
+    LogEvent.STYLE -> "Style"
+    LogEvent.DATABASE -> "Database"
+    LogEvent.HTTP_REQUEST -> "HttpRequest"
+    LogEvent.SPRITE -> "Sprite"
+    LogEvent.IMAGE -> "Image"
+    LogEvent.OPENGL -> "OpenGL"
+    LogEvent.JNI -> "Jni"
+    LogEvent.ANDROID -> "Android"
+    LogEvent.CRASH -> "Crash"
+    LogEvent.GLYPH -> "Glyph"
+    LogEvent.TIMING -> "Timing"
+    else -> "Event$nativeValue"
+  }

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/mlnffi/MlnFfiMapSurface.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/mlnffi/MlnFfiMapSurface.kt
@@ -11,9 +11,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
-import co.touchlab.kermit.Logger
 import kotlin.math.roundToInt
 import kotlin.time.TimeSource
+import org.maplibre.compose.logging.MapLog
 import org.maplibre.compose.map.MapExtent
 import org.maplibre.compose.util.rethrowIfFatal
 
@@ -26,7 +26,7 @@ internal fun MlnFfiMapSurface(
   renderer: MlnFfiMapRenderer,
   hostResult: MlnFfiMapHostResult,
   modifier: Modifier = Modifier,
-  logger: Logger? = null,
+  logger: MapLog? = null,
   presentFrames: Boolean = true,
 ) {
   var frameRequest by remember { mutableLongStateOf(0L) }
@@ -156,7 +156,7 @@ private fun recoverFromFrameFailure(
   drawState: MlnFfiMapDrawState,
   frameId: Long,
   error: Throwable,
-  logger: Logger?,
+  logger: MapLog?,
 ): Boolean {
   if (error !is MlnFfiRecoverableFrameException) {
     logger?.e(error) { "Map frame $frameId failed with an unrecoverable error" }
@@ -215,7 +215,7 @@ private class MlnFfiMapDrawState {
     frameFailures = 0
   }
 
-  fun closeRenderer(renderer: MlnFfiMapRenderer, logger: Logger?) {
+  fun closeRenderer(renderer: MlnFfiMapRenderer, logger: MapLog?) {
     if (rendererClosed) return
     rendererClosed = true
     runCatching { renderer.close() }.onFailure { logger?.e(it) { "Map renderer failed to close" } }

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/mlnffi/MlnFfiRuntimeOptions.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/mlnffi/MlnFfiRuntimeOptions.kt
@@ -1,8 +1,8 @@
 package org.maplibre.compose.mlnffi
 
 import androidx.compose.runtime.Immutable
-import co.touchlab.kermit.Logger
 import kotlinx.io.files.Path
+import org.maplibre.compose.logging.MapLog
 import org.maplibre.compose.resource.MapRequestInterceptor
 import org.maplibre.compose.resource.MapResourceProvider
 import org.maplibre.compose.resource.MlnFfiResourceProvider
@@ -13,9 +13,9 @@ import org.maplibre.compose.resource.MlnFfiResourceProviderFactory
 internal data class MlnFfiRuntimeOptions(
   val cacheFile: Path,
   val maximumCacheSizeBytes: Long? = null,
-  val logger: Logger? = Logger.withTag("maplibre-compose"),
   val requestInterceptor: MapRequestInterceptor? = null,
   val resourceProvider: MapResourceProvider? = null,
+  internal val logger: MapLog? = MapLog(),
   internal val resourceProviderFactory: MlnFfiResourceProviderFactory = ::MlnFfiResourceProvider,
 )
 

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/mlnffi/MlnFfiRuntimeOptions.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/mlnffi/MlnFfiRuntimeOptions.kt
@@ -15,7 +15,7 @@ internal data class MlnFfiRuntimeOptions(
   val maximumCacheSizeBytes: Long? = null,
   val requestInterceptor: MapRequestInterceptor? = null,
   val resourceProvider: MapResourceProvider? = null,
-  internal val logger: MapLog? = MapLog(),
+  val logger: MapLog? = MapLog,
   internal val resourceProviderFactory: MlnFfiResourceProviderFactory = ::MlnFfiResourceProvider,
 )
 

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/offline/MlnFfiOfflineManager.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/offline/MlnFfiOfflineManager.kt
@@ -326,14 +326,14 @@ internal class MlnFfiOfflineManager(
       else ->
         // Event types are value classes over Int, so an FFI upgrade can deliver a type this build
         // has never seen.
-        logger?.v { "Ignoring MapLibre event ${event.type} on the offline runtime" }
+        logger?.d { "Ignoring MapLibre event ${event.type} on the offline runtime" }
     }
   }
 
   private fun publishProgress(regionId: Long, progress: DownloadProgress) {
     val pack = packsById[regionId]
     if (pack == null) {
-      logger?.v { "Ignoring progress for offline region $regionId, which has no pack" }
+      logger?.d { "Ignoring progress for offline region $regionId, which has no pack" }
       return
     }
     pack.progressState.value = progress

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/offline/MlnFfiOfflineRuntime.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/offline/MlnFfiOfflineRuntime.kt
@@ -1,9 +1,9 @@
 package org.maplibre.compose.offline
 
-import co.touchlab.kermit.Logger
 import kotlin.concurrent.Volatile
 import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.io.files.Path
+import org.maplibre.compose.logging.MapLog
 import org.maplibre.compose.mlnffi.MlnFfiOwnerLock
 import org.maplibre.compose.mlnffi.MlnFfiOwnerThread
 import org.maplibre.compose.mlnffi.currentMlnFfiThreadName
@@ -38,7 +38,7 @@ private const val OWNER_THREAD_NAME = "maplibre-compose-offline"
  */
 internal class MlnFfiOfflineRuntime(
   private val cacheFile: Path,
-  private val logger: Logger?,
+  private val logger: MapLog?,
   private val onEvent: (RuntimeEvent) -> Unit,
   private val resourceConfig: MapResourceConfig = MapResourceConfig(),
 ) {
@@ -151,7 +151,7 @@ internal class MlnFfiOfflineRuntime(
         reject = {},
       )
     if (!posted) {
-      logger?.v { "Offline operation ${handle.id} was cancelled after its runtime closed" }
+      logger?.d { "Offline operation ${handle.id} was cancelled after its runtime closed" }
     }
   }
 
@@ -236,7 +236,7 @@ internal class MlnFfiOfflineRuntime(
     val operation = pending.remove(payload.operationId)
     if (operation == null) {
       // Expected after a cancellation: the caller discarded the operation before native finished.
-      logger?.v { "Ignoring the completion of unknown offline operation ${payload.operationId}" }
+      logger?.d { "Ignoring the completion of unknown offline operation ${payload.operationId}" }
       return
     }
 

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/offline/util.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/offline/util.kt
@@ -1,6 +1,6 @@
 package org.maplibre.compose.offline
 
-import co.touchlab.kermit.Logger
+import org.maplibre.compose.logging.MapLog
 import org.maplibre.compose.util.toBoundingBox
 import org.maplibre.compose.util.toLatLngBounds
 import org.maplibre.nativeffi.offline.OfflineRegionDefinition as FfiRegionDefinition
@@ -47,7 +47,7 @@ internal fun OfflinePackDefinition.toFfiRegionDefinition(): FfiRegionDefinition 
  * reports it as `Unknown`, which carries no style URL and so cannot become an
  * [OfflinePackDefinition].
  */
-internal fun FfiRegionDefinition.toOfflinePackDefinition(logger: Logger?): OfflinePackDefinition? =
+internal fun FfiRegionDefinition.toOfflinePackDefinition(logger: MapLog?): OfflinePackDefinition? =
   when (this) {
     is FfiRegionDefinition.TilePyramid ->
       OfflinePackDefinition.TilePyramid(
@@ -72,7 +72,7 @@ internal fun FfiRegionDefinition.toOfflinePackDefinition(logger: Logger?): Offli
     }
   }
 
-internal fun OfflineRegionStatus.toDownloadProgress(logger: Logger?): DownloadProgress =
+internal fun OfflineRegionStatus.toDownloadProgress(logger: MapLog?): DownloadProgress =
   DownloadProgress.Healthy(
     completedResourceCount = completedResourceCount,
     completedResourceBytes = completedResourceSize,
@@ -108,7 +108,7 @@ internal fun ResourceErrorReason.toDownloadErrorReason(): String =
     else -> "REASON_OTHER"
   }
 
-private fun ByteArray.toGeoJsonGeometry(logger: Logger?): Geometry = runCatching {
+private fun ByteArray.toGeoJsonGeometry(logger: MapLog?): Geometry = runCatching {
   Geometry.fromJson(decodeToString())
 }
   .getOrElse {

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/resource/MlnFfiResourceProvider.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/resource/MlnFfiResourceProvider.kt
@@ -1,6 +1,5 @@
 package org.maplibre.compose.resource
 
-import co.touchlab.kermit.Logger
 import kotlin.concurrent.Volatile
 import kotlin.concurrent.atomics.AtomicBoolean
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
@@ -16,6 +15,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import org.maplibre.compose.logging.MapLog
 import org.maplibre.compose.util.rethrowIfFatal
 import org.maplibre.nativeffi.resource.ResourceErrorReason
 import org.maplibre.nativeffi.resource.ResourceLoadingMethod
@@ -38,7 +38,7 @@ private val NETWORK_SCHEMES = setOf("http", "https")
 private const val REQUEST_CANCEL_POLL_MILLIS = 16L
 
 internal typealias MlnFfiResourceProviderFactory =
-  (getLogger: () -> Logger?) -> MlnFfiResourceProvider
+  (getLogger: () -> MapLog?) -> MlnFfiResourceProvider
 
 /**
  * Resolves the `jar:file:` and `file:` resource URIs Compose hands out for packaged resources,
@@ -50,7 +50,7 @@ internal typealias MlnFfiResourceProviderFactory =
  */
 @OptIn(ExperimentalAtomicApi::class)
 internal class MlnFfiResourceProvider(
-  private val getLogger: () -> Logger?,
+  private val getLogger: () -> MapLog?,
   /** Turns a URL into a response. Test seam: a fake can hold a read open mid-shutdown. */
   private val read: (url: String, requestedUrl: String) -> ResourceResponse = { url, requestedUrl ->
     readResource(url, requestedUrl, getLogger())
@@ -64,7 +64,7 @@ internal class MlnFfiResourceProvider(
   @Volatile var userProvider: MapResourceProvider? = null,
 ) : ResourceProviderCallback, AutoCloseable {
 
-  private val logger: Logger?
+  private val logger: MapLog?
     get() = getLogger()
 
   private val accepting = AtomicBoolean(true)
@@ -272,7 +272,7 @@ private class FfiResourceRequest(private val handle: ResourceRequestHandle) : Ta
  * Reads [url] into a response, reporting every failure as one rather than throwing. Blocks, so it
  * must run away from MapLibre's callback thread.
  */
-internal fun readResource(url: String, requestedUrl: String, logger: Logger?): ResourceResponse =
+internal fun readResource(url: String, requestedUrl: String, logger: MapLog?): ResourceResponse =
   try {
     val bytes = readPlatformResourceBytes(url)
     ResourceResponse(ResourceResponseStatus.OK).also {
@@ -314,7 +314,7 @@ private fun failure(
   reason: ResourceErrorReason,
   what: String,
   error: Throwable?,
-  logger: Logger?,
+  logger: MapLog?,
 ): ResourceResponse {
   // The style names one URL and the loader may resolve another; report both so the style is
   // greppable.

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/resource/MlnFfiRuntimeOwner.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/resource/MlnFfiRuntimeOwner.kt
@@ -1,8 +1,9 @@
 package org.maplibre.compose.resource
 
-import co.touchlab.kermit.Logger
 import kotlinx.io.files.Path
 import kotlinx.io.files.SystemFileSystem
+import org.maplibre.compose.logging.MapLog
+import org.maplibre.compose.mlnffi.MlnFfiLogBridge
 import org.maplibre.compose.mlnffi.currentMlnFfiThreadName
 import org.maplibre.compose.mlnffi.normalizeMlnFfiPath
 import org.maplibre.nativeffi.runtime.RuntimeHandle
@@ -19,9 +20,9 @@ internal class MlnFfiRuntimeOwner
 private constructor(
   val runtime: RuntimeHandle,
   private val provider: MlnFfiResourceProvider,
-  private val getLogger: () -> Logger?,
+  private val getLogger: () -> MapLog?,
 ) : AutoCloseable {
-  private val logger: Logger?
+  private val logger: MapLog?
     get() = getLogger()
 
   /**
@@ -44,7 +45,7 @@ private constructor(
      */
     fun open(
       rawCacheFile: Path,
-      getLogger: () -> Logger?,
+      getLogger: () -> MapLog?,
       what: String,
       resourceProviderFactory: MlnFfiResourceProviderFactory = ::MlnFfiResourceProvider,
       resourceConfig: MapResourceConfig = MapResourceConfig(),
@@ -55,6 +56,7 @@ private constructor(
       runCatching { cacheFile.parent?.let { SystemFileSystem.createDirectories(it) } }
         .onFailure { getLogger()?.w(it) { "Could not create the MapLibre cache directory" } }
 
+      MlnFfiLogBridge.ensureInstalled()
       val runtime =
         try {
           RuntimeHandle.create(RuntimeOptions().also { it.cachePath = cacheFile.toString() })

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/style/MlnFfiStyleBinding.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/style/MlnFfiStyleBinding.kt
@@ -1,7 +1,6 @@
 package org.maplibre.compose.style
 
 import androidx.compose.ui.graphics.ImageBitmap
-import co.touchlab.kermit.Logger
 import kotlin.concurrent.Volatile
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
@@ -17,6 +16,7 @@ import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
 import org.maplibre.compose.layers.Layer
 import org.maplibre.compose.layers.UnknownLayer
+import org.maplibre.compose.logging.MapLog
 import org.maplibre.compose.mlnffi.MlnFfiLock
 import org.maplibre.compose.mlnffi.withLock
 import org.maplibre.compose.sources.CustomGeometrySourceOptions
@@ -80,7 +80,7 @@ import org.maplibre.spatialk.geojson.toJson
  */
 internal open class MlnFfiStyleBinding(
   override val identity: StyleIdentity = StyleIdentity.create(),
-  private val loggerProvider: () -> Logger? = { null },
+  private val loggerProvider: () -> MapLog? = { null },
   private val sessionOpen: () -> Boolean = { false },
   private val accessMap: ((MapHandle) -> Unit) -> Boolean = { false },
   private val accessRenderSession: ((RenderSessionHandle) -> Unit) -> Boolean = { false },
@@ -103,7 +103,7 @@ internal open class MlnFfiStyleBinding(
   override val isLoaded: Boolean
     get() = loaded && sessionOpen()
 
-  override val logger: Logger?
+  override val logger: MapLog?
     get() = loggerProvider()
 
   override fun addImage(definition: StyleImageDefinition) {

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/layers/UnsupportedLayerPropertyTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/layers/UnsupportedLayerPropertyTest.kt
@@ -1,5 +1,6 @@
 package org.maplibre.compose.layers
 
+import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -39,9 +40,20 @@ import org.maplibre.spatialk.geojson.Geometry
  */
 class UnsupportedLayerPropertyTest {
 
+  private val previousLogger = MapLogging.logger
+
   @BeforeTest
-  fun clearLog() {
+  fun captureWarnings() {
     CAPTURED.clear()
+    MapLogging.logger = MapLogger { record ->
+      if (record.level >= MapLogLevel.Warning) CAPTURED += record.message
+      previousLogger?.log(record)
+    }
+  }
+
+  @AfterTest
+  fun restoreLogger() {
+    MapLogging.logger = previousLogger
   }
 
   @Test
@@ -172,18 +184,7 @@ class UnsupportedLayerPropertyTest {
       .also { style.install(it) }
 
   private companion object {
-    /**
-     * Warnings the library logged. The logger is process-global, so this is installed once and left
-     * in place; each platform test process runs without parallel forks.
-     */
+    /** Warnings the library logged. */
     val CAPTURED = RecordingList<String>()
-
-    init {
-      val previous = MapLogging.logger
-      MapLogging.logger = MapLogger { record ->
-        if (record.level >= MapLogLevel.Warning) CAPTURED += record.message
-        previous?.log(record)
-      }
-    }
   }
 }

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/layers/UnsupportedLayerPropertyTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/layers/UnsupportedLayerPropertyTest.kt
@@ -1,8 +1,5 @@
 package org.maplibre.compose.layers
 
-import co.touchlab.kermit.LogWriter
-import co.touchlab.kermit.Logger
-import co.touchlab.kermit.Severity
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -17,6 +14,9 @@ import org.maplibre.compose.expressions.dsl.nil
 import org.maplibre.compose.expressions.value.StringValue
 import org.maplibre.compose.expressions.value.SymbolOverlap
 import org.maplibre.compose.expressions.value.TextRotationAlignment
+import org.maplibre.compose.logging.MapLogLevel
+import org.maplibre.compose.logging.MapLogger
+import org.maplibre.compose.logging.MapLogging
 import org.maplibre.compose.mlnffi.BridgeMapFixture
 import org.maplibre.compose.sources.GeoJsonData
 import org.maplibre.compose.sources.GeoJsonOptions
@@ -173,24 +173,17 @@ class UnsupportedLayerPropertyTest {
 
   private companion object {
     /**
-     * Warnings the library logged. Kermit's writers are global and cannot be removed, so this is
-     * installed once; each platform test process runs without parallel forks.
+     * Warnings the library logged. The logger is process-global, so this is installed once and left
+     * in place; each platform test process runs without parallel forks.
      */
     val CAPTURED = RecordingList<String>()
 
     init {
-      Logger.addLogWriter(
-        object : LogWriter() {
-          override fun log(
-            severity: Severity,
-            message: String,
-            tag: String,
-            throwable: Throwable?,
-          ) {
-            if (severity >= Severity.Warn) CAPTURED += message
-          }
-        }
-      )
+      val previous = MapLogging.logger
+      MapLogging.logger = MapLogger { record ->
+        if (record.level >= MapLogLevel.Warning) CAPTURED += record.message
+        previous?.log(record)
+      }
     }
   }
 }

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/MlnFfiMapRuntimeLoopTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/MlnFfiMapRuntimeLoopTest.kt
@@ -2,12 +2,12 @@
 
 package org.maplibre.compose.map
 
-import co.touchlab.kermit.Logger
 import kotlin.concurrent.atomics.AtomicBoolean
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.test.Test
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
+import org.maplibre.compose.logging.MapLog
 import org.maplibre.compose.mlnffi.FfiTestPlatform
 import org.maplibre.compose.mlnffi.TestLatch
 
@@ -27,7 +27,7 @@ class MlnFfiMapRuntimeLoopTest {
       MlnFfiMapRuntimeLoop(
         extent = MapExtent.fromLogical(1, 1, 1.0),
         cacheFile = cacheFile,
-        getLogger = { Logger.withTag("map-runtime-loop-test") },
+        getLogger = { MapLog() },
         onMapCreated = {},
         onMapPublished = { throw expectedFailure },
         onMapClosing = { map ->

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/MlnFfiMapRuntimeLoopTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/MlnFfiMapRuntimeLoopTest.kt
@@ -27,7 +27,7 @@ class MlnFfiMapRuntimeLoopTest {
       MlnFfiMapRuntimeLoop(
         extent = MapExtent.fromLogical(1, 1, 1.0),
         cacheFile = cacheFile,
-        getLogger = { MapLog() },
+        getLogger = { MapLog },
         onMapCreated = {},
         onMapPublished = { throw expectedFailure },
         onMapClosing = { map ->

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/mlnffi/BridgeMapFixture.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/mlnffi/BridgeMapFixture.kt
@@ -65,7 +65,7 @@ private constructor(
     MlnFfiMapSession(
       lifecycleAuthority = state.lifecycle,
       callbacks = recorder,
-      logger = MapLog(),
+      logger = MapLog,
       renderBackend = driver.backends.producer,
       scaleFactor = initialExtent.scaleFactor,
       layoutDirection = LayoutDirection.Ltr,

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/mlnffi/BridgeMapFixture.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/mlnffi/BridgeMapFixture.kt
@@ -3,7 +3,6 @@
 package org.maplibre.compose.mlnffi
 
 import androidx.compose.ui.unit.LayoutDirection
-import co.touchlab.kermit.Logger
 import kotlin.concurrent.atomics.AtomicBoolean
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.time.Duration
@@ -15,6 +14,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
 import kotlinx.io.files.Path
+import org.maplibre.compose.logging.MapLog
 import org.maplibre.compose.map.MapAttachment
 import org.maplibre.compose.map.MapExtent
 import org.maplibre.compose.map.MlnFfiMapSession
@@ -65,7 +65,7 @@ private constructor(
     MlnFfiMapSession(
       lifecycleAuthority = state.lifecycle,
       callbacks = recorder,
-      logger = Logger.withTag("bridge-map"),
+      logger = MapLog(),
       renderBackend = driver.backends.producer,
       scaleFactor = initialExtent.scaleFactor,
       layoutDirection = LayoutDirection.Ltr,

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/mlnffi/MlnFfiMapSurfaceRecoveryTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/mlnffi/MlnFfiMapSurfaceRecoveryTest.kt
@@ -6,12 +6,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.unit.dp
-import co.touchlab.kermit.Logger
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
+import org.maplibre.compose.logging.MapLog
 import org.maplibre.compose.map.MapExtent
 
 @OptIn(ExperimentalTestApi::class)
@@ -327,7 +327,7 @@ class MlnFfiMapSurfaceRecoveryTest {
         renderer = renderer,
         hostResult = hostResult,
         modifier = Modifier.size(64.dp),
-        logger = Logger.withTag("surface-recovery-test"),
+        logger = MapLog(),
       )
     }
   }

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/mlnffi/MlnFfiMapSurfaceRecoveryTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/mlnffi/MlnFfiMapSurfaceRecoveryTest.kt
@@ -327,7 +327,7 @@ class MlnFfiMapSurfaceRecoveryTest {
         renderer = renderer,
         hostResult = hostResult,
         modifier = Modifier.size(64.dp),
-        logger = MapLog(),
+        logger = MapLog,
       )
     }
   }

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/offline/MlnFfiOfflineRuntimeTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/offline/MlnFfiOfflineRuntimeTest.kt
@@ -2,13 +2,13 @@
 
 package org.maplibre.compose.offline
 
-import co.touchlab.kermit.Logger
 import kotlin.concurrent.atomics.AtomicBoolean
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import org.maplibre.compose.logging.MapLog
 import org.maplibre.compose.mlnffi.FfiTestPlatform
 import org.maplibre.compose.mlnffi.TestLatch
 import org.maplibre.compose.mlnffi.parkForTest
@@ -34,7 +34,7 @@ class MlnFfiOfflineRuntimeTest {
   private fun startRuntime(): MlnFfiOfflineRuntime =
     MlnFfiOfflineRuntime(
         cacheFile = cacheFile,
-        logger = Logger.withTag("offline-runtime-test"),
+        logger = MapLog(),
         onEvent = {},
       )
       .also {

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/offline/MlnFfiOfflineRuntimeTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/offline/MlnFfiOfflineRuntimeTest.kt
@@ -34,7 +34,7 @@ class MlnFfiOfflineRuntimeTest {
   private fun startRuntime(): MlnFfiOfflineRuntime =
     MlnFfiOfflineRuntime(
         cacheFile = cacheFile,
-        logger = MapLog(),
+        logger = MapLog,
         onEvent = {},
       )
       .also {

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/offline/OfflineProgressMappingTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/offline/OfflineProgressMappingTest.kt
@@ -10,7 +10,7 @@ import org.maplibre.nativeffi.resource.ResourceErrorReason
 /** How a native offline status or error becomes the [DownloadProgress] common code switches on. */
 class OfflineProgressMappingTest {
 
-  private val logger = MapLog()
+  private val logger = MapLog
 
   @Test
   fun an_inactive_incomplete_region_is_paused_and_carries_its_counts_across() {

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/offline/OfflineProgressMappingTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/offline/OfflineProgressMappingTest.kt
@@ -1,8 +1,8 @@
 package org.maplibre.compose.offline
 
-import co.touchlab.kermit.Logger
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import org.maplibre.compose.logging.MapLog
 import org.maplibre.nativeffi.offline.OfflineRegionDownloadState
 import org.maplibre.nativeffi.offline.OfflineRegionStatus
 import org.maplibre.nativeffi.resource.ResourceErrorReason
@@ -10,7 +10,7 @@ import org.maplibre.nativeffi.resource.ResourceErrorReason
 /** How a native offline status or error becomes the [DownloadProgress] common code switches on. */
 class OfflineProgressMappingTest {
 
-  private val logger = Logger.withTag("offline-progress-mapping-test")
+  private val logger = MapLog()
 
   @Test
   fun an_inactive_incomplete_region_is_paused_and_carries_its_counts_across() {

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/sources/ImageSourceAttachTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/sources/ImageSourceAttachTest.kt
@@ -6,15 +6,16 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
+import org.maplibre.compose.logging.MapLogRecord
+import org.maplibre.compose.logging.MapLogSource
+import org.maplibre.compose.logging.MapLogger
+import org.maplibre.compose.logging.MapLogging
 import org.maplibre.compose.mlnffi.BridgeMapFixture
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.compose.style.MlnFfiStyleBinding
 import org.maplibre.compose.style.install
 import org.maplibre.compose.testing.RecordingList
 import org.maplibre.compose.util.PositionQuad
-import org.maplibre.nativeffi.Maplibre
-import org.maplibre.nativeffi.log.LogCallback
-import org.maplibre.nativeffi.log.LogRecord
 import org.maplibre.spatialk.geojson.Position
 
 /**
@@ -26,22 +27,20 @@ import org.maplibre.spatialk.geojson.Position
  */
 class ImageSourceAttachTest {
 
-  private val records = RecordingList<LogRecord>()
+  private val records = RecordingList<MapLogRecord>()
+  private val previousLogger = MapLogging.logger
 
   init {
     // Process-global; safe because each platform test process runs without parallel forks.
-    // Returning false keeps native logging.
-    Maplibre.setLogCallback(
-      LogCallback { record ->
-        records += record
-        false
-      }
-    )
+    MapLogging.logger = MapLogger { record ->
+      records += record
+      previousLogger?.log(record)
+    }
   }
 
   @AfterTest
-  fun clearLogCallback() {
-    Maplibre.clearLogCallback()
+  fun restoreLogger() {
+    MapLogging.logger = previousLogger
   }
 
   @Test
@@ -77,7 +76,7 @@ class ImageSourceAttachTest {
   }
 
   private fun failedToLoad(sourceId: String): Boolean = records.any {
-    it.message.contains("Failed to load source $sourceId")
+    it.source == MapLogSource.NativeEngine && it.message.contains("Failed to load source $sourceId")
   }
 
   private companion object {


### PR DESCRIPTION
## Description

Removes Kermit from the public API in favor of a library-owned `MapLogger` contract configured once through `MapLogging.logger`, and bridges MapLibre Native's log callback and MapLibre GL JS's error event into it, per `.agents/docs/LOGGING.md`.

## Validation

Compiled every target, and ran the desktop, Android host, browser test suites, and the docs build on macOS.

## AI assistance

Claude Code with Claude Fable 5.1.
