### PR TITLE
fix: resolve floating-point division precision loss in FloatCache

### DIFF
--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/ast/FloatCache.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/ast/FloatCache.kt
@@ -1,13 +1,18 @@
 package org.maplibre.compose.expressions.ast
 
+import kotlin.math.roundToInt
+
 internal class FloatCache<T>(val init: (Float) -> T) {
   private val smallInts = List(SIZE) { init(it.toFloat()) }
   private val smallFloats = List(SIZE) { init(it.toFloat() * RESOLUTION) }
 
   operator fun get(float: Float): T {
+    if (float.isNaN()) return init(float)
+    val floatIndex = (float / RESOLUTION).roundToInt()
     return when {
       float.isSmallInt() -> smallInts[float.toInt()]
-      (float / RESOLUTION).isSmallInt() -> smallFloats[(float / RESOLUTION).toInt()]
+      floatIndex.isSmallInt() && floatIndex.toFloat() * RESOLUTION == float ->
+        smallFloats[floatIndex]
 
       else -> init(float)
     }

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/expressions/ast/FloatCacheTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/expressions/ast/FloatCacheTest.kt
@@ -1,0 +1,76 @@
+package org.maplibre.compose.expressions.ast
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+
+class FloatCacheTest {
+  @Test
+  fun testSmallIntsAreCached() {
+    var initCalls = 0
+    val cache = FloatCache { float ->
+      initCalls++
+      Any()
+    }
+    // During initialization, SIZE (512) ints and SIZE (512) floats are created
+    val initialCalls = initCalls
+    assertEquals(FloatCache.SIZE * 2, initialCalls)
+
+    for (i in 0 until FloatCache.SIZE) {
+      val first = cache[i.toFloat()]
+      val second = cache[i.toFloat()]
+      assertSame(first, second)
+    }
+    // No additional init calls should have occurred
+    assertEquals(initialCalls, initCalls)
+  }
+
+  @Test
+  fun testSmallFloatsAreCached() {
+    val cache = FloatCache { float -> Any() }
+
+    // Verify all 512 multiples of RESOLUTION hit the cache and return identical instances
+    for (i in 0 until FloatCache.SIZE) {
+      val floatValue = i.toFloat() * FloatCache.RESOLUTION
+      val first = cache[floatValue]
+      val second = cache[floatValue]
+      assertSame(first, second, "Failed caching for index $i (float=$floatValue)")
+    }
+  }
+
+  @Test
+  fun testSpecificPrecisionSensitiveFloats() {
+    val cache = FloatCache { float -> Any() }
+
+    // Indices known to fail with naive float division due to precision drift
+    val testIndices = listOf(13, 21, 26, 31, 42, 52, 63, 73, 84, 94, 105)
+    for (idx in testIndices) {
+      val floatValue = idx.toFloat() * FloatCache.RESOLUTION
+      val first = cache[floatValue]
+      val second = cache[floatValue]
+      assertSame(
+        first,
+        second,
+        "Failed caching for known precision-sensitive index $idx (float=$floatValue)",
+      )
+    }
+  }
+
+  @Test
+  fun testNonMultiplesCallInit() {
+    var extraCalls = 0
+    val cache = FloatCache { float ->
+      extraCalls++
+      Any()
+    }
+    val initialCalls = extraCalls
+
+    val nonMultiples =
+      listOf(0.66f, 0.01f, 1.234f, -0.05f, 600f, Float.NaN, Float.POSITIVE_INFINITY)
+    for (f in nonMultiples) {
+      val before = extraCalls
+      cache[f]
+      assertEquals(before + 1, extraCalls, "Expected fresh init for non-multiple $f")
+    }
+  }
+}


### PR DESCRIPTION
## Description

Fixes floating-point precision loss in `FloatCache` that caused cache misses on 76 of the 512 pre-allocated `smallFloats` cache slots.

`FloatCache` caches multiples of `RESOLUTION` (`0.05f`). Because IEEE-754 division `(float / 0.05f)` produces inexact values slightly below integers for certain floats (e.g. `0.65f / 0.05f == 12.999999f`), truncating via `.toInt()` missed the cache.

Key changes:
- Use `(float / RESOLUTION).roundToInt()` and verify round-trip equality `floatIndex.toFloat() * RESOLUTION == float`.
- Guard against `Float.NaN` to avoid exceptions in `roundToInt()`.
- Added `FloatCacheTest` covering cache hits on exact multiples, misses on non-multiples, and edge cases (`NaN`, `Infinity`, negatives).

## Validation

- `mise run check`
- `mise run test:desktop` (including `FloatCacheTest`)
- `mise run test:android`

## AI assistance

Exploration, code cleanup drafting, and verification were performed with Antigravity CLI using Gemini. All changes and descriptions were reviewed by the contributor.