### PR TITLE
Make queryRenderedFeatures wait for a map attachment

### DIFF
--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
@@ -895,21 +895,27 @@ internal constructor(
     it.metersPerDpAtLatitude(latitude)
   }
 
-  /** Queries rendered features at [offset] in front-to-back render order. */
+  /**
+   * Waits for a viewport, then queries rendered features at [offset] in front-to-back render order.
+   * Detaching the map surface during the query cancels it.
+   */
   public suspend fun queryRenderedFeatures(
     offset: DpOffset,
     layerIds: Set<String>? = null,
     predicate: Expression<BooleanValue> = const(true),
   ): List<Feature<Geometry, JsonObject?>> =
-    requireAttachment().queryRenderedFeatures(offset, layerIds, predicate)
+    awaitAttachment().queryRenderedFeatures(offset, layerIds, predicate)
 
-  /** Queries rendered features that intersect [rect] in front-to-back render order. */
+  /**
+   * Waits for a viewport, then queries rendered features that intersect [rect] in front-to-back
+   * render order. Detaching the map surface during the query cancels it.
+   */
   public suspend fun queryRenderedFeatures(
     rect: DpRect,
     layerIds: Set<String>? = null,
     predicate: Expression<BooleanValue> = const(true),
   ): List<Feature<Geometry, JsonObject?>> =
-    requireAttachment().queryRenderedFeatures(rect, layerIds, predicate)
+    awaitAttachment().queryRenderedFeatures(rect, layerIds, predicate)
 
   /** Waits for the first viewport from the current or a future map attachment. */
   public suspend fun awaitViewport(): Viewport =
@@ -1596,9 +1602,6 @@ internal constructor(
     currentMapAttachment = attachment
     nextMapAttachment.complete(attachment)
   }
-
-  private fun requireAttachment(): MapAttachment =
-    checkNotNull(currentMapAttachment) { "The map is not attached to a UI surface" }
 
   private suspend fun awaitAttachment(): MapAttachment {
     val pending = lifecycle.serialized {

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
@@ -392,7 +392,7 @@ class MapPresentationTest {
   }
 
   @Test
-  fun a_detached_map_keeps_durable_camera_commands_and_rejects_surface_operations() = runTest {
+  fun a_detached_map_keeps_durable_camera_commands_and_skips_surface_reads() = runTest {
     val fixture = presentationFixture()
     fixture.state.releasePresentation(fixture.token, fixture.adapter)
     val position = CameraPosition(zoom = 4.0)
@@ -400,9 +400,7 @@ class MapPresentationTest {
     fixture.state.setCameraPosition(position)
     assertEquals(position, fixture.state.cameraPosition)
     assertEquals(CameraPosition(), fixture.adapter.lastCameraPosition)
-    assertFailsWith<IllegalStateException> {
-      fixture.state.queryRenderedFeatures(DpOffset.Zero)
-    }
+    assertNull(fixture.state.positionFromScreenLocation(DpOffset.Zero))
     val viewportReads = fixture.adapter.viewportReads
     fixture.adapter.lastCameraPosition = CameraPosition(zoom = 7.0)
     assertNull(fixture.state.synchronizeCamera(fixture.adapter))
@@ -1238,6 +1236,26 @@ class MapPresentationTest {
     state.close()
     state.awaitClosed()
     runtime.close()
+  }
+
+  @Test
+  fun a_rendered_query_issued_while_detached_waits_for_the_next_attachment() = runTest {
+    val fixture = presentationFixture()
+    fixture.state.releasePresentation(fixture.token, fixture.adapter)
+    val replacement = PresentationTestAdapter()
+    supervisorScope {
+      val query = async { fixture.state.queryRenderedFeatures(DpOffset.Zero) }
+      testScheduler.runCurrent()
+      assertFalse(replacement.queryStarted.isCompleted)
+
+      val token = fixture.state.reservePresentation()
+      fixture.state.publishPresentation(token, replacement)
+      requireNotNull(fixture.state.currentMapAttachment).updateViewport(testViewport())
+      replacement.queryStarted.await()
+      assertFalse(fixture.adapter.queryStarted.isCompleted)
+      query.cancel()
+    }
+    fixture.close()
   }
 
   @Test


### PR DESCRIPTION
## Description

`MapState.queryRenderedFeatures` now waits for a map attachment like the other suspend operations instead of throwing `IllegalStateException` while detached, so `MapState` has two not-attached behaviors: suspend operations wait and synchronous reads return null.

## Validation

Ran `MapPresentationTest` on the Android host target and `mise run fix`.

## AI assistance

Claude Fable 5.1 in Claude Code.