### PR TITLE
Use list rows for settings dropdowns

### DIFF
--- a/demo-app/common/src/commonMain/composeResources/drawable/arrow_drop_down_24px.xml
+++ b/demo-app/common/src/commonMain/composeResources/drawable/arrow_drop_down_24px.xml
@@ -1,0 +1,13 @@
+<vector
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  android:width="24dp"
+  android:height="24dp"
+  android:viewportWidth="960"
+  android:viewportHeight="960"
+  android:tint="?attr/colorControlNormal"
+>
+  <path
+    android:fillColor="#ffffff"
+    android:pathData="M459,579L314,434Q311,431 309.5,427.5Q308,424 308,420Q308,412 313.5,406Q319,400 328,400L632,400Q641,400 646.5,406Q652,412 652,420Q652,422 646,434L501,579Q496,584 491,586Q486,588 480,588Q474,588 469,586Q464,584 459,579Z"
+  />
+</vector>

--- a/demo-app/common/src/commonMain/composeResources/drawable/check_24px.xml
+++ b/demo-app/common/src/commonMain/composeResources/drawable/check_24px.xml
@@ -1,0 +1,13 @@
+<vector
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  android:width="24dp"
+  android:height="24dp"
+  android:viewportWidth="960"
+  android:viewportHeight="960"
+  android:tint="?attr/colorControlNormal"
+>
+  <path
+    android:fillColor="#ffffff"
+    android:pathData="M382,606L721,267Q733,255 749,255Q765,255 777,267Q789,279 789,295.5Q789,312 777,324L410,692Q398,704 382,704Q366,704 354,692L182,520Q170,508 170.5,491.5Q171,475 183,463Q195,451 211.5,451Q228,451 240,463L382,606Z"
+  />
+</vector>

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/design/SettingsComponents.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/design/SettingsComponents.kt
@@ -2,18 +2,18 @@ package org.maplibre.compose.demoapp.design
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
-import androidx.compose.material3.ExposedDropdownMenuAnchorType
-import androidx.compose.material3.ExposedDropdownMenuBox
-import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
@@ -22,14 +22,24 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import kotlin.math.roundToInt
+import org.jetbrains.compose.resources.vectorResource
+import org.maplibre.compose.demoapp.generated.Res
+import org.maplibre.compose.demoapp.generated.arrow_drop_down_24px
+import org.maplibre.compose.demoapp.generated.check_24px
 
 @Composable
 fun SectionHeader(text: String) {
@@ -60,7 +70,7 @@ fun ButtonRow(label: String, onClick: () -> Unit) {
   )
 }
 
-/** A single-choice dropdown of named options, as a settings list item. */
+/** A settings list item that opens a single-choice menu. */
 @Composable
 fun <T> DropdownRow(
   label: String,
@@ -70,21 +80,32 @@ fun <T> DropdownRow(
   onSelect: (T) -> Unit,
 ) {
   var expanded by remember { mutableStateOf(false) }
-  ExposedDropdownMenuBox(
-    expanded = expanded,
-    onExpandedChange = { expanded = it },
-    modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
-  ) {
-    OutlinedTextField(
-      value = optionLabel(selected),
-      onValueChange = {},
-      readOnly = true,
-      label = { Text(label) },
-      trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+  var anchorWidth by remember { mutableIntStateOf(0) }
+  val menuWidth = with(LocalDensity.current) { anchorWidth.toDp() }
+  Box(Modifier.fillMaxWidth()) {
+    ListItem(
+      headlineContent = { Text(label) },
+      supportingContent = { Text(optionLabel(selected)) },
+      trailingContent = {
+        Icon(
+          imageVector = vectorResource(Res.drawable.arrow_drop_down_24px),
+          contentDescription = null,
+          modifier = Modifier.rotate(if (expanded) 180f else 0f),
+        )
+      },
+      colors = ListItemDefaults.colors(containerColor = Color.Transparent),
       modifier =
-        Modifier.fillMaxWidth().menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable),
+        Modifier.fillMaxWidth()
+          .onSizeChanged { anchorWidth = it.width }
+          .clickable(role = Role.Button) {
+            expanded = !expanded
+          },
     )
-    ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+    DropdownMenu(
+      expanded = expanded,
+      onDismissRequest = { expanded = false },
+      modifier = Modifier.width(menuWidth),
+    ) {
       options.forEach { option ->
         DropdownMenuItem(
           text = { Text(optionLabel(option)) },
@@ -92,6 +113,18 @@ fun <T> DropdownRow(
             onSelect(option)
             expanded = false
           },
+          trailingIcon =
+            if (option == selected) {
+              {
+                Icon(
+                  imageVector = vectorResource(Res.drawable.check_24px),
+                  contentDescription = null,
+                )
+              }
+            } else {
+              null
+            },
+          modifier = Modifier.semantics { this.selected = option == selected },
         )
       }
     }


### PR DESCRIPTION
## Description

Replace form-like exposed dropdown fields in the demo settings with list rows whose menus match the row width and mark the selected item.

## Validation

`mise run check`, `mise run build:desktop-app`, and `mise run build:android-app` passed, and manual desktop validation confirmed the menu interaction and width.

## AI assistance

OpenAI Codex with GPT-5 implemented and validated this change.