### PR TITLE
Make the default map runtime configurable

### DIFF
--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoAppState.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoAppState.kt
@@ -15,9 +15,9 @@ import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.demoapp.benchmark.BenchmarkScenario
 import org.maplibre.compose.demoapp.benchmark.BenchmarkUiState
 import org.maplibre.compose.demoapp.benchmark.allBenchmarkScenarios
+import org.maplibre.compose.map.DefaultMapRuntime
 import org.maplibre.compose.map.MapRuntime
 import org.maplibre.compose.map.MapState
-import org.maplibre.compose.map.rememberDefaultMapRuntime
 import org.maplibre.compose.map.rememberMapState
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.spatialk.geojson.Position
@@ -147,7 +147,7 @@ internal data class StyleLoad(val count: Int, val base: BaseStyle?)
 @UiComposable
 @Composable
 fun rememberDemoAppState(): DemoAppState {
-  val mapRuntime = rememberDefaultMapRuntime()
+  val mapRuntime = DefaultMapRuntime.instance
   val settings = rememberDemoSettings()
   val mapConfiguration = remember { DemoMapConfiguration() }
   val appliedStyle = mapConfiguration.appliedStyle(settings)

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Composition.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Composition.kt
@@ -3,15 +3,15 @@
 package org.maplibre.compose.docsnippets
 
 import androidx.compose.runtime.Composable
+import org.maplibre.compose.map.DefaultMapRuntime
 import org.maplibre.compose.map.MaplibreMap
-import org.maplibre.compose.map.rememberDefaultMapRuntime
 import org.maplibre.compose.map.rememberMapState
 import org.maplibre.compose.style.BaseStyle
 
 @Composable
 fun Composition() {
   // #region base-plus-content
-  val runtime = rememberDefaultMapRuntime()
+  val runtime = DefaultMapRuntime.instance
   val state =
     rememberMapState(
       runtime = runtime,

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Requests.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Requests.kt
@@ -4,8 +4,9 @@ package org.maplibre.compose.docsnippets
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import org.maplibre.compose.map.DefaultMapRuntime
+import org.maplibre.compose.map.MapRuntimeOptions
 import org.maplibre.compose.map.MaplibreMap
-import org.maplibre.compose.map.rememberDefaultMapRuntime
 import org.maplibre.compose.map.rememberMapState
 import org.maplibre.compose.resource.MapRequestInterceptor
 import org.maplibre.compose.resource.MapResourceError
@@ -15,7 +16,7 @@ import org.maplibre.compose.resource.MapResourceProvider
 
 @Composable
 fun InterceptorMap(token: String) {
-  val runtime = rememberDefaultMapRuntime()
+  val runtime = DefaultMapRuntime.instance
   // #region interceptor
   DisposableEffect(token) {
     runtime.setRequestInterceptor(
@@ -37,11 +38,11 @@ fun InterceptorMap(token: String) {
 
 @Suppress("UNUSED_PARAMETER") suspend fun readAsset(url: String): ByteArray = ByteArray(0)
 
-fun assetProvider(): MapResourceProvider {
+fun configureAssetProvider() {
   // #region provider
   val provider = MapResourceProvider(scheme = "app") { request -> readAsset(request.url) }
+  DefaultMapRuntime.configure(MapRuntimeOptions(resourceProvider = provider))
   // #endregion provider
-  return provider
 }
 
 @Suppress("UNUSED_PARAMETER") suspend fun readTile(url: String): ByteArray? = null

--- a/demo-app/common/src/maplibreNativeMain/kotlin/org/maplibre/compose/demoapp/benchmark/TilePrefetch.kt
+++ b/demo-app/common/src/maplibreNativeMain/kotlin/org/maplibre/compose/demoapp/benchmark/TilePrefetch.kt
@@ -5,8 +5,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.platform.LocalDensity
 import kotlinx.coroutines.flow.first
+import org.maplibre.compose.map.DefaultMapRuntime
 import org.maplibre.compose.map.MapState
-import org.maplibre.compose.map.rememberDefaultMapRuntime
 import org.maplibre.compose.offline.DownloadProgress
 import org.maplibre.compose.offline.DownloadStatus
 import org.maplibre.compose.offline.OfflineManager
@@ -15,7 +15,7 @@ import org.maplibre.spatialk.geojson.BoundingBox
 
 @Composable
 actual fun rememberTilePrefetcher(): TilePrefetcher {
-  val manager = rememberDefaultMapRuntime().offlineManager
+  val manager = DefaultMapRuntime.instance.offlineManager
   val pixelRatio = LocalDensity.current.density
   return remember(manager, pixelRatio) { OfflinePackPrefetcher(manager, pixelRatio) }
 }

--- a/demo-app/common/src/maplibreNativeMain/kotlin/org/maplibre/compose/demoapp/demos/OfflineRegionSection.kt
+++ b/demo-app/common/src/maplibreNativeMain/kotlin/org/maplibre/compose/demoapp/demos/OfflineRegionSection.kt
@@ -17,14 +17,14 @@ import androidx.compose.ui.platform.LocalDensity
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 import org.maplibre.compose.demoapp.design.SectionHeader
-import org.maplibre.compose.map.rememberDefaultMapRuntime
+import org.maplibre.compose.map.DefaultMapRuntime
 import org.maplibre.compose.material3.OfflinePackListItem
 import org.maplibre.compose.offline.OfflinePackDefinition
 import org.maplibre.spatialk.geojson.BoundingBox
 
 @Composable
 actual fun OfflineRegionSection(region: BoundingBox, styleUrl: String, packName: String) {
-  val offlineManager = rememberDefaultMapRuntime().offlineManager
+  val offlineManager = DefaultMapRuntime.instance.offlineManager
   val pixelRatio = LocalDensity.current.density
   val scope = rememberCoroutineScope()
   val metadata = remember(packName) { packName.encodeToByteArray() }

--- a/demo-app/common/src/maplibreNativeMain/kotlin/org/maplibre/compose/docsnippets/Offline.kt
+++ b/demo-app/common/src/maplibreNativeMain/kotlin/org/maplibre/compose/docsnippets/Offline.kt
@@ -8,7 +8,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.platform.LocalDensity
 import kotlinx.coroutines.launch
-import org.maplibre.compose.map.rememberDefaultMapRuntime
+import org.maplibre.compose.map.DefaultMapRuntime
 import org.maplibre.compose.offline.DownloadProgress
 import org.maplibre.compose.offline.OfflinePackDefinition
 import org.maplibre.spatialk.geojson.BoundingBox
@@ -16,7 +16,7 @@ import org.maplibre.spatialk.geojson.BoundingBox
 @Composable
 fun Offline() {
   // #region manager
-  val offlineManager = rememberDefaultMapRuntime().offlineManager
+  val offlineManager = DefaultMapRuntime.instance.offlineManager
   // #endregion manager
   val scope = rememberCoroutineScope()
   val pixelRatio = LocalDensity.current.density

--- a/docs/src/content/docs/requests.mdx
+++ b/docs/src/content/docs/requests.mdx
@@ -33,9 +33,12 @@ the engine may call the interceptor more than once for one request.
 
 ## Serve the bytes
 
-Pass a <Api of="MapResourceProvider" /> as `resourceProvider` on the runtime
-options when you call <Api of="createMapRuntime" />. The scheme factory
-accepts every URL with that scheme:
+Pass a <Api of="MapResourceProvider" /> as `resourceProvider` in
+<Api of="MapRuntimeOptions" />. <Api of="DefaultMapRuntime.configure" /> sets
+the options for the process-default runtime, and must run before the first
+map, snapshotter, or offline manager. <Api of="createMapRuntime" /> creates a
+separate runtime from the same options. The scheme factory accepts every URL
+with that scheme:
 
 <Code code={region(requests, "provider")} lang="kotlin" title="App.kt" />
 

--- a/lib/maplibre-compose/src/androidDeviceTest/kotlin/org/maplibre/compose/camera/AndroidMapStateRecreationTest.kt
+++ b/lib/maplibre-compose/src/androidDeviceTest/kotlin/org/maplibre/compose/camera/AndroidMapStateRecreationTest.kt
@@ -15,13 +15,13 @@ import kotlin.test.assertTrue
 import org.maplibre.compose.map.DefaultMapRuntime
 import org.maplibre.compose.map.MapAdapter
 import org.maplibre.compose.map.MapRuntime
+import org.maplibre.compose.map.MapRuntimeOptions
 import org.maplibre.compose.map.MapState
 import org.maplibre.compose.map.MaplibreMap
 import org.maplibre.compose.map.StyleLoadState
-import org.maplibre.compose.map.rememberDefaultMapRuntime
 import org.maplibre.compose.map.rememberMapState
+import org.maplibre.compose.map.resetForTest
 import org.maplibre.compose.mlnffi.FfiTestPlatform
-import org.maplibre.compose.mlnffi.MlnFfiRuntimeOptions
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.spatialk.geojson.Position
 
@@ -31,9 +31,7 @@ class AndroidMapStateRecreationTest {
   @Test
   fun camera_position_survives_activity_recreation() {
     val cacheFile = FfiTestPlatform.createCacheFile()
-    DefaultMapRuntime.installForTest(
-      MlnFfiRuntimeOptions(cacheFile = cacheFile, maximumCacheSizeBytes = null)
-    )
+    DefaultMapRuntime.configure(MapRuntimeOptions(cacheFile = cacheFile))
 
     try {
       runAndroidComposeUiTest<MapStateRecreationActivity> {
@@ -122,8 +120,8 @@ class MapStateRecreationActivity : ComponentActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     setContent {
-      val firstRuntime: MapRuntime = rememberDefaultMapRuntime()
-      val secondRuntime: MapRuntime = rememberDefaultMapRuntime()
+      val firstRuntime: MapRuntime = DefaultMapRuntime.instance
+      val secondRuntime: MapRuntime = DefaultMapRuntime.instance
       val state = rememberMapState(firstRuntime, baseStyle = BaseStyle.Empty)
       SideEffect {
         mapState = state

--- a/lib/maplibre-compose/src/androidDeviceTest/kotlin/org/maplibre/compose/mlnffi/AndroidSurfaceReplacementTest.kt
+++ b/lib/maplibre-compose/src/androidDeviceTest/kotlin/org/maplibre/compose/mlnffi/AndroidSurfaceReplacementTest.kt
@@ -26,10 +26,12 @@ import kotlin.test.assertTrue
 import kotlinx.coroutines.flow.first
 import org.maplibre.compose.map.DefaultMapRuntime
 import org.maplibre.compose.map.MapEvent
+import org.maplibre.compose.map.MapRuntimeOptions
 import org.maplibre.compose.map.MapState
 import org.maplibre.compose.map.MaplibreMap
 import org.maplibre.compose.map.MlnFfiMapSession
 import org.maplibre.compose.map.rememberMapState
+import org.maplibre.compose.map.resetForTest
 import org.maplibre.compose.overlay.MapOverlay
 import org.maplibre.compose.overlay.include
 import org.maplibre.compose.style.BaseStyle
@@ -39,9 +41,7 @@ class AndroidSurfaceReplacementTest {
   @Test
   fun a_surface_map_without_an_overlay_produces_a_frame_after_replacement() {
     val cacheFile = FfiTestPlatform.createCacheFile()
-    DefaultMapRuntime.installForTest(
-      MlnFfiRuntimeOptions(cacheFile = cacheFile, maximumCacheSizeBytes = null)
-    )
+    DefaultMapRuntime.configure(MapRuntimeOptions(cacheFile = cacheFile))
 
     try {
       // Screen capture and Compose test synchronization invalidate the window and mask this

--- a/lib/maplibre-compose/src/androidDeviceTest/kotlin/org/maplibre/compose/mlnffi/FfiComposeTestPlatform.android.kt
+++ b/lib/maplibre-compose/src/androidDeviceTest/kotlin/org/maplibre/compose/mlnffi/FfiComposeTestPlatform.android.kt
@@ -7,6 +7,8 @@ import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.v2.runAndroidComposeUiTest
 import org.maplibre.compose.map.DefaultMapRuntime
+import org.maplibre.compose.map.MapRuntimeOptions
+import org.maplibre.compose.map.resetForTest
 
 @OptIn(ExperimentalTestApi::class)
 internal actual fun runFfiComposeUiTest(block: suspend ComposeUiTest.() -> Unit) {
@@ -64,11 +66,11 @@ private fun startHangWatchdog(): Thread {
 
 @OptIn(ExperimentalTestApi::class)
 internal actual fun ComposeUiTest.setFfiTestMapContent(
-  runtimeOptions: MlnFfiRuntimeOptions,
+  runtimeOptions: MapRuntimeOptions,
   presentationCount: Int,
   content: @Composable () -> Unit,
 ) {
   require(presentationCount > 0) { "A map test must prepare at least one presentation" }
-  DefaultMapRuntime.installForTest(runtimeOptions)
+  DefaultMapRuntime.configure(runtimeOptions)
   setContent(content)
 }

--- a/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/layers/LayerClickOrderTest.kt
+++ b/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/layers/LayerClickOrderTest.kt
@@ -19,11 +19,11 @@ import kotlin.test.assertNotNull
 import kotlinx.coroutines.runBlocking
 import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.expressions.dsl.const
+import org.maplibre.compose.map.MapRuntimeOptions
 import org.maplibre.compose.map.MapState
 import org.maplibre.compose.map.MaplibreMap
 import org.maplibre.compose.map.rememberMapState
 import org.maplibre.compose.mlnffi.FfiTestPlatform
-import org.maplibre.compose.mlnffi.MlnFfiRuntimeOptions
 import org.maplibre.compose.mlnffi.runFfiComposeUiTest
 import org.maplibre.compose.mlnffi.setFfiTestMapContent
 import org.maplibre.compose.sources.GeoJsonData
@@ -47,8 +47,7 @@ class LayerClickOrderTest {
 
   private val cacheFile = FfiTestPlatform.createCacheFile()
 
-  private val runtimeOptions =
-    MlnFfiRuntimeOptions(cacheFile = cacheFile, maximumCacheSizeBytes = null)
+  private val runtimeOptions = MapRuntimeOptions(cacheFile = cacheFile)
 
   /** Which layers were offered the event, in the order the map offered them. */
   private val clicked = mutableListOf<String>()

--- a/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MlnFfiMapCompositionTest.kt
+++ b/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MlnFfiMapCompositionTest.kt
@@ -53,7 +53,6 @@ import org.maplibre.compose.layers.CircleLayer
 import org.maplibre.compose.layers.FillLayer
 import org.maplibre.compose.layers.RasterLayer
 import org.maplibre.compose.mlnffi.FfiTestPlatform
-import org.maplibre.compose.mlnffi.MlnFfiRuntimeOptions
 import org.maplibre.compose.mlnffi.runFfiComposeUiTest
 import org.maplibre.compose.mlnffi.setFfiTestMapContent
 import org.maplibre.compose.offline.rememberOfflinePacksSource
@@ -78,8 +77,7 @@ class MlnFfiMapCompositionTest {
 
   private val cacheFile = FfiTestPlatform.createCacheFile()
 
-  private val runtimeOptions =
-    MlnFfiRuntimeOptions(cacheFile = cacheFile, maximumCacheSizeBytes = null)
+  private val runtimeOptions = MapRuntimeOptions(cacheFile = cacheFile)
 
   /** Camera round trips lose a little precision through the projection. */
   private val POSITION_TOLERANCE = 1e-4
@@ -101,7 +99,7 @@ class MlnFfiMapCompositionTest {
 
   @Test
   fun map_state_renders_a_base_style_and_publishes_one_presentation() = runFfiComposeUiTest {
-    val runtime = createNativeMapRuntime(runtimeOptions)
+    val runtime = createMapRuntime(runtimeOptions)
     val state = runtime.createMapState(baseStyle = BaseStyle.Empty)
 
     setFfiTestMapContent(runtimeOptions) { MaplibreMap(state = state) }
@@ -123,7 +121,7 @@ class MlnFfiMapCompositionTest {
 
   @Test
   fun camera_constraints_update_without_replacing_the_native_map() = runFfiComposeUiTest {
-    val runtime = createNativeMapRuntime(runtimeOptions)
+    val runtime = createMapRuntime(runtimeOptions)
     val state =
       runtime.createMapState(
         initialCameraPosition = CameraPosition(zoom = 1.0),
@@ -150,7 +148,7 @@ class MlnFfiMapCompositionTest {
 
   @Test
   fun one_style_composition_is_evaluated_independently_for_two_maps() = runFfiComposeUiTest {
-    val runtime = createNativeMapRuntime(runtimeOptions)
+    val runtime = createMapRuntime(runtimeOptions)
     val evaluatorIdentities = mutableSetOf<Any>()
     var showFirst by mutableStateOf(true)
     val style = StyleComposition {
@@ -218,7 +216,7 @@ class MlnFfiMapCompositionTest {
   @Test
   fun one_style_composition_is_evaluated_independently_for_a_map_and_snapshotter() =
     runFfiComposeUiTest {
-      val runtime = createNativeMapRuntime(runtimeOptions)
+      val runtime = createMapRuntime(runtimeOptions)
       val evaluatorIdentities = mutableSetOf<Any>()
       val composition = StyleComposition {
         val evaluatorIdentity = remember { Any() }
@@ -252,7 +250,7 @@ class MlnFfiMapCompositionTest {
   @Test
   fun detached_native_map_keeps_its_applied_revision_until_current_state_is_reattached() =
     runFfiComposeUiTest {
-      val runtime = createNativeMapRuntime(runtimeOptions)
+      val runtime = createMapRuntime(runtimeOptions)
       var presented by mutableStateOf(true)
       var latest by mutableStateOf(false)
       val composition = StyleComposition {
@@ -300,7 +298,7 @@ class MlnFfiMapCompositionTest {
   @Test
   fun a_later_revision_supersedes_reconciliation_failure_before_the_surface_is_revealed() =
     runFfiComposeUiTest {
-      val runtime = createNativeMapRuntime(runtimeOptions)
+      val runtime = createMapRuntime(runtimeOptions)
       var invalidAnchor by mutableStateOf(true)
       val composition = StyleComposition {
         if (invalidAnchor) {
@@ -337,7 +335,7 @@ class MlnFfiMapCompositionTest {
 
   @Test
   fun a_map_state_retains_its_native_map_between_presentations() = runFfiComposeUiTest {
-    val runtime = createNativeMapRuntime(runtimeOptions)
+    val runtime = createMapRuntime(runtimeOptions)
     val camera = CameraPosition(target = Position(longitude = 11.0, latitude = 47.0), zoom = 6.0)
     val state = runtime.createMapState(initialCameraPosition = camera, baseStyle = BaseStyle.Empty)
     var presented by mutableStateOf(true)
@@ -381,7 +379,7 @@ class MlnFfiMapCompositionTest {
   @Test
   fun an_incompatible_presentation_scale_replaces_the_native_map_and_replays_logical_state() =
     runFfiComposeUiTest {
-      val runtime = createNativeMapRuntime(runtimeOptions)
+      val runtime = createMapRuntime(runtimeOptions)
       val camera =
         CameraPosition(target = Position(longitude = -122.4, latitude = 37.8), zoom = 10.0)
       val state =
@@ -440,7 +438,7 @@ class MlnFfiMapCompositionTest {
 
   @Test
   fun a_base_style_switch_does_not_cover_the_map_with_the_load_placeholder() = runFfiComposeUiTest {
-    val runtime = createNativeMapRuntime(runtimeOptions)
+    val runtime = createMapRuntime(runtimeOptions)
     val first =
       BaseStyle.Json("""{"version":8,"sources":{},"layers":[{"id":"bg-a","type":"background"}]}""")
     val second =
@@ -476,7 +474,7 @@ class MlnFfiMapCompositionTest {
 
   @Test
   fun a_failed_replacement_style_hides_the_native_map() = runFfiComposeUiTest {
-    val runtime = createNativeMapRuntime(runtimeOptions)
+    val runtime = createMapRuntime(runtimeOptions)
     val state = runtime.createMapState(baseStyle = BaseStyle.Empty)
 
     setFfiTestMapContent(runtimeOptions) { MaplibreMap(state = state) }
@@ -531,7 +529,7 @@ class MlnFfiMapCompositionTest {
       onMapLoadFailed = { errors += "mapLoadFailed: $it" },
       onFrame = { onFrame() },
     ) {
-      val offlineManager = rememberDefaultMapRuntime().offlineManager
+      val offlineManager = DefaultMapRuntime.instance.offlineManager
       FillLayer(
         id = "offline-packs",
         source = rememberOfflinePacksSource(offlineManager.packs),

--- a/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MlnFfiStyleSwitchTest.kt
+++ b/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MlnFfiStyleSwitchTest.kt
@@ -49,8 +49,7 @@ class MlnFfiStyleSwitchTest {
 
   private val cacheFile = FfiTestPlatform.createCacheFile()
 
-  private val runtimeOptions =
-    MlnFfiRuntimeOptions(cacheFile = cacheFile, maximumCacheSizeBytes = null)
+  private val runtimeOptions = MapRuntimeOptions(cacheFile = cacheFile)
 
   @AfterTest
   fun cleanUp() {
@@ -59,7 +58,7 @@ class MlnFfiStyleSwitchTest {
 
   @Test
   fun rotating_the_base_style_with_content_composed_over_it() = runFfiComposeUiTest {
-    val runtime = createNativeMapRuntime(runtimeOptions)
+    val runtime = createMapRuntime(runtimeOptions)
     var style by mutableStateOf(STYLES[0])
     var extraLayer by mutableStateOf(false)
     val composition = StyleComposition {
@@ -113,7 +112,7 @@ class MlnFfiStyleSwitchTest {
 
   @Test
   fun recreating_a_replacement_layer_while_switching_the_base_style() = runFfiComposeUiTest {
-    val runtime = createNativeMapRuntime(runtimeOptions)
+    val runtime = createMapRuntime(runtimeOptions)
     var style by mutableStateOf(REPLACEMENT_STYLES[0])
     var sourceLayer by mutableStateOf("places")
     var showReplacement by mutableStateOf(true)
@@ -198,7 +197,7 @@ class MlnFfiStyleSwitchTest {
     }
     val state = runtime.createMapState(baseStyle = INITIAL_STYLE, styleComposition = composition)
 
-    setFfiTestMapContent(options) {
+    setFfiTestMapContent(runtimeOptions) {
       MaplibreMap(modifier = Modifier, state = state)
     }
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/DefaultMapRuntime.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/DefaultMapRuntime.kt
@@ -1,0 +1,45 @@
+package org.maplibre.compose.map
+
+import kotlinx.atomicfu.locks.reentrantLock
+import kotlinx.atomicfu.locks.withLock
+
+/**
+ * The process-default [MapRuntime].
+ *
+ * [instance] creates the runtime on first access with the options from [configure], or the
+ * [MapRuntimeOptions] defaults when nothing configured it. Closing the runtime permanently closes
+ * the process default; later reads return the same closed runtime.
+ */
+public object DefaultMapRuntime {
+  private val lock = reentrantLock()
+  private var options: MapRuntimeOptions? = null
+  private var current: MapRuntime? = null
+
+  /**
+   * Sets the options [instance] uses when it creates the runtime.
+   *
+   * Call this before the first map, snapshotter, or offline manager, such as from `Application`
+   * creation or `main`. Throws [IllegalStateException] once the runtime exists.
+   */
+  public fun configure(options: MapRuntimeOptions): Unit = lock.withLock {
+    check(current == null) {
+      "The default map runtime already exists; configure it before the first use"
+    }
+    this.options = options
+  }
+
+  /** The process-default runtime, created on first access. */
+  public val instance: MapRuntime
+    get() = lock.withLock {
+      current ?: createMapRuntime(options ?: defaultMapRuntimeOptions()).also { current = it }
+    }
+
+  /** Forgets and closes the process default, returning it so a test can await closure. */
+  internal fun clearForTest(): MapRuntime? =
+    lock
+      .withLock {
+        options = null
+        current.also { current = null }
+      }
+      ?.also { it.close() }
+}

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
@@ -95,14 +95,11 @@ import org.maplibre.spatialk.geojson.Position
  */
 public expect class MapRuntimeOptions
 
+/** The options a runtime uses when nothing configures it. */
+internal expect fun defaultMapRuntimeOptions(): MapRuntimeOptions
+
 /** Creates a runtime from [options]. The caller must close the result. */
 public expect fun createMapRuntime(options: MapRuntimeOptions): MapRuntime
-
-/**
- * Returns the default runtime for this process. Closing this runtime permanently closes the process
- * default; later calls return the same closed runtime.
- */
-@Composable public expect fun rememberDefaultMapRuntime(): MapRuntime
 
 /** Creates logical maps that share one application-level configuration. */
 public interface MapRuntime {
@@ -1694,7 +1691,7 @@ private class MapStyleScopeImpl(override val mapState: MapState) : MapStyleScope
  */
 @Composable
 public fun rememberMapState(
-  runtime: MapRuntime = rememberDefaultMapRuntime(),
+  runtime: MapRuntime = DefaultMapRuntime.instance,
   baseStyle: BaseStyle = BaseStyle.Demo,
   styleComposition: StyleComposition = StyleComposition.Empty,
   initialCameraPosition: CameraPosition = CameraPosition(),

--- a/lib/maplibre-compose/src/iosTest/kotlin/org/maplibre/compose/mlnffi/FfiComposeTestPlatform.ios.kt
+++ b/lib/maplibre-compose/src/iosTest/kotlin/org/maplibre/compose/mlnffi/FfiComposeTestPlatform.ios.kt
@@ -5,6 +5,8 @@ import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.v2.runComposeUiTest
 import org.maplibre.compose.map.DefaultMapRuntime
+import org.maplibre.compose.map.MapRuntimeOptions
+import org.maplibre.compose.map.resetForTest
 
 @OptIn(ExperimentalTestApi::class)
 internal actual fun runFfiComposeUiTest(block: suspend ComposeUiTest.() -> Unit) {
@@ -23,13 +25,13 @@ internal actual fun runPlainComposeUiTest(block: suspend ComposeUiTest.() -> Uni
 
 @OptIn(ExperimentalTestApi::class)
 internal actual fun ComposeUiTest.setFfiTestMapContent(
-  runtimeOptions: MlnFfiRuntimeOptions,
+  runtimeOptions: MapRuntimeOptions,
   presentationCount: Int,
   content: @Composable () -> Unit,
 ) {
   // The iOS map view builds its own surface controller, like Android's, so no host factory needs
   // to be prepared off the test thread.
   require(presentationCount > 0) { "A map test must prepare at least one presentation" }
-  DefaultMapRuntime.installForTest(runtimeOptions)
+  DefaultMapRuntime.configure(runtimeOptions)
   setContent(content)
 }

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/MapRuntime.js.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/MapRuntime.js.kt
@@ -1,6 +1,5 @@
 package org.maplibre.compose.map
 
-import androidx.compose.runtime.Composable
 import org.maplibre.compose.logging.MapLog
 import org.maplibre.compose.offline.UnsupportedOfflineManager
 import org.maplibre.compose.resource.GlJsRequestController
@@ -15,6 +14,8 @@ public actual data class MapRuntimeOptions(
   /** Serves bytes for resource URLs this provider accepts. */
   public val resourceProvider: MapResourceProvider? = null,
 )
+
+internal actual fun defaultMapRuntimeOptions(): MapRuntimeOptions = MapRuntimeOptions()
 
 internal class JsRuntimePlatform(
   val options: MapRuntimeOptions,
@@ -37,7 +38,3 @@ public actual fun createMapRuntime(options: MapRuntimeOptions): MapRuntime {
 
 internal val RuntimeImplementation.jsRequests: GlJsRequestController?
   get() = (platformOptions as? JsRuntimePlatform)?.requests
-
-private val defaultMapRuntime: MapRuntime by lazy { createMapRuntime(MapRuntimeOptions()) }
-
-@Composable public actual fun rememberDefaultMapRuntime(): MapRuntime = defaultMapRuntime

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserMapStateTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserMapStateTest.kt
@@ -21,14 +21,14 @@ import org.maplibre.compose.style.BaseStyle
 class BrowserMapStateTest {
 
   @Test
-  fun remembered_runtime_is_shared_and_survives_state_disposal(): Promise<*> = runBrowserMapTest {
+  fun default_runtime_is_shared_and_survives_state_disposal(): Promise<*> = runBrowserMapTest {
     val includeState = mutableStateOf(true)
     lateinit var firstRuntime: MapRuntime
     lateinit var secondRuntime: MapRuntime
     lateinit var state: MapState
     setBrowserMapContent {
-      firstRuntime = rememberDefaultMapRuntime()
-      secondRuntime = rememberDefaultMapRuntime()
+      firstRuntime = DefaultMapRuntime.instance
+      secondRuntime = DefaultMapRuntime.instance
       if (includeState.value) {
         val remembered = rememberMapState(firstRuntime, baseStyle = BaseStyle.Empty)
         SideEffect { state = remembered }

--- a/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/mlnffi/FfiComposeTestPlatform.desktop.kt
+++ b/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/mlnffi/FfiComposeTestPlatform.desktop.kt
@@ -8,6 +8,8 @@ import androidx.compose.ui.test.v2.runComposeUiTest
 import java.awt.EventQueue
 import org.maplibre.compose.map.DefaultMapRuntime
 import org.maplibre.compose.map.LocalMlnFfiMapHostFactory
+import org.maplibre.compose.map.MapRuntimeOptions
+import org.maplibre.compose.map.resetForTest
 import org.maplibre.nativeffi.Maplibre
 import org.maplibre.nativeffi.render.RenderBackend
 
@@ -60,11 +62,11 @@ internal actual fun runPlainComposeUiTest(block: suspend ComposeUiTest.() -> Uni
 
 @OptIn(ExperimentalTestApi::class)
 internal actual fun ComposeUiTest.setFfiTestMapContent(
-  runtimeOptions: MlnFfiRuntimeOptions,
+  runtimeOptions: MapRuntimeOptions,
   presentationCount: Int,
   content: @Composable () -> Unit,
 ) {
-  DefaultMapRuntime.installForTest(runtimeOptions)
+  DefaultMapRuntime.configure(runtimeOptions)
   val preparedFactory = CurrentRuntimeTestMapHostFactory.prepare(presentationCount)
   try {
     setContent {

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MapRuntime.native.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MapRuntime.native.kt
@@ -1,6 +1,5 @@
 package org.maplibre.compose.map
 
-import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import kotlinx.io.files.Path
 import org.maplibre.compose.mlnffi.MlnFfiRuntimeOptions
@@ -23,6 +22,8 @@ public actual data class MapRuntimeOptions(
   public val resourceProvider: MapResourceProvider? = null,
 )
 
+internal actual fun defaultMapRuntimeOptions(): MapRuntimeOptions = MapRuntimeOptions()
+
 /** The cache file that a null [MapRuntimeOptions.cacheFile] selects. */
 internal expect fun defaultCacheFile(): Path
 
@@ -40,10 +41,4 @@ internal fun MapRuntimeOptions.toMlnFfiRuntimeOptions(): MlnFfiRuntimeOptions =
 public actual fun createMapRuntime(options: MapRuntimeOptions): MapRuntime {
   initializeNativePlatform()
   return createNativeMapRuntime(options.toMlnFfiRuntimeOptions())
-}
-
-@Composable
-public actual fun rememberDefaultMapRuntime(): MapRuntime {
-  initializeNativePlatform()
-  return DefaultMapRuntime.getOrCreate { MapRuntimeOptions().toMlnFfiRuntimeOptions() }
 }

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/NativeMapRuntime.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/NativeMapRuntime.kt
@@ -1,40 +1,9 @@
 package org.maplibre.compose.map
 
-import kotlinx.coroutines.runBlocking
-import org.maplibre.compose.mlnffi.MlnFfiLock
 import org.maplibre.compose.mlnffi.MlnFfiRuntimeOptions
 import org.maplibre.compose.mlnffi.normalized
-import org.maplibre.compose.mlnffi.withLock
 import org.maplibre.compose.offline.MlnFfiOfflineManager
 import org.maplibre.compose.resource.MapResourceConfig
-
-internal object DefaultMapRuntime {
-  private val lock = MlnFfiLock()
-  private var current: RuntimeImplementation? = null
-
-  /** Returns the permanent process-default runtime, including after the caller closes it. */
-  fun getOrCreate(defaultOptions: () -> MlnFfiRuntimeOptions): MapRuntime = lock.withLock {
-    current
-      ?: createNativeMapRuntimeImplementation(defaultOptions().normalized()).also { current = it }
-  }
-
-  /** Installs a process-default runtime with controlled options. Tests only. */
-  fun installForTest(options: MlnFfiRuntimeOptions): MapRuntime = lock.withLock {
-    check(current == null) { "The process-default runtime is already initialized" }
-    createNativeMapRuntimeImplementation(options.normalized()).also { current = it }
-  }
-
-  fun resetForTest(): Boolean {
-    val runtime =
-      lock.withLock {
-        current.also {
-          current = null
-        }
-      } ?: return true
-    runtime.close()
-    return runCatching { runBlocking { runtime.awaitClosed() } }.isSuccess
-  }
-}
 
 internal fun createNativeMapRuntime(options: MlnFfiRuntimeOptions): MapRuntime =
   createNativeMapRuntimeImplementation(options.normalized())

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/DefaultMapRuntimeTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/DefaultMapRuntimeTest.kt
@@ -2,12 +2,10 @@ package org.maplibre.compose.map
 
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
-import kotlin.test.assertFalse
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
 import kotlinx.coroutines.test.runTest
 import org.maplibre.compose.mlnffi.FfiTestPlatform
-import org.maplibre.compose.mlnffi.MlnFfiRuntimeOptions
 import org.maplibre.compose.style.BaseStyle
 
 class DefaultMapRuntimeTest {
@@ -15,22 +13,31 @@ class DefaultMapRuntimeTest {
   fun closing_the_default_runtime_is_permanent() = runTest {
     val cacheFile = FfiTestPlatform.createCacheFile()
     try {
-      val first = DefaultMapRuntime.getOrCreate {
-        MlnFfiRuntimeOptions(cacheFile = cacheFile, maximumCacheSizeBytes = null)
-      }
+      DefaultMapRuntime.configure(MapRuntimeOptions(cacheFile = cacheFile))
+      val first = DefaultMapRuntime.instance
       first.close()
       first.awaitClosed()
 
-      var createdReplacement = false
-      val second = DefaultMapRuntime.getOrCreate {
-        createdReplacement = true
-        MlnFfiRuntimeOptions(cacheFile = cacheFile, maximumCacheSizeBytes = 1)
-      }
+      val second = DefaultMapRuntime.instance
 
       assertSame(first, second)
-      assertFalse(createdReplacement)
       assertTrue(second.isClosed)
       assertFailsWith<IllegalStateException> { second.createMapState(BaseStyle.Demo) }
+    } finally {
+      DefaultMapRuntime.resetForTest()
+      FfiTestPlatform.deleteCacheFile(cacheFile)
+    }
+  }
+
+  @Test
+  fun configuring_after_the_default_runtime_exists_fails() {
+    val cacheFile = FfiTestPlatform.createCacheFile()
+    try {
+      DefaultMapRuntime.configure(MapRuntimeOptions(cacheFile = cacheFile))
+      DefaultMapRuntime.instance
+      assertFailsWith<IllegalStateException> {
+        DefaultMapRuntime.configure(MapRuntimeOptions(cacheFile = cacheFile))
+      }
     } finally {
       DefaultMapRuntime.resetForTest()
       FfiTestPlatform.deleteCacheFile(cacheFile)

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/DefaultMapRuntimeTestSupport.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/DefaultMapRuntimeTestSupport.kt
@@ -1,0 +1,9 @@
+package org.maplibre.compose.map
+
+import kotlinx.coroutines.runBlocking
+
+/** Forgets and closes the process default, and waits until it has closed. */
+internal fun DefaultMapRuntime.resetForTest(): Boolean {
+  val runtime = clearForTest() ?: return true
+  return runCatching { runBlocking { runtime.awaitClosed() } }.isSuccess
+}

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/mlnffi/FfiComposeTestPlatform.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/mlnffi/FfiComposeTestPlatform.kt
@@ -3,6 +3,7 @@ package org.maplibre.compose.mlnffi
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
+import org.maplibre.compose.map.MapRuntimeOptions
 
 /** Runs a Compose UI test using the platform runner that can host a real FFI map. */
 @ExperimentalTestApi
@@ -23,7 +24,7 @@ internal expect fun runPlainComposeUiTest(block: suspend ComposeUiTest.() -> Uni
  */
 @ExperimentalTestApi
 internal expect fun ComposeUiTest.setFfiTestMapContent(
-  runtimeOptions: MlnFfiRuntimeOptions,
+  runtimeOptions: MapRuntimeOptions,
   presentationCount: Int = 1,
   content: @Composable () -> Unit,
 )


### PR DESCRIPTION
## Description

Replaces `rememberDefaultMapRuntime()` with a `DefaultMapRuntime` object, where `configure` sets the options for the lazily created process default and throws once it exists, and `instance` returns it from any context.

## Validation

Compiled every main and test target, ran the desktop test suite and the docs build on macOS.

## AI assistance

Claude Fable 5.1 in Claude Code.