### PR TITLE
Observe the style load state before the loaded style is ready

### DIFF
--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
@@ -267,7 +267,10 @@ public class MapStyleState internal constructor(initialBaseStyle: BaseStyle) {
 
   private fun readyLoadedStyle(): StyleBinding? {
     if (loadState != StyleLoadState.Ready) return null
-    return owner?.readyLoadedStyle() ?: loadedStyle.load()
+    // With an owner attached, its serialized check is the only authority: a plain fallback to the
+    // stored reference could return a binding the owner has already moved to Loading.
+    val owner = owner ?: return loadedStyle.load()
+    return owner.readyLoadedStyle()
   }
 
   internal fun attach(owner: MapStyleStateOwner) {

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
@@ -266,9 +266,6 @@ public class MapStyleState internal constructor(initialBaseStyle: BaseStyle) {
   }
 
   private fun readyLoadedStyle(): StyleBinding? {
-    // Read the snapshot-backed load state on every path. The loaded style reference is not snapshot
-    // state, so a composition that asks before the style is ready would otherwise record no
-    // dependency and never see the resources arrive.
     if (loadState != StyleLoadState.Ready) return null
     return owner?.readyLoadedStyle() ?: loadedStyle.load()
   }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
@@ -265,8 +265,13 @@ public class MapStyleState internal constructor(initialBaseStyle: BaseStyle) {
     return layersState[id]
   }
 
-  private fun readyLoadedStyle(): StyleBinding? =
-    owner?.readyLoadedStyle() ?: loadedStyle.load()?.takeIf { loadState == StyleLoadState.Ready }
+  private fun readyLoadedStyle(): StyleBinding? {
+    // Read the snapshot-backed load state on every path. The loaded style reference is not snapshot
+    // state, so a composition that asks before the style is ready would otherwise record no
+    // dependency and never see the resources arrive.
+    if (loadState != StyleLoadState.Ready) return null
+    return owner?.readyLoadedStyle() ?: loadedStyle.load()
+  }
 
   internal fun attach(owner: MapStyleStateOwner) {
     this.owner = owner

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
@@ -1,6 +1,7 @@
 package org.maplibre.compose.map
 
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.ImageBitmapConfig
 import androidx.compose.ui.graphics.colorspace.ColorSpace
@@ -994,6 +995,21 @@ class MapPresentationTest {
       listOf("base attribution", "declarative attribution", "imperative attribution"),
       fixture.state.style.attributions(),
     )
+    fixture.close()
+  }
+
+  @Test
+  fun attributions_observed_before_the_style_is_ready_update_once_it_loads() {
+    val fixture = presentationFixture()
+    val attributions = derivedStateOf { fixture.state.style.attributions() }
+    assertEquals(emptyList(), attributions.value)
+
+    val binding =
+      RecordingStyleBinding(sources = listOf(attributedVectorSource("base", "base attribution")))
+    fixture.state.durableStyleCallbacks().onStyleChanged(fixture.adapter, binding)
+    fixture.state.durableStyleCallbacks().onMapFinishedLoading(fixture.adapter)
+
+    assertEquals(listOf("base attribution"), attributions.value)
     fixture.close()
   }
 


### PR DESCRIPTION
## Description

The ready check for style resources short-circuited on a non-snapshot reference, so a composition that read attributions before the first style loaded never saw them arrive and the attribution button stayed hidden.

## Validation

A new MapPresentationTest case observes attributions before load and fails without the fix; the desktop demo shows the attribution button again.

## AI assistance

Claude Code (Fable 5.1) found the cause, wrote the fix and test, and verified it in the desktop demo.