### PR TITLE
Keep application layers visible across style changes

### DIFF
--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
@@ -208,6 +208,9 @@ internal class GlJsMapSession(
 
   override fun render(target: GlJsFrameTarget, extent: MapExtent): Boolean {
     if (!lifecycle.acceptsWork || extent.isEmpty) return false
+    // A replacement base style has no application resources until its complete desired revision
+    // has been reconciled. Leave the shared target unchanged so Compose retains the previous frame.
+    if (hasPresentableStyle && !revisionApplied) return false
     // A detached map cannot later adopt a context: everything it uploaded belongs to the one it
     // has.
     val composited = target as? GlJsFrameTarget.Composited

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserMapStyleStateTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserMapStyleStateTest.kt
@@ -3,6 +3,7 @@ package org.maplibre.compose.gljs
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.unit.dp
 import kotlin.js.Promise
@@ -15,6 +16,8 @@ import kotlin.test.assertNotSame
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlinx.browser.window
+import org.maplibre.compose.expressions.dsl.const
+import org.maplibre.compose.layers.BackgroundLayer
 import org.maplibre.compose.layers.RasterLayer
 import org.maplibre.compose.map.GlJsMapSession
 import org.maplibre.compose.map.MapRuntimeOptions
@@ -293,6 +296,68 @@ class BrowserMapStyleStateTest {
       } finally {
         deferredStyle.restore()
       }
+
+      runtime.close()
+      runtime.awaitClosed()
+    }
+
+  @Test
+  fun a_web_replacement_style_is_not_rendered_without_application_content(): Promise<*> =
+    runBrowserMapTest {
+      val runtime = createMapRuntime(MapRuntimeOptions())
+      val state =
+        runtime.createMapState(baseStyle = STYLE_A) {
+          BackgroundLayer(id = "application", color = const(Color.Red))
+        }
+
+      setBrowserMapContent { MaplibreMap(state = state) }
+      waitUntilMap("the first style with application content to become ready") {
+        state.style.loadState == StyleLoadState.Ready &&
+          state.currentMapAttachment != null &&
+          (state.currentMapAttachment?.adapter as? GlJsMapSession)
+            ?.engineMapForTest()
+            ?.getStyle()
+            ?.layers
+            ?.any { it.id == "application" } == true
+      }
+
+      val renderedLayerSets = mutableListOf<Set<String>>()
+      val mapPrototype = org.maplibre.compose.gljs.MaplibreMap::class.js.asDynamic().prototype
+      val originalRedraw = mapPrototype.redraw
+      val wrapRedraw =
+        js(
+          """(function(original, record) {
+            return function() {
+              record(this.getStyle().layers.map(function(layer) { return layer.id; }).join(','));
+              return original.call(this);
+            };
+          })"""
+        )
+      mapPrototype.redraw =
+        wrapRedraw(originalRedraw) { ids: String ->
+          renderedLayerSets += ids.split(',').filter(String::isNotEmpty).toSet()
+        }
+      try {
+        runOnIdle { state.style.baseStyle = STYLE_B }
+        waitUntilMap("the replacement style with application content to become ready") {
+          state.style.loadState == StyleLoadState.Ready &&
+            (state.currentMapAttachment?.adapter as? GlJsMapSession)
+              ?.engineMapForTest()
+              ?.getStyle()
+              ?.layers
+              ?.any { it.id == "application" } == true
+        }
+        waitUntilMap("the replacement style to render") { renderedLayerSets.any { "b" in it } }
+      } finally {
+        mapPrototype.redraw = originalRedraw
+      }
+
+      val replacementFrames = renderedLayerSets.filter { "b" in it }
+      assertTrue(replacementFrames.isNotEmpty(), "the replacement style must render")
+      assertTrue(
+        replacementFrames.all { "application" in it },
+        "the replacement base style rendered before application content: $replacementFrames",
+      )
 
       runtime.close()
       runtime.awaitClosed()

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -368,6 +368,9 @@ internal class MlnFfiMapSession(
     }
 
     val map = loop.map ?: return MlnFfiFrameResult.SKIPPED
+    // A replacement base style has no application resources until its complete desired revision
+    // has been reconciled. Keep the last completed frame instead of presenting that partial style.
+    if (hasPresentableStyle && !revisionApplied) return MlnFfiFrameResult.SKIPPED
     renderedCameraPadding = appliedCameraPadding
 
     if (!ensureAttached(map, frame)) return MlnFfiFrameResult.SKIPPED

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/MlnFfiStylePresentationTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/MlnFfiStylePresentationTest.kt
@@ -1,0 +1,89 @@
+package org.maplibre.compose.map
+
+import androidx.compose.ui.graphics.Color
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+import org.maplibre.compose.expressions.ast.ExpressionContext
+import org.maplibre.compose.expressions.dsl.const
+import org.maplibre.compose.layers.Anchor
+import org.maplibre.compose.layers.BackgroundLayer
+import org.maplibre.compose.mlnffi.BridgeMapFixture
+import org.maplibre.compose.mlnffi.MlnFfiFrameResult
+import org.maplibre.compose.style.BaseStyle
+import org.maplibre.compose.style.DesiredStyleLayer
+import org.maplibre.compose.style.DesiredStyleRevision
+import org.maplibre.compose.testing.RgbaPixel
+
+class MlnFfiStylePresentationTest {
+
+  @Test
+  fun a_replacement_base_style_waits_for_application_content_before_presentation() = runBlocking {
+    BridgeMapFixture.create().use { fixture ->
+      val extent = BridgeMapFixture.DEFAULT_EXTENT
+      val centerX = extent.physicalWidth / 2
+      val centerY = extent.physicalHeight / 2
+
+      fixture.loadStyle(INITIAL_STYLE)
+      fixture.session.reconcileStyleRevision(APPLICATION_REVISION)
+      fixture.pumpUntil("the application background to be presented") {
+        fixture.tryReadPixel(centerX, centerY)?.isNear(APPLICATION_COLOR) == true
+      }
+
+      fixture.loadStyleBeforeRendering(REPLACEMENT_STYLE)
+      assertTrue("replacement" in fixture.session.currentStyleLayerIds())
+      assertTrue("application" !in fixture.session.currentStyleLayerIds())
+
+      assertEquals(MlnFfiFrameResult.SKIPPED, fixture.frame())
+      assertTrue(
+        fixture.readPixel(centerX, centerY).isNear(APPLICATION_COLOR),
+        "the last complete frame must remain presented while application content is absent",
+      )
+
+      fixture.session.reconcileStyleRevision(APPLICATION_REVISION)
+      fixture.pumpUntil("the replacement style with application content to be presented") {
+        "application" in fixture.session.currentStyleLayerIds() &&
+          fixture.tryReadPixel(centerX, centerY)?.isNear(APPLICATION_COLOR) == true
+      }
+    }
+  }
+
+  private companion object {
+    val APPLICATION_COLOR = RgbaPixel(red = 0x33, green = 0x66, blue = 0x99, alpha = 0xff)
+
+    val APPLICATION_REVISION =
+      DesiredStyleRevision(
+        sources = emptyList(),
+        layers =
+          listOf(
+            DesiredStyleLayer(
+              definition =
+                BackgroundLayer("application")
+                  .apply {
+                    setBackgroundColor(
+                      const(Color(APPLICATION_COLOR_ARGB)).compile(ExpressionContext.None)
+                    )
+                  }
+                  .definition(),
+              anchor = Anchor.Top,
+              onClick = null,
+              onLongClick = null,
+            )
+          ),
+        images = emptyList(),
+      )
+
+    val INITIAL_STYLE =
+      BaseStyle.Json(
+        """{"version":8,"sources":{},"layers":[{"id":"initial","type":"background","paint":{"background-color":"#ff0000"}}]}"""
+      )
+
+    val REPLACEMENT_STYLE =
+      BaseStyle.Json(
+        """{"version":8,"sources":{},"layers":[{"id":"replacement","type":"background","paint":{"background-color":"#00ff00"}}]}"""
+      )
+
+    const val APPLICATION_COLOR_ARGB = 0xff336699
+  }
+}


### PR DESCRIPTION
## Description

Keep the last complete map frame visible across base-style changes by admitting replacement frames only after the full application-declared style revision has been reconciled on both native and web renderers, with regressions covering both paths; fixes #1258.

## Validation

Validated with `mise run check`, `mise run test:android`, `mise run test:desktop`, `caffeinate -dimsu mise run test:js`, the focused native bridge regression (including its failure before the fix), and live Nucleus Metal style changes through the demo driver.

## AI assistance

Implemented and validated with OpenAI Codex using GPT-5.6.
