### PR TITLE
Log request interceptor and resource provider failures

### DIFF
--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/resource/MapResourceConfig.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/resource/MapResourceConfig.kt
@@ -2,6 +2,7 @@ package org.maplibre.compose.resource
 
 import kotlin.concurrent.atomics.AtomicReference
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
+import org.maplibre.compose.logging.MapLog
 
 /**
  * Live interceptor and construction-time provider for one [org.maplibre.compose.map.MapRuntime].
@@ -10,6 +11,7 @@ import kotlin.concurrent.atomics.ExperimentalAtomicApi
 internal class MapResourceConfig(
   interceptor: MapRequestInterceptor? = null,
   val provider: MapResourceProvider? = null,
+  val logger: MapLog? = null,
 ) {
   private val interceptorRef = AtomicReference(interceptor)
 
@@ -36,9 +38,9 @@ internal fun MapResourceConfig.route(
   request: MapResourceRequest,
   interceptor: MapRequestInterceptor? = interceptor(),
 ): MapResourceRoute {
-  val rewritten = request.copy(url = interceptor.rewrittenUrl(request))
+  val rewritten = request.copy(url = interceptor.rewrittenUrl(request, logger))
   val provider = provider
-  return if (provider != null && provider.acceptsOrDeclines(rewritten)) {
+  return if (provider != null && provider.acceptsOrDeclines(rewritten, logger)) {
     MapResourceRoute.Load(rewritten, provider)
   } else {
     MapResourceRoute.Fetch(rewritten)
@@ -47,34 +49,48 @@ internal fun MapResourceConfig.route(
 
 /**
  * The URL to fetch for [request]. A null interceptor, a null or blank rewrite, and a non-fatal
- * exception all keep the incoming URL.
+ * exception all keep the incoming URL. The exception is logged as a warning.
  */
-internal fun MapRequestInterceptor?.rewrittenUrl(request: MapResourceRequest): String {
+internal fun MapRequestInterceptor?.rewrittenUrl(
+  request: MapResourceRequest,
+  logger: MapLog?,
+): String {
   val rewrite =
     try {
       this?.rewriteUrl(request)
-    } catch (_: Exception) {
+    } catch (error: Exception) {
+      logger?.w(error) { "The request interceptor failed to rewrite the URL of ${request.url}" }
       null
     }
   return if (rewrite.isNullOrBlank()) request.url else rewrite
 }
 
-/** The headers for [request]. A null interceptor and a non-fatal exception add no headers. */
+/**
+ * The headers for [request]. A null interceptor and a non-fatal exception add no headers. The
+ * exception is logged as a warning.
+ */
 internal fun MapRequestInterceptor?.headersOrNone(
-  request: MapResourceRequest
+  request: MapResourceRequest,
+  logger: MapLog?,
 ): Map<String, String> =
   try {
     this?.headers(request) ?: emptyMap()
-  } catch (_: Exception) {
+  } catch (error: Exception) {
+    logger?.w(error) { "The request interceptor failed to supply headers for ${request.url}" }
     emptyMap()
   }
 
 /**
  * Returns false when [MapResourceProvider.accepts] throws, so an engine callback can still decide.
+ * The exception is logged as a warning.
  */
-internal fun MapResourceProvider.acceptsOrDeclines(request: MapResourceRequest): Boolean =
+internal fun MapResourceProvider.acceptsOrDeclines(
+  request: MapResourceRequest,
+  logger: MapLog?,
+): Boolean =
   try {
     accepts(request)
-  } catch (_: Exception) {
+  } catch (error: Exception) {
+    logger?.w(error) { "The resource provider failed to classify ${request.url}" }
     false
   }

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/resource/MapRequestInterceptorTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/resource/MapRequestInterceptorTest.kt
@@ -6,6 +6,11 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlinx.coroutines.test.runTest
+import org.maplibre.compose.logging.MapLog
+import org.maplibre.compose.logging.MapLogLevel
+import org.maplibre.compose.logging.MapLogRecord
+import org.maplibre.compose.logging.MapLogger
+import org.maplibre.compose.logging.MapLogging
 import org.maplibre.compose.map.RuntimeImplementation
 import org.maplibre.compose.map.mapRuntimeForTest
 
@@ -14,14 +19,14 @@ class MapRequestInterceptorTest {
   @Test
   fun a_blank_rewrite_keeps_the_incoming_url() {
     val interceptor = MapRequestInterceptor(rewriteUrl = { "   " })
-    assertEquals(REQUEST.url, interceptor.rewrittenUrl(REQUEST))
+    assertEquals(REQUEST.url, interceptor.rewrittenUrl(REQUEST, null))
   }
 
   @Test
   fun a_null_interceptor_keeps_the_url_and_adds_no_headers() {
     val interceptor: MapRequestInterceptor? = null
-    assertEquals(REQUEST.url, interceptor.rewrittenUrl(REQUEST))
-    assertEquals(emptyMap(), interceptor.headersOrNone(REQUEST))
+    assertEquals(REQUEST.url, interceptor.rewrittenUrl(REQUEST, null))
+    assertEquals(emptyMap(), interceptor.headersOrNone(REQUEST, null))
   }
 
   @Test
@@ -31,15 +36,32 @@ class MapRequestInterceptorTest {
         rewriteUrl = { error("token store exploded") },
         headers = { error("token store exploded") },
       )
-    assertEquals(REQUEST.url, interceptor.rewrittenUrl(REQUEST))
-    assertEquals(emptyMap(), interceptor.headersOrNone(REQUEST))
+    assertEquals(REQUEST.url, interceptor.rewrittenUrl(REQUEST, null))
+    assertEquals(emptyMap(), interceptor.headersOrNone(REQUEST, null))
+  }
+
+  @Test
+  fun an_interceptor_exception_is_logged_as_a_warning() {
+    val records = mutableListOf<MapLogRecord>()
+    val previous = MapLogging.logger
+    MapLogging.logger = MapLogger { records += it }
+    try {
+      val interceptor = MapRequestInterceptor(rewriteUrl = { error("token store exploded") })
+      assertEquals(REQUEST.url, interceptor.rewrittenUrl(REQUEST, MapLog))
+    } finally {
+      MapLogging.logger = previous
+    }
+    val record = records.single()
+    assertEquals(MapLogLevel.Warning, record.level)
+    assertEquals("token store exploded", record.throwable?.message)
+    assertTrue(REQUEST.url in record.message)
   }
 
   @Test
   fun a_fatal_interceptor_error_propagates() {
     val interceptor = MapRequestInterceptor(rewriteUrl = { throw FatalTestError() })
     try {
-      interceptor.rewrittenUrl(REQUEST)
+      interceptor.rewrittenUrl(REQUEST, null)
       error("expected FatalTestError")
     } catch (_: FatalTestError) {}
   }
@@ -73,9 +95,9 @@ class MapRequestInterceptorTest {
     val second = MapRequestInterceptor(rewriteUrl = { "https://second.example/style" })
     runtime.setRequestInterceptor(first)
     val config = (runtime as RuntimeImplementation).resourceConfig
-    assertEquals("https://first.example/style", config.interceptor().rewrittenUrl(REQUEST))
+    assertEquals("https://first.example/style", config.interceptor().rewrittenUrl(REQUEST, null))
     runtime.setRequestInterceptor(second)
-    assertEquals("https://second.example/style", config.interceptor().rewrittenUrl(REQUEST))
+    assertEquals("https://second.example/style", config.interceptor().rewrittenUrl(REQUEST, null))
     runtime.setRequestInterceptor(null)
     assertEquals(null, config.interceptor())
     runtime.close()
@@ -95,7 +117,7 @@ class MapRequestInterceptorTest {
   fun an_accepts_exception_declines_the_request() {
     val provider =
       MapResourceProvider(accepts = { error("classifier exploded") }, load = { error("unused") })
-    assertFalse(provider.acceptsOrDeclines(REQUEST))
+    assertFalse(provider.acceptsOrDeclines(REQUEST, null))
   }
 
   @Test
@@ -103,7 +125,7 @@ class MapRequestInterceptorTest {
     val provider =
       MapResourceProvider(accepts = { throw FatalTestError() }, load = { error("unused") })
     try {
-      provider.acceptsOrDeclines(REQUEST)
+      provider.acceptsOrDeclines(REQUEST, null)
       error("expected FatalTestError")
     } catch (_: FatalTestError) {}
   }

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/MapRuntime.js.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/MapRuntime.js.kt
@@ -22,9 +22,10 @@ internal class JsRuntimePlatform(
 )
 
 public actual fun createMapRuntime(options: MapRuntimeOptions): MapRuntime {
-  val resourceConfig = MapResourceConfig(options.requestInterceptor, options.resourceProvider)
-  val requests = GlJsRequestController(resourceConfig)
   val logger = MapLog
+  val resourceConfig =
+    MapResourceConfig(options.requestInterceptor, options.resourceProvider, logger)
+  val requests = GlJsRequestController(resourceConfig)
   return RuntimeImplementation(
     platformOptions = JsRuntimePlatform(options, requests),
     resources = MapRuntimeResources { requests.close() },

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/resource/GlJsRequestController.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/resource/GlJsRequestController.kt
@@ -40,7 +40,7 @@ internal class GlJsRequestController(private val config: MapResourceConfig) : Au
       is MapResourceRoute.Load ->
         requestParameters(protocolUrl(route.request.url, kind), emptyMap())
       is MapResourceRoute.Fetch -> {
-        val headers = interceptor.headersOrNone(route.request)
+        val headers = interceptor.headersOrNone(route.request, config.logger)
         if (route.request.url == url && headers.isEmpty()) return undefined
         requestParameters(route.request.url, headers)
       }

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/NativeMapRuntime.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/NativeMapRuntime.kt
@@ -42,7 +42,8 @@ internal fun createNativeMapRuntime(options: MlnFfiRuntimeOptions): MapRuntime =
 private fun createNativeMapRuntimeImplementation(
   options: MlnFfiRuntimeOptions
 ): RuntimeImplementation {
-  val resourceConfig = MapResourceConfig(options.requestInterceptor, options.resourceProvider)
+  val resourceConfig =
+    MapResourceConfig(options.requestInterceptor, options.resourceProvider, options.logger)
   val offlineManager = MlnFfiOfflineManager(options, resourceConfig)
   return RuntimeImplementation(
     platformOptions = options,

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/offline/MlnFfiOfflineManager.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/offline/MlnFfiOfflineManager.kt
@@ -28,7 +28,7 @@ import org.maplibre.nativeffi.runtime.RuntimeHandle
 internal class MlnFfiOfflineManager(
   private val options: MlnFfiRuntimeOptions,
   resourceConfig: MapResourceConfig =
-    MapResourceConfig(options.requestInterceptor, options.resourceProvider),
+    MapResourceConfig(options.requestInterceptor, options.resourceProvider, options.logger),
 ) : OfflineManager, OfflinePackOwner {
 
   private val logger = options.logger

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/resource/MlnFfiRequestHooks.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/resource/MlnFfiRequestHooks.kt
@@ -18,17 +18,22 @@ internal fun RuntimeHandle.installRequestInterceptor(config: MapResourceConfig) 
     setHttpHeaderTransform(
       HttpHeaderTransformCallback { request ->
         val mapRequest = MapResourceRequest(request.url, request.kind.toCommon())
-        config.interceptor().headersOrNone(mapRequest).map { HttpHeader(it.key, it.value) }
+        config.interceptor().headersOrNone(mapRequest, config.logger).map {
+          HttpHeader(it.key, it.value)
+        }
       }
     )
   } catch (error: Throwable) {
     rethrowIfFatal(error)
     // OpenHarmony and the browser FFI decline header transforms.
+    config.logger?.w(error) {
+      "This platform declined the header transform; request interceptor headers are ignored"
+    }
   }
   setResourceTransform(
     ResourceTransformCallback { request ->
       val mapRequest = MapResourceRequest(request.url, request.kind.toCommon())
-      val url = config.interceptor().rewrittenUrl(mapRequest)
+      val url = config.interceptor().rewrittenUrl(mapRequest, config.logger)
       if (url == request.url) null else url
     }
   )


### PR DESCRIPTION
## Description

MapResourceConfig carries the runtime logger, and the interceptor and provider helpers log a warning instead of swallowing exceptions, as does a platform that declines the header transform.

## Validation

Ran the interceptor tests on the Android host target and compiled the JVM and JS targets.

## AI assistance

Claude Fable 5.1 in Claude Code.