### PR TITLE
Add zoom buttons and tiered overlay presets

### DIFF
--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoAppState.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoAppState.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.UiComposable
 import kotlinx.coroutines.flow.first
 import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.demoapp.benchmark.BenchmarkScenario
@@ -139,6 +140,10 @@ internal class DemoMapConfiguration {
 
 internal data class StyleLoad(val count: Int, val base: BaseStyle?)
 
+// Pin the composition target to UI. Without it, the @MaplibreComposable content lambda below lets
+// the compiler's target inference mark this function as map content, which leaks into callers whose
+// composition scope is target-inferred (the Nucleus window host) and fails their UI composables.
+@UiComposable
 @Composable
 fun rememberDemoAppState(): DemoAppState {
   val mapRuntime = rememberDefaultMapRuntime()

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoAppState.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoAppState.kt
@@ -141,8 +141,9 @@ internal class DemoMapConfiguration {
 internal data class StyleLoad(val count: Int, val base: BaseStyle?)
 
 // Pin the composition target to UI. Without it, the @MaplibreComposable content lambda below lets
-// the compiler's target inference mark this function as map content, which leaks into callers whose
-// composition scope is target-inferred (the Nucleus window host) and fails their UI composables.
+// the compiler's target inference mark this function as map content. The compiler then propagates
+// that target to target-inferred calling scopes (the Nucleus window host) and rejects their UI
+// composables.
 @UiComposable
 @Composable
 fun rememberDemoAppState(): DemoAppState {

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoMap.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoMap.kt
@@ -38,6 +38,7 @@ import org.maplibre.compose.map.MapState
 import org.maplibre.compose.map.MaplibreMap
 import org.maplibre.compose.map.StyleLoadState
 import org.maplibre.compose.material3.Material3
+import org.maplibre.compose.material3.Material3Full
 import org.maplibre.compose.material3.PointerPinButton
 import org.maplibre.compose.overlay.MapOverlay
 import org.maplibre.compose.overlay.include
@@ -107,7 +108,15 @@ fun DemoMap(state: DemoAppState, viewportInsets: MapViewportInsets) {
       onFrame = { state.frameRateState.record() },
       contentWindowInsets = viewportInsets.asWindowInsets(),
     ) {
-      include(if (state.settings.useMaterial3Controls) MapOverlay.Material3 else MapOverlay.Default)
+      include(
+        when {
+          state.settings.useMaterial3Controls && state.settings.showZoomButtons ->
+            MapOverlay.Material3Full
+          state.settings.useMaterial3Controls -> MapOverlay.Material3
+          state.settings.showZoomButtons -> MapOverlay.Full
+          else -> MapOverlay.Default
+        }
+      )
       selectedDemo?.let { demo ->
         key(demo) {
           with(demo) { Overlay(state) }

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoPanel.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoPanel.kt
@@ -278,6 +278,7 @@ private fun ControlSettingsItems(settings: DemoSettings) {
   SwitchRow("Material 3 controls", settings.useMaterial3Controls) {
     settings.useMaterial3Controls = it
   }
+  SwitchRow("Zoom buttons", settings.showZoomButtons) { settings.showZoomButtons = it }
 
   SectionHeader("Overlays")
   SwitchRow("Frame rate", settings.showFpsOverlay) { settings.showFpsOverlay = it }

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoSettings.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoSettings.kt
@@ -53,6 +53,7 @@ class DemoSettings {
   var showCameraOverlay by mutableStateOf(false)
   var showPointerPinDiagnostics by mutableStateOf(false)
   var useMaterial3Controls by mutableStateOf(true)
+  var showZoomButtons by mutableStateOf(true)
 }
 
 @Composable fun rememberDemoSettings() = remember { DemoSettings() }

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/agent/AgentDriver.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/agent/AgentDriver.kt
@@ -119,6 +119,7 @@ internal data class SettingsDto(
   val mapStyleMode: String,
   val paletteMode: String,
   val useMaterial3Controls: Boolean,
+  val showZoomButtons: Boolean,
   val showFpsOverlay: Boolean,
   val showCameraOverlay: Boolean,
 )
@@ -295,6 +296,7 @@ internal class AgentDriver(
           mapStyleMode = state.settings.mapStyleMode.name,
           paletteMode = state.settings.paletteMode.name,
           useMaterial3Controls = state.settings.useMaterial3Controls,
+          showZoomButtons = state.settings.showZoomButtons,
           showFpsOverlay = state.settings.showFpsOverlay,
           showCameraOverlay = state.settings.showCameraOverlay,
         ),

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Material3.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Material3.kt
@@ -10,6 +10,7 @@ import org.maplibre.compose.material3.CompassButton
 import org.maplibre.compose.material3.ExpandingAttributionButton
 import org.maplibre.compose.material3.Material3
 import org.maplibre.compose.material3.ScaleBar
+import org.maplibre.compose.material3.ZoomButtons
 import org.maplibre.compose.overlay.MapOverlay
 import org.maplibre.compose.overlay.MaplibreLogo
 import org.maplibre.compose.overlay.include
@@ -27,6 +28,7 @@ fun Material3() {
       modifier = Modifier.align(Alignment.TopStart),
     ) // (1)!
     CompassButton(modifier = Modifier.align(Alignment.TopEnd))
+    ZoomButtons(Modifier.align(Alignment.CenterEnd))
     MaplibreLogo(Modifier.align(Alignment.BottomStart))
     ExpandingAttributionButton(
       modifier = Modifier.align(Alignment.BottomEnd),

--- a/docs/src/content/docs/controls.mdx
+++ b/docs/src/content/docs/controls.mdx
@@ -25,7 +25,7 @@ only while they are relevant.
 </Aside>
 
 Two variants cover common needs. `MapOverlay.Full` adds zoom in and zoom out
-buttons above the attribution button. `MapOverlay.AttributionOnly` draws only
+buttons at the middle of the end edge. `MapOverlay.AttributionOnly` draws only
 the logo and the attribution button.
 
 ## Replace the overlay

--- a/docs/src/content/docs/controls.mdx
+++ b/docs/src/content/docs/controls.mdx
@@ -24,10 +24,14 @@ only while they are relevant.
   attribution yourself.
 </Aside>
 
+Two variants cover common needs. `MapOverlay.Full` adds zoom in and zoom out
+buttons above the attribution button. `MapOverlay.AttributionOnly` draws only
+the logo and the attribution button.
+
 ## Replace the overlay
 
-An empty block draws no controls. Use it when your app shows the attribution
-somewhere else, such as an about screen.
+An empty block, or `MapOverlay.None`, draws no controls. Use it when your app
+shows the attribution somewhere else, such as an about screen.
 
 <Code code={region(controls, "disabled")} lang="kotlin" title="App.kt" />
 
@@ -59,6 +63,9 @@ commonMain.dependencies {
 as <Api of="MapOverlay.Default" /> in the same places. Include it in the block:
 
 <Code code={region(material3, "overlay")} lang="kotlin" title="App.kt" />
+
+`MapOverlay.Material3AttributionOnly` and `MapOverlay.Material3Full` apply the
+theme to the other presets.
 
 Each Material 3 control is also a composable that you can place in the trailing
 block:

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/org/maplibre/compose/material3/MapOverlay.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/org/maplibre/compose/material3/MapOverlay.kt
@@ -1,7 +1,6 @@
 package org.maplibre.compose.material3
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.ui.Alignment
@@ -35,25 +34,8 @@ private val Material3DefaultOverlay = MapOverlay {
 }
 
 private val Material3FullOverlay = MapOverlay {
-  DisappearingScaleBar(
-    metersPerDp = mapState.viewport?.metersPerDpAtTarget ?: 0.0,
-    zoom = mapState.cameraPosition.zoom,
-    modifier = Modifier.align(Alignment.TopStart),
-  )
-
-  DisappearingCompassButton(modifier = Modifier.align(Alignment.TopEnd))
-
-  MaplibreLogo(Modifier.align(Alignment.BottomStart))
-
-  val overlayScope = this
-  Column(
-    Modifier.align(Alignment.BottomEnd),
-    horizontalAlignment = Alignment.CenterHorizontally,
-    verticalArrangement = Arrangement.spacedBy(MapOverlay.Spacing),
-  ) {
-    overlayScope.ZoomButtons()
-    overlayScope.ExpandingAttributionButton()
-  }
+  include(Material3DefaultOverlay)
+  ZoomButtons(Modifier.align(Alignment.CenterEnd))
 }
 
 /**

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/org/maplibre/compose/material3/MapOverlay.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/org/maplibre/compose/material3/MapOverlay.kt
@@ -1,22 +1,16 @@
 package org.maplibre.compose.material3
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import org.maplibre.compose.overlay.MapOverlay
 import org.maplibre.compose.overlay.MaplibreLogo
+import org.maplibre.compose.overlay.include
 
-private val Material3Overlay = MapOverlay {
-  DisappearingScaleBar(
-    metersPerDp = mapState.viewport?.metersPerDpAtTarget ?: 0.0,
-    zoom = mapState.cameraPosition.zoom,
-    modifier = Modifier.align(Alignment.TopStart),
-  )
-
-  DisappearingCompassButton(modifier = Modifier.align(Alignment.TopEnd))
-
+private val Material3AttributionOnlyOverlay = MapOverlay {
   val overlayScope = this
   Row(
     Modifier.align(Alignment.BottomStart).fillMaxWidth(),
@@ -28,10 +22,62 @@ private val Material3Overlay = MapOverlay {
   }
 }
 
+private val Material3DefaultOverlay = MapOverlay {
+  DisappearingScaleBar(
+    metersPerDp = mapState.viewport?.metersPerDpAtTarget ?: 0.0,
+    zoom = mapState.cameraPosition.zoom,
+    modifier = Modifier.align(Alignment.TopStart),
+  )
+
+  DisappearingCompassButton(modifier = Modifier.align(Alignment.TopEnd))
+
+  include(Material3AttributionOnlyOverlay)
+}
+
+private val Material3FullOverlay = MapOverlay {
+  DisappearingScaleBar(
+    metersPerDp = mapState.viewport?.metersPerDpAtTarget ?: 0.0,
+    zoom = mapState.cameraPosition.zoom,
+    modifier = Modifier.align(Alignment.TopStart),
+  )
+
+  DisappearingCompassButton(modifier = Modifier.align(Alignment.TopEnd))
+
+  MaplibreLogo(Modifier.align(Alignment.BottomStart))
+
+  val overlayScope = this
+  Column(
+    Modifier.align(Alignment.BottomEnd),
+    horizontalAlignment = Alignment.CenterHorizontally,
+    verticalArrangement = Arrangement.spacedBy(MapOverlay.Spacing),
+  ) {
+    overlayScope.ZoomButtons()
+    overlayScope.ExpandingAttributionButton()
+  }
+}
+
+/**
+ * Applies the Material 3 color scheme and typography to the controls from
+ * [MapOverlay.AttributionOnly]. The empty overlay has no colors to theme, so it stays
+ * [MapOverlay.None].
+ *
+ * The Material 3 theme does not change the MapLibre logo colors.
+ */
+public val MapOverlay.Companion.Material3AttributionOnly: MapOverlay
+  get() = Material3AttributionOnlyOverlay
+
 /**
  * Applies the Material 3 color scheme and typography to the controls from [MapOverlay.Default].
  *
  * The Material 3 theme does not change the MapLibre logo colors.
  */
 public val MapOverlay.Companion.Material3: MapOverlay
-  get() = Material3Overlay
+  get() = Material3DefaultOverlay
+
+/**
+ * Applies the Material 3 color scheme and typography to the controls from [MapOverlay.Full].
+ *
+ * The Material 3 theme does not change the MapLibre logo colors.
+ */
+public val MapOverlay.Companion.Material3Full: MapOverlay
+  get() = Material3FullOverlay

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/org/maplibre/compose/material3/ZoomButtons.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/org/maplibre/compose/material3/ZoomButtons.kt
@@ -1,0 +1,87 @@
+package org.maplibre.compose.material3
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ButtonColors
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ElevatedButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import org.maplibre.compose.camera.CameraPosition
+import org.maplibre.compose.overlay.MapOverlayScope
+import org.maplibre.compose.overlay.ZoomButtons as BaseZoomButtons
+import org.maplibre.compose.overlay.ZoomButtonsDefaults
+import org.maplibre.compose.overlay.ZoomButtonsStyle
+
+/**
+ * Buttons that zoom the camera in and out, drawn as one vertical segmented container.
+ *
+ * This is [org.maplibre.compose.overlay.ZoomButtons] with the colors, shape, and elevation of an
+ * [ElevatedButton].
+ *
+ * @param onZoomIn Called after the zoom-in animation starts.
+ * @param onZoomOut Called after the zoom-out animation starts.
+ * @param colors Container and content colors, defaulting to those of an [ElevatedButton].
+ * @param dividerColor Color of the divider between the buttons.
+ * @param contentDescriptionZoomIn Accessibility label for the zoom-in button.
+ * @param contentDescriptionZoomOut Accessibility label for the zoom-out button.
+ * @param width Width of the container. Each button is a square of this size.
+ * @param contentPadding Gap between a button edge and its icon.
+ * @param shape Shape of the container.
+ * @param zoomInPainter The plus artwork, tinted with the content color.
+ * @param zoomOutPainter The minus artwork, tinted with the content color.
+ * @param getZoomInPosition The camera position that the zoom-in button animates to.
+ * @param getZoomOutPosition The camera position that the zoom-out button animates to.
+ */
+@Composable
+public fun MapOverlayScope.ZoomButtons(
+  modifier: Modifier = Modifier,
+  onZoomIn: () -> Unit = {},
+  onZoomOut: () -> Unit = {},
+  colors: ButtonColors = ButtonDefaults.elevatedButtonColors(),
+  dividerColor: Color = MaterialTheme.colorScheme.outlineVariant,
+  contentDescriptionZoomIn: String = ZoomButtonsDefaults.contentDescriptionZoomIn(),
+  contentDescriptionZoomOut: String = ZoomButtonsDefaults.contentDescriptionZoomOut(),
+  width: Dp = 48.dp,
+  contentPadding: PaddingValues = PaddingValues(12.dp),
+  shape: Shape = RoundedCornerShape(percent = 50),
+  zoomInPainter: Painter = ZoomButtonsDefaults.zoomInPainter(),
+  zoomOutPainter: Painter = ZoomButtonsDefaults.zoomOutPainter(),
+  getZoomInPosition: (CameraPosition) -> CameraPosition = { it.copy(zoom = it.zoom + 1) },
+  getZoomOutPosition: (CameraPosition) -> CameraPosition = { it.copy(zoom = it.zoom - 1) },
+) {
+  BaseZoomButtons(
+    modifier = modifier,
+    onZoomIn = onZoomIn,
+    onZoomOut = onZoomOut,
+    style = elevatedButtonStyle(colors, dividerColor, shape),
+    contentDescriptionZoomIn = contentDescriptionZoomIn,
+    contentDescriptionZoomOut = contentDescriptionZoomOut,
+    width = width,
+    contentPadding = contentPadding,
+    zoomInPainter = zoomInPainter,
+    zoomOutPainter = zoomOutPainter,
+    getZoomInPosition = getZoomInPosition,
+    getZoomOutPosition = getZoomOutPosition,
+  )
+}
+
+/**
+ * The elevations are the ones [ButtonDefaults.elevatedButtonElevation] resolves to. They are not
+ * reachable through [ButtonColors], and [ElevatedButton] changes elevation on hover alone.
+ */
+private fun elevatedButtonStyle(colors: ButtonColors, dividerColor: Color, shape: Shape) =
+  ZoomButtonsStyle(
+    containerColor = colors.containerColor,
+    contentColor = colors.contentColor,
+    dividerColor = dividerColor,
+    shadowElevation = 1.dp,
+    hoveredShadowElevation = 3.dp,
+    shape = shape,
+  )

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/org/maplibre/compose/material3/ZoomButtons.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/org/maplibre/compose/material3/ZoomButtons.kt
@@ -25,8 +25,8 @@ import org.maplibre.compose.overlay.ZoomButtonsStyle
  * This is [org.maplibre.compose.overlay.ZoomButtons] with the colors, shape, and elevation of an
  * [ElevatedButton].
  *
- * @param onZoomIn Called after the zoom-in animation starts.
- * @param onZoomOut Called after the zoom-out animation starts.
+ * @param onZoomIn Called when the zoom-in button is clicked, once its animation is requested.
+ * @param onZoomOut Called when the zoom-out button is clicked, once its animation is requested.
  * @param colors Container and content colors, defaulting to those of an [ElevatedButton].
  * @param dividerColor Color of the divider between the buttons.
  * @param contentDescriptionZoomIn Accessibility label for the zoom-in button.

--- a/lib/maplibre-compose/src/commonMain/composeResources/drawable/add.xml
+++ b/lib/maplibre-compose/src/commonMain/composeResources/drawable/add.xml
@@ -1,0 +1,13 @@
+<vector
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  android:width="24dp"
+  android:height="24dp"
+  android:viewportWidth="960"
+  android:viewportHeight="960"
+  android:tint="?attr/colorControlNormal"
+>
+  <path
+    android:fillColor="#FFFFFF"
+    android:pathData="M440,520L240,520Q223,520 211.5,508.5Q200,497 200,480Q200,463 211.5,451.5Q223,440 240,440L440,440L440,240Q440,223 451.5,211.5Q463,200 480,200Q497,200 508.5,211.5Q520,223 520,240L520,440L720,440Q737,440 748.5,451.5Q760,463 760,480Q760,497 748.5,508.5Q737,520 720,520L520,520L520,720Q520,737 508.5,748.5Q497,760 480,760Q463,760 451.5,748.5Q440,737 440,720L440,520Z"
+  />
+</vector>

--- a/lib/maplibre-compose/src/commonMain/composeResources/drawable/remove.xml
+++ b/lib/maplibre-compose/src/commonMain/composeResources/drawable/remove.xml
@@ -1,0 +1,13 @@
+<vector
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  android:width="24dp"
+  android:height="24dp"
+  android:viewportWidth="960"
+  android:viewportHeight="960"
+  android:tint="?attr/colorControlNormal"
+>
+  <path
+    android:fillColor="#FFFFFF"
+    android:pathData="M240,520Q223,520 211.5,508.5Q200,497 200,480Q200,463 211.5,451.5Q223,440 240,440L720,440Q737,440 748.5,451.5Q760,463 760,480Q760,497 748.5,508.5Q737,520 720,520L240,520Z"
+  />
+</vector>

--- a/lib/maplibre-compose/src/commonMain/composeResources/values-en/strings.xml
+++ b/lib/maplibre-compose/src/commonMain/composeResources/values-en/strings.xml
@@ -1,6 +1,8 @@
 <resources>
   <string name="attribution">Map Attribution</string>
   <string name="compass">Compass</string>
+  <string name="zoom_in">Zoom in</string>
+  <string name="zoom_out">Zoom out</string>
   <string name="meters_symbol">m</string>
   <string name="kilometers_symbol">km</string>
   <string name="feet_symbol">ft</string>

--- a/lib/maplibre-compose/src/commonMain/composeResources/values/strings.xml
+++ b/lib/maplibre-compose/src/commonMain/composeResources/values/strings.xml
@@ -2,6 +2,8 @@
   <string name="attribution">Map Attribution</string>
   <string name="maplibre_logo_description">MapLibre</string>
   <string name="compass">Compass</string>
+  <string name="zoom_in">Zoom in</string>
+  <string name="zoom_out">Zoom out</string>
   <string name="meters_symbol">m</string>
   <string name="kilometers_symbol">km</string>
   <string name="feet_symbol">ft</string>

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/MapOverlay.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/MapOverlay.kt
@@ -1,6 +1,7 @@
 package org.maplibre.compose.overlay
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.LayoutScopeMarker
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
@@ -134,12 +135,33 @@ public class MapOverlay(
     /** Gap between aligned overlay controls and the edge of the unobstructed map region. */
     public val Spacing: Dp = 8.dp
 
+    /** No controls. Use this when the app shows the attribution somewhere else. */
+    public val None: MapOverlay = MapOverlay {}
+
     /**
-     * A scale bar and a compass along the top edge, and the MapLibre logo and an attribution button
-     * along the bottom edge. The scale bar and the compass appear only while they are relevant.
+     * The MapLibre logo and an attribution button along the bottom edge.
      *
-     * Most maps serve tiles under a license that requires attribution, so a map draws these unless
-     * the caller replaces them.
+     * Most maps serve tiles under a license that requires attribution, so a map keeps these unless
+     * the app shows the attribution somewhere else.
+     */
+    public val AttributionOnly: MapOverlay = MapOverlay {
+      val overlayScope = this
+      Row(
+        Modifier.align(Alignment.BottomStart).fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+      ) {
+        MaplibreLogo()
+        overlayScope.ExpandingAttributionButton()
+      }
+    }
+
+    /**
+     * A scale bar and a compass along the top edge, and the controls from [AttributionOnly] along
+     * the bottom edge. The scale bar and the compass appear only while they are relevant.
+     *
+     * A [MaplibreMap][org.maplibre.compose.map.MaplibreMap] draws these unless the caller replaces
+     * them.
      */
     public val Default: MapOverlay = MapOverlay {
       DisappearingScaleBar(
@@ -150,13 +172,32 @@ public class MapOverlay(
 
       DisappearingCompassButton(modifier = Modifier.align(Alignment.TopEnd))
 
+      include(AttributionOnly)
+    }
+
+    /**
+     * The controls from [Default], plus zoom buttons above the attribution button.
+     *
+     * The zoom buttons complement the zoom gestures; they serve pointer devices and accessibility.
+     */
+    public val Full: MapOverlay = MapOverlay {
+      DisappearingScaleBar(
+        metersPerDp = mapState.viewport?.metersPerDpAtTarget ?: 0.0,
+        zoom = mapState.cameraPosition.zoom,
+        modifier = Modifier.align(Alignment.TopStart),
+      )
+
+      DisappearingCompassButton(modifier = Modifier.align(Alignment.TopEnd))
+
+      MaplibreLogo(Modifier.align(Alignment.BottomStart))
+
       val overlayScope = this
-      Row(
-        Modifier.align(Alignment.BottomStart).fillMaxWidth(),
-        horizontalArrangement = Arrangement.SpaceBetween,
-        verticalAlignment = Alignment.CenterVertically,
+      Column(
+        Modifier.align(Alignment.BottomEnd),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(Spacing),
       ) {
-        MaplibreLogo()
+        overlayScope.ZoomButtons()
         overlayScope.ExpandingAttributionButton()
       }
     }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/MapOverlay.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/MapOverlay.kt
@@ -1,7 +1,6 @@
 package org.maplibre.compose.overlay
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.LayoutScopeMarker
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
@@ -176,30 +175,14 @@ public class MapOverlay(
     }
 
     /**
-     * The controls from [Default], plus zoom buttons above the attribution button.
+     * The controls from [Default], plus zoom buttons at the middle of the end edge, clear of the
+     * compass above and the attribution below.
      *
      * The zoom buttons complement the zoom gestures; they serve pointer devices and accessibility.
      */
     public val Full: MapOverlay = MapOverlay {
-      DisappearingScaleBar(
-        metersPerDp = mapState.viewport?.metersPerDpAtTarget ?: 0.0,
-        zoom = mapState.cameraPosition.zoom,
-        modifier = Modifier.align(Alignment.TopStart),
-      )
-
-      DisappearingCompassButton(modifier = Modifier.align(Alignment.TopEnd))
-
-      MaplibreLogo(Modifier.align(Alignment.BottomStart))
-
-      val overlayScope = this
-      Column(
-        Modifier.align(Alignment.BottomEnd),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(Spacing),
-      ) {
-        overlayScope.ZoomButtons()
-        overlayScope.ExpandingAttributionButton()
-      }
+      include(Default)
+      ZoomButtons(Modifier.align(Alignment.CenterEnd))
     }
   }
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/ZoomButtons.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/ZoomButtons.kt
@@ -20,8 +20,10 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -36,6 +38,7 @@ import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
+import org.maplibre.compose.camera.CameraMoveReason
 import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.generated.Res
 import org.maplibre.compose.generated.add
@@ -49,8 +52,8 @@ import org.maplibre.compose.generated.zoom_out
  * This component draws with Compose Foundation alone. The Material 3 module provides a themed
  * version of it.
  *
- * @param onZoomIn Called after the zoom-in animation starts.
- * @param onZoomOut Called after the zoom-out animation starts.
+ * @param onZoomIn Called when the zoom-in button is clicked, once its animation is requested.
+ * @param onZoomOut Called when the zoom-out button is clicked, once its animation is requested.
  * @param style Colors, shape, and elevation of the container behind the buttons.
  * @param contentDescriptionZoomIn Accessibility label for the zoom-in button.
  * @param contentDescriptionZoomOut Accessibility label for the zoom-out button.
@@ -87,6 +90,25 @@ public fun MapOverlayScope.ZoomButtons(
       if (zoomInHovered || zoomOutHovered) style.hoveredShadowElevation else style.shadowElevation
     )
 
+  // Successive presses step from the target of the animation in flight, so three quick presses zoom
+  // three levels instead of restarting each step from the camera's mid-flight position. A gesture
+  // takes the camera elsewhere, so a press after one steps from the camera again.
+  var inFlightTarget by remember { mutableStateOf<CameraPosition?>(null) }
+  fun animateZoom(getPosition: (CameraPosition) -> CameraPosition) {
+    val from =
+      inFlightTarget?.takeIf { currentMapState.cameraMoveReason != CameraMoveReason.GESTURE }
+        ?: currentMapState.cameraPosition
+    val target = getPosition(from)
+    inFlightTarget = target
+    coroutineScope.launch {
+      try {
+        currentMapState.animateCameraPosition(target)
+      } finally {
+        if (inFlightTarget == target) inFlightTarget = null
+      }
+    }
+  }
+
   Column(
     modifier
       .requiredWidth(width)
@@ -96,9 +118,7 @@ public fun MapOverlayScope.ZoomButtons(
   ) {
     ZoomButton(
       onClick = {
-        coroutineScope.launch {
-          currentMapState.animateCameraPosition(getZoomInPosition(currentMapState.cameraPosition))
-        }
+        animateZoom(getZoomInPosition)
         onZoomIn()
       },
       interactionSource = zoomInInteractionSource,
@@ -111,9 +131,7 @@ public fun MapOverlayScope.ZoomButtons(
     Box(Modifier.fillMaxWidth().height(style.dividerThickness).background(style.dividerColor))
     ZoomButton(
       onClick = {
-        coroutineScope.launch {
-          currentMapState.animateCameraPosition(getZoomOutPosition(currentMapState.cameraPosition))
-        }
+        animateZoom(getZoomOutPosition)
         onZoomOut()
       },
       interactionSource = zoomOutInteractionSource,
@@ -157,10 +175,10 @@ private fun ZoomButton(
 }
 
 public object ZoomButtonsDefaults {
-  /** Reads over both light and dark basemaps, in the absence of a theme to draw colors from. */
+  /** Contrasts with both light and dark basemaps, in the absence of a theme to draw colors from. */
   public val ContainerColor: Color = Color.White.copy(alpha = 0.9f)
 
-  /** Reads on [ContainerColor], in the absence of a theme to draw colors from. */
+  /** Contrasts with [ContainerColor], in the absence of a theme to draw colors from. */
   public val ContentColor: Color = Color.Black.copy(alpha = 0.75f)
 
   public val DividerColor: Color = ContentColor.copy(alpha = 0.2f)

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/ZoomButtons.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/ZoomButtons.kt
@@ -1,0 +1,214 @@
+package org.maplibre.compose.overlay
+
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.LocalIndication
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredSize
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.resources.stringResource
+import org.maplibre.compose.camera.CameraPosition
+import org.maplibre.compose.generated.Res
+import org.maplibre.compose.generated.add
+import org.maplibre.compose.generated.remove
+import org.maplibre.compose.generated.zoom_in
+import org.maplibre.compose.generated.zoom_out
+
+/**
+ * Buttons that zoom the camera in and out, drawn as one vertical segmented container.
+ *
+ * This component draws with Compose Foundation alone. The Material 3 module provides a themed
+ * version of it.
+ *
+ * @param onZoomIn Called after the zoom-in animation starts.
+ * @param onZoomOut Called after the zoom-out animation starts.
+ * @param style Colors, shape, and elevation of the container behind the buttons.
+ * @param contentDescriptionZoomIn Accessibility label for the zoom-in button.
+ * @param contentDescriptionZoomOut Accessibility label for the zoom-out button.
+ * @param width Width of the container. Each button is a square of this size.
+ * @param contentPadding Gap between a button edge and its icon.
+ * @param zoomInPainter The plus artwork, tinted with [ZoomButtonsStyle.contentColor].
+ * @param zoomOutPainter The minus artwork, tinted with [ZoomButtonsStyle.contentColor].
+ * @param getZoomInPosition The camera position that the zoom-in button animates to.
+ * @param getZoomOutPosition The camera position that the zoom-out button animates to.
+ */
+@Composable
+public fun MapOverlayScope.ZoomButtons(
+  modifier: Modifier = Modifier,
+  onZoomIn: () -> Unit = {},
+  onZoomOut: () -> Unit = {},
+  style: ZoomButtonsStyle = ZoomButtonsDefaults.style(),
+  contentDescriptionZoomIn: String = ZoomButtonsDefaults.contentDescriptionZoomIn(),
+  contentDescriptionZoomOut: String = ZoomButtonsDefaults.contentDescriptionZoomOut(),
+  width: Dp = 48.dp,
+  contentPadding: PaddingValues = PaddingValues(12.dp),
+  zoomInPainter: Painter = ZoomButtonsDefaults.zoomInPainter(),
+  zoomOutPainter: Painter = ZoomButtonsDefaults.zoomOutPainter(),
+  getZoomInPosition: (CameraPosition) -> CameraPosition = { it.copy(zoom = it.zoom + 1) },
+  getZoomOutPosition: (CameraPosition) -> CameraPosition = { it.copy(zoom = it.zoom - 1) },
+) {
+  val currentMapState = mapState
+  val coroutineScope = rememberCoroutineScope()
+  val zoomInInteractionSource = remember { MutableInteractionSource() }
+  val zoomOutInteractionSource = remember { MutableInteractionSource() }
+  val zoomInHovered by zoomInInteractionSource.collectIsHoveredAsState()
+  val zoomOutHovered by zoomOutInteractionSource.collectIsHoveredAsState()
+  val shadowElevation by
+    animateDpAsState(
+      if (zoomInHovered || zoomOutHovered) style.hoveredShadowElevation else style.shadowElevation
+    )
+
+  Column(
+    modifier
+      .width(width)
+      .shadow(shadowElevation, style.shape, clip = false)
+      .background(style.containerColor, style.shape)
+      .clip(style.shape)
+  ) {
+    ZoomButton(
+      onClick = {
+        coroutineScope.launch {
+          currentMapState.animateCameraPosition(getZoomInPosition(currentMapState.cameraPosition))
+        }
+        onZoomIn()
+      },
+      interactionSource = zoomInInteractionSource,
+      contentDescription = contentDescriptionZoomIn,
+      painter = zoomInPainter,
+      contentColor = style.contentColor,
+      size = width,
+      contentPadding = contentPadding,
+    )
+    Box(Modifier.fillMaxWidth().height(style.dividerThickness).background(style.dividerColor))
+    ZoomButton(
+      onClick = {
+        coroutineScope.launch {
+          currentMapState.animateCameraPosition(getZoomOutPosition(currentMapState.cameraPosition))
+        }
+        onZoomOut()
+      },
+      interactionSource = zoomOutInteractionSource,
+      contentDescription = contentDescriptionZoomOut,
+      painter = zoomOutPainter,
+      contentColor = style.contentColor,
+      size = width,
+      contentPadding = contentPadding,
+    )
+  }
+}
+
+@Composable
+private fun ZoomButton(
+  onClick: () -> Unit,
+  interactionSource: MutableInteractionSource,
+  contentDescription: String,
+  painter: Painter,
+  contentColor: Color,
+  size: Dp,
+  contentPadding: PaddingValues,
+) {
+  Box(
+    Modifier.requiredSize(size)
+      .clickable(
+        interactionSource = interactionSource,
+        indication = LocalIndication.current,
+        role = Role.Button,
+        onClick = onClick,
+      )
+      .padding(contentPadding),
+    contentAlignment = Alignment.Center,
+  ) {
+    Image(
+      painter = painter,
+      contentDescription = contentDescription,
+      modifier = Modifier.fillMaxSize(),
+      colorFilter = ColorFilter.tint(contentColor),
+    )
+  }
+}
+
+public object ZoomButtonsDefaults {
+  /** Reads over both light and dark basemaps, in the absence of a theme to draw colors from. */
+  public val ContainerColor: Color = Color.White.copy(alpha = 0.9f)
+
+  /** Reads on [ContainerColor], in the absence of a theme to draw colors from. */
+  public val ContentColor: Color = Color.Black.copy(alpha = 0.75f)
+
+  public val DividerColor: Color = ContentColor.copy(alpha = 0.2f)
+
+  public val DividerThickness: Dp = 1.dp
+
+  public val ShadowElevation: Dp = 0.dp
+
+  public val HoveredShadowElevation: Dp = 0.dp
+
+  /** Fully rounded ends, so the container reads as a vertical pill. */
+  public val Shape: Shape = RoundedCornerShape(percent = 50)
+
+  /** Accessibility label for the zoom-in button. */
+  @Composable public fun contentDescriptionZoomIn(): String = stringResource(Res.string.zoom_in)
+
+  /** Accessibility label for the zoom-out button. */
+  @Composable public fun contentDescriptionZoomOut(): String = stringResource(Res.string.zoom_out)
+
+  /** The plus icon that the zoom-in button draws. */
+  @Composable public fun zoomInPainter(): Painter = painterResource(Res.drawable.add)
+
+  /** The minus icon that the zoom-out button draws. */
+  @Composable public fun zoomOutPainter(): Painter = painterResource(Res.drawable.remove)
+
+  public fun style(): ZoomButtonsStyle = ZoomButtonsStyle()
+}
+
+@Immutable
+public data class ZoomButtonsStyle(
+  /** Color of the container behind the buttons. */
+  public val containerColor: Color = ZoomButtonsDefaults.ContainerColor,
+
+  /** Color of the button icons. */
+  public val contentColor: Color = ZoomButtonsDefaults.ContentColor,
+
+  /** Color of the divider between the buttons. */
+  public val dividerColor: Color = ZoomButtonsDefaults.DividerColor,
+
+  /** Thickness of the divider between the buttons. */
+  public val dividerThickness: Dp = ZoomButtonsDefaults.DividerThickness,
+
+  /** Shadow elevation of the container at rest. */
+  public val shadowElevation: Dp = ZoomButtonsDefaults.ShadowElevation,
+
+  /** Shadow elevation of the container while a pointer hovers over a button. */
+  public val hoveredShadowElevation: Dp = ZoomButtonsDefaults.HoveredShadowElevation,
+
+  /** Shape of the container. */
+  public val shape: Shape = ZoomButtonsDefaults.Shape,
+)

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/ZoomButtons.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/ZoomButtons.kt
@@ -15,7 +15,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredSize
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.requiredWidth
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
@@ -89,7 +89,7 @@ public fun MapOverlayScope.ZoomButtons(
 
   Column(
     modifier
-      .width(width)
+      .requiredWidth(width)
       .shadow(shadowElevation, style.shape, clip = false)
       .background(style.containerColor, style.shape)
       .clip(style.shape)

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/ZoomButtons.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/ZoomButtons.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.requiredWidth
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -90,21 +91,27 @@ public fun MapOverlayScope.ZoomButtons(
       if (zoomInHovered || zoomOutHovered) style.hoveredShadowElevation else style.shadowElevation
     )
 
-  // Successive presses step from the target of the animation in flight, so three quick presses zoom
-  // three levels instead of restarting each step from the camera's mid-flight position. A gesture
-  // takes the camera elsewhere, so a press after one steps from the camera again.
-  var inFlightTarget by remember { mutableStateOf<CameraPosition?>(null) }
-  fun animateZoom(getPosition: (CameraPosition) -> CameraPosition) {
-    val from =
-      inFlightTarget?.takeIf { currentMapState.cameraMoveReason != CameraMoveReason.GESTURE }
-        ?: currentMapState.cameraPosition
-    val target = getPosition(from)
-    inFlightTarget = target
+  // Successive presses in one direction step from the target of the animation in flight, so three
+  // quick presses zoom three levels instead of restarting each step from the camera mid-flight. A
+  // press in the other direction, or after a gesture, steps from the camera instead: the engine may
+  // have clamped the previous target to a constraint, and a gesture moves the camera elsewhere.
+  var inFlight by remember { mutableStateOf<InFlightZoom?>(null) }
+  LaunchedEffect(currentMapState.isCameraMoving, currentMapState.cameraMoveReason) {
+    if (
+      currentMapState.isCameraMoving && currentMapState.cameraMoveReason == CameraMoveReason.GESTURE
+    ) {
+      inFlight = null
+    }
+  }
+  fun animateZoom(zoomIn: Boolean, getPosition: (CameraPosition) -> CameraPosition) {
+    val from = inFlight?.takeIf { it.zoomIn == zoomIn }?.target ?: currentMapState.cameraPosition
+    val request = InFlightZoom(zoomIn, getPosition(from))
+    inFlight = request
     coroutineScope.launch {
       try {
-        currentMapState.animateCameraPosition(target)
+        currentMapState.animateCameraPosition(request.target)
       } finally {
-        if (inFlightTarget == target) inFlightTarget = null
+        if (inFlight === request) inFlight = null
       }
     }
   }
@@ -118,7 +125,7 @@ public fun MapOverlayScope.ZoomButtons(
   ) {
     ZoomButton(
       onClick = {
-        animateZoom(getZoomInPosition)
+        animateZoom(zoomIn = true, getZoomInPosition)
         onZoomIn()
       },
       interactionSource = zoomInInteractionSource,
@@ -131,7 +138,7 @@ public fun MapOverlayScope.ZoomButtons(
     Box(Modifier.fillMaxWidth().height(style.dividerThickness).background(style.dividerColor))
     ZoomButton(
       onClick = {
-        animateZoom(getZoomOutPosition)
+        animateZoom(zoomIn = false, getZoomOutPosition)
         onZoomOut()
       },
       interactionSource = zoomOutInteractionSource,
@@ -143,6 +150,8 @@ public fun MapOverlayScope.ZoomButtons(
     )
   }
 }
+
+private class InFlightZoom(val zoomIn: Boolean, val target: CameraPosition)
 
 @Composable
 private fun ZoomButton(
@@ -189,7 +198,7 @@ public object ZoomButtonsDefaults {
 
   public val HoveredShadowElevation: Dp = 0.dp
 
-  /** Fully rounded ends, so the container reads as a vertical pill. */
+  /** Fully rounded ends, which make the container a vertical pill. */
   public val Shape: Shape = RoundedCornerShape(percent = 50)
 
   /** Accessibility label for the zoom-in button. */

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/overlay/ZoomButtonsTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/overlay/ZoomButtonsTest.kt
@@ -1,0 +1,61 @@
+package org.maplibre.compose.overlay
+
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.v2.runComposeUiTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import org.maplibre.compose.map.mapRuntimeForTest
+import org.maplibre.compose.style.BaseStyle
+
+@OptIn(ExperimentalTestApi::class)
+class ZoomButtonsTest {
+  @Test
+  fun zoom_buttons_compose_before_the_map_attaches_and_report_clicks() = runComposeUiTest {
+    val mapState = mapRuntimeForTest().createMapState(baseStyle = BaseStyle.Empty)
+    var zoomInClicks = 0
+    var zoomOutClicks = 0
+    setContent {
+      MapOverlayHost(
+        overlay = {
+          ZoomButtons(
+            modifier = Modifier.align(Alignment.BottomEnd),
+            onZoomIn = { zoomInClicks++ },
+            onZoomOut = { zoomOutClicks++ },
+          )
+        },
+        mapState = mapState,
+        contentWindowInsets = WindowInsets(0),
+      )
+    }
+    waitForIdle()
+
+    onNodeWithContentDescription("Zoom in").assertIsDisplayed().performClick()
+    onNodeWithContentDescription("Zoom out").assertIsDisplayed().performClick()
+    runOnIdle {
+      assertEquals(1, zoomInClicks)
+      assertEquals(1, zoomOutClicks)
+    }
+  }
+
+  @Test
+  fun full_overlay_draws_zoom_buttons() = runComposeUiTest {
+    val mapState = mapRuntimeForTest().createMapState(baseStyle = BaseStyle.Empty)
+    setContent {
+      MapOverlayHost(
+        overlay = { include(MapOverlay.Full) },
+        mapState = mapState,
+        contentWindowInsets = WindowInsets(0),
+      )
+    }
+    waitForIdle()
+
+    onNodeWithContentDescription("Zoom in").assertIsDisplayed()
+    onNodeWithContentDescription("Zoom out").assertIsDisplayed()
+  }
+}


### PR DESCRIPTION
## Description

Adds zoom in/out buttons as a segmented overlay control, and splits the built-in overlay into `MapOverlay.None`, `AttributionOnly`, `Default`, and `Full` presets with Material 3 mirrors (`Material3AttributionOnly`, `Material3`, `Material3Full`). `Full` places the zoom buttons at the middle of the end edge.

## Validation

New `ZoomButtonsTest` passes on desktop, `mise run check` is clean, and both themed variants were verified visually in the desktop demo, including a narrow viewport.

## AI assistance

Written by Kimi Code CLI, then reworked by Claude Code (Fable 5.1); the human driving them chose the overlay preset structure and the zoom button placement.