### PR TITLE
perf: allow cancellation during GeoJSON preparation in publishGeoJson

### DIFF
--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleInstallations.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleInstallations.kt
@@ -120,8 +120,12 @@ internal class SourceInstallation(
     storePendingIfNewer(PendingGeoJson(generation, definition))
     geoJsonMutex.withLock {
       val pending = pendingGeoJson.exchange(null) ?: return
-      withContext(NonCancellable + Dispatchers.Default) {
-        style.prepareGeoJson(pending.definition.data, pending.definition.options).use { prepared ->
+      val prepared =
+        withContext(Dispatchers.Default) {
+          style.prepareGeoJson(pending.definition.data, pending.definition.options)
+        }
+      prepared.use {
+        withContext(NonCancellable) {
           style.setGeoJsonSourceData(id, prepared) {
             claimGeoJson(pending.generation, pending.definition)
           }


### PR DESCRIPTION
## Description

Allows cancellation during CPU-intensive GeoJSON preparation in `publishGeoJson`.

Previously, both GeoJSON preparation and style data replacement were wrapped in `withContext(NonCancellable + Dispatchers.Default)`. Because preparing large GeoJSON strings or geometries can take substantial time, running preparation under `NonCancellable` delayed cancellation when map screens navigated away.

Key changes:
- Execute `style.prepareGeoJson` cancellably on `Dispatchers.Default`.
- Restrict `NonCancellable` to the final style mutation (`style.setGeoJsonSourceData`) with `prepared.use { ... }`.

## Validation

- `mise run check`
- `mise run test:desktop`
- `mise run test:android`

## AI assistance

Exploration, code cleanup drafting, and verification were performed with Antigravity CLI using Gemini. All changes and descriptions were reviewed by the contributor.