### PR TITLE
Keep maps visible while replacement styles load

### DIFF
--- a/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MlnFfiMapCompositionTest.kt
+++ b/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MlnFfiMapCompositionTest.kt
@@ -437,6 +437,66 @@ class MlnFfiMapCompositionTest {
     assertEquals(expected.zoom, actual.zoom, POSITION_TOLERANCE, "zoom")
   }
 
+  @Test
+  fun a_base_style_switch_does_not_cover_the_map_with_the_load_placeholder() = runFfiComposeUiTest {
+    val runtime = createNativeMapRuntime(runtimeOptions)
+    val first =
+      BaseStyle.Json("""{"version":8,"sources":{},"layers":[{"id":"bg-a","type":"background"}]}""")
+    val second =
+      BaseStyle.Json("""{"version":8,"sources":{},"layers":[{"id":"bg-b","type":"background"}]}""")
+    val state = runtime.createMapState(baseStyle = first)
+
+    setFfiTestMapContent(runtimeOptions) { MaplibreMap(state = state) }
+    waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) {
+      state.currentMapAttachment != null && state.style.loadState == StyleLoadState.Ready
+    }
+    val session = requireNotNull(state.currentMapAttachment).adapter as MlnFfiMapSession
+    assertTrue(session.hasPresentableStyle)
+    assertTrue(onAllNodesWithTag(MAP_LOAD_PLACEHOLDER_TAG).fetchSemanticsNodes().isEmpty())
+
+    runOnUiThread { state.style.baseStyle = second }
+    waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) { state.style.baseStyle == second }
+    assertTrue(
+      session.hasPresentableStyle,
+      "a later style switch must keep the first loaded style on screen",
+    )
+    assertTrue(
+      onAllNodesWithTag(MAP_LOAD_PLACEHOLDER_TAG).fetchSemanticsNodes().isEmpty(),
+      "a style switch must not cover the map with the load placeholder",
+    )
+    waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) {
+      state.style.loadState == StyleLoadState.Ready && "bg-b" in session.currentStyleLayerIds()
+    }
+    assertTrue(onAllNodesWithTag(MAP_LOAD_PLACEHOLDER_TAG).fetchSemanticsNodes().isEmpty())
+
+    runtime.close()
+    runtime.awaitClosed()
+  }
+
+  @Test
+  fun a_failed_replacement_style_hides_the_native_map() = runFfiComposeUiTest {
+    val runtime = createNativeMapRuntime(runtimeOptions)
+    val state = runtime.createMapState(baseStyle = BaseStyle.Empty)
+
+    setFfiTestMapContent(runtimeOptions) { MaplibreMap(state = state) }
+    waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) {
+      state.currentMapAttachment != null && state.style.loadState == StyleLoadState.Ready
+    }
+    val session = requireNotNull(state.currentMapAttachment).adapter as MlnFfiMapSession
+    assertTrue(session.hasPresentableStyle)
+
+    runOnUiThread { state.style.baseStyle = BaseStyle.Json("{") }
+    waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) {
+      state.style.loadState is StyleLoadState.Failed
+    }
+
+    assertTrue(!session.hasPresentableStyle)
+    onNodeWithTag(MAP_LOAD_PLACEHOLDER_TAG).assertExists()
+
+    runtime.close()
+    runtime.awaitClosed()
+  }
+
   /** Style loading needs no rendering, so no frame runs — and none is drawn — before a style. */
   @Test
   fun an_unloaded_style_keeps_the_transparent_load_placeholder() = runFfiComposeUiTest {

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
@@ -139,8 +139,8 @@ internal class GlJsMapSession(
   /** Whether the current engine map has loaded its first base style. */
   private var hasLoadedInitialStyle = false
 
-  /** Whether the current engine map has reconciled the latest requested style. */
-  private var hasReconciledStyle by mutableStateOf(false)
+  /** Whether the current engine map has a style that can remain visible during replacement. */
+  private var hasPresentableStyle by mutableStateOf(false)
     private set
 
   /** True after the current engine map has applied a non-empty presentation viewport. */
@@ -151,7 +151,7 @@ internal class GlJsMapSession(
 
   /** Whether the current engine map may be copied onto the visible Compose surface. */
   internal val canPresentFrames: Boolean
-    get() = hasReconciledStyle && hasReplayedPresentationState
+    get() = hasPresentableStyle && hasReplayedPresentationState
 
   private var requestedStyle: BaseStyle? = null
   private var appliedStyle: BaseStyle? = null
@@ -377,7 +377,7 @@ internal class GlJsMapSession(
     hasLoadedInitialStyle = false
     val current = map ?: return
     map = null
-    hasReconciledStyle = false
+    hasPresentableStyle = false
     hasUsableViewport = false
     hasReplayedPresentationState = false
     invalidateStyleBinding()
@@ -565,7 +565,7 @@ internal class GlJsMapSession(
     if (styleLoadTracker?.reconciled(trackerRequest, identity) == true) {
       if (lifecycleCallbacks.onMapFinishedLoading(engine, style, this)) {
         reportStyleLoaded = false
-        hasReconciledStyle = true
+        hasPresentableStyle = true
       }
     }
   }
@@ -644,7 +644,6 @@ internal class GlJsMapSession(
 
   override fun setBaseStyle(style: BaseStyle) {
     if (style == requestedStyle) return
-    hasReconciledStyle = false
     revisionApplied = false
     baseStyleReady = false
     // Must precede the new style: the old style's sources and layers would otherwise recompose
@@ -669,23 +668,27 @@ internal class GlJsMapSession(
     val tracker = styleLoadTracker ?: return false
     val wasReady = tracker.state is TrackedStyleLoadState.Ready
     val request = tracker.beginReconciliation()
-    hasReconciledStyle = false
     revisionApplied = false
     try {
       styleReconciler.apply(binding, revision)
     } catch (error: CancellationException) {
       throw error
     } catch (error: Throwable) {
-      tracker.failed(
-        request,
-        TrackedStyleLoadState.Failed.Stage.RECONCILIATION,
-        error.message ?: "Style reconciliation failed",
-      )
+      if (
+        tracker.failed(
+          request,
+          TrackedStyleLoadState.Failed.Stage.RECONCILIATION,
+          error.message ?: "Style reconciliation failed",
+        )
+      ) {
+        hasPresentableStyle = false
+      }
       throw error
     }
     revisionApplied = true
-    if (wasReady && tracker.reconciled(request, binding.identity)) {
-      hasReconciledStyle = true
+    val reconciledImmediately = wasReady && tracker.reconciled(request, binding.identity)
+    if (reconciledImmediately) {
+      hasPresentableStyle = true
       surface?.requestFrame()
     } else {
       val engine = lifecycleEngineIdentity
@@ -693,14 +696,20 @@ internal class GlJsMapSession(
         reportLoadedOnceStyleIsReady(engine, lifecycleStyleIdentity)
       }
     }
-    return hasReconciledStyle
+    return reconciledImmediately
   }
 
   override suspend fun replayStyleRevision(revision: DesiredStyleRevision) {
     val binding = styleBinding ?: return
-    hasReconciledStyle = false
     revisionApplied = false
-    styleReconciler.apply(binding, revision)
+    try {
+      styleReconciler.apply(binding, revision)
+    } catch (error: CancellationException) {
+      throw error
+    } catch (error: Throwable) {
+      hasPresentableStyle = false
+      throw error
+    }
     surface?.requestFrame()
   }
 
@@ -787,6 +796,7 @@ internal class GlJsMapSession(
         if (accepted) {
           if (lifecycleCallbacks.onMapFailLoading(engine, lifecycleRequest, this, reason)) {
             logger?.e { "Map loading failed: $reason" }
+            hasPresentableStyle = false
             if (!hasLoadedInitialStyle) abandonPending(pendingInitialStyleActions)
           }
         } else {
@@ -820,6 +830,7 @@ internal class GlJsMapSession(
         ) == true
       ) {
         lifecycleCallbacks.onMapFailLoading(engine, lifecycleRequest, this, reason)
+        hasPresentableStyle = false
       }
       if (!hasLoadedInitialStyle) abandonPending(pendingInitialStyleActions)
     }

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserMapStyleStateTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserMapStyleStateTest.kt
@@ -115,6 +115,34 @@ class BrowserMapStyleStateTest {
     val resolve: () -> Unit,
   )
 
+  private fun installDeferredStyle(): DeferredStyle {
+    val global = js("window")
+    val original = global.fetch
+    var resolveStyle: ((dynamic) -> Unit)? = null
+    global.fetch = { input: dynamic, init: dynamic ->
+      val url = if (jsTypeOf(input) == "string") input as String else input.url as String
+      if (url == DEFERRED_STYLE_URL) {
+        Promise<dynamic> { resolve, _ -> resolveStyle = resolve }
+      } else {
+        original.call(global, input, init)
+      }
+    }
+    return DeferredStyle(
+      restore = { global.fetch = original },
+      isRequested = { resolveStyle != null },
+      resolve = {
+        checkNotNull(resolveStyle) { "MapLibre has not requested the style" }
+          .invoke(makeJsonResponse(STYLE_B_JSON))
+      },
+    )
+  }
+
+  private class DeferredStyle(
+    val restore: () -> Unit,
+    val isRequested: () -> Boolean,
+    val resolve: () -> Unit,
+  )
+
   private fun makeJsonResponse(body: String): dynamic =
     js("new Response(body, { status: 200, headers: { 'content-type': 'application/json' } })")
 
@@ -228,6 +256,44 @@ class BrowserMapStyleStateTest {
       assertTrue(state.currentMapAttachment === presentation)
       assertTrue(presentation.isValid)
       assertFalse(session.canPresentFrames, "the failed map surface must remain hidden")
+
+      runtime.close()
+      runtime.awaitClosed()
+    }
+
+  @Test
+  fun a_web_style_switch_keeps_presenting_frames_while_the_replacement_loads(): Promise<*> =
+    runBrowserMapTest {
+      val runtime = createMapRuntime(MapRuntimeOptions())
+      val state = runtime.createMapState(baseStyle = STYLE_A)
+
+      setBrowserMapContent { MaplibreMap(state = state) }
+      waitUntilMap("the first style to become ready") {
+        state.currentMapAttachment != null && state.style.loadState == StyleLoadState.Ready
+      }
+      val session = requireNotNull(state.currentMapAttachment).adapter as GlJsMapSession
+      assertTrue(session.canPresentFrames)
+
+      val deferredStyle = installDeferredStyle()
+      try {
+        runOnIdle { state.style.baseStyle = BaseStyle.Uri(DEFERRED_STYLE_URL) }
+        waitUntilMap("MapLibre to request the replacement style") { deferredStyle.isRequested() }
+
+        assertEquals(StyleLoadState.Loading, state.style.loadState)
+        assertTrue(
+          session.canPresentFrames,
+          "the loaded style must remain visible while its replacement loads",
+        )
+
+        deferredStyle.resolve()
+        waitUntilMap("the replacement style to become ready") {
+          state.style.loadState == StyleLoadState.Ready &&
+            session.engineMapForTest()?.getStyle()?.layers?.any { it.id == "b" } == true
+        }
+        assertTrue(session.canPresentFrames)
+      } finally {
+        deferredStyle.restore()
+      }
 
       runtime.close()
       runtime.awaitClosed()
@@ -385,6 +451,9 @@ class BrowserMapStyleStateTest {
         """{"version":8,"name":"b","sources":{},"layers":[{"id":"b","type":"background"}]}"""
       )
     val INVALID_STYLE = BaseStyle.Json("""{"version":7,"sources":{},"layers":[]}""")
+    const val DEFERRED_STYLE_URL = "https://deferred-style.test/style.json"
+    const val STYLE_B_JSON =
+      """{"version":8,"name":"b","sources":{},"layers":[{"id":"b","type":"background"}]}"""
     const val TILE_JSON =
       """{"tilejson":"2.2.0","tiles":["https://example.invalid/{z}/{x}/{y}.pbf"],""" +
         """"attribution":"fetched attribution"}"""

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -214,10 +214,10 @@ internal class MlnFfiMapSession(
   @Volatile private var hostSession: MlnFfiMapHostSession? = null
 
   /**
-   * True once this session has loaded a style. It stays true so a later style switch does not put
-   * the load placeholder back over a live map.
+   * Whether the current presentation has a style to render. This stays true while a replacement
+   * loads and becomes false when the replacement fails.
    */
-  internal var hasLoadedFirstStyle by mutableStateOf(false)
+  internal var hasPresentableStyle by mutableStateOf(false)
     private set
 
   private data class TargetKey(val generation: Long, val extent: MapExtent)
@@ -449,7 +449,7 @@ internal class MlnFfiMapSession(
   }
 
   internal fun preparePresentation() {
-    hasLoadedFirstStyle = false
+    hasPresentableStyle = false
   }
 
   internal val isPresentationPublished: Boolean
@@ -797,7 +797,7 @@ internal class MlnFfiMapSession(
       lifecycleStyleIdentity?.let {
         if (lifecycleCallbacks.onMapFinishedLoading(engine, it, this)) {
           styleLoadUnreported = false
-          hasLoadedFirstStyle = true
+          hasPresentableStyle = true
         }
       }
     }
@@ -873,6 +873,7 @@ internal class MlnFfiMapSession(
             ?.takeIf { it.engine == engine }
             ?.let {
               if (lifecycleCallbacks.onMapFailLoading(engine, it.request, this, reason)) {
+                hasPresentableStyle = false
                 logger?.e { "Map loading failed (code ${event.code}): $reason" }
               }
             }
@@ -1123,7 +1124,6 @@ internal class MlnFfiMapSession(
     if (style == requestedStyle) return
     styleBinding?.invalidate()
     revisionApplied = false
-    hasLoadedFirstStyle = false
     requestedStyle = style
     val engineAvailable = loop != null
     val tracker = styleLoadTracker
@@ -1153,37 +1153,47 @@ internal class MlnFfiMapSession(
     val wasReady = tracker.state is TrackedStyleLoadState.Ready
     val request = tracker.beginReconciliation()
     revisionApplied = false
-    hasLoadedFirstStyle = false
     try {
       styleReconciler.apply(binding, revision)
     } catch (error: CancellationException) {
       throw error
     } catch (error: Throwable) {
-      tracker.failed(
-        request,
-        TrackedStyleLoadState.Failed.Stage.RECONCILIATION,
-        error.message ?: "Style reconciliation failed",
-      )
+      if (
+        tracker.failed(
+          request,
+          TrackedStyleLoadState.Failed.Stage.RECONCILIATION,
+          error.message ?: "Style reconciliation failed",
+        )
+      ) {
+        hasPresentableStyle = false
+      }
       throw error
     }
     revisionApplied = true
-    if (wasReady && tracker.reconciled(request, binding.identity)) {
-      hasLoadedFirstStyle = true
+    val reconciledImmediately = wasReady && tracker.reconciled(request, binding.identity)
+    if (reconciledImmediately) {
+      hasPresentableStyle = true
     }
     val engine = lifecycleEngineIdentity
     runOnMap {
       it.requestRepaint()
-      if (!hasLoadedFirstStyle && engine != null) reportLoadedStyle(engine)
+      if (engine != null) reportLoadedStyle(engine)
     }
     requestRender()
-    return hasLoadedFirstStyle
+    return reconciledImmediately
   }
 
   override suspend fun replayStyleRevision(revision: DesiredStyleRevision) {
     val binding = styleBinding ?: return
     revisionApplied = false
-    hasLoadedFirstStyle = false
-    styleReconciler.apply(binding, revision)
+    try {
+      styleReconciler.apply(binding, revision)
+    } catch (error: CancellationException) {
+      throw error
+    } catch (error: Throwable) {
+      hasPresentableStyle = false
+      throw error
+    }
     onMap { it.requestRepaint() }
     requestRender()
   }

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapView.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapView.kt
@@ -161,7 +161,7 @@ internal fun MlnFfiMapView(
   val continuation = remember(session, inputScope) { GestureContinuation(inputScope) }
 
   // MapLibre renders black until a style loads.
-  val revealSurface = session.hasLoadedFirstStyle
+  val revealSurface = session.hasPresentableStyle
 
   // Before the first render target attaches, gestures would project through the bootstrap 1x1
   // viewport and jump the camera.


### PR DESCRIPTION
## Description

Keep the current map frame visible while a replacement base style loads and reconciles, without marking the replacement ready before its style content finishes.

## Validation

Passed `mise run test:desktop`, `caffeinate -dimsu mise run test:js`, `mise run check`, and the focused native success and failure regression tests.

## AI assistance

Codex (GPT-5) implemented and validated the change in the Codex CLI harness.