### PR TITLE
Replace map event callbacks with a MapEvent stream on MapState

### DIFF
--- a/.agents/docs/EVENT_CALLBACK_REDESIGN.md
+++ b/.agents/docs/EVENT_CALLBACK_REDESIGN.md
@@ -270,6 +270,9 @@ chain.
   `onSourceChanged`.
 - `CameraMoveReason` as a value that a session computes. It stays on `MapState`
   as a value that the gesture token sets.
+- `CameraMoveReason.UNKNOWN`. The token leaves three states: not moved yet, a
+  gesture holds the camera, and a programmatic change. Nothing reports
+  `UNKNOWN`, so it becomes a deprecation.
 
 ### Deferred from the common catalog
 

--- a/.agents/docs/EVENT_CALLBACK_REDESIGN.md
+++ b/.agents/docs/EVENT_CALLBACK_REDESIGN.md
@@ -1,8 +1,8 @@
 # Engine event redesign
 
-Staging notes for replacing the map event callbacks with a stream of the events
-that the engines emit. The shapes below are representative, not locked. A
-prototype will change them.
+Design notes for the stream of engine events that `MapState.events` publishes,
+and for the internal sink that feeds it. The shapes below are the ones in the
+tree.
 
 This is a sibling of [GESTURE_REDESIGN.md](./GESTURE_REDESIGN.md). That document
 owns pointer recognition, bindings, and click dispatch. This document owns the
@@ -10,9 +10,6 @@ events that MapLibre Native FFI and MapLibre GL JS emit. The two meet at one
 point: the gesture token decides whether a camera change is user-driven.
 
 ## What the code was
-
-The redesign replaced this shape. Every step in the [Sequence](#sequence) has
-landed.
 
 `MapAdapter.Callbacks` had ten methods that both engine sessions implemented,
 and `MapLifecycleCallbacks` filtered each call through the engine identity,
@@ -22,30 +19,23 @@ unrelated things.
 **A two-way style handshake.** `onStyleChanged`, `onMapFinishedLoading`,
 `onMapFailLoading`, and `onSourceChanged` were a protocol, not events. The
 session offered a style binding, `MapState` accepted or rejected it, and the
-session branched on the answer: it kept or invalidated the binding, and it
-cleared or kept its own "load unreported" flag.
+session branched on the answer. The handshake survives under protocol names.
 
 **Camera state feeding.** `onCameraMoveStarted`, `onCameraMoved`, and
 `onCameraMoveEnded` existed to set `viewport`, `isCameraMoving`, and
 `cameraMoveReason` on the current attachment. Both sessions ran the same
-coalescing. Native emits `MAP_CAMERA_WILL_CHANGE`, `MAP_CAMERA_IS_CHANGING`, and
-`MAP_CAMERA_DID_CHANGE`; the browser emits `movestart`, `move`, and `moveend`.
-Compose drives a drag as a series of jumps, so each pointer move produced its
-own did-change or moveend. The session read its gesture flag and withheld the
-end callback until the gesture ended, so that a drag reported as one move. The
-session also set `CameraMoveReason` from that same flag.
+coalescing. Compose drives a drag as a series of jumps, so each pointer move
+produced its own did-change or moveend, and the session withheld the end
+callback until its gesture flag cleared so that a drag reported as one move. The
+session also set `CameraMoveReason` from that flag. The three callbacks are
+gone, the sessions post the engine's own camera events, and `MapState` derives
+the state.
 
 **Values that neither engine emits.** `onClick` and `onLongClick` originated in
-Compose input. `MapInput` recognized a tap or long press and called
-`GestureTarget.onPrimaryClick` or `onSecondaryClick`. The session unprojected
-the offset and called back into `MaplibreMap`, which walked the layers.
-`onFrame(fps)` was an inter-frame interval that the session measured in its own
-render loop. The FFI reports `MAP_RENDER_FRAME_FINISHED` with a payload, and GL
-JS reports `render`, and neither reports a rate.
-
-The public surface was `onClick`, `onLongClick`, and `onFrame` on `MaplibreMap`,
-plus `onClick` and `onLongClick` on each layer composable. Load state, viewport,
-and camera motion already surfaced as state on `MapState`.
+Compose input, took a session round trip to unproject the offset, and came back
+into `MaplibreMap`, which walked the layers. `onFrame(fps)` was an inter-frame
+interval that the session measured in its own render loop. Clicks now dispatch
+from Compose input, and the frame signal is the engine's own frame event.
 
 That shape dated from a period when Android `MapView`, iOS `MLNMapView`, and GL
 JS each had a different observer API, clicks arrived from the engine, and there
@@ -94,8 +84,7 @@ GL JS `MapEventType` in maplibre-gl 6.6.0, grouped:
 - Pointer: `click`, `dblclick`, `contextmenu`, `mousemove` and the other mouse
   events, the touch events, `wheel`, `cooperativegestureprevented`
 
-GL JS selects types with `on(type)`. The session subscribes to `style.load`,
-`styledata`, `sourcedata`, `error`, `movestart`, `move`, and `moveend`.
+GL JS selects types with `on(type)`.
 
 ## The shape
 
@@ -104,20 +93,29 @@ publishes the same values. Sessions translate; they do not reshape.
 
 ```text
 engine event  →  identity filter  →  MapState reactions  →  public Flow
-(FFI drain,      (lease or style     (load state,           (MapState.events)
- GL JS on)        identity)           viewport, camera)
+(FFI drain,      (lease, style, or   (viewport, camera     (MapState.events)
+ GL JS on)        engine identity)    change)
 ```
 
-Identity filtering stays. An event from a departed render lease or a superseded
-style request is dropped. `Idle` reports the engine's own progress rather than a
-style's or a lease's, so it filters on the engine identity and arrives after a
-failed style load too. That is ownership, not reshape, and
-`MapLifecycleCallbacks` already does it.
+Identity filtering stays, and `MapLifecycleCallbacks` does it. Each event
+filters on the identity that produced it:
+
+| Identity      | Events                                                                 |
+| ------------- | ---------------------------------------------------------------------- |
+| Render lease  | `CameraMoveStarted`, `CameraMoved`, `CameraMoveEnded`, `FrameRendered` |
+| Style         | `StyleLoaded`, `StyleImageMissing`                                     |
+| Style request | `StyleLoadFailed`                                                      |
+| Engine        | `Idle`                                                                 |
+
+An event from a departed render lease or a superseded style request is dropped.
+`Idle` reports the engine's own progress rather than a style's or a lease's, so
+it filters on the engine identity and arrives after a failed style load too.
+That is ownership, not reshape.
 
 ### Events
 
 Immutable values in `commonMain`. Each one is an event that both engines emit in
-the same terms. Each translation is a rename plus a payload copy.
+the same terms, and each translation is a rename plus a payload copy.
 
 ```kotlin
 public sealed interface MapEvent {
@@ -136,43 +134,45 @@ public sealed interface MapEvent {
   public data class FrameRendered(val stats: RenderStats?) : MapEvent
 
   public data class StyleImageMissing(val imageId: String) : MapEvent
-
-  public data class EngineError(val message: String, val sourceId: String?) : MapEvent
 }
 ```
 
-| Event               | maplibre-native-ffi         | maplibre-gl-js        |
-| ------------------- | --------------------------- | --------------------- |
-| `StyleLoaded`       | `MAP_STYLE_LOADED`          | `style.load`          |
-| `StyleLoadFailed`   | `MAP_LOADING_FAILED`        | `error`, terminal     |
-| `Idle`              | `MAP_IDLE`                  | `idle`                |
-| `CameraMoveStarted` | `MAP_CAMERA_WILL_CHANGE`    | `movestart`           |
-| `CameraMoved`       | `MAP_CAMERA_IS_CHANGING`    | `move`                |
-| `CameraMoveEnded`   | `MAP_CAMERA_DID_CHANGE`     | `moveend`             |
-| `FrameRendered`     | `MAP_RENDER_FRAME_FINISHED` | `render`              |
-| `StyleImageMissing` | `MAP_STYLE_IMAGE_MISSING`   | `styleimagemissing`   |
-| `EngineError`       | `MAP_RENDER_ERROR`          | `error`, non-terminal |
+| Event               | maplibre-native-ffi         | maplibre-gl-js      |
+| ------------------- | --------------------------- | ------------------- |
+| `StyleLoaded`       | `MAP_STYLE_LOADED`          | `style.load`        |
+| `StyleLoadFailed`   | `MAP_LOADING_FAILED`        | `error`, terminal   |
+| `Idle`              | `MAP_IDLE`                  | `idle`              |
+| `CameraMoveStarted` | `MAP_CAMERA_WILL_CHANGE`    | `movestart`         |
+| `CameraMoved`       | `MAP_CAMERA_IS_CHANGING`    | `move`              |
+| `CameraMoveEnded`   | `MAP_CAMERA_DID_CHANGE`     | `moveend`           |
+| `FrameRendered`     | `MAP_RENDER_FRAME_FINISHED` | `render`            |
+| `StyleImageMissing` | `MAP_STYLE_IMAGE_MISSING`   | `styleimagemissing` |
 
-`animated` is the FFI `CameraChangeMode`. GL JS has no such field, so the
-browser session passes null.
+`MlnFfiMapEvents.kt` holds the native translation as
+`RuntimeEvent.toMapEvent()`, and `GlJsMapEvents.kt` holds the browser
+translation as three maps from GL JS type name to translation, one per identity.
 
-`RenderStats` is the FFI frame payload: render mode, needs-repaint,
-placement-changed, encoding time, rendering time, frame count, and draw call
-counts. GL JS `render` has no payload, so the browser session passes null.
+`animated` is true when the FFI `CameraChangeMode` is `ANIMATED`. GL JS has no
+such field, so the browser session passes null.
+
+`RenderStats` is the FFI frame payload: `mode`, `needsRepaint`,
+`placementChanged`, `encodingTime`, `renderingTime`, `frameCount`,
+`drawCallCount`, and `totalDrawCallCount`. The times are `Duration` values
+converted from the FFI's seconds. `mode` is a nested `RenderStats.Mode` of
+`Partial` or `Full`, and it is null for a `RenderMode` that this build does not
+name, because `RenderMode` is an open domain like `RuntimeEventType`. GL JS
+`render` has no payload, so the browser session passes null.
 
 The camera triple is per engine change, not per gesture. A Compose-driven drag
 emits one started and ended pair per pointer move on both engines, because that
-is what the engines emit. `isCameraMoving` stays a derived state, true while a
-gesture token is held or a camera transition is in flight. `CameraMoveReason`
-leaves the event path and stays a presentation fact that the gesture token sets.
+is what the engines emit.
 
 `StyleLoaded` reports that the engine parsed the base style. The composition
 applies after that, so `loadState` reaches `Ready` later. A caller that wants
 the composed style ready reads `loadState`.
 
 A terminal browser `error` is one that ends the base style request. The session
-already separates that from a tile or sprite error with
-`isTerminalStyleLoadFailure`.
+separates that from a tile or sprite error with `isTerminalStyleLoadFailure`.
 
 ### Publication
 
@@ -188,10 +188,17 @@ public class MapState {
 engine flow while the map is detached, and camera and frame events stop while no
 lease is current. This matches `viewport`, which is null while detached.
 
-The backing flow is a `SharedFlow` with a bounded buffer and drop-oldest. The
-owner thread emits and must never block on a slow collector. Frames are the only
-high-rate type, and the library already handles every frame through `onFrame`,
-so a fixed engine mask covering the catalog above costs nothing new.
+The backing flow is a `MutableSharedFlow` with no replay, an extra buffer of 64
+events, and drop-oldest overflow. `MapState.onEvent` calls `tryEmit` after its
+reactions, so a collector reads the values that the event produced. The owner
+thread emits and never blocks on a slow collector; 64 is about half a second of
+frames at 120 Hz. A collector on an undispatched context runs on the thread that
+reported the event, under the lock that serializes the map lifecycle, so the
+KDoc on `events` tells callers to collect on a dispatcher before calling a map
+command.
+
+Frames are the only high-rate type, and the library handled every frame before
+the redesign, so a fixed engine mask covering the catalog costs nothing new.
 Subscription-counted masks, which both engines can express, wait until a
 high-rate optional type such as tile actions joins the catalog.
 
@@ -219,10 +226,15 @@ LaunchedEffect(state) {
 }
 ```
 
+The images page of the documentation site shows the missing-image recipe from
+the `missing-image` region of `docsnippets/Images.kt`. It waits for a ready
+style before the add and supplies each id once. `MapStateEventsTest` runs that
+recipe on both engines.
+
 A completed-frame signal is `FrameRendered`. [#1043] asks for exactly that: a
 caller arms a token after a state change and consumes it on the next frame. The
-demo frame counter already counts frames itself, and the benchmark timestamps
-`FrameRendered` to recover intervals.
+demo frame counter counts `FrameRendered`, and the benchmark timestamps each one
+to recover intervals.
 
 [#1043]: https://github.com/maplibre/maplibre-compose/issues/1043
 
@@ -246,53 +258,80 @@ internal interface MapAdapter.Callbacks {
 }
 ```
 
-`onEvent` returns `Unit`. `MapLifecycleCallbacks` already answers whether the
-identity that produced a call is still current, and the session branches on that
-answer, so the sink does not carry a second one.
+`onEvent` returns `Unit`. `MapLifecycleCallbacks` answers whether the identity
+that produced a call is still current, and the session branches on that answer,
+so the sink does not carry a second one. `MapState` re-checks the adapter before
+it reacts, as `synchronizeCamera` does.
 
 `onStyleSourcesChanged` survives the redesign. The native session finds newly
-arrived TileJSON attribution by polling `styleSourceInfo` on its owner thread,
-and its style binding reports its own adds and removes; neither is an engine
-event. Refreshing sources on every `Idle` instead would rewrite the
-`style.sources` snapshot on each idle and recompose every reader.
+arrived TileJSON attribution by polling `styleSourceInfo` on its owner thread
+and reports each source once, and its style binding reports its own adds and
+removes; neither is an engine event. Refreshing sources on every `Idle` instead
+would rewrite the `style.sources` snapshot on each idle and recompose every
+reader.
 
 `onGestureActive` and `onViewportChanged` are presentation facts that no engine
 emits. The gesture token lives in the session, and on native the gesture ends on
 the owner thread only after the queued camera commands and their events have
-drained, so the session reports it in the right order. A native resize adopts a
-new viewport without emitting a camera event, and publishing a synthetic
-`CameraMoved` for it would reshape rather than translate.
+drained (`finishPendingGesture`), so the session reports it in the right order.
+A native resize adopts a new viewport without emitting a camera event, and
+publishing a synthetic `CameraMoved` for it would reshape rather than translate.
 
 Each session translates one FFI `RuntimeEvent` or one GL JS listener call into
 one `MapEvent` and posts it. The translation does not coalesce a drag, compute a
-rate, or unproject a click. `MapState` reacts inside `onEvent`: it snapshots the
-viewport on the camera triple, starts and ends the camera change that
-`isCameraMoving` reports, and then publishes to `events`.
+rate, or unproject a click. The native session refreshes its viewport mirror
+inside the same acceptance as each camera event, through the `beforeDelegate`
+parameter of the presentation-scoped `MapLifecycleCallbacks.onEvent`, so
+`MapState` reads a fresh viewport during a drag.
+
+`MapState.onEvent` reacts, then publishes. On each of the camera triple it calls
+`synchronizeCamera`, which reads the adapter's camera position and viewport and
+publishes both. `CameraMoveStarted` also marks a camera change in flight on the
+attachment, and `CameraMoveEnded` clears it. `FrameRendered` and the rest carry
+no reaction.
+
+`isCameraMoving` is derived on `MapAttachment`: a gesture holds the camera, or
+an engine camera change is in flight. `cameraMoveReason` becomes `GESTURE` when
+`onGestureActive(true)` arrives, and `PROGRAMMATIC` when a `CameraMoveStarted`
+arrives with no gesture active. A gesture sets the reason even while an engine
+change is in flight, because the token decides whether a change belongs to the
+user. `MapStateEventReactionTest` pins these rules in `commonTest`, and
+`CameraMoveReportingTest` and `MlnFfiGestureTokenOrderingTest` pin them against
+live maps.
 
 A session may consume engine-only events for library reactions without those
-events being common. The browser session keeps its `sourcedata` metadata
-subscription for attribution refresh, and the native session keeps
-`MAP_RENDER_UPDATE_AVAILABLE` for render scheduling and
-`MAP_CAMERA_TRANSITION_FINISHED` for transition waiters.
+events being common. The browser session keeps its `styledata` and `sourcedata`
+subscriptions for load reporting and attribution refresh, and resumes eased
+transitions on an accepted `CameraMoveEnded`. The native session keeps
+`MAP_RENDER_UPDATE_AVAILABLE` for render scheduling, `MAP_LOADING_FINISHED` as a
+second route to reporting a loaded style, and `MAP_CAMERA_TRANSITION_FINISHED`
+for transition waiters. Both engines log their non-terminal errors: native
+`MAP_RENDER_ERROR`, and browser `error` outside a style load.
 
 ### Clicks
 
-Clicks leave the adapter now, ahead of the gesture redesign.
-`MapState.positionFromScreenLocation` is already public, so `MapInput` can
-unproject and dispatch to the map and layer handlers without the session round
-trip. The gesture redesign later replaces the handlers with its tap-family
-chain.
+Clicks left the adapter ahead of the gesture redesign. `MapInput` reports a tap
+or long press to a `MapClickTarget`, and `MapClickDispatcher` in `MaplibreMap`
+unprojects through `MapState.positionFromScreenLocation` and dispatches to the
+map and layer handlers. A click that arrives while the map has no viewport is
+dropped without a log line. The gesture redesign replaces the handlers with its
+tap-family chain.
 
 ### Deleted APIs
 
 - `onFrame` on `MaplibreMap`.
 - `MapAdapter.Callbacks.onCameraMoveStarted`, `onCameraMoved`,
   `onCameraMoveEnded`, `onClick`, `onLongClick`, and `onFrame`.
+- `GestureTarget.onPrimaryClick` and `onSecondaryClick`, moved to
+  `MapClickTarget`.
+- `EngineError`, which appeared in the first draft of the catalog. Native
+  `MAP_RENDER_ERROR` is a render failure, and browser `error` is a tile, sprite,
+  glyph, or source failure with a source id. Both engines log those, and nothing
+  in the tree consumed one event that meant two different things.
 - `CameraMoveReason` as a value that a session computes. It stays on `MapState`
-  as a value that the gesture token sets.
-- `CameraMoveReason.UNKNOWN`. The token leaves three states: not moved yet, a
-  gesture holds the camera, and a programmatic change. Nothing reports
-  `UNKNOWN`, so it becomes a deprecation.
+  as a value that the gesture token and the camera events set.
+- `CameraMoveReason.UNKNOWN` as a reported value. The enum keeps the constant,
+  and its KDoc states that the library never reports it.
 
 ### Deferred from the common catalog
 
@@ -322,52 +361,37 @@ the common type does not gain one.
 | Frame completed             | `onFrame(fps)`                          | `FrameRendered`                          |
 | Frame rate                  | `onFrame(fps)`                          | Timestamps of `FrameRendered`            |
 | Missing sprite              | Logged and dropped                      | `StyleImageMissing`                      |
-| Engine error                | Logged                                  | `EngineError`                            |
+| Engine error                | Logged                                  | Logged                                   |
 | Map or layer click          | Session round trip and layer parameters | Compose dispatch, then the gesture chain |
 | Tile progress, GL JS extras | Unavailable in common                   | `withPlatformMap`                        |
 
-## Sequence
+## What landed
 
-Each step lands on its own. The first two conflict with nothing in flight.
+The redesign landed as five commits, each on its own: clicks out of the adapter,
+the value model and translation, reactions moved to `MapState`, the public flow
+with `onFrame` removed, and the handshake rename. `EngineEventTest` asserts each
+event on a live map on both engines, and `MlnFfiMapEventsTest` and
+`GlJsMapEventsTest` assert the translations.
 
-1. **Clicks out of the adapter.** `MapInput` unprojects through `MapState` and
-   dispatches directly. `onClick` and `onLongClick` leave
-   `MapAdapter.Callbacks`. Behavior is identical.
-2. **Value model and translation.** `MapEvent` and `RenderStats` in
-   `commonMain`. Both sessions post events through `onEvent` beside the existing
-   callbacks. Tests assert that each handled FFI type and each subscribed GL JS
-   type produces one `MapEvent` with the right payload.
-3. **Reactions move.** Viewport snapshots and `isCameraMoving` read `MapEvent`.
-   The camera trio leaves the adapter. A resize changes the projection without a
-   camera event, so both sessions keep a viewport snapshot of their own beside
-   the event path. Existing presentation tests pin the token ordering.
-4. **Public flow.** `MapState.events` publishes. `onFrame` leaves `MaplibreMap`,
-   and the demo frame counter and benchmark move to `FrameRendered`.
-5. **Handshake rename.** The style methods take their protocol names:
-   `onStyleReady`, `onStyleFailed`, and `onStyleSourcesChanged`.
-
-## Open questions
+## Resolved questions
 
 **Missing images on the browser.** GL JS 6.6 fires `styleimagemissing` only
 after its `setMissingStyleImageResolver` callback has had a chance to supply the
-image, and a listener cannot resolve the current request. On native the event
-drains asynchronously, and mbgl re-checks the image set after a later
-`setStyleImage`. The event is enough to stop dropping the FFI event. Whether an
-add from a collector satisfies the pending request on both engines needs a live
-test. If the browser needs the resolver, that is a separate command-style API,
-tracked in [COMMON_API_GAPS.md](./COMMON_API_GAPS.md).
+image, and a listener cannot resolve the current request. Both engines publish
+`StyleImageMissing`, and the KDoc states the difference: on native an image
+added in response satisfies the request at the next placement, and on the
+browser it applies to later requests of that id. `MapStateEventsTest` shows that
+an add from a collector reaches the style on both engines. Whether that add also
+resolves the pending request on the browser is untested. A resolver is a
+separate command-style API, and this catalog does not carry one.
 
-**Frame source on native.** The session's own render loop knows when
-`renderUpdate` drew a frame, and the FFI queues `MAP_RENDER_FRAME_FINISHED` from
-the mbgl observer inside that same render. The event is the engine's contract,
-so `FrameRendered` comes from the drain. A prototype confirms that the drain
-cadence keeps the event close to the frame it describes.
+**Frame source on native.** `FrameRendered` comes from the drain, because the
+event is the engine's contract. The runtime loop parks in `pump` and a queued
+event wakes it, so the event follows the frame it describes without waiting for
+the next pump. The session's own `reportFrameRate` measurement is gone.
 
-**Browser camera mode.** Null is honest. Mapping `isEasing()` is a guess. The
-first version passes null.
+**Browser camera mode.** The browser passes null. Mapping `isEasing()` would be
+a guess.
 
-**Error on the browser.** GL JS `error` carries tile, sprite, glyph, and source
-failures with a `sourceId`. FFI `MAP_RENDER_ERROR` is a render failure, and tile
-errors arrive as `MAP_TILE_ACTION` with the error operation. `EngineError` is
-the lowest-value row in the catalog, and a prototype may drop it rather than
-publish two different things under one name.
+**Error on the browser.** Dropped from the catalog, as the
+[Deleted APIs](#deleted-apis) entry states.

--- a/.agents/docs/EVENT_CALLBACK_REDESIGN.md
+++ b/.agents/docs/EVENT_CALLBACK_REDESIGN.md
@@ -9,42 +9,45 @@ owns pointer recognition, bindings, and click dispatch. This document owns the
 events that MapLibre Native FFI and MapLibre GL JS emit. The two meet at one
 point: the gesture token decides whether a camera change is user-driven.
 
-## What the current code is
+## What the code was
 
-`MapAdapter.Callbacks` has ten methods that both engine sessions implement, and
-`MapLifecycleCallbacks` filters each call through the engine identity, style
-identity, or render lease that produced it. The ten methods are three unrelated
-things.
+The redesign replaced this shape. Every step in the [Sequence](#sequence) has
+landed.
+
+`MapAdapter.Callbacks` had ten methods that both engine sessions implemented,
+and `MapLifecycleCallbacks` filtered each call through the engine identity,
+style identity, or render lease that produced it. The ten methods were three
+unrelated things.
 
 **A two-way style handshake.** `onStyleChanged`, `onMapFinishedLoading`,
-`onMapFailLoading`, and `onSourceChanged` are a protocol, not events. The
-session offers a style binding, `MapState` accepts or rejects it, and the
-session branches on the answer: it keeps or invalidates the binding, and it
-clears or keeps its own "load unreported" flag.
+`onMapFailLoading`, and `onSourceChanged` were a protocol, not events. The
+session offered a style binding, `MapState` accepted or rejected it, and the
+session branched on the answer: it kept or invalidated the binding, and it
+cleared or kept its own "load unreported" flag.
 
 **Camera state feeding.** `onCameraMoveStarted`, `onCameraMoved`, and
-`onCameraMoveEnded` exist to set `viewport`, `isCameraMoving`, and
-`cameraMoveReason` on the current attachment. Both sessions run the same
+`onCameraMoveEnded` existed to set `viewport`, `isCameraMoving`, and
+`cameraMoveReason` on the current attachment. Both sessions ran the same
 coalescing. Native emits `MAP_CAMERA_WILL_CHANGE`, `MAP_CAMERA_IS_CHANGING`, and
 `MAP_CAMERA_DID_CHANGE`; the browser emits `movestart`, `move`, and `moveend`.
-Compose drives a drag as a series of jumps, so each pointer move produces its
-own did-change or moveend. The session reads its gesture flag and withholds the
-end callback until the gesture ends, so that a drag reports as one move. The
-session also sets `CameraMoveReason` from that same flag.
+Compose drives a drag as a series of jumps, so each pointer move produced its
+own did-change or moveend. The session read its gesture flag and withheld the
+end callback until the gesture ended, so that a drag reported as one move. The
+session also set `CameraMoveReason` from that same flag.
 
-**Values that neither engine emits.** `onClick` and `onLongClick` originate in
-Compose input. `MapInput` recognizes a tap or long press and calls
-`GestureTarget.onPrimaryClick` or `onSecondaryClick`. The session unprojects the
-offset and calls back into `MaplibreMap`, which walks the layers. `onFrame(fps)`
-is an inter-frame interval that the session measures in its own render loop. The
-FFI reports `MAP_RENDER_FRAME_FINISHED` with a payload, and GL JS reports
-`render`, and neither reports a rate.
+**Values that neither engine emits.** `onClick` and `onLongClick` originated in
+Compose input. `MapInput` recognized a tap or long press and called
+`GestureTarget.onPrimaryClick` or `onSecondaryClick`. The session unprojected
+the offset and called back into `MaplibreMap`, which walked the layers.
+`onFrame(fps)` was an inter-frame interval that the session measured in its own
+render loop. The FFI reports `MAP_RENDER_FRAME_FINISHED` with a payload, and GL
+JS reports `render`, and neither reports a rate.
 
-The public surface is `onClick`, `onLongClick`, and `onFrame` on `MaplibreMap`,
+The public surface was `onClick`, `onLongClick`, and `onFrame` on `MaplibreMap`,
 plus `onClick` and `onLongClick` on each layer composable. Load state, viewport,
-and camera motion already surface as state on `MapState`.
+and camera motion already surfaced as state on `MapState`.
 
-This shape dates from a period when Android `MapView`, iOS `MLNMapView`, and GL
+That shape dated from a period when Android `MapView`, iOS `MLNMapView`, and GL
 JS each had a different observer API, clicks arrived from the engine, and there
 was no durable `MapState` to hold load or camera state. The portable surface was
 the subset every SDK could fake.
@@ -226,27 +229,45 @@ demo frame counter already counts frames itself, and the benchmark timestamps
 ### Internal sink
 
 The style handshake stays a protocol, because a one-way stream cannot answer
-"did you accept this binding". It shrinks to what it is: offer a loaded binding,
-report the composition ready, report the load failed. Everything else is a
-one-way fact:
+"did you accept this binding". The sink names it: offer a loaded binding, report
+the composition ready, report the load failed, report a source change. The rest
+are one-way facts:
 
 ```kotlin
 internal interface MapAdapter.Callbacks {
   fun onStyleChanged(map: MapAdapter, style: StyleBinding?)
   fun onStyleReady(map: MapAdapter)
   fun onStyleFailed(map: MapAdapter, reason: String?)
+  fun onStyleSourcesChanged(map: MapAdapter, sourceId: String?)
 
-  /** Returns false when the lifecycle rejected the event. */
-  fun onEvent(map: MapAdapter, event: MapEvent): Boolean
+  fun onEvent(map: MapAdapter, event: MapEvent)
+  fun onGestureActive(map: MapAdapter, active: Boolean)
+  fun onViewportChanged(map: MapAdapter)
 }
 ```
+
+`onEvent` returns `Unit`. `MapLifecycleCallbacks` already answers whether the
+identity that produced a call is still current, and the session branches on that
+answer, so the sink does not carry a second one.
+
+`onStyleSourcesChanged` survives the redesign. The native session finds newly
+arrived TileJSON attribution by polling `styleSourceInfo` on its owner thread,
+and its style binding reports its own adds and removes; neither is an engine
+event. Refreshing sources on every `Idle` instead would rewrite the
+`style.sources` snapshot on each idle and recompose every reader.
+
+`onGestureActive` and `onViewportChanged` are presentation facts that no engine
+emits. The gesture token lives in the session, and on native the gesture ends on
+the owner thread only after the queued camera commands and their events have
+drained, so the session reports it in the right order. A native resize adopts a
+new viewport without emitting a camera event, and publishing a synthetic
+`CameraMoved` for it would reshape rather than translate.
 
 Each session translates one FFI `RuntimeEvent` or one GL JS listener call into
 one `MapEvent` and posts it. The translation does not coalesce a drag, compute a
 rate, or unproject a click. `MapState` reacts inside `onEvent`: it snapshots the
-viewport on the camera triple, sets `isCameraMoving` from the gesture token and
-transition state, refreshes attribution on native `Idle`, and then publishes to
-`events`.
+viewport on the camera triple, starts and ends the camera change that
+`isCameraMoving` reports, and then publishes to `events`.
 
 A session may consume engine-only events for library reactions without those
 events being common. The browser session keeps its `sourcedata` metadata
@@ -266,8 +287,7 @@ chain.
 
 - `onFrame` on `MaplibreMap`.
 - `MapAdapter.Callbacks.onCameraMoveStarted`, `onCameraMoved`,
-  `onCameraMoveEnded`, `onClick`, `onLongClick`, `onFrame`, and
-  `onSourceChanged`.
+  `onCameraMoveEnded`, `onClick`, `onLongClick`, and `onFrame`.
 - `CameraMoveReason` as a value that a session computes. It stays on `MapState`
   as a value that the gesture token sets.
 - `CameraMoveReason.UNKNOWN`. The token leaves three states: not moved yet, a
@@ -293,7 +313,7 @@ the common type does not gain one.
 
 ## Mapping
 
-| Caller need                 | Today                                   | After                                    |
+| Caller need                 | Before                                  | After                                    |
 | --------------------------- | --------------------------------------- | ---------------------------------------- |
 | Style ready or failed       | `loadState` plus hidden callbacks       | `loadState`                              |
 | Viewport                    | `viewport` plus `onCameraMoved`         | `viewport`                               |
@@ -317,14 +337,14 @@ Each step lands on its own. The first two conflict with nothing in flight.
    `commonMain`. Both sessions post events through `onEvent` beside the existing
    callbacks. Tests assert that each handled FFI type and each subscribed GL JS
    type produces one `MapEvent` with the right payload.
-3. **Reactions move.** Viewport snapshots, `isCameraMoving`, and attribution
-   refresh read `MapEvent`. The camera trio and `onSourceChanged` leave the
-   adapter. A resize changes the projection without a camera event, so both
-   sessions keep a viewport snapshot of their own beside the event path.
-   Existing presentation tests pin the token ordering.
+3. **Reactions move.** Viewport snapshots and `isCameraMoving` read `MapEvent`.
+   The camera trio leaves the adapter. A resize changes the projection without a
+   camera event, so both sessions keep a viewport snapshot of their own beside
+   the event path. Existing presentation tests pin the token ordering.
 4. **Public flow.** `MapState.events` publishes. `onFrame` leaves `MaplibreMap`,
    and the demo frame counter and benchmark move to `FrameRendered`.
-5. **Handshake rename.** The three style methods take their protocol names.
+5. **Handshake rename.** The style methods take their protocol names:
+   `onStyleReady`, `onStyleFailed`, and `onStyleSourcesChanged`.
 
 ## Open questions
 

--- a/.agents/docs/EVENT_CALLBACK_REDESIGN.md
+++ b/.agents/docs/EVENT_CALLBACK_REDESIGN.md
@@ -103,7 +103,7 @@ filters on the identity that produced it:
 | Identity      | Events                                                                 |
 | ------------- | ---------------------------------------------------------------------- |
 | Render lease  | `CameraMoveStarted`, `CameraMoved`, `CameraMoveEnded`, `FrameRendered` |
-| Style         | `StyleLoaded`, `StyleImageMissing`                                     |
+| Style         | `StyleLoaded`                                                          |
 | Style request | `StyleLoadFailed`                                                      |
 | Engine        | `Idle`                                                                 |
 
@@ -132,25 +132,25 @@ public sealed interface MapEvent {
   public data class CameraMoveEnded(val animated: Boolean?) : MapEvent
 
   public data class FrameRendered(val stats: RenderStats?) : MapEvent
-
-  public data class StyleImageMissing(val imageId: String) : MapEvent
 }
 ```
 
-| Event               | maplibre-native-ffi         | maplibre-gl-js      |
-| ------------------- | --------------------------- | ------------------- |
-| `StyleLoaded`       | `MAP_STYLE_LOADED`          | `style.load`        |
-| `StyleLoadFailed`   | `MAP_LOADING_FAILED`        | `error`, terminal   |
-| `Idle`              | `MAP_IDLE`                  | `idle`              |
-| `CameraMoveStarted` | `MAP_CAMERA_WILL_CHANGE`    | `movestart`         |
-| `CameraMoved`       | `MAP_CAMERA_IS_CHANGING`    | `move`              |
-| `CameraMoveEnded`   | `MAP_CAMERA_DID_CHANGE`     | `moveend`           |
-| `FrameRendered`     | `MAP_RENDER_FRAME_FINISHED` | `render`            |
-| `StyleImageMissing` | `MAP_STYLE_IMAGE_MISSING`   | `styleimagemissing` |
+| Event               | maplibre-native-ffi         | maplibre-gl-js    |
+| ------------------- | --------------------------- | ----------------- |
+| `StyleLoaded`       | `MAP_STYLE_LOADED`          | `style.load`      |
+| `StyleLoadFailed`   | `MAP_LOADING_FAILED`        | `error`, terminal |
+| `Idle`              | `MAP_IDLE`                  | `idle`            |
+| `CameraMoveStarted` | `MAP_CAMERA_WILL_CHANGE`    | `movestart`       |
+| `CameraMoved`       | `MAP_CAMERA_IS_CHANGING`    | `move`            |
+| `CameraMoveEnded`   | `MAP_CAMERA_DID_CHANGE`     | `moveend`         |
+| `FrameRendered`     | `MAP_RENDER_FRAME_FINISHED` | `render`          |
 
 `MlnFfiMapEvents.kt` holds the native translation as
 `RuntimeEvent.toMapEvent()`, and `GlJsMapEvents.kt` holds the browser
-translation as three maps from GL JS type name to translation, one per identity.
+translation as two maps from GL JS type name to translation, one for the engine
+identity and one for the presentation identity. The browser reports the one
+style-identity event, `StyleLoaded`, from its style load tracking rather than
+from a translation map.
 
 `animated` is true when the FFI `CameraChangeMode` is `ANIMATED`. GL JS has no
 such field, so the browser session passes null.
@@ -218,7 +218,6 @@ Transient engine facts become a collection:
 LaunchedEffect(state) {
   state.events.collect { event ->
     when (event) {
-      is MapEvent.StyleImageMissing -> state.style.images.add(event.imageId, fallback)
       is MapEvent.StyleLoadFailed -> logger.e { event.reason }
       else -> Unit
     }
@@ -226,10 +225,9 @@ LaunchedEffect(state) {
 }
 ```
 
-The images page of the documentation site shows the missing-image recipe from
-the `missing-image` region of `docsnippets/Images.kt`. It waits for a ready
-style before the add and supplies each id once. `MapStateEventsTest` runs that
-recipe on both engines.
+A missing style image is a request rather than a fact, so it is a resolver on
+`MapState` rather than an event, under
+[Resolved questions](#resolved-questions).
 
 A completed-frame signal is `FrameRendered`. [#1043] asks for exactly that: a
 caller arms a token after a state change and consumes it on the next frame. The
@@ -243,7 +241,7 @@ to recover intervals.
 The style handshake stays a protocol, because a one-way stream cannot answer
 "did you accept this binding". The sink names it: offer a loaded binding, report
 the composition ready, report the load failed, report a source change. The rest
-are one-way facts:
+are one-way facts, plus one more question:
 
 ```kotlin
 internal interface MapAdapter.Callbacks {
@@ -253,10 +251,14 @@ internal interface MapAdapter.Callbacks {
   fun onStyleSourcesChanged(map: MapAdapter, sourceId: String?)
 
   fun onEvent(map: MapAdapter, event: MapEvent)
+  fun resolveMissingImage(map: MapAdapter, imageId: String): Deferred<Unit>?
   fun onGestureActive(map: MapAdapter, active: Boolean)
   fun onViewportChanged(map: MapAdapter)
 }
 ```
+
+`resolveMissingImage` is the second question in the sink, and the only one that
+returns a value to the session: the browser returns that promise to MapLibre.
 
 `onEvent` returns `Unit`. `MapLifecycleCallbacks` answers whether the identity
 that produced a call is still current, and the session branches on that answer,
@@ -332,6 +334,9 @@ tap-family chain.
   as a value that the gesture token and the camera events set.
 - `CameraMoveReason.UNKNOWN` as a reported value. The enum keeps the constant,
   and its KDoc states that the library never reports it.
+- `MapEvent.StyleImageMissing`, and the `styleimagemissing` subscription and the
+  `GlJsMapEvent.id` field that fed it. `MapState.missingImageResolver` replaces
+  it, under [Resolved questions](#resolved-questions).
 
 ### Deferred from the common catalog
 
@@ -360,7 +365,7 @@ the common type does not gain one.
 | Gesture versus programmatic | `CameraMoveReason` from a session flag  | `cameraMoveReason` from the token        |
 | Frame completed             | `onFrame(fps)`                          | `FrameRendered`                          |
 | Frame rate                  | `onFrame(fps)`                          | Timestamps of `FrameRendered`            |
-| Missing sprite              | Logged and dropped                      | `StyleImageMissing`                      |
+| Missing sprite              | Logged and dropped                      | `MapState.missingImageResolver`          |
 | Engine error                | Logged                                  | Logged                                   |
 | Map or layer click          | Session round trip and layer parameters | Compose dispatch, then the gesture chain |
 | Tile progress, GL JS extras | Unavailable in common                   | `withPlatformMap`                        |
@@ -375,15 +380,47 @@ event on a live map on both engines, and `MlnFfiMapEventsTest` and
 
 ## Resolved questions
 
-**Missing images on the browser.** GL JS 6.6 fires `styleimagemissing` only
-after its `setMissingStyleImageResolver` callback has had a chance to supply the
-image, and a listener cannot resolve the current request. Both engines publish
-`StyleImageMissing`, and the KDoc states the difference: on native an image
-added in response satisfies the request at the next placement, and on the
-browser it applies to later requests of that id. `MapStateEventsTest` shows that
-an add from a collector reaches the style on both engines. Whether that add also
-resolves the pending request on the browser is untested. A resolver is a
-separate command-style API, and this catalog does not carry one.
+**Missing images are a resolver, not an event.** The catalog carried
+`StyleImageMissing`, and it was removed. GL JS 6.6 fires `styleimagemissing`
+only after its `setMissingStyleImageResolver` callback has declined, so a
+listener on the browser can never satisfy the request that reported the event;
+it can only supply the id for later requests. The event also made every caller
+write the same bookkeeping: a set of ids already supplied, a wait for
+`StyleLoadState.Ready`, and a clear on each style load, all from a collector
+that suspends inside a drop-oldest buffer and so can lose the event it is
+waiting on.
+
+`MapState.missingImageResolver` replaces it: a suspending function from image id
+to `ResolvedStyleImage?`, null for unresolved. The options that the resolved
+image needs, `sdf` and `stretch`, belong to the result rather than to the call,
+because they describe the image that the resolver chose rather than the request.
+`MapState` owns the bookkeeping: it resolves each id at most once per loaded
+style and adds the image to the style that asked for it. A new base style, or a
+different resolver, lets the next engine request for that id reach the resolver
+again.
+
+The add cannot wait for `StyleLoadState.Ready`, and cannot assert it afterward
+either. On the browser a style counts as loaded only once every in-view tile has
+parsed, and a tile does not finish parsing until the resolver's promise settles,
+so a wait for ready is a cycle that leaves the map blank. The add waits for the
+style command in progress instead, and afterward checks only that the style it
+added to is still the loaded one.
+
+The reservation the add holds is its own, separate from the one an imperative
+style command takes. An app cannot anticipate a resolution, so a command it
+issues must not fail on one: `requireNoActiveStyleMutation` reads only the
+command's reservation, while a new style revision waits for either.
+
+The browser session registers `setMissingStyleImageResolver` and returns the
+resolution as a promise, which MapLibre awaits before it treats the image as
+missing, so the resolved image satisfies the request that asked for it. The
+native session keeps `MAP_STYLE_IMAGE_MISSING` in its event mask and calls the
+resolver from the drain; mbgl re-checks its image set at the next placement
+after `setStyleImage`, so an asynchronous answer reaches a later frame, not the
+one that raised the miss. `MissingImageResolverTest` asserts on both engines
+that a resolved image reaches the style, that the resolver runs once per loaded
+style, that a reload asks again, and that a replacement resolver answers an id
+the first declined.
 
 **Frame source on native.** `FrameRendered` comes from the drain, because the
 event is the engine's contract. The runtime loop parks in `pump` and a queued

--- a/.agents/docs/EVENT_CALLBACK_REDESIGN.md
+++ b/.agents/docs/EVENT_CALLBACK_REDESIGN.md
@@ -106,7 +106,9 @@ engine event  →  identity filter  →  MapState reactions  →  public Flow
 ```
 
 Identity filtering stays. An event from a departed render lease or a superseded
-style request is dropped. That is ownership, not reshape, and
+style request is dropped. `Idle` reports the engine's own progress rather than a
+style's or a lease's, so it filters on the engine identity and arrives after a
+failed style load too. That is ownership, not reshape, and
 `MapLifecycleCallbacks` already does it.
 
 ### Events
@@ -314,7 +316,9 @@ Each step lands on its own. The first two conflict with nothing in flight.
    type produces one `MapEvent` with the right payload.
 3. **Reactions move.** Viewport snapshots, `isCameraMoving`, and attribution
    refresh read `MapEvent`. The camera trio and `onSourceChanged` leave the
-   adapter. Existing presentation tests pin the token ordering.
+   adapter. A resize changes the projection without a camera event, so both
+   sessions keep a viewport snapshot of their own beside the event path.
+   Existing presentation tests pin the token ordering.
 4. **Public flow.** `MapState.events` publishes. `onFrame` leaves `MaplibreMap`,
    and the demo frame counter and benchmark move to `FrameRendered`.
 5. **Handshake rename.** The three style methods take their protocol names.

--- a/.agents/docs/GESTURE_REDESIGN.md
+++ b/.agents/docs/GESTURE_REDESIGN.md
@@ -12,10 +12,10 @@ prototype will change them.
 This ships against the ownership API: `MaplibreMap(state)` with the camera on
 `MapState`. `GestureOptions` is deleted, with no compatibility layer.
 
-Engine events such as style load, idle, frames, and missing images are a
-separate surface, in [EVENT_CALLBACK_REDESIGN.md](./EVENT_CALLBACK_REDESIGN.md).
-That work moved click dispatch out of `MapAdapter.Callbacks` and into Compose;
-this gesture chain replaces the click handlers.
+Engine events such as style load, idle, and frames are a separate surface, in
+[EVENT_CALLBACK_REDESIGN.md](./EVENT_CALLBACK_REDESIGN.md). That work moved
+click dispatch out of `MapAdapter.Callbacks` and into Compose; this gesture
+chain replaces the click handlers.
 
 ## What the current code is
 

--- a/.agents/docs/GESTURE_REDESIGN.md
+++ b/.agents/docs/GESTURE_REDESIGN.md
@@ -14,8 +14,8 @@ This ships against the ownership API: `MaplibreMap(state)` with the camera on
 
 Engine events such as style load, idle, frames, and missing images are a
 separate surface, in [EVENT_CALLBACK_REDESIGN.md](./EVENT_CALLBACK_REDESIGN.md).
-That work moves click dispatch out of `MapAdapter.Callbacks` and into Compose
-first; this gesture chain then replaces the click handlers.
+That work moved click dispatch out of `MapAdapter.Callbacks` and into Compose;
+this gesture chain replaces the click handlers.
 
 ## What the current code is
 

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoMap.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoMap.kt
@@ -30,10 +30,13 @@ import androidx.compose.ui.unit.dp
 import kotlin.math.roundToInt
 import kotlin.math.sqrt
 import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.jetbrains.compose.resources.vectorResource
 import org.maplibre.compose.demoapp.generated.Res
 import org.maplibre.compose.demoapp.generated.filter_center_focus_24px
+import org.maplibre.compose.map.MapEvent
 import org.maplibre.compose.map.MapState
 import org.maplibre.compose.map.MaplibreMap
 import org.maplibre.compose.map.StyleLoadState
@@ -90,6 +93,13 @@ fun DemoMap(state: DemoAppState, viewportInsets: MapViewportInsets) {
       StyleLoadState.Pending -> Unit
     }
   }
+  LaunchedEffect(state.mapState) {
+    withContext(Dispatchers.Default) {
+      state.mapState.events.collect {
+        if (it is MapEvent.FrameRendered) state.frameRateState.record()
+      }
+    }
+  }
   val pointerPin = selectedDemo?.pointerPin
   val placementPadding =
     PaddingValues.Absolute(
@@ -105,7 +115,6 @@ fun DemoMap(state: DemoAppState, viewportInsets: MapViewportInsets) {
       renderOptions = state.settings.renderOptions,
       gestureOptions = state.settings.gestureOptions,
       tileLodOptions = state.settings.tileLodOptions,
-      onFrame = { state.frameRateState.record() },
       contentWindowInsets = viewportInsets.asWindowInsets(),
     ) {
       include(

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/FrameRateState.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/FrameRateState.kt
@@ -16,10 +16,12 @@ private const val SAMPLE_MILLIS = 500L
 /**
  * How many frames the map has actually drawn, sampled over time.
  *
- * Counts frames rather than using the rate `onFrame` reports, which is instantaneous and so stays
- * high once an idle map stops drawing. The counter is deliberately not snapshot state: [record]
- * runs once per frame on the presenting thread, and writing state there would recompose at frame
- * rate.
+ * [record] counts one [org.maplibre.compose.map.MapEvent.FrameRendered] event. The counter is
+ * deliberately not snapshot state: it advances once per frame, and writing state there would
+ * recompose at frame rate.
+ *
+ * On the browser MapLibre GL JS also draws frames that it schedules itself, so the count can exceed
+ * the frames that the map session drives.
  */
 @Stable
 class FrameRateState {
@@ -34,9 +36,10 @@ class FrameRateState {
   var totalFrames by mutableLongStateOf(0L)
     private set
 
-  /** Called once per rendered frame, from the presenting thread. */
+  /**
+   * Called once per rendered frame. One collector calls this, so a plain increment loses nothing.
+   */
   fun record() {
-    // One writer, so a plain increment loses nothing.
     frames++
   }
 

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/benchmark/BenchmarkMap.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/benchmark/BenchmarkMap.kt
@@ -29,11 +29,14 @@ import co.touchlab.kermit.Logger
 import kotlin.time.TimeSource
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.launch
 import org.maplibre.compose.demoapp.DemoAppState
 import org.maplibre.compose.demoapp.MapViewportInsets
 import org.maplibre.compose.map.GestureOptions
+import org.maplibre.compose.map.MapEvent
 import org.maplibre.compose.map.MapState
 import org.maplibre.compose.map.MaplibreMap
 import org.maplibre.compose.map.RenderOptions
@@ -126,10 +129,20 @@ internal fun BenchmarkMap(state: DemoAppState, viewportInsets: MapViewportInsets
             }
           }
         }
+        // Unconfined, so the mark carries no dispatch delay and a loaded run drops no event. The
+        // collector only writes to the sample arrays, which is all that MapState.events allows on
+        // an undispatched context.
+        val frameJob =
+          launch(Dispatchers.Unconfined) {
+            mapState.events.filterIsInstance<MapEvent.FrameRendered>().collect {
+              session.frames.recordMapFrame(TimeSource.Monotonic.markNow())
+            }
+          }
         try {
           running.run(mapState, session)
         } finally {
           composeJob.cancel()
+          frameJob.cancel()
         }
       }
       val durationMs = started.elapsedNow().inWholeMilliseconds.toDouble()
@@ -203,7 +216,6 @@ internal fun BenchmarkMap(state: DemoAppState, viewportInsets: MapViewportInsets
         renderOptions = RenderOptions.Standard,
         gestureOptions =
           if (scenario.usesGestures) GestureOptions.Standard else GestureOptions.AllDisabled,
-        onFrame = { fps -> session.frames.recordMapFps(fps) },
         contentWindowInsets = viewportInsets.asWindowInsets(),
       ) {}
     }

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/benchmark/FrameTimeCollector.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/benchmark/FrameTimeCollector.kt
@@ -1,11 +1,15 @@
 package org.maplibre.compose.demoapp.benchmark
 
 import kotlin.concurrent.Volatile
+import kotlin.time.DurationUnit
+import kotlin.time.TimeSource
 
 /**
- * Inter-frame intervals from the map's [org.maplibre.compose.map.MaplibreMap] `onFrame` callback
- * and from Compose vsync. [recordMapFps] runs on the presenting thread; [stop] is called from the
- * scenario coroutine after recording ends.
+ * Inter-frame intervals from the map's [org.maplibre.compose.map.MapEvent.FrameRendered] events and
+ * from Compose vsync. One collector calls [recordMapFrame], and [stop] is called from the scenario
+ * coroutine after recording ends.
+ *
+ * A map interval is the difference between two marks that the caller supplies.
  */
 class FrameTimeCollector(private val capacity: Int = 16_384) {
   private val mapMs = DoubleArray(capacity)
@@ -15,6 +19,8 @@ class FrameTimeCollector(private val capacity: Int = 16_384) {
 
   @Volatile private var composeCount = 0
 
+  @Volatile private var lastMapMark: TimeSource.Monotonic.ValueTimeMark? = null
+
   @Volatile
   var recording: Boolean = false
     private set
@@ -22,14 +28,19 @@ class FrameTimeCollector(private val capacity: Int = 16_384) {
   fun start() {
     mapCount = 0
     composeCount = 0
+    lastMapMark = null
     recording = true
   }
 
-  fun recordMapFps(framesPerSecond: Double) {
-    if (!recording || framesPerSecond <= 0.0) return
+  /** Records the interval since the previous frame. The first frame after [start] sets the mark. */
+  fun recordMapFrame(now: TimeSource.Monotonic.ValueTimeMark) {
+    if (!recording) return
+    val previous = lastMapMark
+    lastMapMark = now
+    if (previous == null) return
     val index = mapCount
     if (index >= mapMs.size) return
-    mapMs[index] = 1000.0 / framesPerSecond
+    mapMs[index] = (now - previous).toDouble(DurationUnit.MILLISECONDS)
     mapCount = index + 1
   }
 

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Images.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Images.kt
@@ -3,12 +3,10 @@
 package org.maplibre.compose.docsnippets
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.snapshotFlow
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
-import kotlinx.coroutines.flow.first
 import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.painterResource
 import org.maplibre.compose.demoapp.generated.Res
@@ -17,9 +15,8 @@ import org.maplibre.compose.expressions.dsl.const
 import org.maplibre.compose.expressions.dsl.image
 import org.maplibre.compose.layers.RasterLayer
 import org.maplibre.compose.layers.SymbolLayer
-import org.maplibre.compose.map.MapEvent
 import org.maplibre.compose.map.MaplibreMap
-import org.maplibre.compose.map.StyleLoadState
+import org.maplibre.compose.map.ResolvedStyleImage
 import org.maplibre.compose.map.rememberMapState
 import org.maplibre.compose.sources.GeoJsonData
 import org.maplibre.compose.sources.rememberGeoJsonSource
@@ -68,20 +65,9 @@ fun Images() {
 fun MissingImages(fallback: ImageBitmap) {
   // #region missing-image
   val mapState = rememberMapState()
-  LaunchedEffect(mapState) {
-    val supplied = mutableSetOf<String>()
-    mapState.events.collect { event ->
-      when (event) {
-        // A loaded style keeps none of the images added to the style before it.
-        MapEvent.StyleLoaded -> supplied.clear()
-        is MapEvent.StyleImageMissing ->
-          if (supplied.add(event.imageId)) {
-            snapshotFlow { mapState.style.loadState }.first { it == StyleLoadState.Ready }
-            mapState.style.images.add(event.imageId, fallback)
-          }
-        else -> Unit
-      }
-    }
+  DisposableEffect(mapState, fallback) {
+    mapState.missingImageResolver = { ResolvedStyleImage(fallback) }
+    onDispose { mapState.missingImageResolver = null }
   }
   MaplibreMap(state = mapState)
   // #endregion missing-image

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Images.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Images.kt
@@ -3,8 +3,12 @@
 package org.maplibre.compose.docsnippets
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.flow.first
 import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.painterResource
 import org.maplibre.compose.demoapp.generated.Res
@@ -13,7 +17,9 @@ import org.maplibre.compose.expressions.dsl.const
 import org.maplibre.compose.expressions.dsl.image
 import org.maplibre.compose.layers.RasterLayer
 import org.maplibre.compose.layers.SymbolLayer
+import org.maplibre.compose.map.MapEvent
 import org.maplibre.compose.map.MaplibreMap
+import org.maplibre.compose.map.StyleLoadState
 import org.maplibre.compose.map.rememberMapState
 import org.maplibre.compose.sources.GeoJsonData
 import org.maplibre.compose.sources.rememberGeoJsonSource
@@ -56,4 +62,27 @@ fun Images() {
     // #endregion image-source
   }
   MaplibreMap(state = imageState)
+}
+
+@Composable
+fun MissingImages(fallback: ImageBitmap) {
+  // #region missing-image
+  val mapState = rememberMapState()
+  LaunchedEffect(mapState) {
+    val supplied = mutableSetOf<String>()
+    mapState.events.collect { event ->
+      when (event) {
+        // A loaded style keeps none of the images added to the style before it.
+        MapEvent.StyleLoaded -> supplied.clear()
+        is MapEvent.StyleImageMissing ->
+          if (supplied.add(event.imageId)) {
+            snapshotFlow { mapState.style.loadState }.first { it == StyleLoadState.Ready }
+            mapState.style.images.add(event.imageId, fallback)
+          }
+        else -> Unit
+      }
+    }
+  }
+  MaplibreMap(state = mapState)
+  // #endregion missing-image
 }

--- a/docs/src/content/docs/images.mdx
+++ b/docs/src/content/docs/images.mdx
@@ -34,3 +34,16 @@ An <Api of="ImageSource" /> positions one image on the map by its four corner
 coordinates. A <Api of="RasterLayer" /> draws it:
 
 <Code code={rememberedMapStyle(region(images, "image-source"))} lang="kotlin" title="App.kt" />
+
+## Supply a missing image
+
+A style can reference an icon that its sprite does not contain. The map reports
+the missing icon as a <Api of="MapEvent.StyleImageMissing" /> event. Collect
+<Api of="MapState.events" /> and add an image under the ID that the event
+reports:
+
+<Code code={region(images, "missing-image")} lang="kotlin" title="App.kt" />
+
+Wait for a ready style before you add the image, because the engine reports the
+missing icon while it parses the style. Supply each ID once, because an add
+fails when the style already holds the ID.

--- a/docs/src/content/docs/images.mdx
+++ b/docs/src/content/docs/images.mdx
@@ -37,13 +37,9 @@ coordinates. A <Api of="RasterLayer" /> draws it:
 
 ## Supply a missing image
 
-A style can reference an icon that its sprite does not contain. The map reports
-the missing icon as a <Api of="MapEvent.StyleImageMissing" /> event. Collect
-<Api of="MapState.events" /> and add an image under the ID that the event
-reports:
+A style can reference an icon that its sprite does not contain. Set
+<Api of="MapState.missingImageResolver" /> to supply one. The map calls the
+resolver with the icon's ID and adds the <Api of="ResolvedStyleImage" /> that
+it returns:
 
 <Code code={region(images, "missing-image")} lang="kotlin" title="App.kt" />
-
-Wait for a ready style before you add the image, because the engine reports the
-missing icon while it parses the style. Supply each ID once, because an add
-fails when the style already holds the ID.

--- a/lib/maplibre-compose/src/androidDeviceTest/kotlin/org/maplibre/compose/mlnffi/AndroidSurfaceReplacementTest.kt
+++ b/lib/maplibre-compose/src/androidDeviceTest/kotlin/org/maplibre/compose/mlnffi/AndroidSurfaceReplacementTest.kt
@@ -25,6 +25,7 @@ import kotlin.test.Test
 import kotlin.test.assertTrue
 import kotlinx.coroutines.flow.first
 import org.maplibre.compose.map.DefaultMapRuntime
+import org.maplibre.compose.map.MapEvent
 import org.maplibre.compose.map.MapState
 import org.maplibre.compose.map.MaplibreMap
 import org.maplibre.compose.map.MlnFfiMapSession
@@ -253,10 +254,12 @@ private fun TestMap(
     snapshotFlow { state.currentMapAttachment }.first { it != null }
     onPresentation()
   }
+  LaunchedEffect(state) {
+    state.events.collect { if (it is MapEvent.FrameRendered) onFrame() }
+  }
   MaplibreMap(
     state = state,
     modifier = Modifier.fillMaxSize(),
-    onFrame = { onFrame() },
   ) {
     include(overlay)
   }

--- a/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MapInputRecognitionTest.kt
+++ b/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MapInputRecognitionTest.kt
@@ -411,7 +411,7 @@ class MapInputRecognitionTest {
 }
 
 @Composable
-private fun GestureHost(target: GestureTarget, options: GestureOptions) {
+private fun GestureHost(target: RecordingGestureTarget, options: GestureOptions) {
   val density = LocalDensity.current
   val focusRequester = remember { FocusRequester() }
   val inputScope = rememberCoroutineScope()
@@ -419,12 +419,15 @@ private fun GestureHost(target: GestureTarget, options: GestureOptions) {
   Box(
     Modifier.fillMaxSize()
       .testTag(RECOGNITION_MAP_TAG)
-      .mapInput(target, options, density, focusRequester, continuation)
+      .mapInput(target, target, options, density, focusRequester, continuation)
   )
 }
 
-/** Records every [GestureTarget] call so recognition tests can assert without a map. */
-private class RecordingGestureTarget : GestureTarget {
+/**
+ * Records every [GestureTarget] and [MapClickTarget] call so recognition tests can assert without a
+ * map.
+ */
+private class RecordingGestureTarget : GestureTarget, MapClickTarget {
   var clicks = 0
   var longClicks = 0
   var startedCount = 0

--- a/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MlnFfiMapCompositionTest.kt
+++ b/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MlnFfiMapCompositionTest.kt
@@ -35,6 +35,7 @@ import kotlin.math.abs
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotSame
 import kotlin.test.assertNull
 import kotlin.test.assertSame
@@ -501,18 +502,23 @@ class MlnFfiMapCompositionTest {
   @Test
   fun an_unloaded_style_keeps_the_transparent_load_placeholder() = runFfiComposeUiTest {
     val errors = RecordingList<String>()
-    val frames = AtomicInt(0)
+    lateinit var mapState: MapState
     setFfiTestMapContent(runtimeOptions) {
-      TestMap(
-        modifier = Modifier,
-        baseStyle = BaseStyle.Uri("https://example.invalid/style.json"),
-        onMapLoadFailed = { errors += "mapLoadFailed: $it" },
-        onFrame = { frames.incrementAndFetch() },
-      )
+      mapState =
+        TestMap(
+          modifier = Modifier,
+          baseStyle = BaseStyle.Uri("https://example.invalid/style.json"),
+          onMapLoadFailed = { errors += "mapLoadFailed: $it" },
+        )
     }
     waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) { errors.isNotEmpty() }
     onNodeWithTag(MAP_LOAD_PLACEHOLDER_TAG).assertExists()
-    assertEquals(0, frames.load(), "A frame was rendered before the style loaded: $errors")
+    // The session, because an event collector misses a frame that renders before it subscribes.
+    val session = mapState.currentMapAttachment?.adapter as? MlnFfiMapSession
+    assertFalse(
+      session?.hasRenderedAFrame == true,
+      "A frame was rendered before the style loaded: $errors",
+    )
     assertTrue(errors.any { it.startsWith("mapLoadFailed") }, "The load was not reported: $errors")
   }
 
@@ -818,7 +824,7 @@ private fun TestMap(
   modifier: Modifier = Modifier,
   initialCameraPosition: CameraPosition = CameraPosition(),
   onMapLoadFailed: (String?) -> Unit = {},
-  onFrame: (Double) -> Unit = {},
+  onFrame: () -> Unit = {},
   overlay: MapOverlay = MapOverlay.Default,
   content: @Composable () -> Unit = {},
 ): MapState {
@@ -833,10 +839,12 @@ private fun TestMap(
   LaunchedEffect(loadState) {
     if (loadState is StyleLoadState.Failed) onMapLoadFailed(loadState.reason)
   }
+  LaunchedEffect(state) {
+    state.events.collect { if (it is MapEvent.FrameRendered) onFrame() }
+  }
   MaplibreMap(
     state = state,
     modifier = modifier,
-    onFrame = onFrame,
   ) {
     include(overlay)
   }

--- a/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/map/AndroidMapView.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/map/AndroidMapView.kt
@@ -23,6 +23,7 @@ internal actual fun ComposableMapView(
   onReset: () -> Unit,
   logger: MapLog?,
   callbacks: MapAdapter.Callbacks,
+  clicks: MapClickTarget,
   options: MapViewOptions,
 ) {
   AndroidMlnFfiPlatform.initialize(LocalContext.current)
@@ -56,6 +57,7 @@ internal actual fun ComposableMapView(
       onReset = onReset,
       logger = logger,
       callbacks = callbacks,
+      clicks = clicks,
       options = options,
     )
   }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/CameraMoveReason.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/CameraMoveReason.kt
@@ -2,20 +2,21 @@ package org.maplibre.compose.camera
 
 import androidx.compose.runtime.Immutable
 
+/** What started the most recent camera movement. */
 @Immutable
 public enum class CameraMoveReason {
-  /** The camera hasn't moved yet. */
+  /** The camera has not moved yet. */
   NONE,
 
-  /** The camera moved for a reason we don't understand. File a bug report! */
+  /**
+   * The movement has no attributed cause. The library reports every movement as [GESTURE] or
+   * [PROGRAMMATIC], so it never reports this value.
+   */
   UNKNOWN,
 
-  /**
-   * Camera movement was initiated by the user manipulating the map by panning, zooming, rotating,
-   * or tilting.
-   */
+  /** A gesture on the map moved the camera: a pan, a zoom, a rotation, or a tilt. */
   GESTURE,
 
-  /** Camera movement was initiated by a call to the public API, such as by a compass control. */
+  /** A call to the map's API moved the camera, such as one an overlay control made. */
   PROGRAMMATIC,
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/ComposableMapView.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/ComposableMapView.kt
@@ -17,5 +17,6 @@ internal expect fun ComposableMapView(
   onReset: () -> Unit,
   logger: MapLog?,
   callbacks: MapAdapter.Callbacks,
+  clicks: MapClickTarget,
   options: MapViewOptions,
 )

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/GestureTarget.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/GestureTarget.kt
@@ -18,11 +18,6 @@ internal interface GestureTarget {
 
   fun onGestureEnded(token: GestureToken)
 
-  fun onPrimaryClick(offset: DpOffset)
-
-  /** Stands in for the mobile SDKs' long press. */
-  fun onSecondaryClick(offset: DpOffset)
-
   /** A zero [duration] is a jump. */
   fun moveBy(
     deltaX: Double,
@@ -67,4 +62,12 @@ internal interface GestureTarget {
     duration: Duration,
     gestureToken: GestureToken,
   )
+}
+
+/** The receiver of the taps and long presses that [mapInput] recognizes. */
+internal interface MapClickTarget {
+  fun onPrimaryClick(offset: DpOffset)
+
+  /** Stands in for the mobile SDKs' long press. */
+  fun onSecondaryClick(offset: DpOffset)
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapAdapter.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapAdapter.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.DpRect
 import kotlin.time.Duration
+import kotlinx.coroutines.Deferred
 import kotlinx.serialization.json.JsonObject
 import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.camera.Viewport
@@ -139,6 +140,13 @@ internal interface MapAdapter {
     fun onEvent(map: MapAdapter, event: MapEvent)
 
     /**
+     * Starts resolution of the style image [imageId] that the loaded style does not hold, and
+     * returns the resolution for an engine that awaits it before it treats the image as missing.
+     * Null means that nothing will supply the image.
+     */
+    fun resolveMissingImage(map: MapAdapter, imageId: String): Deferred<Unit>?
+
+    /**
      * Reports whether a gesture holds the camera. Neither engine emits this; the session's gesture
      * token decides it.
      */
@@ -159,6 +167,8 @@ internal object EmptyMapAdapterCallbacks : MapAdapter.Callbacks {
   override fun onStyleSourcesChanged(map: MapAdapter, sourceId: String?) = Unit
 
   override fun onEvent(map: MapAdapter, event: MapEvent) = Unit
+
+  override fun resolveMissingImage(map: MapAdapter, imageId: String): Deferred<Unit>? = null
 
   override fun onGestureActive(map: MapAdapter, active: Boolean) = Unit
 
@@ -185,6 +195,9 @@ internal class DurableStyleCallbacks(private val owner: MapState) : MapAdapter.C
   override fun onEvent(map: MapAdapter, event: MapEvent) {
     owner.onEvent(map, event)
   }
+
+  override fun resolveMissingImage(map: MapAdapter, imageId: String): Deferred<Unit>? =
+    owner.resolveMissingImage(map, imageId)
 
   override fun onGestureActive(map: MapAdapter, active: Boolean) {
     owner.setGestureActive(map, active)

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapAdapter.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapAdapter.kt
@@ -110,15 +110,30 @@ internal interface MapAdapter {
 
   fun metersPerDpAtLatitude(latitude: Double): Double
 
+  /**
+   * The sink that a session reports to. [onStyleChanged], [onStyleReady], [onStyleFailed], and
+   * [onStyleSourcesChanged] are the style handshake: the session offers a binding, reports the
+   * composition ready or a source changed for the binding it holds, and reports that a style
+   * request failed. [onEvent], [onGestureActive], and [onViewportChanged] refer to no binding.
+   */
   interface Callbacks {
+    /** Offers the binding for a loaded style, or null when no binding is current. */
     fun onStyleChanged(map: MapAdapter, style: StyleBinding?)
 
-    fun onMapFinishedLoading(map: MapAdapter)
+    /** Reports that the style composition applied and is ready to present. */
+    fun onStyleReady(map: MapAdapter)
 
-    /** A null [sourceId] means that the adapter cannot identify the changed source. */
-    fun onSourceChanged(map: MapAdapter, sourceId: String?)
+    /**
+     * Reports that the style cannot load, either because the base style request failed or because
+     * attaching the presentation threw. [reason] is the failure text when the failure carried one.
+     */
+    fun onStyleFailed(map: MapAdapter, reason: String?)
 
-    fun onMapFailLoading(map: MapAdapter, reason: String?)
+    /**
+     * Reports that the style's sources changed. A null [sourceId] means that the adapter cannot
+     * identify the changed source.
+     */
+    fun onStyleSourcesChanged(map: MapAdapter, sourceId: String?)
 
     /** Reports one engine event whose producing identity is still current. */
     fun onEvent(map: MapAdapter, event: MapEvent)
@@ -137,11 +152,11 @@ internal interface MapAdapter {
 internal object EmptyMapAdapterCallbacks : MapAdapter.Callbacks {
   override fun onStyleChanged(map: MapAdapter, style: StyleBinding?) = Unit
 
-  override fun onMapFinishedLoading(map: MapAdapter) = Unit
+  override fun onStyleReady(map: MapAdapter) = Unit
 
-  override fun onSourceChanged(map: MapAdapter, sourceId: String?) = Unit
+  override fun onStyleFailed(map: MapAdapter, reason: String?) = Unit
 
-  override fun onMapFailLoading(map: MapAdapter, reason: String?) = Unit
+  override fun onStyleSourcesChanged(map: MapAdapter, sourceId: String?) = Unit
 
   override fun onEvent(map: MapAdapter, event: MapEvent) = Unit
 
@@ -155,16 +170,16 @@ internal class DurableStyleCallbacks(private val owner: MapState) : MapAdapter.C
     owner.updateLoadedStyle(map, style)
   }
 
-  override fun onMapFinishedLoading(map: MapAdapter) {
+  override fun onStyleReady(map: MapAdapter) {
     owner.markStyleReady(map)
   }
 
-  override fun onSourceChanged(map: MapAdapter, sourceId: String?) {
-    owner.refreshStyleSources(map)
+  override fun onStyleFailed(map: MapAdapter, reason: String?) {
+    owner.markStyleFailed(map, reason)
   }
 
-  override fun onMapFailLoading(map: MapAdapter, reason: String?) {
-    owner.markStyleFailed(map, reason)
+  override fun onStyleSourcesChanged(map: MapAdapter, sourceId: String?) {
+    owner.refreshStyleSources(map)
   }
 
   override fun onEvent(map: MapAdapter, event: MapEvent) {

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapAdapter.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapAdapter.kt
@@ -120,8 +120,6 @@ internal interface MapAdapter {
 
     fun onMapFailLoading(map: MapAdapter, reason: String?)
 
-    fun onFrame(fps: Double)
-
     /** Reports one engine event whose producing identity is still current. */
     fun onEvent(map: MapAdapter, event: MapEvent)
 
@@ -144,8 +142,6 @@ internal object EmptyMapAdapterCallbacks : MapAdapter.Callbacks {
   override fun onSourceChanged(map: MapAdapter, sourceId: String?) = Unit
 
   override fun onMapFailLoading(map: MapAdapter, reason: String?) = Unit
-
-  override fun onFrame(fps: Double) = Unit
 
   override fun onEvent(map: MapAdapter, event: MapEvent) = Unit
 
@@ -170,8 +166,6 @@ internal class DurableStyleCallbacks(private val owner: MapState) : MapAdapter.C
   override fun onMapFailLoading(map: MapAdapter, reason: String?) {
     owner.markStyleFailed(map, reason)
   }
-
-  override fun onFrame(fps: Double) = Unit
 
   override fun onEvent(map: MapAdapter, event: MapEvent) {
     owner.onEvent(map, event)

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapAdapter.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapAdapter.kt
@@ -128,6 +128,9 @@ internal interface MapAdapter {
     fun onCameraMoveEnded(map: MapAdapter)
 
     fun onFrame(fps: Double)
+
+    /** Reports one engine event whose producing identity is still current. */
+    fun onEvent(map: MapAdapter, event: MapEvent)
   }
 }
 
@@ -147,6 +150,8 @@ internal object EmptyMapAdapterCallbacks : MapAdapter.Callbacks {
   override fun onCameraMoveEnded(map: MapAdapter) = Unit
 
   override fun onFrame(fps: Double) = Unit
+
+  override fun onEvent(map: MapAdapter, event: MapEvent) = Unit
 }
 
 internal class DurableStyleCallbacks(private val owner: MapState) : MapAdapter.Callbacks {
@@ -173,4 +178,6 @@ internal class DurableStyleCallbacks(private val owner: MapState) : MapAdapter.C
   override fun onCameraMoveEnded(map: MapAdapter) = Unit
 
   override fun onFrame(fps: Double) = Unit
+
+  override fun onEvent(map: MapAdapter, event: MapEvent) = Unit
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapAdapter.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapAdapter.kt
@@ -127,10 +127,6 @@ internal interface MapAdapter {
 
     fun onCameraMoveEnded(map: MapAdapter)
 
-    fun onClick(map: MapAdapter, latLng: Position, offset: DpOffset)
-
-    fun onLongClick(map: MapAdapter, latLng: Position, offset: DpOffset)
-
     fun onFrame(fps: Double)
   }
 }
@@ -149,10 +145,6 @@ internal object EmptyMapAdapterCallbacks : MapAdapter.Callbacks {
   override fun onCameraMoved(map: MapAdapter) = Unit
 
   override fun onCameraMoveEnded(map: MapAdapter) = Unit
-
-  override fun onClick(map: MapAdapter, latLng: Position, offset: DpOffset) = Unit
-
-  override fun onLongClick(map: MapAdapter, latLng: Position, offset: DpOffset) = Unit
 
   override fun onFrame(fps: Double) = Unit
 }
@@ -179,10 +171,6 @@ internal class DurableStyleCallbacks(private val owner: MapState) : MapAdapter.C
   override fun onCameraMoved(map: MapAdapter) = Unit
 
   override fun onCameraMoveEnded(map: MapAdapter) = Unit
-
-  override fun onClick(map: MapAdapter, latLng: Position, offset: DpOffset) = Unit
-
-  override fun onLongClick(map: MapAdapter, latLng: Position, offset: DpOffset) = Unit
 
   override fun onFrame(fps: Double) = Unit
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapAdapter.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapAdapter.kt
@@ -5,7 +5,6 @@ import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.DpRect
 import kotlin.time.Duration
 import kotlinx.serialization.json.JsonObject
-import org.maplibre.compose.camera.CameraMoveReason
 import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.camera.Viewport
 import org.maplibre.compose.expressions.ast.CompiledExpression
@@ -81,7 +80,7 @@ internal interface MapAdapter {
   /**
    * The viewport the map last adopted, with every property read from the same transform, or null
    * before the map has one. Implementations answer from where the map's size actually lands, so a
-   * read made from [Callbacks.onCameraMoved] already describes a finished resize.
+   * read made from [Callbacks.onViewportChanged] already describes a finished resize.
    */
   fun getViewport(): Viewport?
 
@@ -121,16 +120,19 @@ internal interface MapAdapter {
 
     fun onMapFailLoading(map: MapAdapter, reason: String?)
 
-    fun onCameraMoveStarted(map: MapAdapter, reason: CameraMoveReason)
-
-    fun onCameraMoved(map: MapAdapter)
-
-    fun onCameraMoveEnded(map: MapAdapter)
-
     fun onFrame(fps: Double)
 
     /** Reports one engine event whose producing identity is still current. */
     fun onEvent(map: MapAdapter, event: MapEvent)
+
+    /**
+     * Reports whether a gesture holds the camera. Neither engine emits this; the session's gesture
+     * token decides it.
+     */
+    fun onGestureActive(map: MapAdapter, active: Boolean)
+
+    /** Reports a viewport the map adopted without a camera event, such as after a resize. */
+    fun onViewportChanged(map: MapAdapter)
   }
 }
 
@@ -143,15 +145,13 @@ internal object EmptyMapAdapterCallbacks : MapAdapter.Callbacks {
 
   override fun onMapFailLoading(map: MapAdapter, reason: String?) = Unit
 
-  override fun onCameraMoveStarted(map: MapAdapter, reason: CameraMoveReason) = Unit
-
-  override fun onCameraMoved(map: MapAdapter) = Unit
-
-  override fun onCameraMoveEnded(map: MapAdapter) = Unit
-
   override fun onFrame(fps: Double) = Unit
 
   override fun onEvent(map: MapAdapter, event: MapEvent) = Unit
+
+  override fun onGestureActive(map: MapAdapter, active: Boolean) = Unit
+
+  override fun onViewportChanged(map: MapAdapter) = Unit
 }
 
 internal class DurableStyleCallbacks(private val owner: MapState) : MapAdapter.Callbacks {
@@ -171,13 +171,17 @@ internal class DurableStyleCallbacks(private val owner: MapState) : MapAdapter.C
     owner.markStyleFailed(map, reason)
   }
 
-  override fun onCameraMoveStarted(map: MapAdapter, reason: CameraMoveReason) = Unit
-
-  override fun onCameraMoved(map: MapAdapter) = Unit
-
-  override fun onCameraMoveEnded(map: MapAdapter) = Unit
-
   override fun onFrame(fps: Double) = Unit
 
-  override fun onEvent(map: MapAdapter, event: MapEvent) = Unit
+  override fun onEvent(map: MapAdapter, event: MapEvent) {
+    owner.onEvent(map, event)
+  }
+
+  override fun onGestureActive(map: MapAdapter, active: Boolean) {
+    owner.setGestureActive(map, active)
+  }
+
+  override fun onViewportChanged(map: MapAdapter) {
+    owner.synchronizeCamera(map)
+  }
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapEvent.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapEvent.kt
@@ -1,0 +1,87 @@
+package org.maplibre.compose.map
+
+import kotlin.time.Duration
+
+/** One fact reported by the MapLibre engine behind a map. */
+public sealed interface MapEvent {
+
+  /**
+   * The engine parsed the base style. The composition applies after this, so
+   * [MapStyleState.loadState] reaches [StyleLoadState.Ready] later.
+   */
+  public data object StyleLoaded : MapEvent
+
+  /**
+   * The engine could not load the base style.
+   *
+   * [reason] is the engine's failure text, or a message from this library when the engine reports
+   * none.
+   */
+  public data class StyleLoadFailed(val reason: String) : MapEvent
+
+  /** The engine finished every pending load and render, and has nothing more to draw. */
+  public data object Idle : MapEvent
+
+  /**
+   * The engine started one camera change. A drag reports one change per pointer move.
+   *
+   * [animated] is true for an animated transition and false for an immediate change. On the browser
+   * it is null, because MapLibre GL JS reports no such distinction.
+   */
+  public data class CameraMoveStarted(val animated: Boolean?) : MapEvent
+
+  /** The camera reached a new value inside a change that [CameraMoveStarted] began. */
+  public data object CameraMoved : MapEvent
+
+  /**
+   * The engine finished one camera change.
+   *
+   * [animated] is true for an animated transition and false for an immediate change. On the browser
+   * it is null, because MapLibre GL JS reports no such distinction.
+   */
+  public data class CameraMoveEnded(val animated: Boolean?) : MapEvent
+
+  /**
+   * The engine finished rendering one frame.
+   *
+   * [stats] holds the engine's measurements on native platforms. On the browser it is null, because
+   * MapLibre GL JS reports no measurements with its render event.
+   */
+  public data class FrameRendered(val stats: RenderStats?) : MapEvent
+
+  /**
+   * The style references an image named [imageId] that is not in the style's image set.
+   *
+   * On the browser, an image added in response applies to later requests of the same id, not to the
+   * request that reported this event.
+   */
+  public data class StyleImageMissing(val imageId: String) : MapEvent
+}
+
+/** The engine's measurements of one rendered frame. */
+public data class RenderStats(
+  /** Null for a render mode this version of the library does not name. */
+  public val mode: Mode?,
+  /** Whether the engine needs another frame to finish work this one started. */
+  public val needsRepaint: Boolean,
+  /** Whether symbol placement changed during the frame. */
+  public val placementChanged: Boolean,
+  /** Time the engine spent encoding this frame's draw commands. */
+  public val encodingTime: Duration,
+  /** Time the engine spent rendering this frame. */
+  public val renderingTime: Duration,
+  /** Frames the engine has rendered, including this one. */
+  public val frameCount: Long,
+  /** Draw calls the engine issued for this frame. */
+  public val drawCallCount: Long,
+  /** Draw calls the engine has issued, including this frame's. */
+  public val totalDrawCallCount: Long,
+) {
+  /** Whether everything the frame needed had loaded when the engine drew it. */
+  public enum class Mode {
+    /** The engine drew before every tile and image the frame needed had loaded. */
+    Partial,
+    /** The engine drew with everything the frame needed. */
+    Full,
+  }
+}

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapEvent.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapEvent.kt
@@ -48,14 +48,6 @@ public sealed interface MapEvent {
    * MapLibre GL JS reports no measurements with its render event.
    */
   public data class FrameRendered(val stats: RenderStats?) : MapEvent
-
-  /**
-   * The style references an image named [imageId] that is not in the style's image set.
-   *
-   * On the browser, an image added in response applies to later requests of the same id, not to the
-   * request that reported this event.
-   */
-  public data class StyleImageMissing(val imageId: String) : MapEvent
 }
 
 /** The engine's measurements of one rendered frame. */

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapInput.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapInput.kt
@@ -48,6 +48,7 @@ import kotlinx.coroutines.launch
  */
 internal fun Modifier.mapInput(
   target: GestureTarget,
+  clicks: MapClickTarget,
   options: GestureOptions,
   density: Density,
   focusRequester: FocusRequester,
@@ -56,7 +57,7 @@ internal fun Modifier.mapInput(
   this.keyboardInput(target, options, continuation)
     .focusRequester(focusRequester)
     .focusable()
-    .pointerGestures(target, options, density, focusRequester, continuation)
+    .pointerGestures(target, clicks, options, density, focusRequester, continuation)
     .scrollZoom(target, options, density, continuation)
 
 private fun Modifier.keyboardInput(
@@ -96,6 +97,7 @@ private fun Modifier.keyboardInput(
 
 private fun Modifier.pointerGestures(
   target: GestureTarget,
+  clicks: MapClickTarget,
   options: GestureOptions,
   density: Density,
   focusRequester: FocusRequester,
@@ -106,6 +108,7 @@ private fun Modifier.pointerGestures(
     val gesture =
       MapPointerGesture(
         target = target,
+        clicks = clicks,
         options = options,
         density = density,
         focusRequester = focusRequester,
@@ -169,6 +172,7 @@ private fun Modifier.scrollZoom(
 
 private class MapPointerGesture(
   private val target: GestureTarget,
+  private val clicks: MapClickTarget,
   private val options: GestureOptions,
   private val density: Density,
   private val focusRequester: FocusRequester,
@@ -318,7 +322,7 @@ private class MapPointerGesture(
           // This press is a long click, including a paired second tap that was held.
           discardTapWait(emitClick = false)
           continuation.finish(target::onGestureEnded)
-          target.onSecondaryClick(origin.toLogicalDpOffset(density))
+          clicks.onSecondaryClick(origin.toLogicalDpOffset(density))
         }
       }
     }
@@ -698,7 +702,7 @@ private class MapPointerGesture(
   private fun onClick(origin: Offset, timeMillis: Long, pairedSecondTap: Boolean) {
     val where = origin.toLogicalDpOffset(density)
     if (pressedSecondary) {
-      target.onSecondaryClick(where)
+      clicks.onSecondaryClick(where)
       tapWait = TapWait.None
       return
     }
@@ -719,7 +723,7 @@ private class MapPointerGesture(
 
     if (pressedType == PointerType.Mouse || !awaitsSecondTap()) {
       // Mouse clicks are immediate; touch taps wait only when a second tap still has a gesture.
-      target.onPrimaryClick(where)
+      clicks.onPrimaryClick(where)
     }
     rememberFirstTap(where, origin, pressedType, timeMillis)
   }
@@ -792,7 +796,7 @@ private class MapPointerGesture(
           val open = tapWait as? TapWait.Open
           if (open?.tap?.job == launched) {
             tapWait = TapWait.None
-            target.onPrimaryClick(where)
+            clicks.onPrimaryClick(where)
           }
         }
         launched
@@ -807,10 +811,10 @@ private class MapPointerGesture(
     when (val wait = tapWait) {
       is TapWait.Open -> {
         wait.tap.job?.cancel()
-        if (emitClick && wait.tap.clickOnExpiry) target.onPrimaryClick(wait.tap.where)
+        if (emitClick && wait.tap.clickOnExpiry) clicks.onPrimaryClick(wait.tap.where)
       }
       is TapWait.Claimed -> {
-        if (emitClick && wait.tap.clickOnExpiry) target.onPrimaryClick(wait.tap.where)
+        if (emitClick && wait.tap.clickOnExpiry) clicks.onPrimaryClick(wait.tap.where)
       }
       TapWait.None -> Unit
     }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleAuthority.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleAuthority.kt
@@ -275,6 +275,14 @@ internal class MapLifecycleAuthority(
     owner.seedPresentationViewport(token, adapter)
   }
 
+  /**
+   * Ends a camera change that the engine behind [adapter] started and will never finish, such as
+   * one interrupted by the loss of the rendering context.
+   */
+  fun endCurrentPresentationCameraChange(adapter: MapAdapter) {
+    owner.endCameraChange(adapter)
+  }
+
   fun selectAdapterForPresentation(adapter: MapAdapter): Boolean = serialized {
     if (closed) return@serialized false
     val current = attachment ?: return@serialized false

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleCallbacks.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleCallbacks.kt
@@ -27,22 +27,12 @@ internal class MapLifecycleCallbacks(
     }
   }
 
-  fun onMapFinishedLoading(engine: EngineMapIdentity, style: StyleIdentity, map: MapAdapter) =
+  fun onStyleReady(engine: EngineMapIdentity, style: StyleIdentity, map: MapAdapter) =
     withStyle(engine, style) {
-      delegate().onMapFinishedLoading(map)
+      delegate().onStyleReady(map)
     }
 
-  fun onSourceChanged(
-    engine: EngineMapIdentity,
-    style: StyleIdentity,
-    map: MapAdapter,
-    sourceId: String?,
-  ) =
-    withStyle(engine, style) {
-      delegate().onSourceChanged(map, sourceId)
-    }
-
-  fun onMapFailLoading(
+  fun onStyleFailed(
     engine: EngineMapIdentity,
     request: StyleRequestIdentity,
     map: MapAdapter,
@@ -51,7 +41,17 @@ internal class MapLifecycleCallbacks(
   ) =
     lifecycle.acceptStyleRequestEvent(engine, request) {
       beforeDelegate()
-      delegate().onMapFailLoading(map, reason)
+      delegate().onStyleFailed(map, reason)
+    }
+
+  fun onStyleSourcesChanged(
+    engine: EngineMapIdentity,
+    style: StyleIdentity,
+    map: MapAdapter,
+    sourceId: String?,
+  ) =
+    withStyle(engine, style) {
+      delegate().onStyleSourcesChanged(map, sourceId)
     }
 
   fun onGestureActive(

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleCallbacks.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleCallbacks.kt
@@ -1,9 +1,7 @@
 package org.maplibre.compose.map
 
-import androidx.compose.ui.unit.DpOffset
 import org.maplibre.compose.camera.CameraMoveReason
 import org.maplibre.compose.style.StyleBinding
-import org.maplibre.spatialk.geojson.Position
 
 /** Filters platform callbacks through identities captured by their platform producer. */
 internal class MapLifecycleCallbacks(
@@ -90,28 +88,6 @@ internal class MapLifecycleCallbacks(
       } finally {
         afterDelegate()
       }
-    }
-
-  fun onClick(
-    engine: EngineMapIdentity,
-    lease: RenderLease,
-    map: MapAdapter,
-    latLng: Position,
-    offset: DpOffset,
-  ) =
-    withPresentation(engine, lease) {
-      delegate().onClick(map, latLng, offset)
-    }
-
-  fun onLongClick(
-    engine: EngineMapIdentity,
-    lease: RenderLease,
-    map: MapAdapter,
-    latLng: Position,
-    offset: DpOffset,
-  ) =
-    withPresentation(engine, lease) {
-      delegate().onLongClick(map, latLng, offset)
     }
 
   fun onFrame(engine: EngineMapIdentity, lease: RenderLease, fps: Double) =

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleCallbacks.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleCallbacks.kt
@@ -69,9 +69,6 @@ internal class MapLifecycleCallbacks(
       delegate().onViewportChanged(map)
     }
 
-  fun onFrame(engine: EngineMapIdentity, lease: RenderLease, fps: Double) =
-    withPresentation(engine, lease) { delegate().onFrame(fps) }
-
   fun onEvent(engine: EngineMapIdentity, map: MapAdapter, event: MapEvent) =
     lifecycle.acceptEngineEvent(engine) { delegate().onEvent(map, event) }
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleCallbacks.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleCallbacks.kt
@@ -1,6 +1,5 @@
 package org.maplibre.compose.map
 
-import org.maplibre.compose.camera.CameraMoveReason
 import org.maplibre.compose.style.StyleBinding
 
 /** Filters platform callbacks through identities captured by their platform producer. */
@@ -55,39 +54,19 @@ internal class MapLifecycleCallbacks(
       delegate().onMapFailLoading(map, reason)
     }
 
-  fun onCameraMoveStarted(
+  fun onGestureActive(
     engine: EngineMapIdentity,
     lease: RenderLease,
     map: MapAdapter,
-    reason: CameraMoveReason,
+    active: Boolean,
   ) =
     withPresentation(engine, lease) {
-      delegate().onCameraMoveStarted(map, reason)
+      delegate().onGestureActive(map, active)
     }
 
-  fun onCameraMoved(
-    engine: EngineMapIdentity,
-    lease: RenderLease,
-    map: MapAdapter,
-    beforeDelegate: () -> Unit = {},
-  ) =
+  fun onViewportChanged(engine: EngineMapIdentity, lease: RenderLease, map: MapAdapter) =
     withPresentation(engine, lease) {
-      beforeDelegate()
-      delegate().onCameraMoved(map)
-    }
-
-  fun onCameraMoveEnded(
-    engine: EngineMapIdentity,
-    lease: RenderLease,
-    map: MapAdapter,
-    afterDelegate: () -> Unit = {},
-  ) =
-    withPresentation(engine, lease) {
-      try {
-        delegate().onCameraMoveEnded(map)
-      } finally {
-        afterDelegate()
-      }
+      delegate().onViewportChanged(map)
     }
 
   fun onFrame(engine: EngineMapIdentity, lease: RenderLease, fps: Double) =
@@ -96,8 +75,21 @@ internal class MapLifecycleCallbacks(
   fun onEvent(engine: EngineMapIdentity, map: MapAdapter, event: MapEvent) =
     lifecycle.acceptEngineEvent(engine) { delegate().onEvent(map, event) }
 
-  fun onEvent(engine: EngineMapIdentity, lease: RenderLease, map: MapAdapter, event: MapEvent) =
-    withPresentation(engine, lease) { delegate().onEvent(map, event) }
+  /**
+   * [beforeDelegate] runs inside the same acceptance, so a session can publish the viewport the
+   * event describes before the delegate reads it.
+   */
+  fun onEvent(
+    engine: EngineMapIdentity,
+    lease: RenderLease,
+    map: MapAdapter,
+    event: MapEvent,
+    beforeDelegate: () -> Unit = {},
+  ) =
+    withPresentation(engine, lease) {
+      beforeDelegate()
+      delegate().onEvent(map, event)
+    }
 
   fun onEvent(engine: EngineMapIdentity, style: StyleIdentity, map: MapAdapter, event: MapEvent) =
     withStyle(engine, style) { delegate().onEvent(map, event) }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleCallbacks.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleCallbacks.kt
@@ -1,5 +1,6 @@
 package org.maplibre.compose.map
 
+import kotlinx.coroutines.Deferred
 import org.maplibre.compose.style.StyleBinding
 
 /** Filters platform callbacks through identities captured by their platform producer. */
@@ -97,6 +98,18 @@ internal class MapLifecycleCallbacks(
     map: MapAdapter,
     event: MapEvent,
   ) = lifecycle.acceptStyleRequestEvent(engine, request) { delegate().onEvent(map, event) }
+
+  /** Asks the loaded style's owner to supply a missing image. */
+  fun resolveMissingImage(
+    engine: EngineMapIdentity,
+    style: StyleIdentity,
+    map: MapAdapter,
+    imageId: String,
+  ): Deferred<Unit>? {
+    var resolution: Deferred<Unit>? = null
+    withStyle(engine, style) { resolution = delegate().resolveMissingImage(map, imageId) }
+    return resolution
+  }
 
   fun onPresentationEvent(engine: EngineMapIdentity, lease: RenderLease, event: () -> Unit) =
     withPresentation(engine, lease, event)

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleCallbacks.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLifecycleCallbacks.kt
@@ -93,6 +93,22 @@ internal class MapLifecycleCallbacks(
   fun onFrame(engine: EngineMapIdentity, lease: RenderLease, fps: Double) =
     withPresentation(engine, lease) { delegate().onFrame(fps) }
 
+  fun onEvent(engine: EngineMapIdentity, map: MapAdapter, event: MapEvent) =
+    lifecycle.acceptEngineEvent(engine) { delegate().onEvent(map, event) }
+
+  fun onEvent(engine: EngineMapIdentity, lease: RenderLease, map: MapAdapter, event: MapEvent) =
+    withPresentation(engine, lease) { delegate().onEvent(map, event) }
+
+  fun onEvent(engine: EngineMapIdentity, style: StyleIdentity, map: MapAdapter, event: MapEvent) =
+    withStyle(engine, style) { delegate().onEvent(map, event) }
+
+  fun onEvent(
+    engine: EngineMapIdentity,
+    request: StyleRequestIdentity,
+    map: MapAdapter,
+    event: MapEvent,
+  ) = lifecycle.acceptStyleRequestEvent(engine, request) { delegate().onEvent(map, event) }
+
   fun onPresentationEvent(engine: EngineMapIdentity, lease: RenderLease, event: () -> Unit) =
     withPresentation(engine, lease, event)
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
@@ -497,7 +497,8 @@ internal constructor(
   private var validState: Boolean by mutableStateOf(true)
   private var viewportState: Viewport? by mutableStateOf(null)
   private val firstViewport = CompletableDeferred<Viewport>()
-  private var cameraMovingState: Boolean by mutableStateOf(false)
+  private var gestureActiveState: Boolean by mutableStateOf(false)
+  private var cameraChangingState: Boolean by mutableStateOf(false)
   private var moveReasonState: CameraMoveReason by mutableStateOf(CameraMoveReason.NONE)
   val isValid: Boolean
     get() = validState
@@ -506,7 +507,7 @@ internal constructor(
     get() = viewportState
 
   val isCameraMoving: Boolean
-    get() = cameraMovingState
+    get() = gestureActiveState || cameraChangingState
 
   val cameraMoveReason: CameraMoveReason
     get() = moveReasonState
@@ -580,26 +581,34 @@ internal constructor(
     }
   }
 
-  internal fun cameraMoveStarted(reason: CameraMoveReason) {
+  /**
+   * A gesture sets the reason even while an engine camera change is in flight, because the gesture
+   * token decides whether a change belongs to the user.
+   */
+  internal fun setGestureActive(active: Boolean) {
     owner.lifecycle.serialized {
-      moveReasonState = reason
-      cameraMovingState = true
+      gestureActiveState = active
+      if (active) moveReasonState = CameraMoveReason.GESTURE
     }
   }
 
-  internal fun cameraMoved(viewport: Viewport?) {
-    updateViewport(viewport)
+  internal fun cameraChangeStarted() {
+    owner.lifecycle.serialized {
+      cameraChangingState = true
+      if (!gestureActiveState) moveReasonState = CameraMoveReason.PROGRAMMATIC
+    }
   }
 
-  internal fun cameraMoveEnded() {
-    owner.lifecycle.serialized { cameraMovingState = false }
+  internal fun cameraChangeEnded() {
+    owner.lifecycle.serialized { cameraChangingState = false }
   }
 
   internal fun invalidate() {
     owner.lifecycle.serialized {
       validState = false
       viewportState = null
-      cameraMovingState = false
+      gestureActiveState = false
+      cameraChangingState = false
       invalidated.complete(Unit)
     }
   }
@@ -710,12 +719,17 @@ internal constructor(
   public val viewport: Viewport?
     get() = currentMapAttachment?.viewport
 
-  /** Returns true while the current map surface is moving its camera. */
+  /**
+   * Returns true while a gesture holds the camera or an engine camera change is in flight. During a
+   * drag the gesture stays active across every camera change the engine reports, so the value stays
+   * true for the whole drag.
+   */
   public val isCameraMoving: Boolean
     get() = currentMapAttachment?.isCameraMoving == true
 
   /**
-   * Contains the reason for the current camera movement, or [CameraMoveReason.NONE] while detached.
+   * Contains what started the most recent camera movement, or [CameraMoveReason.NONE] while
+   * detached and before the first movement. The value stays after the movement ends.
    */
   public val cameraMoveReason: CameraMoveReason
     get() = currentMapAttachment?.cameraMoveReason ?: CameraMoveReason.NONE
@@ -1195,17 +1209,52 @@ internal constructor(
     }
   }
 
+  /**
+   * Publishes the camera and viewport of [adapter] and returns the presentation that holds them. A
+   * map with no readable viewport keeps the values it has, so a caller that reacts to a camera
+   * event still reaches its presentation.
+   */
   internal fun synchronizeCamera(adapter: MapAdapter): MapAttachment? {
     if (!lifecycle.acceptsPresentation(adapter)) return null
     val cameraPosition = adapter.getCameraPosition()
-    val viewport = adapter.getViewport() ?: return null
+    val viewport = adapter.getViewport()
     return lifecycle.serialized {
       if (!lifecycle.acceptsPresentation(adapter)) return@serialized null
-      cameraPositionState = cameraPosition
       val current = currentMapAttachment ?: return@serialized null
-      current.cameraMoved(viewport)
+      if (viewport != null) {
+        cameraPositionState = cameraPosition
+        current.updateViewport(viewport)
+      }
       current
     }
+  }
+
+  /**
+   * Reacts to one engine event that the lifecycle already accepted. Ignores an [adapter] that is
+   * not the current presentation.
+   */
+  internal fun onEvent(adapter: MapAdapter, event: MapEvent) {
+    when (event) {
+      is MapEvent.CameraMoveStarted -> synchronizeCamera(adapter)?.cameraChangeStarted()
+      MapEvent.CameraMoved -> synchronizeCamera(adapter)
+      is MapEvent.CameraMoveEnded -> synchronizeCamera(adapter)?.cameraChangeEnded()
+      else -> Unit
+    }
+  }
+
+  /** Reports whether a gesture holds the camera of [adapter]. */
+  internal fun setGestureActive(adapter: MapAdapter, active: Boolean) {
+    presentedAttachment(adapter)?.setGestureActive(active)
+  }
+
+  /** Ends a camera change that the engine behind [adapter] will never finish. */
+  internal fun endCameraChange(adapter: MapAdapter) {
+    presentedAttachment(adapter)?.cameraChangeEnded()
+  }
+
+  private fun presentedAttachment(adapter: MapAdapter): MapAttachment? = lifecycle.serialized {
+    if (!lifecycle.acceptsPresentation(adapter)) return@serialized null
+    currentMapAttachment
   }
 
   internal fun isCurrent(candidate: MapAttachment): Boolean = lifecycle.serialized {

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
@@ -32,6 +32,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
@@ -486,6 +487,11 @@ internal class ImperativeSourceRecord(val definition: SourceDefinition)
 
 internal class ImperativeImageRecord
 
+/**
+ * One missing-image resolution, identified by [token] so a stale one cannot evict its successor.
+ */
+internal class MissingImageResolution(val token: Any, val work: Deferred<Unit>)
+
 internal class StyleMutationReservation {
   val completion = CompletableDeferred<Unit>()
 }
@@ -663,7 +669,16 @@ internal constructor(
   private var styleSourceChangeRevision = 0L
   private val imperativeSources = mutableMapOf<String, ImperativeSourceRecord>()
   private val imperativeImages = mutableMapOf<String, ImperativeImageRecord>()
+  private var missingImageResolverState: MissingImageResolver? by mutableStateOf(null)
+  /** Resolutions started for the loaded style, by image id. */
+  private val missingImageResolutions = mutableMapOf<String, MissingImageResolution>()
   private var activeStyleMutation: StyleMutationReservation? = null
+  /**
+   * Held while a resolved missing image reaches the style. A style command the app issues cannot
+   * anticipate this one, so the command waits it out through [beginStyleRevision] or runs beside it
+   * rather than failing on it.
+   */
+  private var backgroundStyleMutation: StyleMutationReservation? = null
   private val eventsFlow =
     MutableSharedFlow<MapEvent>(
       extraBufferCapacity = 64,
@@ -757,6 +772,37 @@ internal constructor(
    * values there. Collect on a dispatcher to call a map command such as [StyleImages.add].
    */
   public val events: Flow<MapEvent> = eventsFlow.asSharedFlow()
+
+  /**
+   * Supplies images that the style draws and the loaded style does not hold, such as an icon that
+   * its sprite does not contain.
+   *
+   * The map calls the resolver with the image id and adds the [ResolvedStyleImage] that it returns
+   * to the loaded style. A resolver that returns null leaves the image unresolved, as does one that
+   * throws, which the map logs. The map calls the resolver at most once per image id per loaded
+   * style. A new base style, or a different resolver set here, lets the next engine request for
+   * that id reach the resolver again.
+   *
+   * The map never calls the resolver inline from the engine's callback, and the resolver may
+   * suspend. MapLibre GL JS waits for it before it draws without the image; MapLibre Native draws
+   * the image at the next symbol placement after the resolver answers. Setting a resolver here does
+   * not stop a resolution that is already in flight, which still supplies the image that it
+   * resolves.
+   *
+   * Set it before or after the style loads. Null, the default, leaves every missing image
+   * unresolved.
+   */
+  public var missingImageResolver: MissingImageResolver?
+    get() = missingImageResolverState
+    set(value) {
+      lifecycle.serialized {
+        if (missingImageResolverState === value) return
+        missingImageResolverState = value
+        // Forgotten rather than cancelled: the request that started a resolution in flight is still
+        // outstanding, and the engine waits on that resolution rather than asking the new resolver.
+        missingImageResolutions.clear()
+      }
+    }
 
   public val isClosed: Boolean
     get() = closedState
@@ -957,6 +1003,7 @@ internal constructor(
       styleHandleEpoch++
       imperativeSources.clear()
       imperativeImages.clear()
+      cancelMissingImageResolutions()
       style.loadState = StyleLoadState.Loading
       style.updateLoadedStyle(loadedStyle)
       true
@@ -979,6 +1026,7 @@ internal constructor(
       val mutation = lifecycle.serialized {
         if (!lifecycle.acceptsAdapter(adapter)) return
         activeStyleMutation
+          ?: backgroundStyleMutation
           ?: run {
             requireNoImperativeResourceConflicts(revision)
             style.invalidateStructurallyReplacedResources(desiredStyleRevision, revision)
@@ -1000,6 +1048,7 @@ internal constructor(
       styleHandleEpoch++
       imperativeSources.clear()
       imperativeImages.clear()
+      cancelMissingImageResolutions()
       style.setBaseStyleState(value)
       style.invalidateLoadedStyle()
       val adapter = lifecycle.currentAdapter()
@@ -1124,6 +1173,123 @@ internal constructor(
     }
   }
 
+  /**
+   * Starts resolution of a missing style image and returns the resolution, or null when no resolver
+   * is set, no style is loaded, or this state no longer accepts [adapter].
+   *
+   * A repeated request for an id already resolving returns that resolution, which the browser needs
+   * to keep the request pending while the first call runs.
+   *
+   * The engine reports the miss from its own thread, so the resolution runs on this state's scope
+   * rather than there.
+   */
+  internal fun resolveMissingImage(adapter: MapAdapter, imageId: String): Deferred<Unit>? =
+    lifecycle.serialized {
+      if (lifecycle.isClosed || !lifecycle.acceptsAdapter(adapter)) return@serialized null
+      val resolver = missingImageResolverState ?: return@serialized null
+      val binding = style.currentLoadedStyle() ?: return@serialized null
+      missingImageResolutions[imageId]?.let {
+        return@serialized it.work
+      }
+      val token = Any()
+      runtime.physicalScope
+        .async { supplyMissingImage(resolver, binding, imageId, token) }
+        .also { missingImageResolutions[imageId] = MissingImageResolution(token, it) }
+    }
+
+  private suspend fun supplyMissingImage(
+    resolver: MissingImageResolver,
+    binding: StyleBinding,
+    imageId: String,
+    token: Any,
+  ) {
+    val resolved =
+      try {
+        resolver(imageId)
+      } catch (error: CancellationException) {
+        throw error
+      } catch (error: Throwable) {
+        runtime.logger?.w(error) { "The missing-image resolver failed for image '$imageId'" }
+        null
+      }
+    if (resolved == null) return
+    try {
+      addResolvedStyleImage(binding, imageId, resolved)
+    } catch (error: CancellationException) {
+      throw error
+    } catch (error: Throwable) {
+      // A composition can claim the id while the resolver runs. Dropping the record lets a repeated
+      // request try again, unless a later resolution already holds the id.
+      lifecycle.serialized {
+        if (missingImageResolutions[imageId]?.token === token)
+          missingImageResolutions.remove(imageId)
+      }
+      runtime.logger?.w(error) { "Could not add the resolved image '$imageId'" }
+    }
+  }
+
+  /**
+   * Adds a resolved image to [binding].
+   *
+   * The engine asks as soon as it lays out a tile, so this waits out a style command in progress
+   * rather than failing on it, and abandons the add once [binding] is no longer the loaded style.
+   * The style that it adds to is not ready yet: the browser counts a style as loaded only once
+   * every in-view tile has parsed, and a tile does not finish parsing until this add answers it.
+   */
+  private suspend fun addResolvedStyleImage(
+    binding: StyleBinding,
+    imageId: String,
+    resolved: ResolvedStyleImage,
+  ) {
+    val record = ImperativeImageRecord()
+    val reservation = StyleMutationReservation()
+    while (true) {
+      val inProgress = lifecycle.serialized {
+        if (lifecycle.isClosed) return
+        if (style.currentLoadedStyle() !== binding) return
+        (activeStyleMutation ?: backgroundStyleMutation)?.let {
+          return@serialized it
+        }
+        if (hasDesiredImage(imageId) || imageId in imperativeImages) return
+        imperativeImages[imageId] = record
+        backgroundStyleMutation = reservation
+        null
+      }
+      if (inProgress == null) break
+      inProgress.completion.await()
+    }
+    var committed = false
+    try {
+      if (binding.imageExists(imageId) == true) return
+      binding.addImage(imageId, resolved.image, resolved.sdf, resolved.stretch)
+      committed = lifecycle.serialized {
+        !lifecycle.isClosed && style.isCurrentLoadedStyle(binding)
+      }
+    } catch (error: CancellationException) {
+      throw error
+    } catch (error: Throwable) {
+      // A style load can invalidate [binding] between the check above and these calls, which fails
+      // the add for a style that nothing waits on any more.
+      if (lifecycle.serialized { !lifecycle.isClosed && style.isCurrentLoadedStyle(binding) }) {
+        if (error is StyleMutationException) {
+          throw StyleHandleException("Could not add image '$imageId': ${error.message}", error)
+        }
+        throw error
+      }
+    } finally {
+      lifecycle.serialized {
+        if (!committed && imperativeImages[imageId] === record) imperativeImages.remove(imageId)
+        completeStyleMutation(reservation)
+      }
+    }
+  }
+
+  /** Ends every resolution in flight: none of them can still reach the style that asked. */
+  private fun cancelMissingImageResolutions() {
+    missingImageResolutions.values.forEach { it.work.cancel() }
+    missingImageResolutions.clear()
+  }
+
   internal fun removeStyleImage(id: String): Boolean {
     val reservation = StyleMutationReservation()
     val binding = lifecycle.serialized {
@@ -1172,8 +1338,10 @@ internal constructor(
     }
   }
 
+  private fun hasDesiredImage(id: String): Boolean = desiredStyleRevision.images.any { it.id == id }
+
   private fun requireNoDesiredImage(id: String) {
-    if (desiredStyleRevision.images.any { it.id == id }) {
+    if (hasDesiredImage(id)) {
       throw StyleHandleException("Image ID '$id' is owned by StyleComposition")
     }
   }
@@ -1199,6 +1367,7 @@ internal constructor(
 
   private fun completeStyleMutation(reservation: StyleMutationReservation) {
     if (activeStyleMutation === reservation) activeStyleMutation = null
+    if (backgroundStyleMutation === reservation) backgroundStyleMutation = null
     reservation.completion.complete(Unit)
   }
 
@@ -1269,8 +1438,7 @@ internal constructor(
         is MapEvent.FrameRendered -> lifecycle.acceptsPresentation(adapter)
         MapEvent.StyleLoaded,
         is MapEvent.StyleLoadFailed,
-        MapEvent.Idle,
-        is MapEvent.StyleImageMissing -> lifecycle.acceptsAdapter(adapter)
+        MapEvent.Idle -> lifecycle.acceptsAdapter(adapter)
       }
     if (accepted) eventsFlow.tryEmit(event)
   }
@@ -1309,6 +1477,7 @@ internal constructor(
 
   internal fun commitClosed() {
     styleHandleEpoch++
+    cancelMissingImageResolutions()
     style.invalidateLoadedStyle()
     Snapshot.withMutableSnapshot {
       closedState = true

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
@@ -36,7 +36,11 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.selects.select
 import kotlinx.serialization.json.JsonElement
@@ -660,6 +664,11 @@ internal constructor(
   private val imperativeSources = mutableMapOf<String, ImperativeSourceRecord>()
   private val imperativeImages = mutableMapOf<String, ImperativeImageRecord>()
   private var activeStyleMutation: StyleMutationReservation? = null
+  private val eventsFlow =
+    MutableSharedFlow<MapEvent>(
+      extraBufferCapacity = 64,
+      onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
   private var closedState: Boolean by mutableStateOf(false)
   private var cameraPositionState: CameraPosition by
     mutableStateOf(initialCameraPosition, structuralEqualityPolicy())
@@ -733,6 +742,21 @@ internal constructor(
    */
   public val cameraMoveReason: CameraMoveReason
     get() = currentMapAttachment?.cameraMoveReason ?: CameraMoveReason.NONE
+
+  /**
+   * Emits each [MapEvent] that the engine behind this map reports.
+   *
+   * A collector receives the events that the map reports after it subscribes. The flow replays
+   * nothing, and a bounded buffer drops the oldest event that a collector has not taken. Style and
+   * idle events continue while a retained native engine stays alive between presentations, and
+   * camera and frame events stop while no map surface is attached.
+   *
+   * A collector on an undispatched context runs on the thread that reported the event, which is the
+   * map's own thread on native platforms and the MapLibre GL JS event listener on the browser, and
+   * it runs while the map holds the lock that serializes its lifecycle. Read state and record
+   * values there. Collect on a dispatcher to call a map command such as [StyleImages.add].
+   */
+  public val events: Flow<MapEvent> = eventsFlow.asSharedFlow()
 
   public val isClosed: Boolean
     get() = closedState
@@ -1230,16 +1254,25 @@ internal constructor(
   }
 
   /**
-   * Reacts to one engine event that the lifecycle already accepted. Ignores an [adapter] that is
-   * not the current presentation.
+   * Reacts to one engine event that the lifecycle already accepted, then publishes it to [events].
+   * Ignores an [adapter] that this state no longer accepts. Publication follows the reaction, so a
+   * collector reads the values that the event produced.
    */
   internal fun onEvent(adapter: MapAdapter, event: MapEvent) {
-    when (event) {
-      is MapEvent.CameraMoveStarted -> synchronizeCamera(adapter)?.cameraChangeStarted()
-      MapEvent.CameraMoved -> synchronizeCamera(adapter)
-      is MapEvent.CameraMoveEnded -> synchronizeCamera(adapter)?.cameraChangeEnded()
-      else -> Unit
-    }
+    val accepted =
+      when (event) {
+        is MapEvent.CameraMoveStarted ->
+          synchronizeCamera(adapter)?.also { it.cameraChangeStarted() } != null
+        MapEvent.CameraMoved -> synchronizeCamera(adapter) != null
+        is MapEvent.CameraMoveEnded ->
+          synchronizeCamera(adapter)?.also { it.cameraChangeEnded() } != null
+        is MapEvent.FrameRendered -> lifecycle.acceptsPresentation(adapter)
+        MapEvent.StyleLoaded,
+        is MapEvent.StyleLoadFailed,
+        MapEvent.Idle,
+        is MapEvent.StyleImageMissing -> lifecycle.acceptsAdapter(adapter)
+      }
+    if (accepted) eventsFlow.tryEmit(event)
   }
 
   /** Reports whether a gesture holds the camera of [adapter]. */

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MaplibreMap.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MaplibreMap.kt
@@ -243,6 +243,9 @@ private fun MaplibreMapPresentation(
           state.onEvent(map, event)
         }
 
+        override fun resolveMissingImage(map: MapAdapter, imageId: String) =
+          state.resolveMissingImage(map, imageId)
+
         override fun onGestureActive(map: MapAdapter, active: Boolean) {
           state.setGestureActive(map, active)
         }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MaplibreMap.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MaplibreMap.kt
@@ -86,7 +86,6 @@ public fun MaplibreMap(
   tileLodOptions: TileLodOptions = TileLodOptions.Standard,
   onClick: MapClickHandler = { _, _ -> ClickResult.Pass },
   onLongClick: MapClickHandler = { _, _ -> ClickResult.Pass },
-  onFrame: (framesPerSecond: Double) -> Unit = {},
   contentWindowInsets: WindowInsets = WindowInsets.safeDrawing,
   overlay: @Composable @UiComposable MapOverlayScope.() -> Unit = {
     include(MapOverlay.Default)
@@ -115,7 +114,6 @@ public fun MaplibreMap(
       mapViewOptions = mapViewOptions,
       onClick = onClick,
       onLongClick = onLongClick,
-      onFrame = onFrame,
       contentWindowInsets = contentWindowInsets,
       overlay = overlay,
     )
@@ -130,7 +128,6 @@ private fun PresentedMaplibreMap(
   mapViewOptions: MapViewOptions,
   onClick: MapClickHandler,
   onLongClick: MapClickHandler,
-  onFrame: (Double) -> Unit,
   contentWindowInsets: WindowInsets,
   overlay: @Composable @UiComposable MapOverlayScope.() -> Unit,
 ) {
@@ -144,7 +141,6 @@ private fun PresentedMaplibreMap(
     mapViewOptions = mapViewOptions,
     onClick = onClick,
     onLongClick = onLongClick,
-    onFrame = onFrame,
     contentWindowInsets = contentWindowInsets,
     overlay = overlay,
   )
@@ -158,7 +154,6 @@ private fun MaplibreMapPresentation(
   mapViewOptions: MapViewOptions,
   onClick: MapClickHandler,
   onLongClick: MapClickHandler,
-  onFrame: (Double) -> Unit,
   contentWindowInsets: WindowInsets,
   overlay: @Composable @UiComposable MapOverlayScope.() -> Unit,
 ) {
@@ -220,7 +215,7 @@ private fun MaplibreMapPresentation(
   }
 
   val adapterCallbacks =
-    remember(attachment, mapAttachment, onFrame) {
+    remember(attachment, mapAttachment) {
       object : MapAdapter.Callbacks {
         private fun synchronizeCamera(map: MapAdapter): MapAttachment? {
           return state.synchronizeCamera(map)
@@ -242,12 +237,6 @@ private fun MaplibreMapPresentation(
 
         override fun onSourceChanged(map: MapAdapter, sourceId: String?) {
           state.refreshStyleSources(map)
-        }
-
-        override fun onFrame(fps: Double) {
-          val map = state.currentMapAttachment?.adapter ?: return
-          synchronizeCamera(map)
-          onFrame(fps)
         }
 
         override fun onEvent(map: MapAdapter, event: MapEvent) {

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MaplibreMap.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MaplibreMap.kt
@@ -9,11 +9,13 @@ import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.UiComposable
@@ -22,6 +24,7 @@ import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import org.maplibre.compose.camera.CameraMoveReason
 import org.maplibre.compose.overlay.MapOverlay
@@ -35,7 +38,6 @@ import org.maplibre.compose.style.rememberStyleComposition
 import org.maplibre.compose.util.ClickResult
 import org.maplibre.compose.util.FeaturesClickHandler
 import org.maplibre.compose.util.MapClickHandler
-import org.maplibre.spatialk.geojson.Position
 
 private class MapStateAttachment(
   val state: MapState,
@@ -164,8 +166,11 @@ private fun MaplibreMapPresentation(
   contentWindowInsets: WindowInsets,
   overlay: @Composable @UiComposable MapOverlayScope.() -> Unit,
 ) {
-  var rememberedStyle by remember { mutableStateOf<StyleBinding?>(null) }
-  val desiredRevision by
+  // The dispatcher reads this state directly: a click can arrive between the style binding's
+  // invalidation and the recomposition that clears it.
+  val rememberedStyleState = remember { mutableStateOf<StyleBinding?>(null) }
+  var rememberedStyle by rememberedStyleState
+  val desiredRevisionState =
     rememberStyleComposition(
       composition = state.styleComposition,
       maybeStyle = rememberedStyle,
@@ -176,8 +181,25 @@ private fun MaplibreMapPresentation(
           it.definition.id
         },
     )
+  val desiredRevision by desiredRevisionState
   val mapClickScope = rememberCoroutineScope()
   val mapAttachment = state.currentMapAttachment
+  val currentOnClick = rememberUpdatedState(onClick)
+  val currentOnLongClick = rememberUpdatedState(onLongClick)
+  // The style subcomposition publishes into a revision state it re-creates per loaded style, and
+  // the dispatcher must keep its identity because the pointer input holding it does not restart.
+  val currentDesiredRevision = rememberUpdatedState(desiredRevisionState)
+  val clickDispatcher =
+    remember(state, mapClickScope) {
+      MapClickDispatcher(
+        state = state,
+        scope = mapClickScope,
+        onClick = currentOnClick,
+        onLongClick = currentOnLongClick,
+        desiredRevision = currentDesiredRevision,
+        loadedStyle = rememberedStyleState,
+      )
+    }
   var retainedRevisionReplayed by remember(rememberedStyle, mapAttachment) { mutableStateOf(false) }
 
   LaunchedEffect(rememberedStyle, mapAttachment, attachment) {
@@ -202,15 +224,7 @@ private fun MaplibreMapPresentation(
   }
 
   val adapterCallbacks =
-    remember(
-      desiredRevision,
-      mapClickScope,
-      attachment,
-      mapAttachment,
-      onClick,
-      onLongClick,
-      onFrame,
-    ) {
+    remember(attachment, mapAttachment, onFrame) {
       object : MapAdapter.Callbacks {
         private fun currentAttachment(map: MapAdapter): MapAttachment? =
           attachment.currentAttachment(map)
@@ -249,54 +263,6 @@ private fun MaplibreMapPresentation(
           synchronizeCamera(map)?.cameraMoveEnded()
         }
 
-        private fun layerNodesInOrder(): List<DesiredStyleLayer> {
-          val layerNodes = desiredRevision?.layers?.associateBy { it.definition.id }.orEmpty()
-          val layers = rememberedStyle?.getLayers().orEmpty()
-          return layers.asReversed().mapNotNull { layer -> layerNodes[layer.id] }
-        }
-
-        private fun dispatchPointerEvent(
-          map: MapAdapter,
-          latLng: Position,
-          offset: DpOffset,
-          mapHandler: MapClickHandler,
-          layerHandler: (DesiredStyleLayer) -> FeaturesClickHandler?,
-        ) {
-          if (currentAttachment(map) == null) return
-          if (mapHandler(latLng, offset).consumed) return
-          mapClickScope.launch {
-            for (node in layerNodesInOrder()) {
-              if (layerHandler(node) == null) continue
-              val features =
-                map.queryRenderedFeatures(
-                  offset = offset,
-                  layerIds = setOf(node.definition.id),
-                  predicate = null,
-                )
-              // Recomposition may replace or remove the node while the query is suspended. A
-              // removed node never receives the click; a replaced one answers with the handler
-              // it has now.
-              val currentHandle =
-                layerNodesInOrder()
-                  .firstOrNull { it.definition.id == node.definition.id }
-                  ?.let(layerHandler) ?: continue
-              if (features.isNotEmpty() && currentHandle(features).consumed) break
-            }
-          }
-        }
-
-        override fun onClick(map: MapAdapter, latLng: Position, offset: DpOffset) =
-          dispatchPointerEvent(map, latLng, offset, onClick, DesiredStyleLayer::onClick)
-
-        override fun onLongClick(map: MapAdapter, latLng: Position, offset: DpOffset) =
-          dispatchPointerEvent(
-            map,
-            latLng,
-            offset,
-            onLongClick,
-            DesiredStyleLayer::onLongClick,
-          )
-
         override fun onFrame(fps: Double) {
           val map = state.currentMapAttachment?.adapter ?: return
           synchronizeCamera(map)
@@ -325,6 +291,7 @@ private fun MaplibreMapPresentation(
       },
       logger = state.runtime.logger,
       callbacks = adapterCallbacks,
+      clicks = clickDispatcher,
       options = mapViewOptions,
     )
 
@@ -334,5 +301,54 @@ private fun MaplibreMapPresentation(
       contentWindowInsets = contentWindowInsets,
       modifier = Modifier.matchParentSize(),
     )
+  }
+}
+
+/**
+ * Sends a recognized tap or long press to the map handler, then to each composed layer from front
+ * to back until a handler consumes it.
+ */
+private class MapClickDispatcher(
+  private val state: MapState,
+  private val scope: CoroutineScope,
+  private val onClick: State<MapClickHandler>,
+  private val onLongClick: State<MapClickHandler>,
+  private val desiredRevision: State<State<DesiredStyleRevision?>>,
+  private val loadedStyle: State<StyleBinding?>,
+) : MapClickTarget {
+  override fun onPrimaryClick(offset: DpOffset) =
+    dispatch(offset, onClick.value, DesiredStyleLayer::onClick)
+
+  override fun onSecondaryClick(offset: DpOffset) =
+    dispatch(offset, onLongClick.value, DesiredStyleLayer::onLongClick)
+
+  private fun layerNodesInOrder(): List<DesiredStyleLayer> {
+    val layerNodes = desiredRevision.value.value?.layers?.associateBy { it.definition.id }.orEmpty()
+    val layers = loadedStyle.value?.takeIf { it.isLoaded }?.getLayers().orEmpty()
+    return layers.asReversed().mapNotNull { layer -> layerNodes[layer.id] }
+  }
+
+  private fun dispatch(
+    offset: DpOffset,
+    mapHandler: MapClickHandler,
+    layerHandler: (DesiredStyleLayer) -> FeaturesClickHandler?,
+  ) {
+    val attachment = state.currentMapAttachment ?: return
+    val position = attachment.positionFromScreenLocation(offset) ?: return
+    if (mapHandler(position, offset).consumed) return
+    scope.launch {
+      for (node in layerNodesInOrder()) {
+        if (layerHandler(node) == null) continue
+        val features =
+          attachment.queryRenderedFeatures(offset = offset, layerIds = setOf(node.definition.id))
+        // Recomposition may replace or remove the node while the query is suspended. A removed
+        // node never receives the click; a replaced one answers with the handler it has now.
+        val currentHandle =
+          layerNodesInOrder()
+            .firstOrNull { it.definition.id == node.definition.id }
+            ?.let(layerHandler) ?: continue
+        if (features.isNotEmpty() && currentHandle(features).consumed) break
+      }
+    }
   }
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MaplibreMap.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MaplibreMap.kt
@@ -26,7 +26,6 @@ import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import org.maplibre.compose.camera.CameraMoveReason
 import org.maplibre.compose.overlay.MapOverlay
 import org.maplibre.compose.overlay.MapOverlayHost
 import org.maplibre.compose.overlay.MapOverlayScope
@@ -46,9 +45,6 @@ private class MapStateAttachment(
   fun publish(map: MapAdapter) {
     state.publishPresentation(token, map)
   }
-
-  fun currentAttachment(map: MapAdapter): MapAttachment? =
-    state.currentMapAttachment?.takeIf { it.adapter === map }
 
   fun release(map: MapAdapter? = null) {
     state.releasePresentation(token, map)
@@ -226,9 +222,6 @@ private fun MaplibreMapPresentation(
   val adapterCallbacks =
     remember(attachment, mapAttachment, onFrame) {
       object : MapAdapter.Callbacks {
-        private fun currentAttachment(map: MapAdapter): MapAttachment? =
-          attachment.currentAttachment(map)
-
         private fun synchronizeCamera(map: MapAdapter): MapAttachment? {
           return state.synchronizeCamera(map)
         }
@@ -251,25 +244,23 @@ private fun MaplibreMapPresentation(
           state.refreshStyleSources(map)
         }
 
-        override fun onCameraMoveStarted(map: MapAdapter, reason: CameraMoveReason) {
-          currentAttachment(map)?.cameraMoveStarted(reason)
-        }
-
-        override fun onCameraMoved(map: MapAdapter) {
-          synchronizeCamera(map)
-        }
-
-        override fun onCameraMoveEnded(map: MapAdapter) {
-          synchronizeCamera(map)?.cameraMoveEnded()
-        }
-
         override fun onFrame(fps: Double) {
           val map = state.currentMapAttachment?.adapter ?: return
           synchronizeCamera(map)
           onFrame(fps)
         }
 
-        override fun onEvent(map: MapAdapter, event: MapEvent) = Unit
+        override fun onEvent(map: MapAdapter, event: MapEvent) {
+          state.onEvent(map, event)
+        }
+
+        override fun onGestureActive(map: MapAdapter, active: Boolean) {
+          state.setGestureActive(map, active)
+        }
+
+        override fun onViewportChanged(map: MapAdapter) {
+          synchronizeCamera(map)
+        }
       }
     }
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MaplibreMap.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MaplibreMap.kt
@@ -227,15 +227,15 @@ private fun MaplibreMapPresentation(
           synchronizeCamera(map)
         }
 
-        override fun onMapFailLoading(map: MapAdapter, reason: String?) {
-          attachment.markStyleFailed(map, reason)
-        }
-
-        override fun onMapFinishedLoading(map: MapAdapter) {
+        override fun onStyleReady(map: MapAdapter) {
           attachment.markStyleReady(map)
         }
 
-        override fun onSourceChanged(map: MapAdapter, sourceId: String?) {
+        override fun onStyleFailed(map: MapAdapter, reason: String?) {
+          attachment.markStyleFailed(map, reason)
+        }
+
+        override fun onStyleSourcesChanged(map: MapAdapter, sourceId: String?) {
           state.refreshStyleSources(map)
         }
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MaplibreMap.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MaplibreMap.kt
@@ -268,6 +268,8 @@ private fun MaplibreMapPresentation(
           synchronizeCamera(map)
           onFrame(fps)
         }
+
+        override fun onEvent(map: MapAdapter, event: MapEvent) = Unit
       }
     }
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MissingImageResolver.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MissingImageResolver.kt
@@ -1,0 +1,26 @@
+package org.maplibre.compose.map
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.graphics.ImageBitmap
+import org.maplibre.compose.util.ImageStretch
+
+/**
+ * Supplies the image that the engine asks for by id, or null when the resolver has none.
+ *
+ * See [MapState.missingImageResolver].
+ */
+public typealias MissingImageResolver = suspend (id: String) -> ResolvedStyleImage?
+
+/**
+ * The image that a [MissingImageResolver] supplies, with the options that [StyleImages.add] takes
+ * for it.
+ */
+@Immutable
+public data class ResolvedStyleImage(
+  /** The pixels that the engine draws. */
+  public val image: ImageBitmap,
+  /** Whether [image] is a signed distance field, which a layer recolors. */
+  public val sdf: Boolean = false,
+  /** Stretch and content box for an icon that a symbol layer sizes to wrap its text. */
+  public val stretch: ImageStretch? = null,
+)

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
@@ -15,6 +15,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
@@ -912,6 +913,51 @@ class MapPresentationTest {
     assertNull(sky.getProperty("sky-color"))
     assertNull(projection.getProperty("type"))
     assertFailsWith<IllegalStateException> { transition.set(options) }
+    fixture.close()
+  }
+
+  @Test
+  fun a_resolved_missing_image_reaches_a_style_that_has_not_gone_ready() = runTest {
+    val fixture = presentationFixture()
+    val binding = RecordingStyleBinding()
+    var calls = 0
+    fixture.state.missingImageResolver = {
+      calls++
+      ResolvedStyleImage(FakeImageBitmap(1, 1))
+    }
+    // The style is loading, not ready: the browser asks while it parses the tiles that decide
+    // whether the style has loaded.
+    fixture.state.durableStyleCallbacks().onStyleChanged(fixture.adapter, binding)
+    assertEquals(StyleLoadState.Loading, fixture.state.style.loadState)
+
+    assertNotNull(fixture.state.resolveMissingImage(fixture.adapter, "icon")).await()
+    assertNotNull(fixture.state.resolveMissingImage(fixture.adapter, "icon")).await()
+
+    assertTrue(binding.imageExists("icon") == true)
+    assertEquals(1, calls, "the map asked the resolver twice for one image ID")
+    fixture.close()
+  }
+
+  @Test
+  fun a_replaced_resolver_leaves_the_resolution_in_flight_to_finish() = runTest {
+    val fixture = presentationFixture()
+    val binding = RecordingStyleBinding()
+    val release = CompletableDeferred<Unit>()
+    fixture.state.missingImageResolver = {
+      release.await()
+      ResolvedStyleImage(FakeImageBitmap(1, 1))
+    }
+    fixture.state.durableStyleCallbacks().onStyleChanged(fixture.adapter, binding)
+    val resolution = assertNotNull(fixture.state.resolveMissingImage(fixture.adapter, "icon"))
+
+    fixture.state.missingImageResolver = { null }
+    release.complete(Unit)
+    resolution.await()
+
+    assertTrue(
+      binding.imageExists("icon") == true,
+      "replacing the resolver abandoned the request that the engine made",
+    )
     fixture.close()
   }
 

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
@@ -137,7 +137,7 @@ class MapPresentationTest {
     assertFailsWith<MapCleanupException> { session.awaitClosed() }
     testScheduler.runCurrent()
 
-    state.durableStyleCallbacks().onMapFailLoading(session, "stale callback")
+    state.durableStyleCallbacks().onStyleFailed(session, "stale callback")
     assertFalse(state.style.loadState is StyleLoadState.Failed)
 
     val replacement = PresentationTestAdapter()
@@ -309,7 +309,7 @@ class MapPresentationTest {
     val callbacks = state.durableStyleCallbacks()
     val token = state.reservePresentation()
     val adapter = FailureDuringConfigurationAdapter { map ->
-      callbacks.onMapFailLoading(map, "style refused")
+      callbacks.onStyleFailed(map, "style refused")
     }
 
     state.publishPresentation(token, adapter)
@@ -347,7 +347,7 @@ class MapPresentationTest {
 
     assertTrue(state.lifecycle.selectAdapterForPresentation(adapter))
     callbacks.onStyleChanged(adapter, style)
-    callbacks.onMapFinishedLoading(adapter)
+    callbacks.onStyleReady(adapter)
     state.publishPresentation(token, adapter)
 
     assertEquals(StyleLoadState.Ready, state.style.loadState)
@@ -468,7 +468,7 @@ class MapPresentationTest {
     state.releasePresentation(token, adapter)
     testScheduler.advanceUntilIdle()
 
-    state.durableStyleCallbacks().onMapFailLoading(adapter, "style refused")
+    state.durableStyleCallbacks().onStyleFailed(adapter, "style refused")
 
     assertTrue(state.style.loadState is StyleLoadState.Failed)
     state.close()
@@ -485,12 +485,12 @@ class MapPresentationTest {
     val style = RecordingStyleBinding(sources = listOf(attributedVectorSource()))
     val callbacks = state.durableStyleCallbacks()
     callbacks.onStyleChanged(adapter, style)
-    callbacks.onMapFinishedLoading(adapter)
+    callbacks.onStyleReady(adapter)
     state.releasePresentation(token, adapter)
     testScheduler.advanceUntilIdle()
 
     style.removeSource("tiles")
-    callbacks.onSourceChanged(adapter, "tiles")
+    callbacks.onStyleSourcesChanged(adapter, "tiles")
 
     assertTrue(state.style.sources.none())
     state.close()
@@ -515,7 +515,7 @@ class MapPresentationTest {
     assertNull(fixture.state.style.sources["points"])
     fixture.state.durableStyleCallbacks().onStyleChanged(fixture.adapter, firstStyle)
     assertNull(fixture.state.style.sources["points"])
-    fixture.state.durableStyleCallbacks().onMapFinishedLoading(fixture.adapter)
+    fixture.state.durableStyleCallbacks().onStyleReady(fixture.adapter)
 
     val handle = assertIs<GeoJsonSourceHandle>(fixture.state.style.sources["points"])
     assertNull(fixture.state.style.sources["missing"])
@@ -541,7 +541,7 @@ class MapPresentationTest {
           )
       )
     fixture.state.durableStyleCallbacks().onStyleChanged(fixture.adapter, replacement)
-    fixture.state.durableStyleCallbacks().onMapFinishedLoading(fixture.adapter)
+    fixture.state.durableStyleCallbacks().onStyleReady(fixture.adapter)
 
     assertFailsWith<IllegalStateException> {
       handle.setFeatureState("7", buildJsonObject { put("stale", true) })
@@ -567,7 +567,7 @@ class MapPresentationTest {
       )
     val loadedStyle = RecordingStyleBinding(sources = listOf(geoJson))
     fixture.state.durableStyleCallbacks().onStyleChanged(fixture.adapter, loadedStyle)
-    fixture.state.durableStyleCallbacks().onMapFinishedLoading(fixture.adapter)
+    fixture.state.durableStyleCallbacks().onStyleReady(fixture.adapter)
     val handle = assertIs<GeoJsonSourceHandle>(fixture.state.style.sources["shared"])
     val vector = VectorSource("shared", "https://example.com/tiles.json")
 
@@ -598,7 +598,7 @@ class MapPresentationTest {
     val original = attributedVectorSource("shared", "original")
     val binding = RecordingStyleBinding(sources = listOf(original))
     fixture.state.durableStyleCallbacks().onStyleChanged(fixture.adapter, binding)
-    fixture.state.durableStyleCallbacks().onMapFinishedLoading(fixture.adapter)
+    fixture.state.durableStyleCallbacks().onStyleReady(fixture.adapter)
     val stale = checkNotNull(fixture.state.style.sources["shared"])
 
     assertTrue(fixture.state.style.sources.remove("shared"))
@@ -618,7 +618,7 @@ class MapPresentationTest {
       DesiredStyleRevision(listOf(original.definition()), emptyList(), emptyList())
     val binding = RecordingStyleBinding(sources = listOf(original))
     fixture.state.durableStyleCallbacks().onStyleChanged(fixture.adapter, binding)
-    fixture.state.durableStyleCallbacks().onMapFinishedLoading(fixture.adapter)
+    fixture.state.durableStyleCallbacks().onStyleReady(fixture.adapter)
     val stale = checkNotNull(fixture.state.style.sources["shared"])
     val replacement = attributedVectorSource("shared", "replacement")
 
@@ -649,7 +649,7 @@ class MapPresentationTest {
           )
       )
     fixture.state.durableStyleCallbacks().onStyleChanged(fixture.adapter, loadedStyle)
-    fixture.state.durableStyleCallbacks().onMapFinishedLoading(fixture.adapter)
+    fixture.state.durableStyleCallbacks().onStyleReady(fixture.adapter)
     val handle = assertIs<GeoJsonSourceHandle>(fixture.state.style.sources["points"])
     val point =
       buildFeatureCollection<Geometry, JsonObject?> {
@@ -684,7 +684,7 @@ class MapPresentationTest {
           )
       )
     state.durableStyleCallbacks().onStyleChanged(first, firstStyle)
-    state.durableStyleCallbacks().onMapFinishedLoading(first)
+    state.durableStyleCallbacks().onStyleReady(first)
     val handle = assertIs<GeoJsonSourceHandle>(state.style.sources["points"])
     state.releasePresentation(firstToken, first)
     testScheduler.advanceUntilIdle()
@@ -705,7 +705,7 @@ class MapPresentationTest {
     val fixture = presentationFixture()
     val loadedStyle = RecordingStyleBinding(layers = listOf(BackgroundLayer("background")))
     fixture.state.durableStyleCallbacks().onStyleChanged(fixture.adapter, loadedStyle)
-    fixture.state.durableStyleCallbacks().onMapFinishedLoading(fixture.adapter)
+    fixture.state.durableStyleCallbacks().onStyleReady(fixture.adapter)
 
     val handle = assertIs<LayerHandle>(fixture.state.style.layers["background"])
     assertNull(fixture.state.style.layers["missing"])
@@ -726,7 +726,7 @@ class MapPresentationTest {
       DesiredStyleRevision(emptyList(), listOf(original), emptyList())
     val binding = RecordingStyleBinding(layers = listOf(layer))
     fixture.state.durableStyleCallbacks().onStyleChanged(fixture.adapter, binding)
-    fixture.state.durableStyleCallbacks().onMapFinishedLoading(fixture.adapter)
+    fixture.state.durableStyleCallbacks().onStyleReady(fixture.adapter)
     val stale = checkNotNull(fixture.state.style.layers["background"])
 
     fixture.state.beginStyleRevision(
@@ -781,7 +781,7 @@ class MapPresentationTest {
       styleImages.add("unready", FakeImageBitmap(1, 1))
     }
     fixture.state.durableStyleCallbacks().onStyleChanged(fixture.adapter, binding)
-    fixture.state.durableStyleCallbacks().onMapFinishedLoading(fixture.adapter)
+    fixture.state.durableStyleCallbacks().onStyleReady(fixture.adapter)
 
     assertSame(styleSources, fixture.state.style.sources)
     assertSame(styleLayers, fixture.state.style.layers)
@@ -800,7 +800,7 @@ class MapPresentationTest {
     val fixture = presentationFixture()
     val binding = RecordingStyleBinding(refusedSourceRemovals = setOf("blocked"))
     fixture.state.durableStyleCallbacks().onStyleChanged(fixture.adapter, binding)
-    fixture.state.durableStyleCallbacks().onMapFinishedLoading(fixture.adapter)
+    fixture.state.durableStyleCallbacks().onStyleReady(fixture.adapter)
     val added = attributedVectorSource("added", "added attribution")
     val blocked = attributedVectorSource("blocked", "blocked attribution")
 
@@ -829,7 +829,7 @@ class MapPresentationTest {
     val binding = RecordingStyleBinding()
     val image = FakeImageBitmap(1, 1)
     fixture.state.durableStyleCallbacks().onStyleChanged(fixture.adapter, binding)
-    fixture.state.durableStyleCallbacks().onMapFinishedLoading(fixture.adapter)
+    fixture.state.durableStyleCallbacks().onStyleReady(fixture.adapter)
 
     fixture.state.style.images.add("marker", image)
     assertEquals(setOf("marker"), binding.imageIds)
@@ -863,7 +863,7 @@ class MapPresentationTest {
     assertFailsWith<IllegalStateException> { sky.set(Sky()) }
     assertFailsWith<IllegalStateException> { projection.set(Projection()) }
     fixture.state.durableStyleCallbacks().onStyleChanged(fixture.adapter, binding)
-    fixture.state.durableStyleCallbacks().onMapFinishedLoading(fixture.adapter)
+    fixture.state.durableStyleCallbacks().onStyleReady(fixture.adapter)
 
     assertEquals(TransitionOptions(), transition.get())
     transition.set(options)
@@ -936,7 +936,7 @@ class MapPresentationTest {
       )
     val binding = RecordingStyleBinding(images = listOf("owned" to image), sources = listOf(source))
     fixture.state.durableStyleCallbacks().onStyleChanged(fixture.adapter, binding)
-    fixture.state.durableStyleCallbacks().onMapFinishedLoading(fixture.adapter)
+    fixture.state.durableStyleCallbacks().onStyleReady(fixture.adapter)
 
     assertFailsWith<StyleHandleException> { fixture.state.style.sources.remove("owned") }
     assertFailsWith<StyleHandleException> { fixture.state.style.images.remove("owned") }
@@ -952,7 +952,7 @@ class MapPresentationTest {
     val source = attributedVectorSource("shared", "shared attribution")
     val image = FakeImageBitmap(1, 1)
     fixture.state.durableStyleCallbacks().onStyleChanged(fixture.adapter, binding)
-    fixture.state.durableStyleCallbacks().onMapFinishedLoading(fixture.adapter)
+    fixture.state.durableStyleCallbacks().onStyleReady(fixture.adapter)
     fixture.state.style.sources.add(source)
 
     assertFailsWith<StyleHandleException> {
@@ -1006,7 +1006,7 @@ class MapPresentationTest {
         }
       )
     fixture.state.durableStyleCallbacks().onStyleChanged(fixture.adapter, binding)
-    fixture.state.durableStyleCallbacks().onMapFinishedLoading(fixture.adapter)
+    fixture.state.durableStyleCallbacks().onStyleReady(fixture.adapter)
 
     fixture.state.style.images.add("shared", image)
 
@@ -1029,7 +1029,7 @@ class MapPresentationTest {
       )
     val binding = RecordingStyleBinding(sources = listOf(base, declarative))
     fixture.state.durableStyleCallbacks().onStyleChanged(fixture.adapter, binding)
-    fixture.state.durableStyleCallbacks().onMapFinishedLoading(fixture.adapter)
+    fixture.state.durableStyleCallbacks().onStyleReady(fixture.adapter)
 
     fixture.state.style.sources.add(attributedVectorSource("imperative", "imperative attribution"))
 
@@ -1049,7 +1049,7 @@ class MapPresentationTest {
     val binding =
       RecordingStyleBinding(sources = listOf(attributedVectorSource("base", "base attribution")))
     fixture.state.durableStyleCallbacks().onStyleChanged(fixture.adapter, binding)
-    fixture.state.durableStyleCallbacks().onMapFinishedLoading(fixture.adapter)
+    fixture.state.durableStyleCallbacks().onStyleReady(fixture.adapter)
 
     assertEquals(listOf("base attribution"), attributions.value)
     fixture.close()
@@ -1064,7 +1064,7 @@ class MapPresentationTest {
     val binding = RecordingStyleBinding()
     state.publishPresentation(token, adapter)
     state.durableStyleCallbacks().onStyleChanged(adapter, binding)
-    state.durableStyleCallbacks().onMapFinishedLoading(adapter)
+    state.durableStyleCallbacks().onStyleReady(adapter)
     state.style.sources.add(attributedVectorSource("retained", "retained attribution"))
 
     state.releasePresentation(token, adapter)
@@ -1078,7 +1078,7 @@ class MapPresentationTest {
     val replacementAdapter = RetainedAdapter(failOnClose = false)
     state.publishPresentation(replacementToken, replacementAdapter)
     state.durableStyleCallbacks().onStyleChanged(replacementAdapter, replacement)
-    state.durableStyleCallbacks().onMapFinishedLoading(replacementAdapter)
+    state.durableStyleCallbacks().onStyleReady(replacementAdapter)
     assertTrue(state.style.sources.none())
     state.close()
     runtime.close()

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapStateEventReactionTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapStateEventReactionTest.kt
@@ -143,13 +143,13 @@ class MapStateEventReactionTest {
       state.events.collect { published += it to state.isCameraMoving }
     }
 
-    state.onEvent(adapter, MapEvent.StyleImageMissing("x"))
-    state.onEvent(other, MapEvent.StyleImageMissing("y"))
+    state.onEvent(adapter, MapEvent.StyleLoaded)
+    state.onEvent(other, MapEvent.StyleLoaded)
     state.onEvent(adapter, MapEvent.CameraMoveStarted(animated = false))
 
     assertEquals(
       listOf(
-        MapEvent.StyleImageMissing("x") to false,
+        MapEvent.StyleLoaded to false,
         MapEvent.CameraMoveStarted(animated = false) to true,
       ),
       published,

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapStateEventReactionTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapStateEventReactionTest.kt
@@ -7,6 +7,8 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.maplibre.compose.camera.CameraMoveReason
 import org.maplibre.compose.camera.Viewport
@@ -16,7 +18,8 @@ import org.maplibre.spatialk.geojson.BoundingBox
 import org.maplibre.spatialk.geojson.Position
 
 /**
- * [MapState] derives the camera viewport, flag, and reason from [MapEvent] and the gesture fact.
+ * [MapState] derives the camera viewport, flag, and reason from [MapEvent] and the gesture fact,
+ * then publishes the event it accepted.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class MapStateEventReactionTest {
@@ -121,6 +124,36 @@ class MapStateEventReactionTest {
     state.invalidatePresentation(adapter)
 
     assertFalse(state.isCameraMoving)
+
+    state.close()
+    state.awaitClosed()
+    runtime.close()
+  }
+
+  @Test
+  fun an_accepted_event_reaches_the_public_flow_after_its_reaction() = runTest {
+    val runtime = mapRuntimeForTest(physicalScope = backgroundScope)
+    val state = runtime.createMapState(BaseStyle.Demo)
+    val adapter = presentedAdapter(state)
+    val other = PresentationTestAdapter()
+    val published = mutableListOf<Pair<MapEvent, Boolean>>()
+    // An unconfined collector runs at the emission, so it reads the state that the event produced
+    // rather than the state after every call returned.
+    backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+      state.events.collect { published += it to state.isCameraMoving }
+    }
+
+    state.onEvent(adapter, MapEvent.StyleImageMissing("x"))
+    state.onEvent(other, MapEvent.StyleImageMissing("y"))
+    state.onEvent(adapter, MapEvent.CameraMoveStarted(animated = false))
+
+    assertEquals(
+      listOf(
+        MapEvent.StyleImageMissing("x") to false,
+        MapEvent.CameraMoveStarted(animated = false) to true,
+      ),
+      published,
+    )
 
     state.close()
     state.awaitClosed()

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapStateEventReactionTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapStateEventReactionTest.kt
@@ -1,0 +1,154 @@
+package org.maplibre.compose.map
+
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.maplibre.compose.camera.CameraMoveReason
+import org.maplibre.compose.camera.Viewport
+import org.maplibre.compose.style.BaseStyle
+import org.maplibre.compose.util.VisibleRegion
+import org.maplibre.spatialk.geojson.BoundingBox
+import org.maplibre.spatialk.geojson.Position
+
+/**
+ * [MapState] derives the camera viewport, flag, and reason from [MapEvent] and the gesture fact.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class MapStateEventReactionTest {
+
+  @Test
+  fun an_engine_camera_change_moves_the_camera_and_reads_as_programmatic() = runTest {
+    val runtime = mapRuntimeForTest(physicalScope = backgroundScope)
+    val state = runtime.createMapState(BaseStyle.Demo)
+    val adapter = presentedAdapter(state)
+
+    state.onEvent(adapter, MapEvent.CameraMoveStarted(animated = false))
+
+    assertTrue(state.isCameraMoving)
+    assertEquals(CameraMoveReason.PROGRAMMATIC, state.cameraMoveReason)
+    assertEquals(adapter.currentViewport, state.viewport)
+
+    state.onEvent(adapter, MapEvent.CameraMoveEnded(animated = false))
+
+    assertFalse(state.isCameraMoving)
+    assertEquals(CameraMoveReason.PROGRAMMATIC, state.cameraMoveReason)
+
+    state.close()
+    state.awaitClosed()
+    runtime.close()
+  }
+
+  @Test
+  fun a_gesture_spans_the_camera_changes_the_engine_reports_one_by_one() = runTest {
+    val runtime = mapRuntimeForTest(physicalScope = backgroundScope)
+    val state = runtime.createMapState(BaseStyle.Demo)
+    val adapter = presentedAdapter(state)
+
+    state.setGestureActive(adapter, true)
+
+    assertTrue(state.isCameraMoving)
+    assertEquals(CameraMoveReason.GESTURE, state.cameraMoveReason)
+
+    repeat(3) {
+      state.onEvent(adapter, MapEvent.CameraMoveStarted(animated = false))
+      state.onEvent(adapter, MapEvent.CameraMoveEnded(animated = false))
+      assertTrue(state.isCameraMoving, "the drag ended at jump $it")
+      assertEquals(CameraMoveReason.GESTURE, state.cameraMoveReason)
+    }
+
+    state.setGestureActive(adapter, false)
+
+    assertFalse(state.isCameraMoving)
+    assertEquals(CameraMoveReason.GESTURE, state.cameraMoveReason)
+
+    state.close()
+    state.awaitClosed()
+    runtime.close()
+  }
+
+  @Test
+  fun a_camera_change_reports_a_move_while_the_map_has_no_viewport() = runTest {
+    val runtime = mapRuntimeForTest(physicalScope = backgroundScope)
+    val state = runtime.createMapState(BaseStyle.Demo)
+    val adapter = presentedAdapter(state, viewport = null)
+
+    state.onEvent(adapter, MapEvent.CameraMoveStarted(animated = false))
+
+    assertTrue(state.isCameraMoving)
+    assertEquals(CameraMoveReason.PROGRAMMATIC, state.cameraMoveReason)
+
+    state.onEvent(adapter, MapEvent.CameraMoveEnded(animated = false))
+
+    assertFalse(state.isCameraMoving)
+
+    state.close()
+    state.awaitClosed()
+    runtime.close()
+  }
+
+  @Test
+  fun an_adapter_that_is_not_the_current_presentation_reports_nothing() = runTest {
+    val runtime = mapRuntimeForTest(physicalScope = backgroundScope)
+    val state = runtime.createMapState(BaseStyle.Demo)
+    presentedAdapter(state)
+    val other = PresentationTestAdapter()
+
+    state.onEvent(other, MapEvent.CameraMoveStarted(animated = false))
+    state.setGestureActive(other, true)
+
+    assertFalse(state.isCameraMoving)
+    assertEquals(CameraMoveReason.NONE, state.cameraMoveReason)
+
+    state.close()
+    state.awaitClosed()
+    runtime.close()
+  }
+
+  @Test
+  fun a_detached_map_stops_reporting_a_move() = runTest {
+    val runtime = mapRuntimeForTest(physicalScope = backgroundScope)
+    val state = runtime.createMapState(BaseStyle.Demo)
+    val adapter = presentedAdapter(state)
+    state.setGestureActive(adapter, true)
+    state.onEvent(adapter, MapEvent.CameraMoveStarted(animated = false))
+    assertTrue(state.isCameraMoving)
+
+    state.invalidatePresentation(adapter)
+
+    assertFalse(state.isCameraMoving)
+
+    state.close()
+    state.awaitClosed()
+    runtime.close()
+  }
+
+  private fun presentedAdapter(
+    state: MapState,
+    viewport: Viewport? = testViewport(),
+  ): PresentationTestAdapter {
+    val adapter = PresentationTestAdapter()
+    adapter.currentViewport = viewport
+    val token = state.reservePresentation(MapPresentationOwnerToken())
+    state.publishPresentation(token, adapter)
+    return adapter
+  }
+
+  private fun testViewport(): Viewport =
+    Viewport(
+      size = DpSize(100.dp, 100.dp),
+      visibleBoundingBox = BoundingBox(Position(-1.0, -1.0), Position(1.0, 1.0)),
+      visibleRegion =
+        VisibleRegion(
+          farLeft = Position(-1.0, 1.0),
+          farRight = Position(1.0, 1.0),
+          nearLeft = Position(-1.0, -1.0),
+          nearRight = Position(1.0, -1.0),
+        ),
+      metersPerDpAtTarget = 1.0,
+    )
+}

--- a/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/map/IosMapView.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/map/IosMapView.kt
@@ -19,6 +19,7 @@ internal actual fun ComposableMapView(
   onReset: () -> Unit,
   logger: MapLog?,
   callbacks: MapAdapter.Callbacks,
+  clicks: MapClickTarget,
   options: MapViewOptions,
 ) {
   val runtimeBackends = remember { loadRuntimeBackends(logger) }
@@ -41,6 +42,7 @@ internal actual fun ComposableMapView(
     onReset = onReset,
     logger = logger,
     callbacks = callbacks,
+    clicks = clicks,
     options = options,
   )
 }

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsEvents.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsEvents.kt
@@ -4,23 +4,26 @@ internal fun interface GlJsSubscription {
   fun cancel()
 }
 
-internal fun MaplibreMap.subscribe(event: String, listener: (MapEvent) -> Unit): GlJsSubscription {
+internal fun MaplibreMap.subscribe(
+  event: String,
+  listener: (GlJsMapEvent) -> Unit,
+): GlJsSubscription {
   val subscription = on(event, listener)
   return GlJsSubscription { subscription.unsubscribe() }
 }
 
-internal fun Light.subscribe(event: String, listener: (MapEvent) -> Unit): GlJsSubscription {
+internal fun Light.subscribe(event: String, listener: (GlJsMapEvent) -> Unit): GlJsSubscription {
   val subscription = on(event, listener)
   return GlJsSubscription { subscription.unsubscribe() }
 }
 
-internal fun Sky.subscribe(event: String, listener: (MapEvent) -> Unit): GlJsSubscription {
+internal fun Sky.subscribe(event: String, listener: (GlJsMapEvent) -> Unit): GlJsSubscription {
   val subscription = on(event, listener)
   return GlJsSubscription { subscription.unsubscribe() }
 }
 
 /** Whether an error event ended a base-style request rather than one source or tile request. */
-internal fun MapEvent.isTerminalStyleLoadFailure(): Boolean {
+internal fun GlJsMapEvent.isTerminalStyleLoadFailure(): Boolean {
   val style = asDynamic().style ?: return false
   return style._loaded != true && style._loadStyleRequest == null && style._frameRequest == null
 }

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsModule.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsModule.kt
@@ -28,7 +28,7 @@ internal external class MaplibreMap(options: MapOptions) {
   var showPadding: Boolean
   var showOverdrawInspector: Boolean
 
-  fun on(type: String, listener: (event: MapEvent) -> Unit): Subscription
+  fun on(type: String, listener: (event: GlJsMapEvent) -> Unit): Subscription
 
   fun fire(type: String, properties: Any)
 
@@ -194,10 +194,10 @@ internal external class Style {
  * with no evented parent, so a listener on the map never hears it.
  */
 internal external class Light {
-  fun on(type: String, listener: (event: MapEvent) -> Unit): Subscription
+  fun on(type: String, listener: (event: GlJsMapEvent) -> Unit): Subscription
 }
 
 /** The style's sky reports a rejected write the same way as [Light]. */
 internal external class Sky {
-  fun on(type: String, listener: (event: MapEvent) -> Unit): Subscription
+  fun on(type: String, listener: (event: GlJsMapEvent) -> Unit): Subscription
 }

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsModule.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsModule.kt
@@ -162,6 +162,12 @@ internal external class MaplibreMap(options: MapOptions) {
   fun hasImage(id: String): Boolean
 
   fun removeImage(id: String)
+
+  /**
+   * MapLibre awaits the promise that the resolver returns before it treats the image as missing. A
+   * null [resolver] removes the one in place; MapLibre exposes no separate remover.
+   */
+  fun setMissingStyleImageResolver(resolver: ((id: String) -> Promise<*>?)?)
 }
 
 internal external class LngLat(lng: Double, lat: Double) {

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsTypes.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsTypes.kt
@@ -13,11 +13,12 @@ internal external interface Subscription {
   fun unsubscribe()
 }
 
-/** Only the `error` event carries an [error]. */
-internal external interface MapEvent {
+/** Only the `error` event carries an [error], and only `styleimagemissing` carries an [id]. */
+internal external interface GlJsMapEvent {
   val error: JsError?
   val sourceId: String?
   val sourceDataType: String?
+  val id: String?
 }
 
 internal external interface JsError {

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsTypes.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsTypes.kt
@@ -13,12 +13,11 @@ internal external interface Subscription {
   fun unsubscribe()
 }
 
-/** Only the `error` event carries an [error], and only `styleimagemissing` carries an [id]. */
+/** Only the `error` event carries an [error]. */
 internal external interface GlJsMapEvent {
   val error: JsError?
   val sourceId: String?
   val sourceDataType: String?
-  val id: String?
 }
 
 internal external interface JsError {

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapEvents.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapEvents.kt
@@ -1,0 +1,23 @@
+package org.maplibre.compose.map
+
+import org.maplibre.compose.gljs.GlJsMapEvent
+
+/** Null when the event lacks the payload its catalog entry needs. */
+internal typealias GlJsEventTranslation = (GlJsMapEvent) -> MapEvent?
+
+/** MapLibre GL JS events that report the engine's own progress. */
+internal val ENGINE_GL_JS_EVENTS: Map<String, GlJsEventTranslation> =
+  mapOf("idle" to { MapEvent.Idle })
+
+/** MapLibre GL JS events that belong to the style loaded when they arrive. */
+internal val STYLE_GL_JS_EVENTS: Map<String, GlJsEventTranslation> =
+  mapOf("styleimagemissing" to { event -> event.id?.let { MapEvent.StyleImageMissing(it) } })
+
+/** MapLibre GL JS events that belong to the render lease that produced them. */
+internal val PRESENTATION_GL_JS_EVENTS: Map<String, GlJsEventTranslation> =
+  mapOf(
+    "movestart" to { MapEvent.CameraMoveStarted(animated = null) },
+    "move" to { MapEvent.CameraMoved },
+    "moveend" to { MapEvent.CameraMoveEnded(animated = null) },
+    "render" to { MapEvent.FrameRendered(stats = null) },
+  )

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapEvents.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapEvents.kt
@@ -2,16 +2,11 @@ package org.maplibre.compose.map
 
 import org.maplibre.compose.gljs.GlJsMapEvent
 
-/** Null when the event lacks the payload its catalog entry needs. */
-internal typealias GlJsEventTranslation = (GlJsMapEvent) -> MapEvent?
+internal typealias GlJsEventTranslation = (GlJsMapEvent) -> MapEvent
 
 /** MapLibre GL JS events that report the engine's own progress. */
 internal val ENGINE_GL_JS_EVENTS: Map<String, GlJsEventTranslation> =
   mapOf("idle" to { MapEvent.Idle })
-
-/** MapLibre GL JS events that belong to the style loaded when they arrive. */
-internal val STYLE_GL_JS_EVENTS: Map<String, GlJsEventTranslation> =
-  mapOf("styleimagemissing" to { event -> event.id?.let { MapEvent.StyleImageMissing(it) } })
 
 /** MapLibre GL JS events that belong to the render lease that produced them. */
 internal val PRESENTATION_GL_JS_EVENTS: Map<String, GlJsEventTranslation> =

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
@@ -559,7 +559,7 @@ internal class GlJsMapSession(
     val trackerRequest = appliedStyleRequest ?: return
     val identity = styleBinding?.identity ?: return
     if (styleLoadTracker?.reconciled(trackerRequest, identity) == true) {
-      if (lifecycleCallbacks.onMapFinishedLoading(engine, style, this)) {
+      if (lifecycleCallbacks.onStyleReady(engine, style, this)) {
         reportStyleLoaded = false
         hasPresentableStyle = true
       }
@@ -733,7 +733,7 @@ internal class GlJsMapSession(
               if (event.sourceDataType == "metadata") {
                 applyTileLod(map)
                 event.sourceId?.let {
-                  lifecycleCallbacks.onSourceChanged(engine, acceptedStyle, this, it)
+                  lifecycleCallbacks.onStyleSourcesChanged(engine, acceptedStyle, this, it)
                 }
               }
             }
@@ -764,7 +764,7 @@ internal class GlJsMapSession(
             reason,
           ) == true
         if (accepted) {
-          if (lifecycleCallbacks.onMapFailLoading(engine, lifecycleRequest, this, reason)) {
+          if (lifecycleCallbacks.onStyleFailed(engine, lifecycleRequest, this, reason)) {
             logger?.e { "Map loading failed: $reason" }
             hasPresentableStyle = false
             if (!hasLoadedInitialStyle) abandonPending(pendingInitialStyleActions)
@@ -805,7 +805,7 @@ internal class GlJsMapSession(
           reason,
         ) == true
       ) {
-        lifecycleCallbacks.onMapFailLoading(engine, lifecycleRequest, this, reason)
+        lifecycleCallbacks.onStyleFailed(engine, lifecycleRequest, this, reason)
         hasPresentableStyle = false
         lifecycleCallbacks.onEvent(
           engine,

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
@@ -19,7 +19,6 @@ import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.serialization.json.JsonObject
-import org.maplibre.compose.camera.CameraMoveReason
 import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.camera.Viewport
 import org.maplibre.compose.expressions.ast.CompiledExpression
@@ -194,13 +193,15 @@ internal class GlJsMapSession(
     val engine = lifecycleEngineIdentity
     val lease = lifecycleRenderLease
     if (engine != null && lease != null) {
-      try {
-        endCameraMove(engine, lease)
-      } finally {
-        surface = null
-        invalidateStyleBinding()
-        lifecycle.beginEngineReplacement(engine, lease)
-      }
+      // The replacement keeps the presentation, and the destroyed map emits no `moveend`. A
+      // gesture that ends while the replacement is attaching cannot report, so its fact is
+      // withdrawn here; a gesture that continues re-reports on its next camera command.
+      activeGestureToken = null
+      reportGestureActive(false)
+      lifecycleAuthority.endCurrentPresentationCameraChange(this)
+      surface = null
+      invalidateStyleBinding()
+      lifecycle.beginEngineReplacement(engine, lease)
     } else {
       surface = null
     }
@@ -262,11 +263,7 @@ internal class GlJsMapSession(
     if (lentContext != null) null else map?.getCanvas()
 
   override fun close() {
-    try {
-      endCameraMove()
-    } finally {
-      lifecycle.close()
-    }
+    lifecycle.close()
   }
 
   override suspend fun awaitClosed() {
@@ -301,7 +298,7 @@ internal class GlJsMapSession(
   }
 
   override suspend fun closeResources() {
-    isGestureInProgress = false
+    activeGestureToken = null
     abandonPending(pendingMapActions)
     abandonPending(pendingInitialStyleActions)
     abandonPending(pendingPlatformMapAccess)
@@ -424,12 +421,12 @@ internal class GlJsMapSession(
     map.setPixelRatio(extent.scaleFactor)
     map.resize()
     hasUsableViewport = true
-    // resize() may also fire `move`; a second onCameraMoved is how overlays learn the viewport
-    // changed when the camera position did not. Seed here too: the first resize can land before
-    // the lease is Attached, and acceptPresentationEvent then drops that callback.
+    // resize() may also fire `move`; this report is how overlays learn the viewport changed when
+    // the camera position did not. Seed here too: the first resize can land before the lease is
+    // Attached, and acceptPresentationEvent then drops that callback.
     lifecycleAuthority.seedCurrentPresentationViewport(this)
     withLifecyclePresentation { engine, lease ->
-      lifecycleCallbacks.onCameraMoved(engine, lease, this)
+      lifecycleCallbacks.onViewportChanged(engine, lease, this)
     }
   }
 
@@ -543,24 +540,16 @@ internal class GlJsMapSession(
       }
     }
 
-    map.subscribe("movestart") { beginCameraMove(engine, lease) }
-    map.subscribe("move") { lifecycleCallbacks.onCameraMoved(engine, lease, this) }
-    map.subscribe("moveend") {
-      if (lifecycleCallbacks.onCameraMoved(engine, lease, this)) {
-        // A drag is a stream of jumps, each with its own moveend.
-        if (!isGestureInProgress) endCameraMove(engine, lease)
-        resumeTransitions()
-      }
-    }
-
     subscribeTranslated(map, ENGINE_GL_JS_EVENTS) { lifecycleCallbacks.onEvent(engine, this, it) }
     subscribeTranslated(map, STYLE_GL_JS_EVENTS) { event ->
       // The style is whichever one is loaded when the event arrives, so the identity is read here
       // rather than captured with the subscription.
       lifecycleStyleIdentity?.let { lifecycleCallbacks.onEvent(engine, it, this, event) }
     }
-    subscribeTranslated(map, PRESENTATION_GL_JS_EVENTS) {
-      lifecycleCallbacks.onEvent(engine, lease, this, it)
+    subscribeTranslated(map, PRESENTATION_GL_JS_EVENTS) { event ->
+      val accepted = lifecycleCallbacks.onEvent(engine, lease, this, event)
+      // A `moveend` is how GL JS reports that an eased transition finished.
+      if (accepted && event is MapEvent.CameraMoveEnded) resumeTransitions()
     }
   }
 
@@ -589,33 +578,6 @@ internal class GlJsMapSession(
       }
     }
   }
-
-  /** A move spans the gesture rather than the jump, as every other platform reports it. */
-  private fun beginCameraMove(
-    engine: EngineMapIdentity? = lifecycleEngineIdentity,
-    lease: RenderLease? = lifecycleRenderLease,
-  ) {
-    val reason =
-      if (isGestureInProgress) CameraMoveReason.GESTURE else CameraMoveReason.PROGRAMMATIC
-    if (reportedMoveReason == reason) return
-    if (engine != null && lease != null) {
-      if (lifecycleCallbacks.onCameraMoveStarted(engine, lease, this, reason)) {
-        reportedMoveReason = reason
-      }
-    }
-  }
-
-  private fun endCameraMove(
-    engine: EngineMapIdentity? = lifecycleEngineIdentity,
-    lease: RenderLease? = lifecycleRenderLease,
-  ) {
-    if (reportedMoveReason == null) return
-    if (engine != null && lease != null) {
-      lifecycleCallbacks.onCameraMoveEnded(engine, lease, this) { reportedMoveReason = null }
-    }
-  }
-
-  private var reportedMoveReason: CameraMoveReason? = null
 
   // endregion
 
@@ -1176,7 +1138,6 @@ internal class GlJsMapSession(
 
   // region input, called from Compose
 
-  private var isGestureInProgress = false
   private var nextGestureToken = 0L
   private var activeGestureToken: GestureToken? = null
 
@@ -1185,16 +1146,22 @@ internal class GlJsMapSession(
   override fun onGestureEnded(token: GestureToken) {
     if (activeGestureToken != token) return
     activeGestureToken = null
-    isGestureInProgress = false
-    endCameraMove()
+    reportGestureActive(false)
   }
 
+  /** Reports on every camera command: a report made before the lease attaches is dropped. */
   private fun activateGesture(token: GestureToken?) {
     if (token == null) return
     val active = activeGestureToken
     if (active != null && token.value < active.value) return
     activeGestureToken = token
-    isGestureInProgress = true
+    reportGestureActive(true)
+  }
+
+  private fun reportGestureActive(active: Boolean) {
+    withLifecyclePresentation { engine, lease ->
+      lifecycleCallbacks.onGestureActive(engine, lease, this, active)
+    }
   }
 
   override fun moveBy(

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
@@ -177,7 +177,6 @@ internal class GlJsMapSession(
   private var cameraConstraints: CameraConstraints? = null
   private var tileLodOptions: TileLodOptions = TileLodOptions.Standard
   private var lastRenderTime = TimeSource.Monotonic.markNow()
-  private var lastFrameTime = TimeSource.Monotonic.markNow()
   private var hasRenderedAFrame = false
 
   // region surface lifecycle
@@ -255,7 +254,6 @@ internal class GlJsMapSession(
       }
     }
     lastRenderTime = now
-    reportFrameRate()
     return true
   }
 
@@ -506,17 +504,6 @@ internal class GlJsMapSession(
     if (fps <= 0) return true
     val elapsed = (now - lastRenderTime).toDouble(DurationUnit.SECONDS)
     return elapsed >= (1.0 / fps) * (1.0 - FRAME_INTERVAL_SLACK)
-  }
-
-  private fun reportFrameRate() {
-    val now = TimeSource.Monotonic.markNow()
-    val elapsed = (now - lastFrameTime).toDouble(DurationUnit.SECONDS)
-    lastFrameTime = now
-    if (elapsed > 0.0) {
-      withLifecyclePresentation { engine, lease ->
-        lifecycleCallbacks.onFrame(engine, lease, 1.0 / elapsed)
-      }
-    }
   }
 
   // endregion

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
@@ -17,6 +17,7 @@ import kotlin.time.DurationUnit
 import kotlin.time.TimeSource
 import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.asPromise
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.serialization.json.JsonObject
 import org.maplibre.compose.camera.CameraPosition
@@ -376,6 +377,7 @@ internal class GlJsMapSession(
     hasUsableViewport = false
     hasReplayedPresentationState = false
     invalidateStyleBinding()
+    current.setMissingStyleImageResolver(null)
     styleLoadSubscription?.cancel()
     styleLoadSubscription = null
     styleErrorSubscription?.cancel()
@@ -527,12 +529,19 @@ internal class GlJsMapSession(
       }
     }
 
-    subscribeTranslated(map, ENGINE_GL_JS_EVENTS) { lifecycleCallbacks.onEvent(engine, this, it) }
-    subscribeTranslated(map, STYLE_GL_JS_EVENTS) { event ->
-      // The style is whichever one is loaded when the event arrives, so the identity is read here
-      // rather than captured with the subscription.
-      lifecycleStyleIdentity?.let { lifecycleCallbacks.onEvent(engine, it, this, event) }
+    // MapLibre awaits this before it treats the image as missing, so a resolved image satisfies
+    // the request that asked for it rather than only later ones.
+    map.setMissingStyleImageResolver { imageId ->
+      // The style is whichever one is loaded when MapLibre asks, so the identity is read here
+      // rather than captured with the resolver.
+      val style = lifecycleStyleIdentity
+      val resolution =
+        if (style == null) null
+        else lifecycleCallbacks.resolveMissingImage(engine, style, this, imageId)
+      resolution?.asPromise()
     }
+
+    subscribeTranslated(map, ENGINE_GL_JS_EVENTS) { lifecycleCallbacks.onEvent(engine, this, it) }
     subscribeTranslated(map, PRESENTATION_GL_JS_EVENTS) { event ->
       val accepted = lifecycleCallbacks.onEvent(engine, lease, this, event)
       // A `moveend` is how GL JS reports that an eased transition finished.
@@ -546,7 +555,7 @@ internal class GlJsMapSession(
     deliver: (MapEvent) -> Unit,
   ) {
     for ((type, translate) in translations) {
-      map.subscribe(type) { event -> translate(event)?.let(deliver) }
+      map.subscribe(type) { event -> deliver(translate(event)) }
     }
   }
 

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
@@ -552,6 +552,26 @@ internal class GlJsMapSession(
         resumeTransitions()
       }
     }
+
+    subscribeTranslated(map, ENGINE_GL_JS_EVENTS) { lifecycleCallbacks.onEvent(engine, this, it) }
+    subscribeTranslated(map, STYLE_GL_JS_EVENTS) { event ->
+      // The style is whichever one is loaded when the event arrives, so the identity is read here
+      // rather than captured with the subscription.
+      lifecycleStyleIdentity?.let { lifecycleCallbacks.onEvent(engine, it, this, event) }
+    }
+    subscribeTranslated(map, PRESENTATION_GL_JS_EVENTS) {
+      lifecycleCallbacks.onEvent(engine, lease, this, it)
+    }
+  }
+
+  private fun subscribeTranslated(
+    map: MaplibreMap,
+    translations: Map<String, GlJsEventTranslation>,
+    deliver: (MapEvent) -> Unit,
+  ) {
+    for ((type, translate) in translations) {
+      map.subscribe(type) { event -> translate(event)?.let(deliver) }
+    }
   }
 
   private fun reportLoadedOnceStyleIsReady(
@@ -751,6 +771,7 @@ internal class GlJsMapSession(
           styleBinding?.invalidate()
           styleBinding = binding
           lifecycleStyleIdentity = acceptedStyle
+          lifecycleCallbacks.onEvent(engine, acceptedStyle, this, MapEvent.StyleLoaded)
           styleDataSubscription =
             map.subscribe("styledata") {
               if (!baseStyleReady && map.isStyleLoaded()) baseStyleReady = true
@@ -798,6 +819,12 @@ internal class GlJsMapSession(
             logger?.e { "Map loading failed: $reason" }
             hasPresentableStyle = false
             if (!hasLoadedInitialStyle) abandonPending(pendingInitialStyleActions)
+            lifecycleCallbacks.onEvent(
+              engine,
+              lifecycleRequest,
+              this,
+              MapEvent.StyleLoadFailed(reason),
+            )
           }
         } else {
           applyRequestedStyle(map)
@@ -831,6 +858,12 @@ internal class GlJsMapSession(
       ) {
         lifecycleCallbacks.onMapFailLoading(engine, lifecycleRequest, this, reason)
         hasPresentableStyle = false
+        lifecycleCallbacks.onEvent(
+          engine,
+          lifecycleRequest,
+          this,
+          MapEvent.StyleLoadFailed(reason),
+        )
       }
       if (!hasLoadedInitialStyle) abandonPending(pendingInitialStyleActions)
     }

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
@@ -1269,21 +1269,6 @@ internal class GlJsMapSession(
     this.duration = duration.inWholeMilliseconds.toDouble()
   }
 
-  override fun onPrimaryClick(offset: DpOffset) {
-    val position = map?.unprojectAt(offset.x.value.toDouble(), offset.y.value.toDouble()) ?: return
-    withLifecyclePresentation { engine, lease ->
-      lifecycleCallbacks.onClick(engine, lease, this, position, offset)
-    }
-  }
-
-  /** A mouse has no press-and-hold convention, so the secondary button is the long press. */
-  override fun onSecondaryClick(offset: DpOffset) {
-    val position = map?.unprojectAt(offset.x.value.toDouble(), offset.y.value.toDouble()) ?: return
-    withLifecyclePresentation { engine, lease ->
-      lifecycleCallbacks.onLongClick(engine, lease, this, position, offset)
-    }
-  }
-
   private inline fun withLifecyclePresentation(action: (EngineMapIdentity, RenderLease) -> Unit) {
     val engine = lifecycleEngineIdentity ?: return
     val lease = lifecycleRenderLease ?: return

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/JsMapView.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/JsMapView.kt
@@ -27,6 +27,7 @@ internal actual fun ComposableMapView(
   onReset: () -> Unit,
   logger: MapLog?,
   callbacks: MapAdapter.Callbacks,
+  clicks: MapClickTarget,
   options: MapViewOptions,
 ) {
   val density = LocalDensity.current
@@ -77,7 +78,14 @@ internal actual fun ComposableMapView(
     GlJsMapSurface(
       renderer = session,
       modifier =
-        modifier.mapInput(session, options.gestureOptions, density, focusRequester, continuation),
+        modifier.mapInput(
+          session,
+          clicks,
+          options.gestureOptions,
+          density,
+          focusRequester,
+          continuation,
+        ),
       logger = logger,
       presentFrames = session.canPresentFrames,
     )

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/CompositedMap.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/CompositedMap.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.launch
 import org.maplibre.compose.camera.CameraMoveReason
 import org.maplibre.compose.map.GlJsMapSession
 import org.maplibre.compose.map.MapAdapter
+import org.maplibre.compose.map.MapEvent
 import org.maplibre.compose.map.MapExtent
 import org.maplibre.compose.map.RenderOptions
 import org.maplibre.compose.map.mapRuntimeForTest
@@ -111,5 +112,7 @@ internal class CompositedMap(style: BaseStyle, private val scaleFactor: Double =
     override fun onCameraMoveEnded(map: MapAdapter) = Unit
 
     override fun onFrame(fps: Double) = Unit
+
+    override fun onEvent(map: MapAdapter, event: MapEvent) = Unit
   }
 }

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/CompositedMap.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/CompositedMap.kt
@@ -7,7 +7,6 @@ import kotlin.js.Date
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
-import org.maplibre.compose.camera.CameraMoveReason
 import org.maplibre.compose.map.GlJsMapSession
 import org.maplibre.compose.map.MapAdapter
 import org.maplibre.compose.map.MapEvent
@@ -105,14 +104,12 @@ internal class CompositedMap(style: BaseStyle, private val scaleFactor: Double =
       loadFailure = reason ?: "unknown"
     }
 
-    override fun onCameraMoveStarted(map: MapAdapter, reason: CameraMoveReason) = Unit
-
-    override fun onCameraMoved(map: MapAdapter) = Unit
-
-    override fun onCameraMoveEnded(map: MapAdapter) = Unit
-
     override fun onFrame(fps: Double) = Unit
 
     override fun onEvent(map: MapAdapter, event: MapEvent) = Unit
+
+    override fun onGestureActive(map: MapAdapter, active: Boolean) = Unit
+
+    override fun onViewportChanged(map: MapAdapter) = Unit
   }
 }

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/CompositedMap.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/CompositedMap.kt
@@ -94,15 +94,15 @@ internal class CompositedMap(style: BaseStyle, private val scaleFactor: Double =
       }
     }
 
-    override fun onMapFinishedLoading(map: MapAdapter) {
+    override fun onStyleReady(map: MapAdapter) {
       styleLoaded = true
     }
 
-    override fun onSourceChanged(map: MapAdapter, sourceId: String?) = Unit
-
-    override fun onMapFailLoading(map: MapAdapter, reason: String?) {
+    override fun onStyleFailed(map: MapAdapter, reason: String?) {
       loadFailure = reason ?: "unknown"
     }
+
+    override fun onStyleSourcesChanged(map: MapAdapter, sourceId: String?) = Unit
 
     override fun onEvent(map: MapAdapter, event: MapEvent) = Unit
 

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/CompositedMap.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/CompositedMap.kt
@@ -104,8 +104,6 @@ internal class CompositedMap(style: BaseStyle, private val scaleFactor: Double =
       loadFailure = reason ?: "unknown"
     }
 
-    override fun onFrame(fps: Double) = Unit
-
     override fun onEvent(map: MapAdapter, event: MapEvent) = Unit
 
     override fun onGestureActive(map: MapAdapter, active: Boolean) = Unit

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/CompositedMap.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/CompositedMap.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import kotlin.js.Date
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
@@ -105,6 +106,8 @@ internal class CompositedMap(style: BaseStyle, private val scaleFactor: Double =
     override fun onStyleSourcesChanged(map: MapAdapter, sourceId: String?) = Unit
 
     override fun onEvent(map: MapAdapter, event: MapEvent) = Unit
+
+    override fun resolveMissingImage(map: MapAdapter, imageId: String): Deferred<Unit>? = null
 
     override fun onGestureActive(map: MapAdapter, active: Boolean) = Unit
 

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/CompositedMap.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/CompositedMap.kt
@@ -16,7 +16,6 @@ import org.maplibre.compose.map.mapRuntimeForTest
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.compose.style.DesiredStyleRevision
 import org.maplibre.compose.style.StyleBinding
-import org.maplibre.spatialk.geojson.Position
 
 private const val RENDER_TIMEOUT_MS = 30_000
 
@@ -110,10 +109,6 @@ internal class CompositedMap(style: BaseStyle, private val scaleFactor: Double =
     override fun onCameraMoved(map: MapAdapter) = Unit
 
     override fun onCameraMoveEnded(map: MapAdapter) = Unit
-
-    override fun onClick(map: MapAdapter, latLng: Position, offset: DpOffset) = Unit
-
-    override fun onLongClick(map: MapAdapter, latLng: Position, offset: DpOffset) = Unit
 
     override fun onFrame(fps: Double) = Unit
   }

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserCameraTransitionLifecycleTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserCameraTransitionLifecycleTest.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.maplibre.compose.camera.CameraPosition
-import org.maplibre.compose.gljs.MapEvent
+import org.maplibre.compose.gljs.GlJsMapEvent
 import org.maplibre.compose.gljs.isNear
 import org.maplibre.compose.gljs.runBrowserMapTest
 import org.maplibre.compose.gljs.setBrowserMapContent
@@ -91,7 +91,7 @@ class BrowserCameraTransitionLifecycleTest {
       }
 
       departedSession.setCameraPosition(STALE_CAMERA)
-      departedEngine.fire("move", unsafeJso<MapEvent>())
+      departedEngine.fire("move", unsafeJso<GlJsMapEvent>())
       waitForIdle()
 
       assertTrue(state.cameraPosition.isNear(CURRENT_CAMERA))

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/GlJsMapEventsTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/GlJsMapEventsTest.kt
@@ -1,0 +1,40 @@
+package org.maplibre.compose.map
+
+import js.objects.unsafeJso
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import org.maplibre.compose.gljs.GlJsMapEvent
+
+class GlJsMapEventsTest {
+
+  @Test
+  fun the_camera_events_translate_without_an_animation_flag() {
+    assertEquals(MapEvent.CameraMoveStarted(animated = null), translate("movestart"))
+    assertEquals(MapEvent.CameraMoved, translate("move"))
+    assertEquals(MapEvent.CameraMoveEnded(animated = null), translate("moveend"))
+  }
+
+  @Test
+  fun a_render_translates_without_stats() {
+    assertEquals(MapEvent.FrameRendered(stats = null), translate("render"))
+  }
+
+  @Test
+  fun an_idle_translates() {
+    assertEquals(MapEvent.Idle, translate("idle"))
+  }
+
+  @Test
+  fun a_missing_image_carries_its_id() {
+    assertEquals(
+      MapEvent.StyleImageMissing("missing-icon"),
+      translate("styleimagemissing", eventWithId("missing-icon")),
+    )
+  }
+
+  private fun translate(type: String, event: GlJsMapEvent = unsafeJso()) =
+    (ENGINE_GL_JS_EVENTS + STYLE_GL_JS_EVENTS + PRESENTATION_GL_JS_EVENTS).getValue(type)(event)
+
+  private fun eventWithId(id: String): GlJsMapEvent =
+    unsafeJso<GlJsMapEvent>().also { it.asDynamic().id = id }
+}

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/GlJsMapEventsTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/GlJsMapEventsTest.kt
@@ -24,17 +24,6 @@ class GlJsMapEventsTest {
     assertEquals(MapEvent.Idle, translate("idle"))
   }
 
-  @Test
-  fun a_missing_image_carries_its_id() {
-    assertEquals(
-      MapEvent.StyleImageMissing("missing-icon"),
-      translate("styleimagemissing", eventWithId("missing-icon")),
-    )
-  }
-
   private fun translate(type: String, event: GlJsMapEvent = unsafeJso()) =
-    (ENGINE_GL_JS_EVENTS + STYLE_GL_JS_EVENTS + PRESENTATION_GL_JS_EVENTS).getValue(type)(event)
-
-  private fun eventWithId(id: String): GlJsMapEvent =
-    unsafeJso<GlJsMapEvent>().also { it.asDynamic().id = id }
+    (ENGINE_GL_JS_EVENTS + PRESENTATION_GL_JS_EVENTS).getValue(type)(event)
 }

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/testing/GlJsMapFixture.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/testing/GlJsMapFixture.kt
@@ -96,7 +96,6 @@ internal class GlJsMapFixture(private val extent: MapExtent) : MapFixture {
       }
     }
     glJsSession.reconcileStyleRevision(DesiredStyleRevision.Empty)
-    state.updateLoadedStyle(glJsSession, recorder.style)
     state.markStyleReady(glJsSession)
   }
 

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/testing/GlJsMapFixture.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/testing/GlJsMapFixture.kt
@@ -75,6 +75,7 @@ internal class GlJsMapFixture(private val extent: MapExtent) : MapFixture {
     )
     state.publishPresentation(token, glJsSession)
     recorder.attachment = requireNotNull(state.currentMapAttachment)
+    recorder.state = state
   }
 
   private fun frame(): Boolean {

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/testing/GlJsMapFixture.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/testing/GlJsMapFixture.kt
@@ -20,6 +20,7 @@ import org.maplibre.compose.logging.MapLog
 import org.maplibre.compose.map.GestureTarget
 import org.maplibre.compose.map.GlJsMapSession
 import org.maplibre.compose.map.MapAdapter
+import org.maplibre.compose.map.MapEvent
 import org.maplibre.compose.map.MapExtent
 import org.maplibre.compose.map.mapRuntimeForTest
 import org.maplibre.compose.style.BaseStyle
@@ -50,6 +51,9 @@ internal class GlJsMapFixture(private val extent: MapExtent) : MapFixture {
 
   override val events: MutableList<String>
     get() = recorder.events
+
+  override val engineEvents: MutableList<MapEvent>
+    get() = recorder.engineEvents
 
   override val sourceChanges: MutableList<String?>
     get() = recorder.sourceChanges

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/map/DesktopMapView.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/map/DesktopMapView.kt
@@ -28,6 +28,7 @@ internal actual fun ComposableMapView(
   onReset: () -> Unit,
   logger: MapLog?,
   callbacks: MapAdapter.Callbacks,
+  clicks: MapClickTarget,
   options: MapViewOptions,
 ) {
   val hostFactory =
@@ -46,6 +47,7 @@ internal actual fun ComposableMapView(
     onReset = onReset,
     logger = logger,
     callbacks = callbacks,
+    clicks = clicks,
     options = options,
   )
 }

--- a/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/desktop/bridge/LinuxVulkanOpenGlInteropTest.kt
+++ b/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/desktop/bridge/LinuxVulkanOpenGlInteropTest.kt
@@ -67,6 +67,7 @@ import org.maplibre.compose.desktop.ComposeGpuContext
 import org.maplibre.compose.desktop.ComposeMapPresentationHost
 import org.maplibre.compose.desktop.OpenGlComposeGpuContext
 import org.maplibre.compose.map.MapAdapter
+import org.maplibre.compose.map.MapEvent
 import org.maplibre.compose.map.MapExtent
 import org.maplibre.compose.map.MlnFfiMapSession
 import org.maplibre.compose.map.mapRuntimeForTest
@@ -264,6 +265,8 @@ class LinuxVulkanOpenGlInteropTest {
         override fun onCameraMoveEnded(map: MapAdapter) {}
 
         override fun onFrame(fps: Double) {}
+
+        override fun onEvent(map: MapAdapter, event: MapEvent) {}
       }
 
     private val runtime = mapRuntimeForTest()

--- a/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/desktop/bridge/LinuxVulkanOpenGlInteropTest.kt
+++ b/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/desktop/bridge/LinuxVulkanOpenGlInteropTest.kt
@@ -249,13 +249,13 @@ class LinuxVulkanOpenGlInteropTest {
           if (style != null) styleLoads++
         }
 
-        override fun onMapFailLoading(map: MapAdapter, reason: String?) {
+        override fun onStyleReady(map: MapAdapter) {}
+
+        override fun onStyleFailed(map: MapAdapter, reason: String?) {
           failure = reason ?: "unknown map load failure"
         }
 
-        override fun onMapFinishedLoading(map: MapAdapter) {}
-
-        override fun onSourceChanged(map: MapAdapter, sourceId: String?) {}
+        override fun onStyleSourcesChanged(map: MapAdapter, sourceId: String?) {}
 
         override fun onEvent(map: MapAdapter, event: MapEvent) {}
 

--- a/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/desktop/bridge/LinuxVulkanOpenGlInteropTest.kt
+++ b/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/desktop/bridge/LinuxVulkanOpenGlInteropTest.kt
@@ -4,7 +4,6 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.asComposeCanvas
 import androidx.compose.ui.graphics.drawscope.CanvasDrawScope
 import androidx.compose.ui.unit.Density
-import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.LayoutDirection
 import java.lang.invoke.MethodHandles
 import java.nio.file.Files
@@ -82,7 +81,6 @@ import org.maplibre.compose.style.StyleBinding
 import org.maplibre.compose.testing.RgbaPixel
 import org.maplibre.nativeffi.Maplibre
 import org.maplibre.nativeffi.render.RenderBackend
-import org.maplibre.spatialk.geojson.Position
 
 class LinuxVulkanOpenGlInteropTest {
 
@@ -264,10 +262,6 @@ class LinuxVulkanOpenGlInteropTest {
         override fun onCameraMoved(map: MapAdapter) {}
 
         override fun onCameraMoveEnded(map: MapAdapter) {}
-
-        override fun onClick(map: MapAdapter, latLng: Position, offset: DpOffset) {}
-
-        override fun onLongClick(map: MapAdapter, latLng: Position, offset: DpOffset) {}
 
         override fun onFrame(fps: Double) {}
       }

--- a/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/desktop/bridge/LinuxVulkanOpenGlInteropTest.kt
+++ b/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/desktop/bridge/LinuxVulkanOpenGlInteropTest.kt
@@ -62,7 +62,6 @@ import org.lwjgl.system.MemoryUtil.memGetAddress
 import org.lwjgl.system.MemoryUtil.memPutAddress
 import org.lwjgl.system.Pointer.POINTER_SIZE
 import org.lwjgl.system.libffi.LibFFI.ffi_type_pointer
-import org.maplibre.compose.camera.CameraMoveReason
 import org.maplibre.compose.desktop.ComposeGpuContext
 import org.maplibre.compose.desktop.ComposeMapPresentationHost
 import org.maplibre.compose.desktop.OpenGlComposeGpuContext
@@ -258,15 +257,13 @@ class LinuxVulkanOpenGlInteropTest {
 
         override fun onSourceChanged(map: MapAdapter, sourceId: String?) {}
 
-        override fun onCameraMoveStarted(map: MapAdapter, reason: CameraMoveReason) {}
-
-        override fun onCameraMoved(map: MapAdapter) {}
-
-        override fun onCameraMoveEnded(map: MapAdapter) {}
-
         override fun onFrame(fps: Double) {}
 
         override fun onEvent(map: MapAdapter, event: MapEvent) {}
+
+        override fun onGestureActive(map: MapAdapter, active: Boolean) {}
+
+        override fun onViewportChanged(map: MapAdapter) {}
       }
 
     private val runtime = mapRuntimeForTest()

--- a/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/desktop/bridge/LinuxVulkanOpenGlInteropTest.kt
+++ b/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/desktop/bridge/LinuxVulkanOpenGlInteropTest.kt
@@ -13,6 +13,7 @@ import kotlin.test.assertIs
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.TimeSource
+import kotlinx.coroutines.Deferred
 import kotlinx.io.files.Path
 import org.jetbrains.skia.Bitmap
 import org.jetbrains.skia.ColorAlphaType
@@ -258,6 +259,8 @@ class LinuxVulkanOpenGlInteropTest {
         override fun onStyleSourcesChanged(map: MapAdapter, sourceId: String?) {}
 
         override fun onEvent(map: MapAdapter, event: MapEvent) {}
+
+        override fun resolveMissingImage(map: MapAdapter, imageId: String): Deferred<Unit>? = null
 
         override fun onGestureActive(map: MapAdapter, active: Boolean) {}
 

--- a/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/desktop/bridge/LinuxVulkanOpenGlInteropTest.kt
+++ b/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/desktop/bridge/LinuxVulkanOpenGlInteropTest.kt
@@ -257,8 +257,6 @@ class LinuxVulkanOpenGlInteropTest {
 
         override fun onSourceChanged(map: MapAdapter, sourceId: String?) {}
 
-        override fun onFrame(fps: Double) {}
-
         override fun onEvent(map: MapAdapter, event: MapEvent) {}
 
         override fun onGestureActive(map: MapAdapter, active: Boolean) {}

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/EngineEventTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/EngineEventTest.kt
@@ -8,6 +8,8 @@ import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
 import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.style.BaseStyle
+import org.maplibre.compose.testing.MISSING_ICON_ID
+import org.maplibre.compose.testing.MISSING_ICON_STYLE
 import org.maplibre.compose.testing.MapLibreFlavor
 import org.maplibre.compose.testing.MapTestResult
 import org.maplibre.compose.testing.createMapFixture
@@ -105,35 +107,6 @@ class EngineEventTest {
         MapLibreFlavor.GL_JS -> "/missing-maplibre-compose-style.json"
         MapLibreFlavor.NATIVE -> "https://example.invalid/style.json"
       }
-
-    const val MISSING_ICON_ID = "missing-icon"
-
-    val MISSING_ICON_STYLE =
-      """
-      {
-        "version": 8,
-        "name": "missing icon",
-        "sources": {
-          "points": {
-            "type": "geojson",
-            "data": {
-              "type": "Feature",
-              "geometry": { "type": "Point", "coordinates": [0, 0] },
-              "properties": {}
-            }
-          }
-        },
-        "layers": [
-          {
-            "id": "icons",
-            "type": "symbol",
-            "source": "points",
-            "layout": { "icon-image": "$MISSING_ICON_ID", "icon-allow-overlap": true }
-          }
-        ]
-      }
-      """
-        .trimIndent()
 
     val DESTINATION = CameraPosition(target = Position(10.0, 10.0), zoom = 4.0)
 

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/EngineEventTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/EngineEventTest.kt
@@ -1,0 +1,142 @@
+package org.maplibre.compose.map
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+import org.maplibre.compose.camera.CameraPosition
+import org.maplibre.compose.style.BaseStyle
+import org.maplibre.compose.testing.MapLibreFlavor
+import org.maplibre.compose.testing.MapTestResult
+import org.maplibre.compose.testing.createMapFixture
+import org.maplibre.compose.testing.mapLibreFlavor
+import org.maplibre.compose.testing.runMapTest
+import org.maplibre.spatialk.geojson.Position
+
+/** Both engines translate the events they emit into the same [MapEvent] catalog. */
+class EngineEventTest {
+
+  @Test
+  fun a_loaded_style_is_reported_once(): MapTestResult = runMapTest {
+    createMapFixture().use { fixture ->
+      fixture.loadStyle(BaseStyle.Empty)
+
+      assertEquals(1, fixture.engineEvents.count { it is MapEvent.StyleLoaded })
+    }
+  }
+
+  @Test
+  fun an_unreachable_style_reports_a_failure_with_a_reason(): MapTestResult = runMapTest {
+    createMapFixture().use { fixture ->
+      fixture.session.setBaseStyle(BaseStyle.Uri(UNREACHABLE_STYLE_URI))
+      fixture.pumpUntil("the style load to fail") {
+        fixture.engineEvents.any { it is MapEvent.StyleLoadFailed }
+      }
+
+      val failures = fixture.engineEvents.filterIsInstance<MapEvent.StyleLoadFailed>()
+      assertEquals(1, failures.size)
+      assertTrue(failures.single().reason.isNotBlank())
+    }
+  }
+
+  @Test
+  fun a_rendered_map_reports_frames_and_an_idle(): MapTestResult = runMapTest {
+    createMapFixture().use { fixture ->
+      fixture.loadStyle(BaseStyle.Empty)
+      fixture.awaitMapReady()
+      fixture.settle()
+
+      val frames = fixture.engineEvents.filterIsInstance<MapEvent.FrameRendered>()
+      assertTrue(frames.isNotEmpty(), "no frame was reported")
+      when (mapLibreFlavor) {
+        MapLibreFlavor.NATIVE -> assertNotNull(frames.first().stats)
+        MapLibreFlavor.GL_JS -> assertNull(frames.first().stats)
+      }
+      assertTrue(fixture.engineEvents.any { it is MapEvent.Idle }, "no idle was reported")
+    }
+  }
+
+  @Test
+  fun an_animated_camera_reports_a_complete_move(): MapTestResult = runMapTest {
+    createMapFixture().use { fixture ->
+      fixture.loadStyle(BaseStyle.Empty)
+      fixture.awaitMapReady()
+      fixture.settle()
+      fixture.engineEvents.clear()
+
+      fixture.awaitWhileRendering("the camera animation to finish") {
+        fixture.session.animateCameraPosition(DESTINATION, ANIMATION_DURATION)
+      }
+
+      val started = fixture.engineEvents.indexOfFirst { it is MapEvent.CameraMoveStarted }
+      val ended = fixture.engineEvents.indexOfLast { it is MapEvent.CameraMoveEnded }
+      assertTrue(started >= 0, "no camera move started: ${fixture.engineEvents}")
+      assertTrue(ended > started, "no camera move ended after it started: ${fixture.engineEvents}")
+      assertTrue(
+        fixture.engineEvents.subList(started, ended).any { it is MapEvent.CameraMoved },
+        "the move reported no progress: ${fixture.engineEvents}",
+      )
+
+      val animated = (fixture.engineEvents[started] as MapEvent.CameraMoveStarted).animated
+      when (mapLibreFlavor) {
+        MapLibreFlavor.NATIVE -> assertEquals(true, animated)
+        MapLibreFlavor.GL_JS -> assertNull(animated)
+      }
+    }
+  }
+
+  @Test
+  fun a_missing_icon_is_reported_with_its_id(): MapTestResult = runMapTest {
+    createMapFixture().use { fixture ->
+      fixture.loadStyle(BaseStyle.Json(MISSING_ICON_STYLE))
+
+      fixture.pumpUntil("the missing icon to be reported", timeout = 20.seconds) {
+        MapEvent.StyleImageMissing(MISSING_ICON_ID) in fixture.engineEvents
+      }
+    }
+  }
+
+  private companion object {
+    val UNREACHABLE_STYLE_URI: String =
+      when (mapLibreFlavor) {
+        // The browser resolves a relative path against the Karma server, which answers 404.
+        MapLibreFlavor.GL_JS -> "/missing-maplibre-compose-style.json"
+        MapLibreFlavor.NATIVE -> "https://example.invalid/style.json"
+      }
+
+    const val MISSING_ICON_ID = "missing-icon"
+
+    val MISSING_ICON_STYLE =
+      """
+      {
+        "version": 8,
+        "name": "missing icon",
+        "sources": {
+          "points": {
+            "type": "geojson",
+            "data": {
+              "type": "Feature",
+              "geometry": { "type": "Point", "coordinates": [0, 0] },
+              "properties": {}
+            }
+          }
+        },
+        "layers": [
+          {
+            "id": "icons",
+            "type": "symbol",
+            "source": "points",
+            "layout": { "icon-image": "$MISSING_ICON_ID", "icon-allow-overlap": true }
+          }
+        ]
+      }
+      """
+        .trimIndent()
+
+    val DESTINATION = CameraPosition(target = Position(10.0, 10.0), zoom = 4.0)
+
+    val ANIMATION_DURATION = 1.seconds
+  }
+}

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/EngineEventTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/EngineEventTest.kt
@@ -8,8 +8,6 @@ import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
 import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.style.BaseStyle
-import org.maplibre.compose.testing.MISSING_ICON_ID
-import org.maplibre.compose.testing.MISSING_ICON_STYLE
 import org.maplibre.compose.testing.MapLibreFlavor
 import org.maplibre.compose.testing.MapTestResult
 import org.maplibre.compose.testing.createMapFixture
@@ -85,17 +83,6 @@ class EngineEventTest {
       when (mapLibreFlavor) {
         MapLibreFlavor.NATIVE -> assertEquals(true, animated)
         MapLibreFlavor.GL_JS -> assertNull(animated)
-      }
-    }
-  }
-
-  @Test
-  fun a_missing_icon_is_reported_with_its_id(): MapTestResult = runMapTest {
-    createMapFixture().use { fixture ->
-      fixture.loadStyle(BaseStyle.Json(MISSING_ICON_STYLE))
-
-      fixture.pumpUntil("the missing icon to be reported", timeout = 20.seconds) {
-        MapEvent.StyleImageMissing(MISSING_ICON_ID) in fixture.engineEvents
       }
     }
   }

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/MapStateEventsTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/MapStateEventsTest.kt
@@ -1,18 +1,12 @@
 package org.maplibre.compose.map
 
-import androidx.compose.ui.graphics.ImageBitmap
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertTrue
-import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.first
 import org.maplibre.compose.style.BaseStyle
-import org.maplibre.compose.testing.MISSING_ICON_ID
-import org.maplibre.compose.testing.MISSING_ICON_STYLE
 import org.maplibre.compose.testing.MapTestResult
 import org.maplibre.compose.testing.createMapFixture
 import org.maplibre.compose.testing.runMapTest
@@ -25,41 +19,21 @@ class MapStateEventsTest {
     createMapFixture().use { fixture ->
       fixture.awaitWhileRendering("the style load and a frame to be published") {
         coroutineScope {
-          // Subscribed before the style is set, because the flow replays nothing.
+          // Both subscribe before the style is set, because the flow replays nothing and the map
+          // stops asking for frames once it has drawn the loaded style.
           val styleLoaded =
             async(start = CoroutineStart.UNDISPATCHED) {
               fixture.state.events.first { it is MapEvent.StyleLoaded }
             }
+          val frameRendered =
+            async(start = CoroutineStart.UNDISPATCHED) {
+              fixture.state.events.first { it is MapEvent.FrameRendered }
+            }
           fixture.session.setBaseStyle(BaseStyle.Empty)
 
           assertEquals(MapEvent.StyleLoaded, styleLoaded.await())
-          fixture.state.events.first { it is MapEvent.FrameRendered }
+          frameRendered.await()
         }
-      }
-    }
-  }
-
-  /** The recipe the documentation publishes for a style that references a missing icon. */
-  @Test
-  fun an_image_added_for_a_published_miss_reaches_the_style(): MapTestResult = runMapTest {
-    createMapFixture().use { fixture ->
-      coroutineScope {
-        // Subscribed before the style is set, because the flow replays nothing.
-        val missing =
-          async(start = CoroutineStart.UNDISPATCHED) {
-            fixture.state.events.filterIsInstance<MapEvent.StyleImageMissing>().first()
-          }
-        fixture.loadStyle(BaseStyle.Json(MISSING_ICON_STYLE))
-        fixture.pumpUntil("the missing icon to be published", timeout = 20.seconds) {
-          missing.isCompleted
-        }
-
-        val imageId = missing.await().imageId
-        assertEquals(MISSING_ICON_ID, imageId)
-        fixture.state.style.images.add(imageId, ImageBitmap(1, 1))
-        fixture.settle()
-
-        assertTrue(fixture.state.style.images.remove(imageId))
       }
     }
   }

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/MapStateEventsTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/MapStateEventsTest.kt
@@ -1,0 +1,66 @@
+package org.maplibre.compose.map
+
+import androidx.compose.ui.graphics.ImageBitmap
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.first
+import org.maplibre.compose.style.BaseStyle
+import org.maplibre.compose.testing.MISSING_ICON_ID
+import org.maplibre.compose.testing.MISSING_ICON_STYLE
+import org.maplibre.compose.testing.MapTestResult
+import org.maplibre.compose.testing.createMapFixture
+import org.maplibre.compose.testing.runMapTest
+
+/** [MapState.events] publishes the events that both engines report. */
+class MapStateEventsTest {
+
+  @Test
+  fun a_loaded_rendering_map_publishes_a_style_load_and_a_frame(): MapTestResult = runMapTest {
+    createMapFixture().use { fixture ->
+      fixture.awaitWhileRendering("the style load and a frame to be published") {
+        coroutineScope {
+          // Subscribed before the style is set, because the flow replays nothing.
+          val styleLoaded =
+            async(start = CoroutineStart.UNDISPATCHED) {
+              fixture.state.events.first { it is MapEvent.StyleLoaded }
+            }
+          fixture.session.setBaseStyle(BaseStyle.Empty)
+
+          assertEquals(MapEvent.StyleLoaded, styleLoaded.await())
+          fixture.state.events.first { it is MapEvent.FrameRendered }
+        }
+      }
+    }
+  }
+
+  /** The recipe the documentation publishes for a style that references a missing icon. */
+  @Test
+  fun an_image_added_for_a_published_miss_reaches_the_style(): MapTestResult = runMapTest {
+    createMapFixture().use { fixture ->
+      coroutineScope {
+        // Subscribed before the style is set, because the flow replays nothing.
+        val missing =
+          async(start = CoroutineStart.UNDISPATCHED) {
+            fixture.state.events.filterIsInstance<MapEvent.StyleImageMissing>().first()
+          }
+        fixture.loadStyle(BaseStyle.Json(MISSING_ICON_STYLE))
+        fixture.pumpUntil("the missing icon to be published", timeout = 20.seconds) {
+          missing.isCompleted
+        }
+
+        val imageId = missing.await().imageId
+        assertEquals(MISSING_ICON_ID, imageId)
+        fixture.state.style.images.add(imageId, ImageBitmap(1, 1))
+        fixture.settle()
+
+        assertTrue(fixture.state.style.images.remove(imageId))
+      }
+    }
+  }
+}

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/MissingImageResolverTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/MissingImageResolverTest.kt
@@ -1,0 +1,119 @@
+package org.maplibre.compose.map
+
+import androidx.compose.ui.graphics.ImageBitmap
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CompletableDeferred
+import org.maplibre.compose.camera.CameraPosition
+import org.maplibre.compose.style.BaseStyle
+import org.maplibre.compose.testing.MISSING_ICON_ID
+import org.maplibre.compose.testing.MapTestResult
+import org.maplibre.compose.testing.RecordingList
+import org.maplibre.compose.testing.createMapFixture
+import org.maplibre.compose.testing.missingIconStyle
+import org.maplibre.compose.testing.runMapTest
+import org.maplibre.spatialk.geojson.Position
+
+/** Both engines ask [MapState.missingImageResolver] for an image that the style draws and lacks. */
+class MissingImageResolverTest {
+
+  @Test
+  fun a_resolved_image_reaches_the_style(): MapTestResult = runMapTest {
+    createMapFixture().use { fixture ->
+      val requests = RecordingList<String>()
+      val firstRequest = CompletableDeferred<String>()
+      fixture.state.missingImageResolver = { id ->
+        requests += id
+        firstRequest.complete(id)
+        ResolvedStyleImage(ImageBitmap(1, 1))
+      }
+
+      fixture.loadStyle(BaseStyle.Json(missingIconStyle()))
+      fixture.pumpUntil("the missing icon to be requested", timeout = 20.seconds) {
+        firstRequest.isCompleted
+      }
+      assertEquals(MISSING_ICON_ID, firstRequest.await())
+      fixture.settle()
+
+      assertEquals(listOf(MISSING_ICON_ID), requests.toList(), "the resolver ran more than once")
+      assertTrue(
+        fixture.state.style.images.remove(MISSING_ICON_ID),
+        "the resolved image did not reach the style",
+      )
+    }
+  }
+
+  @Test
+  fun a_reloaded_style_asks_the_resolver_again(): MapTestResult = runMapTest {
+    createMapFixture().use { fixture ->
+      val requests = RecordingList<String>()
+      fixture.state.missingImageResolver = { id ->
+        requests += id
+        ResolvedStyleImage(ImageBitmap(1, 1))
+      }
+
+      fixture.loadStyle(BaseStyle.Json(missingIconStyle()))
+      fixture.pumpUntil("the missing icon to be requested", timeout = 20.seconds) {
+        requests.size == 1
+      }
+      fixture.settle()
+
+      // The name differs because the native fixture times out reloading identical style JSON.
+      fixture.loadStyle(BaseStyle.Json(missingIconStyle(name = "missing icon again")))
+      fixture.pumpUntil("the reloaded style to ask for the missing icon", timeout = 20.seconds) {
+        requests.size == 2
+      }
+      fixture.settle()
+
+      assertEquals(listOf(MISSING_ICON_ID, MISSING_ICON_ID), requests.toList())
+      assertTrue(
+        fixture.state.style.images.remove(MISSING_ICON_ID),
+        "the resolved image did not reach the reloaded style",
+      )
+    }
+  }
+
+  @Test
+  fun a_replacement_resolver_answers_an_id_the_first_declined(): MapTestResult = runMapTest {
+    createMapFixture().use { fixture ->
+      val declined = RecordingList<String>()
+      val supplied = RecordingList<String>()
+      fixture.state.missingImageResolver = { id ->
+        declined += id
+        null
+      }
+
+      fixture.loadStyle(BaseStyle.Json(missingIconStyle()))
+      fixture.pumpUntil("the missing icon to be declined", timeout = 20.seconds) {
+        declined.size == 1
+      }
+      fixture.settle()
+      assertFalse(
+        fixture.state.style.images.remove(MISSING_ICON_ID),
+        "a declined image reached the style",
+      )
+
+      fixture.state.missingImageResolver = { id ->
+        supplied += id
+        ResolvedStyleImage(ImageBitmap(1, 1))
+      }
+      // Each engine asks once per tile parse, so a new zoom is what puts the request in front of
+      // the replacement resolver.
+      fixture.state.setCameraPosition(CameraPosition(target = Position(0.0, 0.0), zoom = 4.0))
+      fixture.pumpUntil("the replacement resolver to be asked", timeout = 20.seconds) {
+        supplied.size == 1
+      }
+      fixture.settle()
+
+      assertEquals(listOf(MISSING_ICON_ID), supplied.toList())
+      assertEquals(listOf(MISSING_ICON_ID), declined.toList(), "the replaced resolver ran again")
+      assertTrue(
+        fixture.state.style.images.remove(MISSING_ICON_ID),
+        "the resolved image did not reach the style",
+      )
+    }
+  }
+}

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/testing/MapFixture.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/testing/MapFixture.kt
@@ -168,10 +168,6 @@ internal class RecordingMapCallbacks(
     errors += "mapFailLoading: $reason"
   }
 
-  override fun onFrame(fps: Double) {
-    attachment?.let { it.updateViewport(it.adapter.getViewport()) }
-  }
-
   override fun onEvent(map: MapAdapter, event: MapEvent) {
     engineEvents += event
     state?.onEvent(map, event)

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/testing/MapFixture.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/testing/MapFixture.kt
@@ -5,6 +5,7 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.TimeSource
+import kotlinx.coroutines.Deferred
 import org.maplibre.compose.map.GestureTarget
 import org.maplibre.compose.map.MapAdapter
 import org.maplibre.compose.map.MapAttachment
@@ -152,6 +153,9 @@ internal class RecordingMapCallbacks(
   override fun onStyleChanged(map: MapAdapter, style: StyleBinding?) {
     beforeStyleChanged(map, style)
     this.style = style
+    // The state learns of the binding here, as it does in composition, so that work the engine
+    // starts on a freshly loaded style reaches it.
+    state?.updateLoadedStyle(map, style)
     attachment?.updateViewport(map.getViewport())
     events += if (style == null) "styleChanged(null)" else MapFixture.STYLE_LOADED
   }
@@ -172,6 +176,9 @@ internal class RecordingMapCallbacks(
     engineEvents += event
     state?.onEvent(map, event)
   }
+
+  override fun resolveMissingImage(map: MapAdapter, imageId: String): Deferred<Unit>? =
+    state?.resolveMissingImage(map, imageId)
 
   override fun onGestureActive(map: MapAdapter, active: Boolean) {
     events += "gesture($active)"

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/testing/MapFixture.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/testing/MapFixture.kt
@@ -5,7 +5,6 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.TimeSource
-import org.maplibre.compose.camera.CameraMoveReason
 import org.maplibre.compose.map.GestureTarget
 import org.maplibre.compose.map.MapAdapter
 import org.maplibre.compose.map.MapAttachment
@@ -136,6 +135,9 @@ internal class RecordingMapCallbacks(
 
   var attachment: MapAttachment? = null
 
+  /** Set so the recorder exercises the real reactions rather than a copy of them. */
+  var state: MapState? = null
+
   val events: MutableList<String> = RecordingList()
 
   val engineEvents: MutableList<MapEvent> = RecordingList()
@@ -166,29 +168,22 @@ internal class RecordingMapCallbacks(
     errors += "mapFailLoading: $reason"
   }
 
-  override fun onCameraMoveStarted(map: MapAdapter, reason: CameraMoveReason) {
-    attachment?.cameraMoveStarted(reason)
-    events += "cameraMoveStarted($reason)"
-  }
-
-  override fun onCameraMoved(map: MapAdapter) {
-    attachment?.cameraMoved(map.getViewport())
-    events += "cameraMoved"
-  }
-
-  override fun onCameraMoveEnded(map: MapAdapter) {
-    attachment?.let {
-      it.cameraMoved(map.getViewport())
-      it.cameraMoveEnded()
-    }
-    events += "cameraMoveEnded"
-  }
-
   override fun onFrame(fps: Double) {
-    attachment?.let { it.cameraMoved(it.adapter.getViewport()) }
+    attachment?.let { it.updateViewport(it.adapter.getViewport()) }
   }
 
   override fun onEvent(map: MapAdapter, event: MapEvent) {
     engineEvents += event
+    state?.onEvent(map, event)
+  }
+
+  override fun onGestureActive(map: MapAdapter, active: Boolean) {
+    events += "gesture($active)"
+    state?.setGestureActive(map, active)
+  }
+
+  override fun onViewportChanged(map: MapAdapter) {
+    events += "viewportChanged"
+    state?.synchronizeCamera(map)
   }
 }

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/testing/MapFixture.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/testing/MapFixture.kt
@@ -1,6 +1,5 @@
 package org.maplibre.compose.testing
 
-import androidx.compose.ui.unit.DpOffset
 import kotlin.math.abs
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
@@ -14,7 +13,6 @@ import org.maplibre.compose.map.MapExtent
 import org.maplibre.compose.map.MapState
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.compose.style.StyleBinding
-import org.maplibre.spatialk.geojson.Position
 
 /**
  * A real map session on whichever MapLibre this platform uses, driven frame by frame by the test.
@@ -178,14 +176,6 @@ internal class RecordingMapCallbacks(
       it.cameraMoveEnded()
     }
     events += "cameraMoveEnded"
-  }
-
-  override fun onClick(map: MapAdapter, latLng: Position, offset: DpOffset) {
-    events += "click"
-  }
-
-  override fun onLongClick(map: MapAdapter, latLng: Position, offset: DpOffset) {
-    events += "longClick"
   }
 
   override fun onFrame(fps: Double) {

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/testing/MapFixture.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/testing/MapFixture.kt
@@ -77,7 +77,7 @@ internal interface MapFixture : AutoCloseable {
   companion object {
     const val STYLE_LOADED: String = "styleLoaded"
 
-    const val LOAD_FINISHED: String = "mapFinishedLoading"
+    const val STYLE_READY: String = "styleReady"
 
     /** Big enough for tiles to be selected at zoom 0 and for a query to have something to hit. */
     val DEFAULT_EXTENT: MapExtent =
@@ -156,16 +156,16 @@ internal class RecordingMapCallbacks(
     events += if (style == null) "styleChanged(null)" else MapFixture.STYLE_LOADED
   }
 
-  override fun onMapFinishedLoading(map: MapAdapter) {
-    events += MapFixture.LOAD_FINISHED
+  override fun onStyleReady(map: MapAdapter) {
+    events += MapFixture.STYLE_READY
   }
 
-  override fun onSourceChanged(map: MapAdapter, sourceId: String?) {
+  override fun onStyleFailed(map: MapAdapter, reason: String?) {
+    errors += "styleFailed: $reason"
+  }
+
+  override fun onStyleSourcesChanged(map: MapAdapter, sourceId: String?) {
     sourceChanges += sourceId
-  }
-
-  override fun onMapFailLoading(map: MapAdapter, reason: String?) {
-    errors += "mapFailLoading: $reason"
   }
 
   override fun onEvent(map: MapAdapter, event: MapEvent) {

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/testing/MapFixture.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/testing/MapFixture.kt
@@ -9,6 +9,7 @@ import org.maplibre.compose.camera.CameraMoveReason
 import org.maplibre.compose.map.GestureTarget
 import org.maplibre.compose.map.MapAdapter
 import org.maplibre.compose.map.MapAttachment
+import org.maplibre.compose.map.MapEvent
 import org.maplibre.compose.map.MapExtent
 import org.maplibre.compose.map.MapState
 import org.maplibre.compose.style.BaseStyle
@@ -30,6 +31,9 @@ internal interface MapFixture : AutoCloseable {
   val style: StyleBinding?
 
   val events: MutableList<String>
+
+  /** Every [MapEvent] the session posted through the adapter callbacks. */
+  val engineEvents: MutableList<MapEvent>
 
   val sourceChanges: MutableList<String?>
 
@@ -134,6 +138,8 @@ internal class RecordingMapCallbacks(
 
   val events: MutableList<String> = RecordingList()
 
+  val engineEvents: MutableList<MapEvent> = RecordingList()
+
   val sourceChanges: MutableList<String?> = RecordingList()
 
   val errors: MutableList<String> = RecordingList()
@@ -180,5 +186,9 @@ internal class RecordingMapCallbacks(
 
   override fun onFrame(fps: Double) {
     attachment?.let { it.cameraMoved(it.adapter.getViewport()) }
+  }
+
+  override fun onEvent(map: MapAdapter, event: MapEvent) {
+    engineEvents += event
   }
 }

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/testing/TestStyles.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/testing/TestStyles.kt
@@ -1,0 +1,32 @@
+package org.maplibre.compose.testing
+
+/** The icon ID that [MISSING_ICON_STYLE] draws and no sprite supplies. */
+internal const val MISSING_ICON_ID: String = "missing-icon"
+
+/** A style whose one symbol layer draws [MISSING_ICON_ID] at one point. */
+internal val MISSING_ICON_STYLE: String =
+  """
+  {
+    "version": 8,
+    "name": "missing icon",
+    "sources": {
+      "points": {
+        "type": "geojson",
+        "data": {
+          "type": "Feature",
+          "geometry": { "type": "Point", "coordinates": [0, 0] },
+          "properties": {}
+        }
+      }
+    },
+    "layers": [
+      {
+        "id": "icons",
+        "type": "symbol",
+        "source": "points",
+        "layout": { "icon-image": "$MISSING_ICON_ID", "icon-allow-overlap": true }
+      }
+    ]
+  }
+  """
+    .trimIndent()

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/testing/TestStyles.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/testing/TestStyles.kt
@@ -1,14 +1,19 @@
 package org.maplibre.compose.testing
 
-/** The icon ID that [MISSING_ICON_STYLE] draws and no sprite supplies. */
+/** The icon ID that [missingIconStyle] draws and no sprite supplies. */
 internal const val MISSING_ICON_ID: String = "missing-icon"
 
-/** A style whose one symbol layer draws [MISSING_ICON_ID] at one point. */
-internal val MISSING_ICON_STYLE: String =
+/**
+ * A style whose one symbol layer draws [MISSING_ICON_ID] at one point.
+ *
+ * [name] distinguishes one load from the next: the native fixture times out reloading identical
+ * style JSON.
+ */
+internal fun missingIconStyle(name: String = "missing icon"): String =
   """
   {
     "version": 8,
-    "name": "missing icon",
+    "name": "$name",
     "sources": {
       "points": {
         "type": "geojson",

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapEvents.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapEvents.kt
@@ -18,7 +18,6 @@ internal fun RuntimeEvent.toMapEvent(): MapEvent? =
     RuntimeEventType.MAP_CAMERA_DID_CHANGE -> MapEvent.CameraMoveEnded(isAnimatedChange())
     RuntimeEventType.MAP_RENDER_FRAME_FINISHED ->
       MapEvent.FrameRendered((payload as? RuntimeEventPayload.RenderFrame)?.toRenderStats())
-    RuntimeEventType.MAP_STYLE_IMAGE_MISSING -> MapEvent.StyleImageMissing(message)
     else -> null
   }
 

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapEvents.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapEvents.kt
@@ -1,0 +1,50 @@
+package org.maplibre.compose.map
+
+import kotlin.time.Duration.Companion.seconds
+import org.maplibre.nativeffi.render.RenderMode
+import org.maplibre.nativeffi.runtime.CameraChangeMode
+import org.maplibre.nativeffi.runtime.RuntimeEvent
+import org.maplibre.nativeffi.runtime.RuntimeEventPayload
+import org.maplibre.nativeffi.runtime.RuntimeEventType
+
+/** Null for an event type that has no counterpart in the common catalog. */
+internal fun RuntimeEvent.toMapEvent(): MapEvent? =
+  when (type) {
+    RuntimeEventType.MAP_STYLE_LOADED -> MapEvent.StyleLoaded
+    RuntimeEventType.MAP_LOADING_FAILED -> MapEvent.StyleLoadFailed(styleLoadFailureReason())
+    RuntimeEventType.MAP_IDLE -> MapEvent.Idle
+    RuntimeEventType.MAP_CAMERA_WILL_CHANGE -> MapEvent.CameraMoveStarted(isAnimatedChange())
+    RuntimeEventType.MAP_CAMERA_IS_CHANGING -> MapEvent.CameraMoved
+    RuntimeEventType.MAP_CAMERA_DID_CHANGE -> MapEvent.CameraMoveEnded(isAnimatedChange())
+    RuntimeEventType.MAP_RENDER_FRAME_FINISHED ->
+      MapEvent.FrameRendered((payload as? RuntimeEventPayload.RenderFrame)?.toRenderStats())
+    RuntimeEventType.MAP_STYLE_IMAGE_MISSING -> MapEvent.StyleImageMissing(message)
+    else -> null
+  }
+
+/** The engine's failure text, or a stated reason when the engine reports none. */
+internal fun RuntimeEvent.styleLoadFailureReason(): String = message.ifBlank {
+  "MapLibre failed to load the map"
+}
+
+private fun RuntimeEvent.isAnimatedChange(): Boolean =
+  CameraChangeMode(code) == CameraChangeMode.ANIMATED
+
+private fun RuntimeEventPayload.RenderFrame.toRenderStats(): RenderStats =
+  RenderStats(
+    mode = mode.toRenderStatsMode(),
+    needsRepaint = needsRepaint,
+    placementChanged = placementChanged,
+    encodingTime = stats.encodingTime.seconds,
+    renderingTime = stats.renderingTime.seconds,
+    frameCount = stats.frameCount,
+    drawCallCount = stats.drawCallCount,
+    totalDrawCallCount = stats.totalDrawCallCount,
+  )
+
+private fun RenderMode.toRenderStatsMode(): RenderStats.Mode? =
+  when (this) {
+    RenderMode.PARTIAL -> RenderStats.Mode.Partial
+    RenderMode.FULL -> RenderStats.Mode.Full
+    else -> null
+  }

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -1909,31 +1909,6 @@ internal class MlnFfiMapSession(
     }
   }
 
-  override fun onPrimaryClick(offset: DpOffset) {
-    if (!lifecycle.acceptsWork) return
-    val position = withSnapshotProjection { it.latLngForPixel(offset.toScreenPoint()).toPosition() }
-    if (position == null) {
-      logger?.w { "Dropped a map click at $offset: the map has no viewport" }
-      return
-    }
-    withLifecyclePresentation { engine, lease ->
-      lifecycleCallbacks.onClick(engine, lease, this, position, offset)
-    }
-  }
-
-  /** A mouse has no press-and-hold convention, so the secondary button is the long press. */
-  override fun onSecondaryClick(offset: DpOffset) {
-    if (!lifecycle.acceptsWork) return
-    val position = withSnapshotProjection { it.latLngForPixel(offset.toScreenPoint()).toPosition() }
-    if (position == null) {
-      logger?.w { "Dropped a map long click at $offset: the map has no viewport" }
-      return
-    }
-    withLifecyclePresentation { engine, lease ->
-      lifecycleCallbacks.onLongClick(engine, lease, this, position, offset)
-    }
-  }
-
   private inline fun withLifecycleStyle(action: (EngineMapIdentity, StyleIdentity) -> Unit) {
     val engine = lifecycleEngineIdentity ?: return
     val style = lifecycleStyleIdentity ?: return

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -29,7 +29,6 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.io.files.Path
 import kotlinx.serialization.json.JsonObject
-import org.maplibre.compose.camera.CameraMoveReason
 import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.camera.Viewport
 import org.maplibre.compose.expressions.ast.CompiledExpression
@@ -247,12 +246,9 @@ internal class MlnFfiMapSession(
   private var appliedStyleRequest: StyleRequestId? = null
 
   /** Gesture attribution is owner-thread state; input threads communicate only through tokens. */
-  private var isGestureInProgress = false
   private val nextGestureToken = AtomicLong(0L)
   private var activeGestureToken: GestureToken? = null
   private var pendingGestureEndToken: GestureToken? = null
-
-  private var reportedMoveReason: CameraMoveReason? = null
 
   @Volatile private var styleBinding: MlnFfiStyleBinding? = null
   private val styleReconciler = StyleReconciler()
@@ -438,11 +434,7 @@ internal class MlnFfiMapSession(
   }
 
   override fun close() {
-    try {
-      endCameraMove()
-    } finally {
-      lifecycle.close()
-    }
+    lifecycle.close()
   }
 
   override suspend fun awaitClosed() {
@@ -582,7 +574,6 @@ internal class MlnFfiMapSession(
       stopping?.close()
     } finally {
       // After the join, so the owner thread is gone and this is the only reader of that state.
-      isGestureInProgress = false
       activeGestureToken = null
       pendingGestureEndToken = null
       resumeStrandedTransitions()
@@ -890,33 +881,12 @@ internal class MlnFfiMapSession(
         }
       }
 
-      RuntimeEventType.MAP_CAMERA_WILL_CHANGE -> {
-        beginCameraMove(engine, lease)
-        postPresentationEvent(engine, lease, mapEvent)
-      }
-
-      RuntimeEventType.MAP_CAMERA_IS_CHANGING -> {
-        lease?.let {
-          lifecycleCallbacks.onCameraMoved(engine, it, this) {
-            loop?.map?.let(::snapshotViewport)
-          }
-        }
-        postPresentationEvent(engine, lease, mapEvent)
-      }
-
-      RuntimeEventType.MAP_CAMERA_DID_CHANGE -> {
-        lease?.let {
-          if (
-            lifecycleCallbacks.onCameraMoved(engine, it, this) {
-              loop?.map?.let(::snapshotViewport)
-            }
-          ) {
-            // A drag is a stream of jumps, each with its own did-change.
-            if (!isGestureInProgress) endCameraMove(engine, lease)
-          }
-        }
-        postPresentationEvent(engine, lease, mapEvent)
-      }
+      // MapState reads the camera and viewport on each of the three, so the mirror the getters
+      // read is refreshed before the event is delivered.
+      RuntimeEventType.MAP_CAMERA_WILL_CHANGE,
+      RuntimeEventType.MAP_CAMERA_IS_CHANGING,
+      RuntimeEventType.MAP_CAMERA_DID_CHANGE ->
+        postPresentationEvent(engine, lease, mapEvent) { loop?.map?.let(::snapshotViewport) }
 
       RuntimeEventType.MAP_CAMERA_TRANSITION_FINISHED -> {
         val payload = event.payload
@@ -961,9 +931,10 @@ internal class MlnFfiMapSession(
     engine: EngineMapIdentity,
     lease: RenderLease?,
     event: MapEvent?,
+    beforeDelegate: () -> Unit = {},
   ) {
     if (lease == null || event == null) return
-    lifecycleCallbacks.onEvent(engine, lease, this, event)
+    lifecycleCallbacks.onEvent(engine, lease, this, event, beforeDelegate)
   }
 
   private fun postStyleEvent(engine: EngineMapIdentity, style: StyleIdentity, event: MapEvent?) {
@@ -978,34 +949,6 @@ internal class MlnFfiMapSession(
   ) {
     if (event == null) return
     lifecycleCallbacks.onEvent(engine, request, this, event)
-  }
-
-  /**
-   * The reason is re-reported when it changes: the gesture flag is set from the UI thread and can
-   * arrive after a drag's first camera change.
-   */
-  private fun beginCameraMove(
-    engine: EngineMapIdentity? = lifecycleEngineIdentity,
-    lease: RenderLease? = lifecycleRenderLease,
-  ) {
-    val reason =
-      if (isGestureInProgress) CameraMoveReason.GESTURE else CameraMoveReason.PROGRAMMATIC
-    if (reportedMoveReason == reason) return
-    if (engine != null && lease != null) {
-      if (lifecycleCallbacks.onCameraMoveStarted(engine, lease, this, reason)) {
-        reportedMoveReason = reason
-      }
-    }
-  }
-
-  private fun endCameraMove(
-    engine: EngineMapIdentity? = lifecycleEngineIdentity,
-    lease: RenderLease? = lifecycleRenderLease,
-  ) {
-    if (reportedMoveReason == null) return
-    if (engine != null && lease != null) {
-      lifecycleCallbacks.onCameraMoveEnded(engine, lease, this) { reportedMoveReason = null }
-    }
   }
 
   /** Exists for tests. */
@@ -1327,7 +1270,7 @@ internal class MlnFfiMapSession(
     // itself so a dropped camera callback cannot leave MapState.viewport null.
     lifecycleAuthority.seedCurrentPresentationViewport(this)
     withLifecyclePresentation { engine, lease ->
-      lifecycleCallbacks.onCameraMoved(engine, lease, this)
+      lifecycleCallbacks.onViewportChanged(engine, lease, this)
     }
   }
 
@@ -1812,15 +1755,19 @@ internal class MlnFfiMapSession(
     loop?.post(action = { if (activeGestureToken == token) pendingGestureEndToken = token })
   }
 
-  /** Owner thread only. */
+  /**
+   * Owner thread only. Reports on every camera command, because a report made before the lease
+   * attaches is dropped.
+   */
   private fun activateGesture(map: MapHandle, token: GestureToken) {
     val active = activeGestureToken
     if (active != null && token.value < active.value) return
-    if (active == token) return
-    activeGestureToken = token
-    pendingGestureEndToken = null
-    isGestureInProgress = true
-    map.isGestureInProgress = true
+    if (active != token) {
+      activeGestureToken = token
+      pendingGestureEndToken = null
+      map.isGestureInProgress = true
+    }
+    reportGestureActive(true)
   }
 
   /** Runs once the runtime event queue is momentarily empty. Owner thread only. */
@@ -1829,9 +1776,18 @@ internal class MlnFfiMapSession(
     pendingGestureEndToken = null
     if (activeGestureToken != token) return
     activeGestureToken = null
-    isGestureInProgress = false
     map.isGestureInProgress = false
-    endCameraMove()
+    reportGestureActive(false)
+  }
+
+  /**
+   * Owner thread only, so the fact keeps program order with the camera events this thread drains.
+   * Reported from the UI thread instead, a gesture end would land before the queued move it ends.
+   */
+  private fun reportGestureActive(active: Boolean) {
+    val engine = lifecycleEngineIdentity ?: return
+    val lease = ownerThreadRenderLease ?: return
+    lifecycleCallbacks.onGestureActive(engine, lease, this, active)
   }
 
   private fun onEventsDrained(engine: EngineMapIdentity, map: MapHandle) {

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -136,6 +136,7 @@ private val HANDLED_MAP_EVENTS: RuntimeEventMask =
     RuntimeEventMask.MAP_CAMERA_DID_CHANGE +
     RuntimeEventMask.MAP_CAMERA_TRANSITION_FINISHED +
     RuntimeEventMask.MAP_RENDER_ERROR +
+    RuntimeEventMask.MAP_RENDER_FRAME_FINISHED +
     RuntimeEventMask.MAP_STYLE_IMAGE_MISSING
 
 /** The fraction of a capped frame interval a frame may arrive early and still be drawn. */
@@ -806,6 +807,7 @@ internal class MlnFfiMapSession(
   /** Runs on the map's owner thread, as do the callbacks it makes. */
   private fun handleEvent(engine: EngineMapIdentity, event: RuntimeEvent) {
     val lease = ownerThreadRenderLease
+    val mapEvent = event.toMapEvent()
     when (event.type) {
       RuntimeEventType.MAP_RENDER_UPDATE_AVAILABLE -> requestRender()
 
@@ -833,6 +835,7 @@ internal class MlnFfiMapSession(
           binding.invalidate()
           return
         }
+        postStyleEvent(engine, acceptedStyle, mapEvent)
         // A producer frame that started before this callback can still hold the previous style.
         // requestRepaint dirties mbgl so the next renderUpdate draws instead of returning
         // NO_UPDATE; requestRender lets that draw through the session skip gate.
@@ -853,13 +856,14 @@ internal class MlnFfiMapSession(
         } else {
           reportNewlyArrivedAttribution()
         }
+        postEngineEvent(engine, mapEvent)
       }
 
       RuntimeEventType.MAP_LOADING_FAILED -> {
         styleLoadPending = false
         // The only channel for a URL style's failure; a malformed inline style also throws from the
         // setter.
-        val reason = event.message.ifBlank { "MapLibre failed to load the map" }
+        val reason = event.styleLoadFailureReason()
         val request = appliedStyleRequest
         val accepted =
           request != null &&
@@ -878,6 +882,7 @@ internal class MlnFfiMapSession(
                 }
               ) {
                 logger?.e { "Map loading failed (code ${event.code}): $reason" }
+                postStyleRequestEvent(engine, it.request, mapEvent)
               }
             }
         } else {
@@ -885,7 +890,10 @@ internal class MlnFfiMapSession(
         }
       }
 
-      RuntimeEventType.MAP_CAMERA_WILL_CHANGE -> beginCameraMove(engine, lease)
+      RuntimeEventType.MAP_CAMERA_WILL_CHANGE -> {
+        beginCameraMove(engine, lease)
+        postPresentationEvent(engine, lease, mapEvent)
+      }
 
       RuntimeEventType.MAP_CAMERA_IS_CHANGING -> {
         lease?.let {
@@ -893,6 +901,7 @@ internal class MlnFfiMapSession(
             loop?.map?.let(::snapshotViewport)
           }
         }
+        postPresentationEvent(engine, lease, mapEvent)
       }
 
       RuntimeEventType.MAP_CAMERA_DID_CHANGE -> {
@@ -906,6 +915,7 @@ internal class MlnFfiMapSession(
             if (!isGestureInProgress) endCameraMove(engine, lease)
           }
         }
+        postPresentationEvent(engine, lease, mapEvent)
       }
 
       RuntimeEventType.MAP_CAMERA_TRANSITION_FINISHED -> {
@@ -927,17 +937,47 @@ internal class MlnFfiMapSession(
         }
       }
 
+      RuntimeEventType.MAP_RENDER_FRAME_FINISHED -> postPresentationEvent(engine, lease, mapEvent)
+
       RuntimeEventType.MAP_RENDER_ERROR ->
         logger?.e { "MapLibre render error: ${event.message.ifBlank { "unknown" }}" }
 
       RuntimeEventType.MAP_STYLE_IMAGE_MISSING ->
-        // Supplying the image would need a callback the common API does not have.
-        logger?.d { "Style image missing: ${event.message}" }
+        withLifecycleStyle { e, style -> postStyleEvent(e, style, mapEvent) }
 
       // Event types are value classes over Int, so an FFI upgrade can add one this build has never
       // seen. Types this session does not select are never queued.
       else -> logger?.d { "Unrecognized MapLibre event type ${event.type}" }
     }
+  }
+
+  /** These four post nothing for a null [event]: a type outside the common catalog. */
+  private fun postEngineEvent(engine: EngineMapIdentity, event: MapEvent?) {
+    if (event == null) return
+    lifecycleCallbacks.onEvent(engine, this, event)
+  }
+
+  private fun postPresentationEvent(
+    engine: EngineMapIdentity,
+    lease: RenderLease?,
+    event: MapEvent?,
+  ) {
+    if (lease == null || event == null) return
+    lifecycleCallbacks.onEvent(engine, lease, this, event)
+  }
+
+  private fun postStyleEvent(engine: EngineMapIdentity, style: StyleIdentity, event: MapEvent?) {
+    if (event == null) return
+    lifecycleCallbacks.onEvent(engine, style, this, event)
+  }
+
+  private fun postStyleRequestEvent(
+    engine: EngineMapIdentity,
+    request: StyleRequestIdentity,
+    event: MapEvent?,
+  ) {
+    if (event == null) return
+    lifecycleCallbacks.onEvent(engine, request, this, event)
   }
 
   /**

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -235,7 +235,10 @@ internal class MlnFfiMapSession(
 
   private val renderRequested = AtomicBoolean(true)
 
-  private var hasRenderedAFrame = false
+  /** Renderer-thread state, read by tests. */
+  @Volatile
+  internal var hasRenderedAFrame: Boolean = false
+    private set
 
   private var failureReported = false
 
@@ -327,9 +330,6 @@ internal class MlnFfiMapSession(
   private var tileLodOptions: TileLodOptions = TileLodOptions.Standard
   private var lastRenderTime = TimeSource.Monotonic.markNow()
 
-  private val frameTimer = TimeSource.Monotonic
-  private var lastFrameTime = frameTimer.markNow()
-
   // region host surface lifecycle
 
   override fun onSurfaceAvailable(session: MlnFfiMapHostSession) {
@@ -417,7 +417,6 @@ internal class MlnFfiMapSession(
       }
     }
     lastRenderTime = renderStart
-    reportFrameRate()
     return MlnFfiFrameResult.RENDERED
   }
 
@@ -977,17 +976,6 @@ internal class MlnFfiMapSession(
     val minimumInterval = 1.0 / fps
     val elapsed = (now - lastRenderTime).toDouble(DurationUnit.SECONDS)
     return elapsed >= minimumInterval * (1.0 - FRAME_INTERVAL_SLACK)
-  }
-
-  private fun reportFrameRate() {
-    val now = frameTimer.markNow()
-    val elapsed = (now - lastFrameTime).toDouble(DurationUnit.SECONDS)
-    lastFrameTime = now
-    if (elapsed > 0.0) {
-      withLifecyclePresentation { engine, lease ->
-        lifecycleCallbacks.onFrame(engine, lease, 1.0 / elapsed)
-      }
-    }
   }
 
   // endregion

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -911,8 +911,12 @@ internal class MlnFfiMapSession(
       RuntimeEventType.MAP_RENDER_ERROR ->
         logger?.e { "MapLibre render error: ${event.message.ifBlank { "unknown" }}" }
 
+      // mbgl re-checks its image set at the next placement after setStyleImage, so a resolution
+      // that finishes after this drain still reaches a later frame.
       RuntimeEventType.MAP_STYLE_IMAGE_MISSING ->
-        withLifecycleStyle { e, style -> postStyleEvent(e, style, mapEvent) }
+        withLifecycleStyle { e, style ->
+          lifecycleCallbacks.resolveMissingImage(e, style, this, event.message)
+        }
 
       // Event types are value classes over Int, so an FFI upgrade can add one this build has never
       // seen. Types this session does not select are never queued.

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -285,7 +285,7 @@ internal class MlnFfiMapSession(
           reportedUrlAttribution.add(id)
       ) {
         withLifecycleStyle { engine, style ->
-          lifecycleCallbacks.onSourceChanged(engine, style, this, id)
+          lifecycleCallbacks.onStyleSourcesChanged(engine, style, this, id)
         }
       }
     }
@@ -318,7 +318,7 @@ internal class MlnFfiMapSession(
         featureStateReplayPending.store(true)
         reportedUrlAttribution.remove(sourceId)
         withLifecycleStyle { engine, style ->
-          lifecycleCallbacks.onSourceChanged(engine, style, this, sourceId)
+          lifecycleCallbacks.onStyleSourcesChanged(engine, style, this, sourceId)
         }
       },
       getScale = ::imageScale,
@@ -786,7 +786,7 @@ internal class MlnFfiMapSession(
     val identity = styleBinding?.identity ?: return
     if (styleLoadTracker?.reconciled(request, identity) == true) {
       lifecycleStyleIdentity?.let {
-        if (lifecycleCallbacks.onMapFinishedLoading(engine, it, this)) {
+        if (lifecycleCallbacks.onStyleReady(engine, it, this)) {
           styleLoadUnreported = false
           hasPresentableStyle = true
         }
@@ -867,7 +867,7 @@ internal class MlnFfiMapSession(
             ?.takeIf { it.engine == engine }
             ?.let {
               if (
-                lifecycleCallbacks.onMapFailLoading(engine, it.request, this, reason) {
+                lifecycleCallbacks.onStyleFailed(engine, it.request, this, reason) {
                   hasPresentableStyle = false
                 }
               ) {

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapView.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapView.kt
@@ -43,6 +43,7 @@ internal fun MlnFfiMapView(
   onReset: () -> Unit,
   logger: MapLog?,
   callbacks: MapAdapter.Callbacks,
+  clicks: MapClickTarget,
   options: MapViewOptions,
 ) {
   val density = LocalDensity.current
@@ -71,6 +72,7 @@ internal fun MlnFfiMapView(
     onReset = onReset,
     logger = logger,
     callbacks = callbacks,
+    clicks = clicks,
     options = options,
   )
 }
@@ -87,6 +89,7 @@ internal fun MlnFfiMapView(
   onReset: () -> Unit,
   logger: MapLog?,
   callbacks: MapAdapter.Callbacks,
+  clicks: MapClickTarget,
   options: MapViewOptions,
 ) {
   val applicationOptions = state.runtime.nativeRuntimeOptions
@@ -167,7 +170,14 @@ internal fun MlnFfiMapView(
   // viewport and jump the camera.
   val inputModifier =
     if (revealSurface) {
-      modifier.mapInput(session, options.gestureOptions, density, focusRequester, continuation)
+      modifier.mapInput(
+        session,
+        clicks,
+        options.gestureOptions,
+        density,
+        focusRequester,
+        continuation,
+      )
     } else {
       modifier
     }

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapView.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapView.kt
@@ -149,7 +149,7 @@ internal fun MlnFfiMapView(
     } catch (error: CancellationException) {
       throw error
     } catch (error: Throwable) {
-      callbacks.onMapFailLoading(session, error.message)
+      callbacks.onStyleFailed(session, error.message)
     }
   }
 

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/MlnFfiGestureTokenOrderingTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/MlnFfiGestureTokenOrderingTest.kt
@@ -1,57 +1,71 @@
 package org.maplibre.compose.map
 
+import kotlin.math.abs
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
-import org.maplibre.compose.mlnffi.BridgeMapFixture
+import org.maplibre.compose.camera.CameraMoveReason
+import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.mlnffi.TestLatch
 import org.maplibre.compose.style.BaseStyle
+import org.maplibre.compose.testing.MapTestResult
+import org.maplibre.compose.testing.createMapFixture
+import org.maplibre.compose.testing.runMapTest
 
 /** The rest of the camera-move contract is in [CameraMoveReportingTest], on every platform. */
 class MlnFfiGestureTokenOrderingTest {
 
   @Test
-  fun a_backlogged_owner_thread_orders_newer_gesture_tokens_and_ignores_stale_ends() {
-    BridgeMapFixture.create().use { fixture ->
+  fun a_backlogged_owner_thread_orders_newer_gesture_tokens_and_ignores_stale_ends():
+    MapTestResult = runMapTest {
+    createMapFixture().use { fixture ->
+      val session = fixture.session as MlnFfiMapSession
       fixture.loadStyle(BaseStyle.Empty)
-      fixture.pumpUntilRendered()
+      fixture.awaitMapReady()
+      // Zoomed in, so the world is taller than the viewport and a vertical pan is not constrained.
+      fixture.state.setCameraPosition(CameraPosition(zoom = START_ZOOM))
+      fixture.pumpUntil("the camera to adopt the start zoom") {
+        abs(session.getCameraPosition().zoom - START_ZOOM) < ZOOM_TOLERANCE
+      }
       fixture.settle()
       fixture.events.clear()
+      val start = session.getCameraPosition()
 
       val entered = TestLatch(1)
       val release = TestLatch(1)
       assertTrue(
-        fixture.session.postOwnerTaskForTest {
+        session.postOwnerTaskForTest {
           entered.countDown()
           check(release.await(5_000))
         }
       )
       assertTrue(entered.await(5_000))
 
-      val stale = fixture.session.onGestureStarted()
-      fixture.session.moveBy(DRAG_STEP_DP, 0.0, gestureToken = stale)
-      val latest = fixture.session.onGestureStarted()
-      fixture.session.moveBy(0.0, DRAG_STEP_DP, gestureToken = latest)
-      fixture.session.onGestureEnded(latest)
-      fixture.session.onGestureEnded(stale)
+      val stale = fixture.gestures.onGestureStarted()
+      fixture.gestures.moveBy(DRAG_STEP_DP, 0.0, gestureToken = stale)
+      val latest = fixture.gestures.onGestureStarted()
+      fixture.gestures.moveBy(0.0, DRAG_STEP_DP, gestureToken = latest)
+      fixture.gestures.onGestureEnded(latest)
+      fixture.gestures.onGestureEnded(stale)
       release.countDown()
       fixture.pump(FRAMES)
+      fixture.settle()
 
-      val events = fixture.events.toList()
+      val camera = session.getCameraPosition()
+      assertTrue(
+        abs(camera.target.longitude - start.target.longitude) > MIN_DELTA_DEGREES &&
+          abs(camera.target.latitude - start.target.latitude) > MIN_DELTA_DEGREES,
+        "both queued deltas should have reached the camera: $start then $camera",
+      )
+      assertEquals(CameraMoveReason.GESTURE, fixture.state.cameraMoveReason)
+      assertFalse(fixture.state.isCameraMoving)
+
+      val gestures = fixture.events.filter { it.startsWith("gesture(") }
       assertEquals(
         1,
-        events.count { it == "cameraMoveStarted(GESTURE)" },
-        "both queued commands should form one gesture-attributed move: $events",
-      )
-      assertEquals(
-        1,
-        events.count { it == "cameraMoveEnded" },
-        "move ended more than once: $events",
-      )
-      assertEquals(
-        "cameraMoveEnded",
-        events.last(),
-        "the stale end won over the latest token: $events",
+        gestures.count { it == "gesture(false)" },
+        "the gesture ended more than once: $gestures",
       )
     }
   }
@@ -60,5 +74,11 @@ class MlnFfiGestureTokenOrderingTest {
     const val DRAG_STEP_DP = 10.0
 
     const val FRAMES = 8
+
+    const val START_ZOOM = 3.0
+
+    const val ZOOM_TOLERANCE = 0.01
+
+    const val MIN_DELTA_DEGREES = 0.5
   }
 }

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/MlnFfiMapEventsTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/MlnFfiMapEventsTest.kt
@@ -110,16 +110,9 @@ class MlnFfiMapEventsTest {
   }
 
   @Test
-  fun a_missing_image_carries_its_id() {
-    assertEquals(
-      MapEvent.StyleImageMissing("missing-icon"),
-      runtimeEvent(RuntimeEventType.MAP_STYLE_IMAGE_MISSING, message = "missing-icon").toMapEvent(),
-    )
-  }
-
-  @Test
   fun an_event_outside_the_catalog_translates_to_nothing() {
     assertNull(runtimeEvent(RuntimeEventType.MAP_RENDER_ERROR).toMapEvent())
+    assertNull(runtimeEvent(RuntimeEventType.MAP_STYLE_IMAGE_MISSING).toMapEvent())
     assertNull(runtimeEvent(RuntimeEventType(9999)).toMapEvent())
   }
 

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/MlnFfiMapEventsTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/MlnFfiMapEventsTest.kt
@@ -1,0 +1,157 @@
+package org.maplibre.compose.map
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+import org.maplibre.nativeffi.map.RenderingStats
+import org.maplibre.nativeffi.render.RenderMode
+import org.maplibre.nativeffi.runtime.CameraChangeMode
+import org.maplibre.nativeffi.runtime.RuntimeEvent
+import org.maplibre.nativeffi.runtime.RuntimeEventPayload
+import org.maplibre.nativeffi.runtime.RuntimeEventSourceType
+import org.maplibre.nativeffi.runtime.RuntimeEventType
+
+class MlnFfiMapEventsTest {
+
+  @Test
+  fun a_loaded_style_translates() {
+    assertEquals(
+      MapEvent.StyleLoaded,
+      runtimeEvent(RuntimeEventType.MAP_STYLE_LOADED).toMapEvent(),
+    )
+  }
+
+  @Test
+  fun a_load_failure_carries_the_engine_message() {
+    assertEquals(
+      MapEvent.StyleLoadFailed("no route to host"),
+      runtimeEvent(RuntimeEventType.MAP_LOADING_FAILED, message = "no route to host").toMapEvent(),
+    )
+  }
+
+  @Test
+  fun a_blank_load_failure_carries_a_stated_reason() {
+    val event = runtimeEvent(RuntimeEventType.MAP_LOADING_FAILED).toMapEvent()
+    assertTrue((event as MapEvent.StyleLoadFailed).reason.isNotBlank())
+  }
+
+  @Test
+  fun an_idle_translates() {
+    assertEquals(MapEvent.Idle, runtimeEvent(RuntimeEventType.MAP_IDLE).toMapEvent())
+  }
+
+  @Test
+  fun a_camera_change_reports_whether_it_is_animated() {
+    assertEquals(
+      MapEvent.CameraMoveStarted(animated = true),
+      runtimeEvent(
+          RuntimeEventType.MAP_CAMERA_WILL_CHANGE,
+          code = CameraChangeMode.ANIMATED.nativeValue,
+        )
+        .toMapEvent(),
+    )
+    assertEquals(
+      MapEvent.CameraMoveEnded(animated = false),
+      runtimeEvent(
+          RuntimeEventType.MAP_CAMERA_DID_CHANGE,
+          code = CameraChangeMode.IMMEDIATE.nativeValue,
+        )
+        .toMapEvent(),
+    )
+    assertEquals(
+      MapEvent.CameraMoved,
+      runtimeEvent(RuntimeEventType.MAP_CAMERA_IS_CHANGING).toMapEvent(),
+    )
+  }
+
+  @Test
+  fun a_finished_frame_carries_the_render_stats() {
+    val event =
+      runtimeEvent(
+          RuntimeEventType.MAP_RENDER_FRAME_FINISHED,
+          payload =
+            RuntimeEventPayload.RenderFrame(
+              mode = RenderMode.FULL,
+              needsRepaint = true,
+              placementChanged = false,
+              stats =
+                RenderingStats(
+                  encodingTime = 1.5,
+                  renderingTime = 2.5,
+                  frameCount = 3L,
+                  drawCallCount = 4L,
+                  totalDrawCallCount = 5L,
+                ),
+            ),
+        )
+        .toMapEvent()
+
+    val stats = (event as MapEvent.FrameRendered).stats!!
+    assertEquals(RenderStats.Mode.Full, stats.mode)
+    assertTrue(stats.needsRepaint)
+    assertTrue(!stats.placementChanged)
+    assertEquals(1.5.seconds, stats.encodingTime)
+    assertEquals(2.5.seconds, stats.renderingTime)
+    assertEquals(3L, stats.frameCount)
+    assertEquals(4L, stats.drawCallCount)
+    assertEquals(5L, stats.totalDrawCallCount)
+  }
+
+  @Test
+  fun a_partial_frame_reports_its_mode() {
+    assertEquals(RenderStats.Mode.Partial, frameStats(RenderMode.PARTIAL)?.mode)
+  }
+
+  @Test
+  fun a_frame_in_an_unnamed_render_mode_reports_no_mode() {
+    assertNull(frameStats(RenderMode(99))?.mode)
+  }
+
+  @Test
+  fun a_missing_image_carries_its_id() {
+    assertEquals(
+      MapEvent.StyleImageMissing("missing-icon"),
+      runtimeEvent(RuntimeEventType.MAP_STYLE_IMAGE_MISSING, message = "missing-icon").toMapEvent(),
+    )
+  }
+
+  @Test
+  fun an_event_outside_the_catalog_translates_to_nothing() {
+    assertNull(runtimeEvent(RuntimeEventType.MAP_RENDER_ERROR).toMapEvent())
+    assertNull(runtimeEvent(RuntimeEventType(9999)).toMapEvent())
+  }
+
+  private fun frameStats(mode: RenderMode): RenderStats? {
+    val event =
+      runtimeEvent(
+        RuntimeEventType.MAP_RENDER_FRAME_FINISHED,
+        payload =
+          RuntimeEventPayload.RenderFrame(
+            mode = mode,
+            needsRepaint = false,
+            placementChanged = false,
+            stats = RenderingStats(0.0, 0.0, 0L, 0L, 0L),
+          ),
+      )
+    return (event.toMapEvent() as MapEvent.FrameRendered).stats
+  }
+
+  private fun runtimeEvent(
+    type: RuntimeEventType,
+    code: Int = 0,
+    payload: RuntimeEventPayload = RuntimeEventPayload.None,
+    message: String = "",
+  ) =
+    RuntimeEvent(
+      type = type,
+      sourceType = RuntimeEventSourceType.MAP,
+      sourceId = 0L,
+      runtimeSource = null,
+      mapSource = null,
+      code = code,
+      payload = payload,
+      message = message,
+    )
+}

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/MlnFfiProjectionTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/MlnFfiProjectionTest.kt
@@ -101,7 +101,7 @@ class MlnFfiProjectionTest {
           projected.isNear(SCREEN_CENTER)
       }
 
-      val movedBefore = fixture.events.count { it == "cameraMoved" }
+      val movedBefore = fixture.events.count { it == "viewportChanged" }
       fixture.hasRendered = false
       fixture.pumpUntil("the resized map to render", extent = WIDE_EXTENT) { fixture.hasRendered }
       fixture.pumpUntil("the camera target to land on the resized screen center") {
@@ -109,8 +109,8 @@ class MlnFfiProjectionTest {
       }
 
       assertTrue(
-        fixture.events.count { it == "cameraMoved" } > movedBefore,
-        "a resize should report cameraMoved so Compose overlays re-read the projection",
+        fixture.events.count { it == "viewportChanged" } > movedBefore,
+        "a resize should report viewportChanged so Compose overlays re-read the projection",
       )
     }
   }

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/MlnFfiRenderOptionsTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/MlnFfiRenderOptionsTest.kt
@@ -14,7 +14,7 @@ class MlnFfiRenderOptionsTest {
   fun camera_projection_reaches_the_map_and_returns_to_perspective() {
     BridgeMapFixture.create().use { fixture ->
       fixture.loadStyle(BaseStyle.Empty)
-      val movedBefore = fixture.events.count { it == "cameraMoved" }
+      val movedBefore = fixture.events.count { it == "viewportChanged" }
       fixture.session.setRenderSettings(
         RenderOptions(cameraProjection = CameraProjection.Axonometric())
       )
@@ -24,8 +24,8 @@ class MlnFfiRenderOptionsTest {
       assertEquals(0.0, defaultAxonometric.xSkew)
       assertEquals(1.0, defaultAxonometric.ySkew)
       assertTrue(
-        fixture.events.count { it == "cameraMoved" } > movedBefore,
-        "a projection change should report cameraMoved so overlays re-read the projection",
+        fixture.events.count { it == "viewportChanged" } > movedBefore,
+        "a projection change should report viewportChanged so overlays re-read the projection",
       )
 
       fixture.session.setRenderSettings(

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/MlnFfiStyleFailureTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/MlnFfiStyleFailureTest.kt
@@ -13,9 +13,7 @@ class MlnFfiStyleFailureTest {
     fixture.use {
       it.session.setBaseStyle(BaseStyle.Uri("https://example.invalid/style.json"))
 
-      it.pumpUntil("the load to fail") {
-        it.errors.any { error -> error.startsWith("mapFailLoading") }
-      }
+      it.pumpUntil("the load to fail") { it.errors.isNotEmpty() }
     }
   }
 }

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/mlnffi/BridgeMapFixture.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/mlnffi/BridgeMapFixture.kt
@@ -15,9 +15,9 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
 import kotlinx.io.files.Path
 import org.maplibre.compose.logging.MapLog
-import org.maplibre.compose.map.MapAttachment
 import org.maplibre.compose.map.MapEvent
 import org.maplibre.compose.map.MapExtent
+import org.maplibre.compose.map.MapState
 import org.maplibre.compose.map.MlnFfiMapSession
 import org.maplibre.compose.map.mapRuntimeForTest
 import org.maplibre.compose.resource.MapResourceConfig
@@ -79,8 +79,9 @@ private constructor(
       resourceConfig = resourceConfig,
     )
 
-  fun bindAttachment(attachment: MapAttachment) {
-    recorder.attachment = attachment
+  fun bindState(state: MapState) {
+    recorder.attachment = requireNotNull(state.currentMapAttachment)
+    recorder.state = state
   }
 
   private val hostSession =

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/mlnffi/BridgeMapFixture.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/mlnffi/BridgeMapFixture.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.io.files.Path
 import org.maplibre.compose.logging.MapLog
 import org.maplibre.compose.map.MapAttachment
+import org.maplibre.compose.map.MapEvent
 import org.maplibre.compose.map.MapExtent
 import org.maplibre.compose.map.MlnFfiMapSession
 import org.maplibre.compose.map.mapRuntimeForTest
@@ -47,6 +48,9 @@ private constructor(
 
   val events: MutableList<String>
     get() = recorder.events
+
+  val engineEvents: MutableList<MapEvent>
+    get() = recorder.engineEvents
 
   val sourceChanges: MutableList<String?>
     get() = recorder.sourceChanges

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/resource/MlnFfiRequestInterceptorCustomSchemeTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/resource/MlnFfiRequestInterceptorCustomSchemeTest.kt
@@ -33,9 +33,7 @@ class MlnFfiRequestInterceptorCustomSchemeTest {
       )
     fixture.use {
       it.session.setBaseStyle(BaseStyle.Uri("custom://style.json"))
-      it.pumpUntil("the rewritten load to fail") {
-        it.errors.any { error -> error.startsWith("mapFailLoading") }
-      }
+      it.pumpUntil("the rewritten load to fail") { it.errors.isNotEmpty() }
     }
     assertTrue(
       rewritten.toList().any { it.startsWith("custom://") },

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/testing/MlnFfiMapFixture.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/testing/MlnFfiMapFixture.kt
@@ -27,7 +27,7 @@ internal class MlnFfiMapFixture(val bridge: BridgeMapFixture, private val extent
 
   init {
     state.publishPresentation(token, bridge.session)
-    bridge.bindAttachment(requireNotNull(state.currentMapAttachment))
+    bridge.bindState(state)
   }
 
   override val session: MapAdapter

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/testing/MlnFfiMapFixture.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/testing/MlnFfiMapFixture.kt
@@ -54,11 +54,11 @@ internal class MlnFfiMapFixture(val bridge: BridgeMapFixture, private val extent
   override suspend fun loadStyle(style: BaseStyle, timeout: Duration) {
     state.style.loadState = org.maplibre.compose.map.StyleLoadState.Loading
     state.updateLoadedStyle(bridge.session, null)
-    val finishedLoadsBefore = events.count { it == MapFixture.LOAD_FINISHED }
+    val styleReadyCountBefore = events.count { it == MapFixture.STYLE_READY }
     bridge.loadStyle(style, timeout, extent)
     bridge.session.reconcileStyleRevision(DesiredStyleRevision.Empty)
     bridge.pumpUntil("style $style to finish reconciliation", timeout, extent) {
-      events.count { it == MapFixture.LOAD_FINISHED } > finishedLoadsBefore
+      events.count { it == MapFixture.STYLE_READY } > styleReadyCountBefore
     }
     state.updateLoadedStyle(bridge.session, bridge.style)
     state.markStyleReady(bridge.session)

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/testing/MlnFfiMapFixture.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/testing/MlnFfiMapFixture.kt
@@ -60,7 +60,6 @@ internal class MlnFfiMapFixture(val bridge: BridgeMapFixture, private val extent
     bridge.pumpUntil("style $style to finish reconciliation", timeout, extent) {
       events.count { it == MapFixture.STYLE_READY } > styleReadyCountBefore
     }
-    state.updateLoadedStyle(bridge.session, bridge.style)
     state.markStyleReady(bridge.session)
   }
 

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/testing/MlnFfiMapFixture.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/testing/MlnFfiMapFixture.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.runBlocking
 import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.map.GestureTarget
 import org.maplibre.compose.map.MapAdapter
+import org.maplibre.compose.map.MapEvent
 import org.maplibre.compose.map.MapExtent
 import org.maplibre.compose.map.mapRuntimeForTest
 import org.maplibre.compose.mlnffi.BridgeMapFixture
@@ -40,6 +41,9 @@ internal class MlnFfiMapFixture(val bridge: BridgeMapFixture, private val extent
 
   override val events: MutableList<String>
     get() = bridge.events
+
+  override val engineEvents: MutableList<MapEvent>
+    get() = bridge.engineEvents
 
   override val sourceChanges: MutableList<String?>
     get() = bridge.sourceChanges


### PR DESCRIPTION
## Description

Implements `.agents/docs/EVENT_CALLBACK_REDESIGN.md`: sessions translate engine events into a common `MapEvent` catalog, `MapState` reacts and publishes them as `MapState.events`, clicks dispatch from Compose input, and `onFrame` is removed.

## Validation

`mise run check`, `test:android`, `test:desktop`, and `test:js` pass on every commit, and the iOS simulator target compiles.

## AI assistance

Claude Code with Fable 5.1 and Opus 5 subagents in a workflow.