### PR TITLE
Add mbtilesUrl for packaged MBTiles files

### DIFF
--- a/lib/maplibre-compose/src/androidDeviceTest/kotlin/org/maplibre/compose/map/AndroidExplicitRuntimeTest.kt
+++ b/lib/maplibre-compose/src/androidDeviceTest/kotlin/org/maplibre/compose/map/AndroidExplicitRuntimeTest.kt
@@ -11,18 +11,12 @@ import org.maplibre.compose.style.BaseStyle
 @OptIn(DelicateMapApi::class)
 class AndroidExplicitRuntimeTest {
   @Test
-  fun explicit_runtime_initializes_android_platform() = runBlocking {
+  fun explicit_runtime_uses_the_application_context() = runBlocking {
     val context = InstrumentationRegistry.getInstrumentation().targetContext
     val cacheDirectory = context.cacheDir.resolve("explicit-runtime-${System.nanoTime()}")
     check(cacheDirectory.mkdirs()) { "Could not create test directory $cacheDirectory" }
-    AndroidMlnFfiPlatform.resetForTest()
     val runtime =
-      createMapRuntime(
-        MapRuntimeOptions(
-          context = context,
-          cacheFile = cacheDirectory.resolve("cache.db"),
-        )
-      )
+      createMapRuntime(MapRuntimeOptions(cacheFile = cacheDirectory.resolve("cache.db")))
     val state = runtime.createMapState(baseStyle = BaseStyle.Empty)
 
     try {

--- a/lib/maplibre-compose/src/androidDeviceTest/kotlin/org/maplibre/compose/mlnffi/FfiTestPlatform.android.kt
+++ b/lib/maplibre-compose/src/androidDeviceTest/kotlin/org/maplibre/compose/mlnffi/FfiTestPlatform.android.kt
@@ -1,6 +1,5 @@
 package org.maplibre.compose.mlnffi
 
-import androidx.test.platform.app.InstrumentationRegistry
 import java.io.File
 import kotlinx.io.files.Path
 import org.junit.Assume.assumeTrue
@@ -9,7 +8,7 @@ internal actual object FfiTestPlatform {
   actual val runtimeCapabilities = FfiTestRuntimeCapabilities(customGeometrySourceCallbacks = true)
 
   actual fun initialize() {
-    AndroidMlnFfiPlatform.initialize(InstrumentationRegistry.getInstrumentation().targetContext)
+    AndroidMlnFfiPlatform.initialize()
   }
 
   actual fun createCacheFile(): Path {

--- a/lib/maplibre-compose/src/androidJvmMain/kotlin/org/maplibre/compose/sources/PackagedFileCopy.kt
+++ b/lib/maplibre-compose/src/androidJvmMain/kotlin/org/maplibre/compose/sources/PackagedFileCopy.kt
@@ -2,6 +2,7 @@ package org.maplibre.compose.sources
 
 import java.io.File
 import java.io.InputStream
+import java.security.MessageDigest
 import java.util.concurrent.ConcurrentHashMap
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.sync.Mutex
@@ -25,7 +26,8 @@ internal suspend fun copyPackagedFile(
   open: () -> InputStream,
 ): File {
   val destination = File(directory, packagedCopyName(uri))
-  // The file name is a lossy key, so the stamp records the source URI as well.
+  // The stamp records the source URI as well as the package version, so a copy is never reused for
+  // a different resource.
   val expected = "$uri\n$stamp"
   val lock = copyLocks.getOrPut(destination.absolutePath) { Mutex() }
   lock.withLock {
@@ -51,8 +53,9 @@ internal suspend fun copyPackagedFile(
   return destination
 }
 
-/** The file name for the copy of [uri]: its last path segment, made unique by the whole URI. */
+/** The file name for the copy of [uri]: a digest of the whole URI, then its last path segment. */
 private fun packagedCopyName(uri: String): String {
   val name = uri.substringAfterLast('/').substringBefore('?').ifEmpty { "tiles.mbtiles" }
-  return Integer.toHexString(uri.hashCode()) + "-" + name
+  val digest = MessageDigest.getInstance("SHA-256").digest(uri.encodeToByteArray())
+  return digest.take(8).joinToString("") { "%02x".format(it) } + "-" + name
 }

--- a/lib/maplibre-compose/src/androidJvmMain/kotlin/org/maplibre/compose/sources/PackagedFileCopy.kt
+++ b/lib/maplibre-compose/src/androidJvmMain/kotlin/org/maplibre/compose/sources/PackagedFileCopy.kt
@@ -2,6 +2,7 @@ package org.maplibre.compose.sources
 
 import java.io.File
 import java.io.InputStream
+import java.io.OutputStream
 import java.security.MessageDigest
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.time.Duration.Companion.days
@@ -13,6 +14,9 @@ import kotlinx.coroutines.withContext
 /** One lock per URI, so two callers in one process read and copy the same resource once. */
 private val copyLocks = ConcurrentHashMap<String, Mutex>()
 
+/** Copies this process has returned. They stay on disk for the life of the process. */
+private val copiesInUse: MutableSet<String> = ConcurrentHashMap.newKeySet()
+
 /** A copy that no call has used for this long is deleted. */
 private val UNUSED_COPY_LIFETIME = 30.days
 
@@ -23,7 +27,7 @@ private val UNUSED_COPY_LIFETIME = 30.days
  * whenever it exists, a changed resource gets a new copy, and two processes that copy the same
  * resource at the same time write the same file. Every call reads the resource once to identify it,
  * and a call that finds no copy reads it a second time to write one. Copies that no call has used
- * for [UNUSED_COPY_LIFETIME] are deleted.
+ * for [UNUSED_COPY_LIFETIME] are deleted, except copies this process has returned.
  */
 internal suspend fun copyPackagedFile(
   uri: String,
@@ -33,42 +37,59 @@ internal suspend fun copyPackagedFile(
   val lock = copyLocks.getOrPut(uri) { Mutex() }
   return lock.withLock {
     withContext(Dispatchers.IO) {
-      val destination = File(directory, open().use { it.sha256Hex() } + ".mbtiles")
-      if (!destination.isFile) {
-        directory.mkdirs()
-        val temporary = File.createTempFile("copy", ".part", directory)
-        try {
-          open().use { input -> temporary.outputStream().use { output -> input.copyTo(output) } }
-          // A rename onto a copy that another process just finished may fail; that copy is the
-          // same bytes.
-          if (!temporary.renameTo(destination) && !destination.isFile) {
-            error("Could not move $temporary to $destination")
-          }
-        } finally {
-          temporary.delete()
+      // Another process may evict a copy between finding it and marking it used, so try twice.
+      repeat(2) {
+        val copy = findOrWriteCopy(directory, open)
+        copiesInUse += copy.absolutePath
+        copy.setLastModified(System.currentTimeMillis())
+        if (copy.isFile) {
+          deleteUnusedCopies(directory)
+          return@withContext copy
         }
       }
-      destination.setLastModified(System.currentTimeMillis())
-      deleteUnusedCopies(directory, keep = destination)
-      destination
+      error("The copy of $uri disappeared while it was being resolved")
     }
   }
 }
 
-private fun InputStream.sha256Hex(): String {
+private fun findOrWriteCopy(directory: File, open: () -> InputStream): File {
+  val existing = File(directory, open().use { it.sha256Hex(to = null) } + ".mbtiles")
+  if (existing.isFile) return existing
+  directory.mkdirs()
+  val temporary = File.createTempFile("copy", ".part", directory)
+  try {
+    // The name comes from the bytes written, in case the resource changed since the first read.
+    val digest = open().use { input -> temporary.outputStream().use { input.sha256Hex(to = it) } }
+    val destination = File(directory, "$digest.mbtiles")
+    // A rename onto a copy that another process just finished may fail; that copy is the same
+    // bytes.
+    if (!destination.isFile && !temporary.renameTo(destination) && !destination.isFile) {
+      error("Could not move $temporary to $destination")
+    }
+    return destination
+  } finally {
+    temporary.delete()
+  }
+}
+
+/** Digests the stream, and writes it to [to] when given. */
+private fun InputStream.sha256Hex(to: OutputStream?): String {
   val digest = MessageDigest.getInstance("SHA-256")
   val buffer = ByteArray(64 * 1024)
   while (true) {
     val read = read(buffer)
     if (read < 0) break
     digest.update(buffer, 0, read)
+    to?.write(buffer, 0, read)
   }
   return digest.digest().joinToString("") { "%02x".format(it) }
 }
 
-private fun deleteUnusedCopies(directory: File, keep: File) {
+private fun deleteUnusedCopies(directory: File) {
   val cutoff = System.currentTimeMillis() - UNUSED_COPY_LIFETIME.inWholeMilliseconds
   directory
-    .listFiles { file -> file != keep && file.isFile && file.lastModified() < cutoff }
+    .listFiles { file ->
+      file.isFile && file.absolutePath !in copiesInUse && file.lastModified() < cutoff
+    }
     ?.forEach { it.delete() }
 }

--- a/lib/maplibre-compose/src/androidJvmMain/kotlin/org/maplibre/compose/sources/PackagedFileCopy.kt
+++ b/lib/maplibre-compose/src/androidJvmMain/kotlin/org/maplibre/compose/sources/PackagedFileCopy.kt
@@ -1,0 +1,61 @@
+package org.maplibre.compose.sources
+
+import java.io.File
+import java.io.InputStream
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+import java.util.concurrent.ConcurrentHashMap
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+
+/** One lock per destination, so two callers that want the same file copy it once. */
+private val copyLocks = ConcurrentHashMap<String, Mutex>()
+
+/**
+ * Copies a packaged resource to [destination] unless a copy with the same [stamp] is already there,
+ * and returns [destination].
+ *
+ * [stamp] identifies the package version that the resource came from. The copy is written to a
+ * temporary file and moved into place, so a reader sees either the old copy or the new one.
+ */
+internal suspend fun copyPackagedFile(
+  destination: File,
+  stamp: String,
+  open: () -> InputStream,
+): File {
+  val lock = copyLocks.getOrPut(destination.absolutePath) { Mutex() }
+  lock.withLock {
+    withContext(Dispatchers.IO) {
+      val stampFile = File(destination.path + ".stamp")
+      val current = destination.isFile && stampFile.isFile && stampFile.readText() == stamp
+      if (!current) {
+        destination.parentFile?.mkdirs()
+        stampFile.delete()
+        val temporary = File.createTempFile(destination.name, ".part", destination.parentFile)
+        try {
+          open().use { input -> temporary.outputStream().use { output -> input.copyTo(output) } }
+          // An atomic move onto an existing file is platform-specific, so remove the old copy
+          // first.
+          destination.delete()
+          Files.move(
+            temporary.toPath(),
+            destination.toPath(),
+            StandardCopyOption.ATOMIC_MOVE,
+          )
+        } finally {
+          temporary.delete()
+        }
+        stampFile.writeText(stamp)
+      }
+    }
+  }
+  return destination
+}
+
+/** The file name for the copy of [uri]: its last path segment, made unique by the whole URI. */
+internal fun packagedCopyName(uri: String): String {
+  val name = uri.substringAfterLast('/').substringBefore('?').ifEmpty { "tiles.mbtiles" }
+  return Integer.toHexString(uri.hashCode()) + "-" + name
+}

--- a/lib/maplibre-compose/src/androidJvmMain/kotlin/org/maplibre/compose/sources/PackagedFileCopy.kt
+++ b/lib/maplibre-compose/src/androidJvmMain/kotlin/org/maplibre/compose/sources/PackagedFileCopy.kt
@@ -4,62 +4,71 @@ import java.io.File
 import java.io.InputStream
 import java.security.MessageDigest
 import java.util.concurrent.ConcurrentHashMap
+import kotlin.time.Duration.Companion.days
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 
-/** One lock per destination, so two callers that want the same file copy it once. */
+/** One lock per URI, so two callers in one process read and copy the same resource once. */
 private val copyLocks = ConcurrentHashMap<String, Mutex>()
 
+/** A copy that no call has used for this long is deleted. */
+private val UNUSED_COPY_LIFETIME = 30.days
+
 /**
- * Copies the packaged resource at [uri] into [directory] unless a copy of the same [uri] with the
- * same [stamp] is already there, and returns the copy.
+ * Returns a copy of the packaged resource that [open] reads, in [directory].
  *
- * [stamp] identifies the package version that the resource came from. The copy is written to a
- * temporary file and moved into place, so a reader sees either the old copy or the new one.
+ * The copy is named by the SHA-256 digest of its content, so a copy is complete and correct
+ * whenever it exists, a changed resource gets a new copy, and two processes that copy the same
+ * resource at the same time write the same file. Every call reads the resource once to identify it,
+ * and a call that finds no copy reads it a second time to write one. Copies that no call has used
+ * for [UNUSED_COPY_LIFETIME] are deleted.
  */
 internal suspend fun copyPackagedFile(
   uri: String,
   directory: File,
-  stamp: String,
   open: () -> InputStream,
 ): File {
-  val destination = File(directory, packagedCopyName(uri))
-  // The stamp records the source URI as well as the package version, so a copy is never reused for
-  // a different resource.
-  val expected = "$uri\n$stamp"
-  val lock = copyLocks.getOrPut(destination.absolutePath) { Mutex() }
-  lock.withLock {
+  val lock = copyLocks.getOrPut(uri) { Mutex() }
+  return lock.withLock {
     withContext(Dispatchers.IO) {
-      val stampFile = File(destination.path + ".stamp")
-      // Another process may complete the same copy at any point, so the check repeats after the
-      // slow steps rather than trusting the first answer.
-      fun isCurrent() = destination.isFile && stampFile.isFile && stampFile.readText() == expected
-      if (isCurrent()) return@withContext
-      destination.parentFile?.mkdirs()
-      val temporary = File.createTempFile(destination.name, ".part", destination.parentFile)
-      try {
-        open().use { input -> temporary.outputStream().use { output -> input.copyTo(output) } }
-        if (isCurrent()) return@withContext
-        stampFile.delete()
-        // A rename onto an existing file is platform-specific, so remove the old copy first.
-        destination.delete()
-        if (!temporary.renameTo(destination) && !isCurrent()) {
-          error("Could not move $temporary to $destination")
+      val destination = File(directory, open().use { it.sha256Hex() } + ".mbtiles")
+      if (!destination.isFile) {
+        directory.mkdirs()
+        val temporary = File.createTempFile("copy", ".part", directory)
+        try {
+          open().use { input -> temporary.outputStream().use { output -> input.copyTo(output) } }
+          // A rename onto a copy that another process just finished may fail; that copy is the
+          // same bytes.
+          if (!temporary.renameTo(destination) && !destination.isFile) {
+            error("Could not move $temporary to $destination")
+          }
+        } finally {
+          temporary.delete()
         }
-      } finally {
-        temporary.delete()
       }
-      if (!stampFile.isFile) stampFile.writeText(expected)
+      destination.setLastModified(System.currentTimeMillis())
+      deleteUnusedCopies(directory, keep = destination)
+      destination
     }
   }
-  return destination
 }
 
-/** The file name for the copy of [uri]: a digest of the whole URI, then its last path segment. */
-private fun packagedCopyName(uri: String): String {
-  val name = uri.substringAfterLast('/').substringBefore('?').ifEmpty { "tiles.mbtiles" }
-  val digest = MessageDigest.getInstance("SHA-256").digest(uri.encodeToByteArray())
-  return digest.take(8).joinToString("") { "%02x".format(it) } + "-" + name
+private fun InputStream.sha256Hex(): String {
+  val digest = MessageDigest.getInstance("SHA-256")
+  val buffer = ByteArray(64 * 1024)
+  while (true) {
+    val read = read(buffer)
+    if (read < 0) break
+    digest.update(buffer, 0, read)
+  }
+  return digest.digest().joinToString("") { "%02x".format(it) }
+}
+
+private fun deleteUnusedCopies(directory: File, keep: File) {
+  val cutoff = System.currentTimeMillis() - UNUSED_COPY_LIFETIME.inWholeMilliseconds
+  directory
+    .listFiles { file -> file != keep && file.isFile && file.lastModified() < cutoff }
+    ?.forEach { it.delete() }
 }

--- a/lib/maplibre-compose/src/androidJvmMain/kotlin/org/maplibre/compose/sources/PackagedFileCopy.kt
+++ b/lib/maplibre-compose/src/androidJvmMain/kotlin/org/maplibre/compose/sources/PackagedFileCopy.kt
@@ -33,21 +33,25 @@ internal suspend fun copyPackagedFile(
   lock.withLock {
     withContext(Dispatchers.IO) {
       val stampFile = File(destination.path + ".stamp")
-      val current = destination.isFile && stampFile.isFile && stampFile.readText() == expected
-      if (!current) {
-        destination.parentFile?.mkdirs()
+      // Another process may complete the same copy at any point, so the check repeats after the
+      // slow steps rather than trusting the first answer.
+      fun isCurrent() = destination.isFile && stampFile.isFile && stampFile.readText() == expected
+      if (isCurrent()) return@withContext
+      destination.parentFile?.mkdirs()
+      val temporary = File.createTempFile(destination.name, ".part", destination.parentFile)
+      try {
+        open().use { input -> temporary.outputStream().use { output -> input.copyTo(output) } }
+        if (isCurrent()) return@withContext
         stampFile.delete()
-        val temporary = File.createTempFile(destination.name, ".part", destination.parentFile)
-        try {
-          open().use { input -> temporary.outputStream().use { output -> input.copyTo(output) } }
-          // A rename onto an existing file is platform-specific, so remove the old copy first.
-          destination.delete()
-          check(temporary.renameTo(destination)) { "Could not move $temporary to $destination" }
-        } finally {
-          temporary.delete()
+        // A rename onto an existing file is platform-specific, so remove the old copy first.
+        destination.delete()
+        if (!temporary.renameTo(destination) && !isCurrent()) {
+          error("Could not move $temporary to $destination")
         }
-        stampFile.writeText(expected)
+      } finally {
+        temporary.delete()
       }
+      if (!stampFile.isFile) stampFile.writeText(expected)
     }
   }
   return destination

--- a/lib/maplibre-compose/src/androidJvmMain/kotlin/org/maplibre/compose/sources/PackagedFileCopy.kt
+++ b/lib/maplibre-compose/src/androidJvmMain/kotlin/org/maplibre/compose/sources/PackagedFileCopy.kt
@@ -12,22 +12,26 @@ import kotlinx.coroutines.withContext
 private val copyLocks = ConcurrentHashMap<String, Mutex>()
 
 /**
- * Copies a packaged resource to [destination] unless a copy with the same [stamp] is already there,
- * and returns [destination].
+ * Copies the packaged resource at [uri] into [directory] unless a copy of the same [uri] with the
+ * same [stamp] is already there, and returns the copy.
  *
  * [stamp] identifies the package version that the resource came from. The copy is written to a
  * temporary file and moved into place, so a reader sees either the old copy or the new one.
  */
 internal suspend fun copyPackagedFile(
-  destination: File,
+  uri: String,
+  directory: File,
   stamp: String,
   open: () -> InputStream,
 ): File {
+  val destination = File(directory, packagedCopyName(uri))
+  // The file name is a lossy key, so the stamp records the source URI as well.
+  val expected = "$uri\n$stamp"
   val lock = copyLocks.getOrPut(destination.absolutePath) { Mutex() }
   lock.withLock {
     withContext(Dispatchers.IO) {
       val stampFile = File(destination.path + ".stamp")
-      val current = destination.isFile && stampFile.isFile && stampFile.readText() == stamp
+      val current = destination.isFile && stampFile.isFile && stampFile.readText() == expected
       if (!current) {
         destination.parentFile?.mkdirs()
         stampFile.delete()
@@ -40,7 +44,7 @@ internal suspend fun copyPackagedFile(
         } finally {
           temporary.delete()
         }
-        stampFile.writeText(stamp)
+        stampFile.writeText(expected)
       }
     }
   }
@@ -48,7 +52,7 @@ internal suspend fun copyPackagedFile(
 }
 
 /** The file name for the copy of [uri]: its last path segment, made unique by the whole URI. */
-internal fun packagedCopyName(uri: String): String {
+private fun packagedCopyName(uri: String): String {
   val name = uri.substringAfterLast('/').substringBefore('?').ifEmpty { "tiles.mbtiles" }
   return Integer.toHexString(uri.hashCode()) + "-" + name
 }

--- a/lib/maplibre-compose/src/androidJvmMain/kotlin/org/maplibre/compose/sources/PackagedFileCopy.kt
+++ b/lib/maplibre-compose/src/androidJvmMain/kotlin/org/maplibre/compose/sources/PackagedFileCopy.kt
@@ -2,8 +2,6 @@ package org.maplibre.compose.sources
 
 import java.io.File
 import java.io.InputStream
-import java.nio.file.Files
-import java.nio.file.StandardCopyOption
 import java.util.concurrent.ConcurrentHashMap
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.sync.Mutex
@@ -36,14 +34,9 @@ internal suspend fun copyPackagedFile(
         val temporary = File.createTempFile(destination.name, ".part", destination.parentFile)
         try {
           open().use { input -> temporary.outputStream().use { output -> input.copyTo(output) } }
-          // An atomic move onto an existing file is platform-specific, so remove the old copy
-          // first.
+          // A rename onto an existing file is platform-specific, so remove the old copy first.
           destination.delete()
-          Files.move(
-            temporary.toPath(),
-            destination.toPath(),
-            StandardCopyOption.ATOMIC_MOVE,
-          )
+          check(temporary.renameTo(destination)) { "Could not move $temporary to $destination" }
         } finally {
           temporary.delete()
         }

--- a/lib/maplibre-compose/src/androidMain/AndroidManifest.xml
+++ b/lib/maplibre-compose/src/androidMain/AndroidManifest.xml
@@ -1,4 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <uses-permission android:name="android.permission.INTERNET" />
+
+  <application>
+    <provider
+      android:name="org.maplibre.compose.mlnffi.AndroidContextProvider"
+      android:authorities="${applicationId}.maplibre-compose.context"
+      android:exported="false"
+    />
+  </application>
 </manifest>

--- a/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/map/AndroidMapView.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/map/AndroidMapView.kt
@@ -4,10 +4,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import org.maplibre.compose.logging.MapLog
 import org.maplibre.compose.mlnffi.AndroidMapSurfaceKind
-import org.maplibre.compose.mlnffi.AndroidMlnFfiPlatform
 import org.maplibre.compose.mlnffi.AndroidMlnFfiSurface
 import org.maplibre.compose.mlnffi.MapRenderBackend
 import org.maplibre.compose.style.BaseStyle
@@ -25,7 +23,6 @@ internal actual fun ComposableMapView(
   callbacks: MapAdapter.Callbacks,
   options: MapViewOptions,
 ) {
-  AndroidMlnFfiPlatform.initialize(LocalContext.current)
   val runtimeBackends = remember { loadRuntimeBackends(logger) }
   val renderBackend =
     remember(runtimeBackends) { runtimeBackends.firstOrNull() ?: MapRenderBackend.OPENGL }

--- a/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/map/MapRuntime.android.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/map/MapRuntime.android.kt
@@ -1,9 +1,7 @@
 package org.maplibre.compose.map
 
-import android.content.Context
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
-import androidx.compose.ui.platform.LocalContext
 import java.io.File
 import kotlinx.io.files.Path
 import org.maplibre.compose.mlnffi.AndroidMlnFfiPlatform
@@ -14,10 +12,9 @@ import org.maplibre.compose.resource.MapResourceProvider
 /** Configuration for one Android map runtime. */
 @Immutable
 public actual data class MapRuntimeOptions(
-  /** Context used to initialize Android platform services; only its application is retained. */
-  public val context: Context,
   /** Where the ambient resource cache and offline-region database live. */
-  public val cacheFile: File = context.applicationContext.cacheDir.resolve("maplibre-cache.db"),
+  public val cacheFile: File =
+    AndroidMlnFfiPlatform.applicationContext.cacheDir.resolve("maplibre-cache.db"),
   /** Maximum ambient cache size in bytes, or null for MapLibre's own default. */
   public val maximumCacheSizeBytes: Long? = null,
   /** Rewrites URLs and headers for every resource this runtime fetches. */
@@ -35,15 +32,12 @@ internal fun MapRuntimeOptions.toMlnFfiRuntimeOptions(): MlnFfiRuntimeOptions =
   )
 
 public actual fun createMapRuntime(options: MapRuntimeOptions): MapRuntime {
-  AndroidMlnFfiPlatform.initialize(options.context)
+  AndroidMlnFfiPlatform.initialize()
   return createNativeMapRuntime(options.toMlnFfiRuntimeOptions())
 }
 
 @Composable
 public actual fun rememberDefaultMapRuntime(): MapRuntime {
-  val context = LocalContext.current
-  AndroidMlnFfiPlatform.initialize(context)
-  return DefaultMapRuntime.getOrCreate {
-    MapRuntimeOptions(context).toMlnFfiRuntimeOptions()
-  }
+  AndroidMlnFfiPlatform.initialize()
+  return DefaultMapRuntime.getOrCreate { MapRuntimeOptions().toMlnFfiRuntimeOptions() }
 }

--- a/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/mlnffi/AndroidContextProvider.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/mlnffi/AndroidContextProvider.kt
@@ -1,0 +1,51 @@
+package org.maplibre.compose.mlnffi
+
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.content.Context
+import android.database.Cursor
+import android.net.Uri
+
+/**
+ * Captures the application context at process start, so library functions that read the package
+ * need no context parameter. Declared in the library manifest, the same way Compose Resources
+ * obtains its context.
+ */
+internal class AndroidContextProvider : ContentProvider() {
+  override fun onCreate(): Boolean {
+    applicationContext = checkNotNull(context) { "The content provider has no context" }
+    return true
+  }
+
+  override fun query(
+    uri: Uri,
+    projection: Array<out String>?,
+    selection: String?,
+    selectionArgs: Array<out String>?,
+    sortOrder: String?,
+  ): Cursor? = null
+
+  override fun getType(uri: Uri): String? = null
+
+  override fun insert(uri: Uri, values: ContentValues?): Uri? = null
+
+  override fun delete(uri: Uri, selection: String?, selectionArgs: Array<out String>?): Int = 0
+
+  override fun update(
+    uri: Uri,
+    values: ContentValues?,
+    selection: String?,
+    selectionArgs: Array<out String>?,
+  ): Int = 0
+
+  internal companion object {
+    @Volatile private var applicationContext: Context? = null
+
+    /** The application context, or throws when the library manifest was not merged. */
+    val context: Context
+      get() =
+        checkNotNull(applicationContext) {
+          "MapLibre Compose has no application context; the library manifest was not merged"
+        }
+  }
+}

--- a/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/mlnffi/AndroidMlnFfiPlatform.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/mlnffi/AndroidMlnFfiPlatform.kt
@@ -11,7 +11,7 @@ internal object AndroidMlnFfiPlatform {
   val applicationContext: Context
     get() = AndroidContextProvider.context
 
-  /** Hands the application context to MapLibre Native once per process. */
+  /** Initializes MapLibre Native with the application context once per process. */
   fun initialize() {
     if (initialized) return
     synchronized(this) {

--- a/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/mlnffi/AndroidMlnFfiPlatform.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/mlnffi/AndroidMlnFfiPlatform.kt
@@ -1,31 +1,23 @@
 package org.maplibre.compose.mlnffi
 
-import android.app.Application
 import android.content.Context
 import org.maplibre.nativeffi.MaplibreAndroid
 
 /** Process-wide Android services required by the FFI runtime and packaged resource reader. */
 internal object AndroidMlnFfiPlatform {
-  @Volatile private var application: Application? = null
+  @Volatile private var initialized = false
 
+  /** The application context that [AndroidContextProvider] captured at process start. */
   val applicationContext: Context
-    get() = checkNotNull(application) { "MapLibre Compose has not initialized its Android context" }
+    get() = AndroidContextProvider.context
 
-  fun initialize(context: Context) {
-    if (application != null) return
+  /** Hands the application context to MapLibre Native once per process. */
+  fun initialize() {
+    if (initialized) return
     synchronized(this) {
-      if (application != null) return
-      val application =
-        context.applicationContext as? Application
-          ?: context as? Application
-          ?: error("Android application context is unavailable")
-      MaplibreAndroid.initialize(application)
-      this.application = application
+      if (initialized) return
+      MaplibreAndroid.initialize(applicationContext)
+      initialized = true
     }
-  }
-
-  /** Clears the Compose-side initialization guard. Tests only. */
-  internal fun resetForTest() {
-    synchronized(this) { application = null }
   }
 }

--- a/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/sources/MbtilesUrl.android.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/sources/MbtilesUrl.android.kt
@@ -2,28 +2,23 @@ package org.maplibre.compose.sources
 
 import android.net.Uri
 import java.io.File
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import org.maplibre.compose.mlnffi.AndroidMlnFfiPlatform
 
 private const val ASSET_PREFIX = "/android_asset/"
 
 internal actual suspend fun localMbtilesPath(uri: String): String {
   val parsed = Uri.parse(uri)
-  require(parsed.scheme == "file") { "MapLibre Native reads MBTiles from a file: URI, not '$uri'" }
+  require(parsed.scheme == "file" && parsed.authority.isNullOrEmpty()) {
+    "MapLibre Native reads MBTiles from a local file: URI, not '$uri'"
+  }
   val path = requireNotNull(parsed.path) { "'$uri' has no path" }
   if (!path.startsWith(ASSET_PREFIX)) return File(path).absolutePath
   val context = AndroidMlnFfiPlatform.applicationContext
   val assetPath = path.removePrefix(ASSET_PREFIX)
-  return withContext(Dispatchers.IO) {
-    // Assets change only with the package, so the installed APK identifies the copy.
-    val apk = File(context.applicationInfo.sourceDir)
-    copyPackagedFile(
-        uri = uri,
-        directory = File(context.cacheDir, "maplibre-compose/mbtiles"),
-        stamp = "${apk.length()}-${apk.lastModified()}",
-        open = { context.assets.open(assetPath) },
-      )
-      .absolutePath
-  }
+  return copyPackagedFile(
+      uri = uri,
+      directory = File(context.cacheDir, "maplibre-compose/mbtiles"),
+      open = { context.assets.open(assetPath) },
+    )
+    .absolutePath
 }

--- a/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/sources/MbtilesUrl.android.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/sources/MbtilesUrl.android.kt
@@ -1,0 +1,25 @@
+package org.maplibre.compose.sources
+
+import android.net.Uri
+import java.io.File
+import org.maplibre.compose.mlnffi.AndroidContextProvider
+
+private const val ASSET_PREFIX = "/android_asset/"
+
+internal actual suspend fun localMbtilesPath(uri: String): String {
+  val parsed = Uri.parse(uri)
+  require(parsed.scheme == "file") { "MapLibre Native reads MBTiles from a file: URI, not '$uri'" }
+  val path = requireNotNull(parsed.path) { "'$uri' has no path" }
+  if (!path.startsWith(ASSET_PREFIX)) return File(path).absolutePath
+  val context = AndroidContextProvider.context
+  val assetPath = path.removePrefix(ASSET_PREFIX)
+  // Assets change only with the package, so the installed APK identifies the copy.
+  val apk = File(context.applicationInfo.sourceDir)
+  val copy =
+    copyPackagedFile(
+      destination = File(context.cacheDir, "maplibre-compose/mbtiles/" + packagedCopyName(uri)),
+      stamp = "${apk.length()}-${apk.lastModified()}",
+      open = { context.assets.open(assetPath) },
+    )
+  return copy.absolutePath
+}

--- a/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/sources/MbtilesUrl.android.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/sources/MbtilesUrl.android.kt
@@ -2,7 +2,7 @@ package org.maplibre.compose.sources
 
 import android.net.Uri
 import java.io.File
-import org.maplibre.compose.mlnffi.AndroidContextProvider
+import org.maplibre.compose.mlnffi.AndroidMlnFfiPlatform
 
 private const val ASSET_PREFIX = "/android_asset/"
 
@@ -11,7 +11,7 @@ internal actual suspend fun localMbtilesPath(uri: String): String {
   require(parsed.scheme == "file") { "MapLibre Native reads MBTiles from a file: URI, not '$uri'" }
   val path = requireNotNull(parsed.path) { "'$uri' has no path" }
   if (!path.startsWith(ASSET_PREFIX)) return File(path).absolutePath
-  val context = AndroidContextProvider.context
+  val context = AndroidMlnFfiPlatform.applicationContext
   val assetPath = path.removePrefix(ASSET_PREFIX)
   // Assets change only with the package, so the installed APK identifies the copy.
   val apk = File(context.applicationInfo.sourceDir)

--- a/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/sources/MbtilesUrl.android.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/sources/MbtilesUrl.android.kt
@@ -2,6 +2,8 @@ package org.maplibre.compose.sources
 
 import android.net.Uri
 import java.io.File
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import org.maplibre.compose.mlnffi.AndroidMlnFfiPlatform
 
 private const val ASSET_PREFIX = "/android_asset/"
@@ -13,14 +15,15 @@ internal actual suspend fun localMbtilesPath(uri: String): String {
   if (!path.startsWith(ASSET_PREFIX)) return File(path).absolutePath
   val context = AndroidMlnFfiPlatform.applicationContext
   val assetPath = path.removePrefix(ASSET_PREFIX)
-  // Assets change only with the package, so the installed APK identifies the copy.
-  val apk = File(context.applicationInfo.sourceDir)
-  val copy =
+  return withContext(Dispatchers.IO) {
+    // Assets change only with the package, so the installed APK identifies the copy.
+    val apk = File(context.applicationInfo.sourceDir)
     copyPackagedFile(
-      uri = uri,
-      directory = File(context.cacheDir, "maplibre-compose/mbtiles"),
-      stamp = "${apk.length()}-${apk.lastModified()}",
-      open = { context.assets.open(assetPath) },
-    )
-  return copy.absolutePath
+        uri = uri,
+        directory = File(context.cacheDir, "maplibre-compose/mbtiles"),
+        stamp = "${apk.length()}-${apk.lastModified()}",
+        open = { context.assets.open(assetPath) },
+      )
+      .absolutePath
+  }
 }

--- a/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/sources/MbtilesUrl.android.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/sources/MbtilesUrl.android.kt
@@ -17,7 +17,8 @@ internal actual suspend fun localMbtilesPath(uri: String): String {
   val apk = File(context.applicationInfo.sourceDir)
   val copy =
     copyPackagedFile(
-      destination = File(context.cacheDir, "maplibre-compose/mbtiles/" + packagedCopyName(uri)),
+      uri = uri,
+      directory = File(context.cacheDir, "maplibre-compose/mbtiles"),
       stamp = "${apk.length()}-${apk.lastModified()}",
       open = { context.assets.open(assetPath) },
     )

--- a/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/sources/MbtilesUrl.android.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/sources/MbtilesUrl.android.kt
@@ -8,7 +8,7 @@ private const val ASSET_PREFIX = "/android_asset/"
 
 internal actual suspend fun localMbtilesPath(uri: String): String {
   val parsed = Uri.parse(uri)
-  require(parsed.scheme == "file" && parsed.authority.isNullOrEmpty()) {
+  require(parsed.scheme.equals("file", ignoreCase = true) && parsed.authority.isNullOrEmpty()) {
     "MapLibre Native reads MBTiles from a local file: URI, not '$uri'"
   }
   val path = requireNotNull(parsed.path) { "'$uri' has no path" }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/sources/MbtilesUrl.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/sources/MbtilesUrl.kt
@@ -27,12 +27,15 @@ public suspend fun mbtilesUrl(uri: String): String = mbtilesUrlForPath(localMbti
  * Returns the `mbtiles:` URL of the MBTiles file at [uri] once [mbtilesUrl] has produced it, and
  * null before that.
  *
- * The state stays null while the first call copies a packaged resource out of the application
- * package. Declare the source once the value is available.
+ * The state is null while the first call copies a packaged resource out of the application package,
+ * and returns to null when [uri] changes. Declare the source once the value is available.
  */
 @Composable
 public fun rememberMbtilesUrl(uri: String): State<String?> =
-  produceState<String?>(initialValue = null, uri) { value = mbtilesUrl(uri) }
+  produceState<String?>(initialValue = null, uri) {
+    value = null
+    value = mbtilesUrl(uri)
+  }
 
 /**
  * The absolute file system path of the MBTiles file at [uri], copied out of the package if needed.

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/sources/MbtilesUrl.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/sources/MbtilesUrl.kt
@@ -3,6 +3,7 @@ package org.maplibre.compose.sources
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.produceState
+import org.maplibre.compose.resource.encodeResourceUrl
 
 /**
  * Returns the `mbtiles:` URL of the MBTiles file at [uri], for the `tiles` list of a [VectorSource]
@@ -47,25 +48,5 @@ internal expect suspend fun localMbtilesPath(uri: String): String
  * Percent-encodes [path] after the `mbtiles://` prefix. MapLibre Native percent-decodes the rest of
  * the URL to a path, so `/` stays as is and every other reserved character is encoded.
  */
-internal fun mbtilesUrlForPath(path: String): String {
-  val out = StringBuilder("mbtiles://")
-  for (byte in path.encodeToByteArray()) {
-    val value = byte.toInt() and 0xFF
-    val char = value.toChar()
-    if (char == '/' || char.isUnreservedUrlChar()) out.append(char)
-    else {
-      out.append('%')
-      out.append(value.toString(16).padStart(2, '0').uppercase())
-    }
-  }
-  return out.toString()
-}
-
-private fun Char.isUnreservedUrlChar(): Boolean =
-  this in 'a'..'z' ||
-    this in 'A'..'Z' ||
-    this in '0'..'9' ||
-    this == '-' ||
-    this == '_' ||
-    this == '.' ||
-    this == '~'
+internal fun mbtilesUrlForPath(path: String): String =
+  "mbtiles://" + path.split('/').joinToString("/", transform = ::encodeResourceUrl)

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/sources/MbtilesUrl.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/sources/MbtilesUrl.kt
@@ -11,8 +11,9 @@ import androidx.compose.runtime.produceState
  * MapLibre Native opens an MBTiles file through SQLite, so the file must be on the file system. A
  * `file:` URI that names a file on the file system converts directly. A URI that names a packaged
  * resource, such as an Android asset or a jar entry in a packaged desktop application, is copied
- * into the application's cache directory on the first call. A later call reuses the copy until the
- * application package changes.
+ * into the application's cache directory. The copy is named by a digest of its content, so every
+ * call reads the resource to identify it, and a later call reuses the copy while the content is
+ * unchanged.
  *
  * `Res.getUri` from Compose Resources returns one of these URIs on every platform except the
  * browser.

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/sources/MbtilesUrl.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/sources/MbtilesUrl.kt
@@ -1,0 +1,67 @@
+package org.maplibre.compose.sources
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.produceState
+
+/**
+ * Returns the `mbtiles:` URL of the MBTiles file at [uri], for the `tiles` list of a [VectorSource]
+ * or a [RasterSource].
+ *
+ * MapLibre Native opens an MBTiles file through SQLite, so the file must be on the file system. A
+ * `file:` URI that names a file on the file system converts directly. A URI that names a packaged
+ * resource, such as an Android asset or a jar entry in a packaged desktop application, is copied
+ * into the application's cache directory on the first call. A later call reuses the copy until the
+ * application package changes.
+ *
+ * `Res.getUri` from Compose Resources returns one of these URIs on every platform except the
+ * browser.
+ *
+ * @throws UnsupportedOperationException on the browser platform. MapLibre GL JS does not read
+ *   MBTiles files.
+ * @throws IllegalArgumentException when [uri] is not a URI that this platform reads.
+ */
+public suspend fun mbtilesUrl(uri: String): String = mbtilesUrlForPath(localMbtilesPath(uri))
+
+/**
+ * Returns the `mbtiles:` URL of the MBTiles file at [uri] once [mbtilesUrl] has produced it, and
+ * null before that.
+ *
+ * The state stays null while the first call copies a packaged resource out of the application
+ * package. Declare the source once the value is available.
+ */
+@Composable
+public fun rememberMbtilesUrl(uri: String): State<String?> =
+  produceState<String?>(initialValue = null, uri) { value = mbtilesUrl(uri) }
+
+/**
+ * The absolute file system path of the MBTiles file at [uri], copied out of the package if needed.
+ */
+internal expect suspend fun localMbtilesPath(uri: String): String
+
+/**
+ * Percent-encodes [path] after the `mbtiles://` prefix. MapLibre Native percent-decodes the rest of
+ * the URL to a path, so `/` stays as is and every other reserved character is encoded.
+ */
+internal fun mbtilesUrlForPath(path: String): String {
+  val out = StringBuilder("mbtiles://")
+  for (byte in path.encodeToByteArray()) {
+    val value = byte.toInt() and 0xFF
+    val char = value.toChar()
+    if (char == '/' || char.isUnreservedUrlChar()) out.append(char)
+    else {
+      out.append('%')
+      out.append(value.toString(16).padStart(2, '0').uppercase())
+    }
+  }
+  return out.toString()
+}
+
+private fun Char.isUnreservedUrlChar(): Boolean =
+  this in 'a'..'z' ||
+    this in 'A'..'Z' ||
+    this in '0'..'9' ||
+    this == '-' ||
+    this == '_' ||
+    this == '.' ||
+    this == '~'

--- a/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/sources/MbtilesUrl.ios.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/sources/MbtilesUrl.ios.kt
@@ -1,0 +1,10 @@
+package org.maplibre.compose.sources
+
+import platform.Foundation.NSURL
+
+/** Bundle resources are files on disk on iOS, so a `file:` URI needs no copy. */
+internal actual suspend fun localMbtilesPath(uri: String): String {
+  val url = requireNotNull(NSURL.URLWithString(uri)) { "'$uri' is not a URL" }
+  require(url.scheme == "file") { "MapLibre Native reads MBTiles from a file: URI, not '$uri'" }
+  return requireNotNull(url.path) { "'$uri' has no path" }
+}

--- a/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/sources/MbtilesUrl.ios.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/sources/MbtilesUrl.ios.kt
@@ -5,6 +5,8 @@ import platform.Foundation.NSURL
 /** Bundle resources are files on disk on iOS, so a `file:` URI needs no copy. */
 internal actual suspend fun localMbtilesPath(uri: String): String {
   val url = requireNotNull(NSURL.URLWithString(uri)) { "'$uri' is not a URL" }
-  require(url.scheme == "file") { "MapLibre Native reads MBTiles from a file: URI, not '$uri'" }
+  require(url.scheme.equals("file", ignoreCase = true) && url.host.isNullOrEmpty()) {
+    "MapLibre Native reads MBTiles from a local file: URI, not '$uri'"
+  }
   return requireNotNull(url.path) { "'$uri' has no path" }
 }

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/sources/MbtilesUrl.js.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/sources/MbtilesUrl.js.kt
@@ -1,0 +1,4 @@
+package org.maplibre.compose.sources
+
+internal actual suspend fun localMbtilesPath(uri: String): String =
+  throw UnsupportedOperationException("MapLibre GL JS does not read MBTiles files")

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/DesktopCache.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/DesktopCache.kt
@@ -28,19 +28,21 @@ internal fun desktopRuntimeOptions(
  * Cache database path for [applicationId] in the current operating system's per-user cache
  * directory.
  */
-internal fun desktopCachePath(applicationId: String): Path {
+internal fun desktopCachePath(applicationId: String): Path =
+  desktopUserCacheDirectory().resolve(applicationId).resolve("maplibre-cache.db")
+
+/** The current operating system's per-user cache directory. */
+internal fun desktopUserCacheDirectory(): Path {
   val os = System.getProperty("os.name")?.lowercase().orEmpty()
   val home = System.getProperty("user.home") ?: "."
-  val base =
-    absoluteEnvironmentPath(System.getenv("XDG_CACHE_HOME"))
-      ?: when {
-        os.contains("mac") -> Paths.get(home, "Library", "Caches")
-        os.contains("windows") ->
-          absoluteEnvironmentPath(System.getenv("LOCALAPPDATA"))
-            ?: Paths.get(home, "AppData", "Local")
-        else -> Paths.get(home, ".cache")
-      }
-  return base.resolve(applicationId).resolve("maplibre-cache.db")
+  return absoluteEnvironmentPath(System.getenv("XDG_CACHE_HOME"))
+    ?: when {
+      os.contains("mac") -> Paths.get(home, "Library", "Caches")
+      os.contains("windows") ->
+        absoluteEnvironmentPath(System.getenv("LOCALAPPDATA"))
+          ?: Paths.get(home, "AppData", "Local")
+      else -> Paths.get(home, ".cache")
+    }
 }
 
 internal fun absoluteEnvironmentPath(value: String?): Path? =

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/sources/MbtilesUrl.desktop.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/sources/MbtilesUrl.desktop.kt
@@ -33,20 +33,18 @@ internal suspend fun desktopMbtilesPath(uri: String, directory: File): String =
     if (parsed.scheme.equals("file", ignoreCase = true)) {
       return@withContext Paths.get(parsed).toAbsolutePath().toString()
     }
-    val jar = jarFileOf(parsed)
+    requireJarOnDisk(parsed)
     val copy =
       copyPackagedFile(
         uri = uri,
         directory = directory,
-        // A jar entry changes only with its jar, so the jar identifies the copy.
-        stamp = "${jar.length()}-${jar.lastModified()}",
         open = { parsed.toURL().openConnection().apply { useCaches = false }.getInputStream() },
       )
     copy.absolutePath
   }
 
-/** The jar on disk that holds the entry at [uri], which is a `jar:file:` URI. */
-private fun jarFileOf(uri: URI): File {
+/** Requires [uri] to be a `jar:file:` URI whose jar exists. */
+private fun requireJarOnDisk(uri: URI) {
   val rejection = "mbtilesUrl reads a file: URI or a jar: entry in a jar on disk, not '$uri'"
   require(uri.scheme.equals("jar", ignoreCase = true)) { rejection }
   val connection =
@@ -56,5 +54,4 @@ private fun jarFileOf(uri: URI): File {
   }
     .getOrElse { throw IllegalArgumentException(rejection, it) }
   require(jar.isFile) { "'$uri' names a jar that does not exist: $jar" }
-  return jar
 }

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/sources/MbtilesUrl.desktop.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/sources/MbtilesUrl.desktop.kt
@@ -43,7 +43,8 @@ internal suspend fun desktopMbtilesPath(uri: String, directory: File): String {
       .joinToString("-")
   val copy =
     copyPackagedFile(
-      destination = File(directory, packagedCopyName(uri)),
+      uri = uri,
+      directory = directory,
       stamp = stamp,
       open = { url.openConnection().apply { useCaches = false }.getInputStream() },
     )

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/sources/MbtilesUrl.desktop.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/sources/MbtilesUrl.desktop.kt
@@ -1,0 +1,51 @@
+package org.maplibre.compose.sources
+
+import java.io.File
+import java.net.JarURLConnection
+import java.net.URI
+import java.nio.file.Paths
+import org.maplibre.compose.desktop.desktopCachePath
+import org.maplibre.compose.desktop.inferredApplicationId
+
+/** Copies land beside the application's cache database, in the per-user cache directory. */
+internal actual suspend fun localMbtilesPath(uri: String): String {
+  val parsed = URI(uri)
+  if (parsed.scheme.equals("file", ignoreCase = true)) {
+    return Paths.get(parsed).toAbsolutePath().toString()
+  }
+  val directory = desktopCachePath(inferredApplicationId()).resolveSibling("mbtiles").toFile()
+  return desktopMbtilesPath(uri, directory)
+}
+
+/**
+ * Resolves [uri] to a file on disk, copying a `jar:` entry or any other non-file URL that the JDK
+ * can open into [directory].
+ */
+internal suspend fun desktopMbtilesPath(uri: String, directory: File): String {
+  val parsed = URI(uri)
+  if (parsed.scheme.equals("file", ignoreCase = true)) {
+    return Paths.get(parsed).toAbsolutePath().toString()
+  }
+  val url = parsed.toURL()
+  val connection = url.openConnection().apply { useCaches = false }
+  // The entry's own size and time, plus the enclosing jar's when there is one, identify the copy.
+  val jar =
+    (connection as? JarURLConnection)?.jarFileURL?.toURI()?.let {
+      runCatching { File(it) }.getOrNull()
+    }
+  val stamp =
+    listOfNotNull(
+        connection.contentLengthLong,
+        connection.lastModified,
+        jar?.length(),
+        jar?.lastModified(),
+      )
+      .joinToString("-")
+  val copy =
+    copyPackagedFile(
+      destination = File(directory, packagedCopyName(uri)),
+      stamp = stamp,
+      open = { url.openConnection().apply { useCaches = false }.getInputStream() },
+    )
+  return copy.absolutePath
+}

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/sources/MbtilesUrl.desktop.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/sources/MbtilesUrl.desktop.kt
@@ -4,49 +4,62 @@ import java.io.File
 import java.net.JarURLConnection
 import java.net.URI
 import java.nio.file.Paths
-import org.maplibre.compose.desktop.desktopCachePath
-import org.maplibre.compose.desktop.inferredApplicationId
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.maplibre.compose.desktop.desktopUserCacheDirectory
 
-/** Copies land beside the application's cache database, in the per-user cache directory. */
-internal actual suspend fun localMbtilesPath(uri: String): String {
-  val parsed = URI(uri)
-  if (parsed.scheme.equals("file", ignoreCase = true)) {
-    return Paths.get(parsed).toAbsolutePath().toString()
-  }
-  val directory = desktopCachePath(inferredApplicationId()).resolveSibling("mbtiles").toFile()
-  return desktopMbtilesPath(uri, directory)
-}
+/** Copies are stored under `maplibre-compose/mbtiles` in the per-user cache directory. */
+internal actual suspend fun localMbtilesPath(uri: String): String =
+  desktopMbtilesPath(
+    uri,
+    desktopUserCacheDirectory().resolve("maplibre-compose").resolve("mbtiles").toFile(),
+  )
 
 /**
  * Resolves [uri] to a file on disk, copying a `jar:` entry or any other non-file URL that the JDK
  * can open into [directory].
+ *
+ * @throws IllegalArgumentException when [uri] is not a URI or names a protocol the JDK cannot open.
  */
-internal suspend fun desktopMbtilesPath(uri: String, directory: File): String {
-  val parsed = URI(uri)
-  if (parsed.scheme.equals("file", ignoreCase = true)) {
-    return Paths.get(parsed).toAbsolutePath().toString()
+internal suspend fun desktopMbtilesPath(uri: String, directory: File): String =
+  withContext(Dispatchers.IO) {
+    val parsed =
+      try {
+        URI(uri)
+      } catch (error: java.net.URISyntaxException) {
+        throw IllegalArgumentException("'$uri' is not a URI", error)
+      }
+    if (parsed.scheme.equals("file", ignoreCase = true)) {
+      return@withContext Paths.get(parsed).toAbsolutePath().toString()
+    }
+    val url =
+      try {
+        parsed.toURL()
+      } catch (error: Exception) {
+        throw IllegalArgumentException("'$uri' names a protocol this platform cannot open", error)
+      }
+    val copy =
+      copyPackagedFile(
+        uri = uri,
+        directory = directory,
+        stamp = packagedStamp(url),
+        open = { url.openConnection().apply { useCaches = false }.getInputStream() },
+      )
+    copy.absolutePath
   }
-  val url = parsed.toURL()
+
+/**
+ * Identifies the package version behind [url]. A jar entry changes only with its jar, so the jar's
+ * size and modification time serve without opening the archive. Any other URL is opened for its
+ * headers, and the stream is closed at once.
+ */
+private fun packagedStamp(url: java.net.URL): String {
   val connection = url.openConnection().apply { useCaches = false }
-  // The entry's own size and time, plus the enclosing jar's when there is one, identify the copy.
   val jar =
     (connection as? JarURLConnection)?.jarFileURL?.toURI()?.let {
       runCatching { File(it) }.getOrNull()
     }
-  val stamp =
-    listOfNotNull(
-        connection.contentLengthLong,
-        connection.lastModified,
-        jar?.length(),
-        jar?.lastModified(),
-      )
-      .joinToString("-")
-  val copy =
-    copyPackagedFile(
-      uri = uri,
-      directory = directory,
-      stamp = stamp,
-      open = { url.openConnection().apply { useCaches = false }.getInputStream() },
-    )
-  return copy.absolutePath
+  if (jar != null) return "${jar.length()}-${jar.lastModified()}"
+  connection.getInputStream().close()
+  return "${connection.contentLengthLong}-${connection.lastModified}"
 }

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/sources/MbtilesUrl.desktop.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/sources/MbtilesUrl.desktop.kt
@@ -3,6 +3,7 @@ package org.maplibre.compose.sources
 import java.io.File
 import java.net.JarURLConnection
 import java.net.URI
+import java.net.URISyntaxException
 import java.nio.file.Paths
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -16,50 +17,44 @@ internal actual suspend fun localMbtilesPath(uri: String): String =
   )
 
 /**
- * Resolves [uri] to a file on disk, copying a `jar:` entry or any other non-file URL that the JDK
- * can open into [directory].
+ * Resolves [uri] to a file on disk, copying a `jar:` entry into [directory].
  *
- * @throws IllegalArgumentException when [uri] is not a URI or names a protocol the JDK cannot open.
+ * @throws IllegalArgumentException when [uri] is not a URI, or is neither a `file:` URI nor an
+ *   entry in a jar on disk.
  */
 internal suspend fun desktopMbtilesPath(uri: String, directory: File): String =
   withContext(Dispatchers.IO) {
     val parsed =
       try {
         URI(uri)
-      } catch (error: java.net.URISyntaxException) {
+      } catch (error: URISyntaxException) {
         throw IllegalArgumentException("'$uri' is not a URI", error)
       }
     if (parsed.scheme.equals("file", ignoreCase = true)) {
       return@withContext Paths.get(parsed).toAbsolutePath().toString()
     }
-    val url =
-      try {
-        parsed.toURL()
-      } catch (error: Exception) {
-        throw IllegalArgumentException("'$uri' names a protocol this platform cannot open", error)
-      }
+    val jar = jarFileOf(parsed)
     val copy =
       copyPackagedFile(
         uri = uri,
         directory = directory,
-        stamp = packagedStamp(url),
-        open = { url.openConnection().apply { useCaches = false }.getInputStream() },
+        // A jar entry changes only with its jar, so the jar identifies the copy.
+        stamp = "${jar.length()}-${jar.lastModified()}",
+        open = { parsed.toURL().openConnection().apply { useCaches = false }.getInputStream() },
       )
     copy.absolutePath
   }
 
-/**
- * Identifies the package version behind [url]. A jar entry changes only with its jar, so the jar's
- * size and modification time serve without opening the archive. Any other URL is opened for its
- * headers, and the stream is closed at once.
- */
-private fun packagedStamp(url: java.net.URL): String {
-  val connection = url.openConnection().apply { useCaches = false }
-  val jar =
-    (connection as? JarURLConnection)?.jarFileURL?.toURI()?.let {
-      runCatching { File(it) }.getOrNull()
-    }
-  if (jar != null) return "${jar.length()}-${jar.lastModified()}"
-  connection.getInputStream().close()
-  return "${connection.contentLengthLong}-${connection.lastModified}"
+/** The jar on disk that holds the entry at [uri], which is a `jar:file:` URI. */
+private fun jarFileOf(uri: URI): File {
+  val rejection = "mbtilesUrl reads a file: URI or a jar: entry in a jar on disk, not '$uri'"
+  require(uri.scheme.equals("jar", ignoreCase = true)) { rejection }
+  val connection =
+    uri.toURL().openConnection() as? JarURLConnection ?: throw IllegalArgumentException(rejection)
+  val jar = runCatching {
+    File(connection.jarFileURL.toURI())
+  }
+    .getOrElse { throw IllegalArgumentException(rejection, it) }
+  require(jar.isFile) { "'$uri' names a jar that does not exist: $jar" }
+  return jar
 }

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/sources/MbtilesUrl.desktop.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/sources/MbtilesUrl.desktop.kt
@@ -1,7 +1,6 @@
 package org.maplibre.compose.sources
 
 import java.io.File
-import java.net.JarURLConnection
 import java.net.URI
 import java.net.URISyntaxException
 import java.nio.file.Paths
@@ -47,10 +46,8 @@ internal suspend fun desktopMbtilesPath(uri: String, directory: File): String =
 private fun requireJarOnDisk(uri: URI) {
   val rejection = "mbtilesUrl reads a file: URI or a jar: entry in a jar on disk, not '$uri'"
   require(uri.scheme.equals("jar", ignoreCase = true)) { rejection }
-  val connection =
-    uri.toURL().openConnection() as? JarURLConnection ?: throw IllegalArgumentException(rejection)
   val jar = runCatching {
-    File(connection.jarFileURL.toURI())
+    File(URI(uri.rawSchemeSpecificPart.substringBefore("!/")))
   }
     .getOrElse { throw IllegalArgumentException(rejection, it) }
   require(jar.isFile) { "'$uri' names a jar that does not exist: $jar" }

--- a/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/sources/DesktopMbtilesUrlTest.kt
+++ b/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/sources/DesktopMbtilesUrlTest.kt
@@ -7,6 +7,7 @@ import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
 import kotlinx.coroutines.test.runTest
@@ -47,14 +48,11 @@ class DesktopMbtilesUrlTest {
       )
 
     val first = desktopMbtilesPath(uri, directory)
-    val copiedAt = File(first).lastModified()
-    Thread.sleep(20)
     val second = desktopMbtilesPath(uri, directory)
 
     assertEquals(first, second)
     assertEquals("first", File(first).readText())
-    assertEquals(copiedAt, File(second).lastModified(), "the second call reused the copy")
-    assertTrue(File(first).name.endsWith("city.mbtiles"), first)
+    assertEquals(listOf(File(first).name), directory.list()?.toList(), "one copy, no leftovers")
   }
 
   @Test
@@ -64,22 +62,35 @@ class DesktopMbtilesUrlTest {
     val first = desktopMbtilesPath(uri, directory)
     assertEquals("first", File(first).readText())
 
-    Thread.sleep(20)
     fixture.jarEntry("app.jar", "files/city.mbtiles", mapOf("files/city.mbtiles" to "second!"))
     val second = desktopMbtilesPath(uri, directory)
 
-    assertEquals(first, second)
+    assertNotEquals(first, second, "a changed resource gets a new copy")
     assertEquals("second!", File(second).readText())
-    assertNotEquals("first", File(second).readText())
+    assertEquals("first", File(first).readText(), "the old copy stays until it is unused")
   }
 
   @Test
-  fun `entries whose URIs share a name and a hash code keep their own copies`() = runTest {
-    // "Aa" and "BB" have the same String.hashCode, so these two URIs collide.
+  fun `a copy that no call has used for a month is deleted`() = runTest {
+    val old =
+      File(directory, "0000.mbtiles").apply {
+        parentFile.mkdirs()
+        writeText("old")
+      }
+    old.setLastModified(System.currentTimeMillis() - 31L * 24 * 60 * 60 * 1000)
+    val uri = fixture.jarEntry("app.jar", "city.mbtiles", mapOf("city.mbtiles" to "new"))
+
+    val copy = desktopMbtilesPath(uri, directory)
+
+    assertFalse(old.exists(), "the unused copy was deleted")
+    assertTrue(File(copy).isFile)
+  }
+
+  @Test
+  fun `entries with the same name keep their own copies`() = runTest {
     val entries = mapOf("Aa/city.mbtiles" to "from Aa", "BB/city.mbtiles" to "from BB")
     val first = fixture.jarEntry("app.jar", "Aa/city.mbtiles", entries)
     val second = fixture.jarEntry("app.jar", "BB/city.mbtiles", entries)
-    assertEquals(first.hashCode(), second.hashCode(), "the URIs must collide for this to be a test")
 
     assertEquals("from Aa", File(desktopMbtilesPath(first, directory)).readText())
     assertEquals("from BB", File(desktopMbtilesPath(second, directory)).readText())

--- a/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/sources/DesktopMbtilesUrlTest.kt
+++ b/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/sources/DesktopMbtilesUrlTest.kt
@@ -1,10 +1,12 @@
 package org.maplibre.compose.sources
 
 import java.io.File
+import java.net.URI
 import java.nio.file.Files
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
 import kotlinx.coroutines.test.runTest
@@ -28,8 +30,9 @@ class DesktopMbtilesUrlTest {
 
     val url = mbtilesUrlForPath(desktopMbtilesPath(uri, directory))
 
-    assertTrue(url.startsWith("mbtiles:///"), url)
+    assertTrue(url.startsWith("mbtiles://"), url)
     val path = decodeResourceUrl(url.removePrefix("mbtiles://"))
+    assertEquals(File(URI(uri)).absolutePath, path)
     assertEquals("sqlite", File(path).readText())
     assertEquals(emptyList(), directory.list()?.toList().orEmpty(), "nothing was copied")
   }
@@ -81,6 +84,12 @@ class DesktopMbtilesUrlTest {
     assertEquals("from Aa", File(desktopMbtilesPath(first, directory)).readText())
     assertEquals("from BB", File(desktopMbtilesPath(second, directory)).readText())
     assertEquals("from Aa", File(desktopMbtilesPath(first, directory)).readText())
+  }
+
+  @Test
+  fun `a string that is not a URI is rejected as an argument`() = runTest {
+    assertFailsWith<IllegalArgumentException> { desktopMbtilesPath("not a uri", directory) }
+    assertFailsWith<IllegalArgumentException> { desktopMbtilesPath("nope:tiles", directory) }
   }
 
   @Test

--- a/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/sources/DesktopMbtilesUrlTest.kt
+++ b/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/sources/DesktopMbtilesUrlTest.kt
@@ -1,0 +1,82 @@
+package org.maplibre.compose.sources
+
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+import org.maplibre.compose.resource.PackagedResourceFixture
+import org.maplibre.compose.resource.decodeResourceUrl
+
+class DesktopMbtilesUrlTest {
+
+  private val fixture = PackagedResourceFixture()
+  private val directory = Files.createTempDirectory("mbtiles copies").toFile()
+
+  @AfterTest
+  fun cleanUp() {
+    fixture.close()
+    directory.deleteRecursively()
+  }
+
+  @Test
+  fun `a file on disk is referenced in place`() = runTest {
+    val uri = fixture.file("tiles/city map.mbtiles", "sqlite")
+
+    val url = mbtilesUrlForPath(desktopMbtilesPath(uri, directory))
+
+    assertTrue(url.startsWith("mbtiles:///"), url)
+    val path = decodeResourceUrl(url.removePrefix("mbtiles://"))
+    assertEquals("sqlite", File(path).readText())
+    assertEquals(emptyList(), directory.list()?.toList().orEmpty(), "nothing was copied")
+  }
+
+  @Test
+  fun `a jar entry is copied once and reused`() = runTest {
+    val uri =
+      fixture.jarEntry(
+        "app.jar",
+        "composeResources/files/city.mbtiles",
+        mapOf("composeResources/files/city.mbtiles" to "first"),
+      )
+
+    val first = desktopMbtilesPath(uri, directory)
+    val copiedAt = File(first).lastModified()
+    Thread.sleep(20)
+    val second = desktopMbtilesPath(uri, directory)
+
+    assertEquals(first, second)
+    assertEquals("first", File(first).readText())
+    assertEquals(copiedAt, File(second).lastModified(), "the second call reused the copy")
+    assertTrue(File(first).name.endsWith("city.mbtiles"), first)
+  }
+
+  @Test
+  fun `a changed jar entry is copied again`() = runTest {
+    val uri =
+      fixture.jarEntry("app.jar", "files/city.mbtiles", mapOf("files/city.mbtiles" to "first"))
+    val first = desktopMbtilesPath(uri, directory)
+    assertEquals("first", File(first).readText())
+
+    Thread.sleep(20)
+    fixture.jarEntry("app.jar", "files/city.mbtiles", mapOf("files/city.mbtiles" to "second!"))
+    val second = desktopMbtilesPath(uri, directory)
+
+    assertEquals(first, second)
+    assertEquals("second!", File(second).readText())
+    assertNotEquals("first", File(second).readText())
+  }
+
+  @Test
+  fun `the URL decodes back to the path`() {
+    val path = "/tmp/ké 地図/city.mbtiles"
+
+    val url = mbtilesUrlForPath(path)
+
+    assertEquals("mbtiles:///tmp/k%C3%A9%20%E5%9C%B0%E5%9B%B3/city.mbtiles", url)
+    assertEquals(path, decodeResourceUrl(url.removePrefix("mbtiles://")))
+  }
+}

--- a/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/sources/DesktopMbtilesUrlTest.kt
+++ b/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/sources/DesktopMbtilesUrlTest.kt
@@ -71,6 +71,19 @@ class DesktopMbtilesUrlTest {
   }
 
   @Test
+  fun `entries whose URIs share a name and a hash code keep their own copies`() = runTest {
+    // "Aa" and "BB" have the same String.hashCode, so these two URIs collide.
+    val entries = mapOf("Aa/city.mbtiles" to "from Aa", "BB/city.mbtiles" to "from BB")
+    val first = fixture.jarEntry("app.jar", "Aa/city.mbtiles", entries)
+    val second = fixture.jarEntry("app.jar", "BB/city.mbtiles", entries)
+    assertEquals(first.hashCode(), second.hashCode(), "the URIs must collide for this to be a test")
+
+    assertEquals("from Aa", File(desktopMbtilesPath(first, directory)).readText())
+    assertEquals("from BB", File(desktopMbtilesPath(second, directory)).readText())
+    assertEquals("from Aa", File(desktopMbtilesPath(first, directory)).readText())
+  }
+
+  @Test
   fun `the URL decodes back to the path`() {
     val path = "/tmp/ké 地図/city.mbtiles"
 

--- a/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/sources/DesktopMbtilesUrlTest.kt
+++ b/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/sources/DesktopMbtilesUrlTest.kt
@@ -87,9 +87,22 @@ class DesktopMbtilesUrlTest {
   }
 
   @Test
-  fun `a string that is not a URI is rejected as an argument`() = runTest {
+  fun `anything but a file or a jar entry on disk is rejected as an argument`() = runTest {
     assertFailsWith<IllegalArgumentException> { desktopMbtilesPath("not a uri", directory) }
     assertFailsWith<IllegalArgumentException> { desktopMbtilesPath("nope:tiles", directory) }
+    assertFailsWith<IllegalArgumentException> {
+      desktopMbtilesPath("https://example.com/city.mbtiles", directory)
+    }
+    assertFailsWith<IllegalArgumentException> {
+      desktopMbtilesPath("jar:https://example.com/app.jar!/city.mbtiles", directory)
+    }
+    assertFailsWith<IllegalArgumentException> {
+      desktopMbtilesPath(
+        fixture.jarUri(fixture.root.resolve("missing.jar"), "city.mbtiles"),
+        directory,
+      )
+    }
+    assertEquals(emptyList(), directory.list()?.toList().orEmpty(), "nothing was copied")
   }
 
   @Test


### PR DESCRIPTION
## Description

Adds `mbtilesUrl` and `rememberMbtilesUrl`, which copy a packaged MBTiles file out of an Android asset or a desktop jar into the app cache directory and return its `mbtiles:` URL, and replaces the Android `Context` parameter on `MapRuntimeOptions` with a content provider that captures the application context. Closes #435.

## Validation

Desktop unit tests for the copy path, the full Android device suite on an emulator, and compilation on every target.

## AI assistance

Claude Fable 5.1 in Claude Code.