### PR TITLE
refactor: preserve caller coroutine scopes on provider close

### DIFF
--- a/lib/location-runtime-linux/src/main/kotlin/org/maplibre/compose/location/desktop/linux/LinuxPortalLocationBackend.kt
+++ b/lib/location-runtime-linux/src/main/kotlin/org/maplibre/compose/location/desktop/linux/LinuxPortalLocationBackend.kt
@@ -6,7 +6,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow

--- a/lib/location-runtime-linux/src/main/kotlin/org/maplibre/compose/location/desktop/linux/LinuxPortalLocationBackend.kt
+++ b/lib/location-runtime-linux/src/main/kotlin/org/maplibre/compose/location/desktop/linux/LinuxPortalLocationBackend.kt
@@ -4,6 +4,7 @@ import java.util.Locale
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
@@ -138,6 +139,9 @@ internal constructor(
     } else {
       LocationBackendAvailability.Unsupported
     }
+
+  private val job = SupervisorJob(coroutineScope.coroutineContext[Job])
+  private val scope = CoroutineScope(coroutineScope.coroutineContext + job)
   private val mutableStatus =
     MutableStateFlow<LocationPermission>(LocationPermission.NotGranted(canRequest = null))
 
@@ -157,7 +161,7 @@ internal constructor(
     ) {
       return
     }
-    coroutineScope.launch {
+    scope.launch {
       try {
         mutableStatus.value =
           when (portal.requestPermission()) {
@@ -175,7 +179,7 @@ internal constructor(
 
   /** Cancels pending requests and closes the portal. */
   override fun close() {
-    coroutineScope.cancel()
+    job.cancel()
     portal.close()
   }
 }

--- a/lib/location-runtime-linux/src/test/kotlin/org/maplibre/compose/location/desktop/linux/LinuxPortalLocationProviderTest.kt
+++ b/lib/location-runtime-linux/src/test/kotlin/org/maplibre/compose/location/desktop/linux/LinuxPortalLocationProviderTest.kt
@@ -9,12 +9,15 @@ import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeout
@@ -179,6 +182,14 @@ class LinuxPortalLocationProviderTest {
     val result = withTimeout(30.seconds) { portal.requestPermission() }
     assertNotEquals(PortalPermissionResult.Unavailable::class, result::class)
     portal.close()
+  }
+
+  @Test
+  fun closeDoesNotCancelCallerScope() {
+    val callerScope = CoroutineScope(SupervisorJob())
+    val requester = LinuxPortalLocationPermissionRequester(FakeLinuxLocationPortal(), callerScope)
+    requester.close()
+    assertTrue(callerScope.isActive)
   }
 }
 

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/resource/MlnFfiResourceProvider.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/resource/MlnFfiResourceProvider.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
@@ -67,11 +68,15 @@ internal class MlnFfiResourceProvider(
     get() = getLogger()
 
   private val accepting = AtomicBoolean(true)
+  private val userJob = SupervisorJob(userCoroutineScope?.coroutineContext?.get(Job))
   private val userScope =
-    userCoroutineScope
-      ?: CoroutineScope(
-        SupervisorJob() + Dispatchers.Default + CoroutineName("maplibre-compose-resource-provider")
+    if (userCoroutineScope != null) {
+      CoroutineScope(userCoroutineScope.coroutineContext + userJob)
+    } else {
+      CoroutineScope(
+        userJob + Dispatchers.Default + CoroutineName("maplibre-compose-resource-provider")
       )
+    }
 
   override fun handle(
     request: ResourceRequest,
@@ -218,7 +223,7 @@ internal class MlnFfiResourceProvider(
    */
   override fun close() {
     accepting.store(false)
-    userScope.cancel()
+    userJob.cancel()
   }
 
   private suspend fun loadWhileRequestOpen(

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/resource/MlnFfiResourceProvider.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/resource/MlnFfiResourceProvider.kt
@@ -11,7 +11,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/resource/MlnFfiResourceRequestTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/resource/MlnFfiResourceRequestTest.kt
@@ -17,6 +17,7 @@ import kotlin.time.TimeSource
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.suspendCancellableCoroutine
 import org.maplibre.compose.mlnffi.TestLatch
 import org.maplibre.compose.mlnffi.launchTestTask
@@ -101,6 +102,19 @@ class MlnFfiResourceRequestTest {
     assertEquals(1, request.closes)
     assertEquals(1, request.completions)
     assertEquals(ResourceResponseStatus.ERROR, request.response.status)
+  }
+
+  @Test
+  fun close_does_not_cancel_caller_user_scope() {
+    val callerScope = CoroutineScope(SupervisorJob())
+    val provider =
+      MlnFfiResourceProvider(
+        getLogger = { null },
+        passThroughNetwork = true,
+        userCoroutineScope = callerScope,
+      )
+    provider.close()
+    assertTrue(callerScope.isActive)
   }
 
   @Test


### PR DESCRIPTION
## Description

Give the Linux portal permission requester and native resource provider their own child supervisor jobs. Closing either component cancels its work while preserving the caller's scope; parent cancellation still propagates to the component.

Includes tests that the caller scope stays active after close, and removes obsolete cancellation imports.

## Validation

- Original PR reported `mise run check`, `mise run test:desktop`, and `mise run test:android`.
- Import cleanup: `mise run check` passed. No behavior changed in this follow-up.

## AI assistance

Original changes were generated with Gemini through Antigravity CLI. Codex reviewed the implementation and removed obsolete imports.
