### PR TITLE
refactor: remove redundant core map code and comments

### DIFF
--- a/lib/maplibre-compose/MODULE.md
+++ b/lib/maplibre-compose/MODULE.md
@@ -1,10 +1,10 @@
 # Module maplibre-compose
 
-The primary entry point for MapLibre Compose.
+Compose maps, camera controls, styles, and offline data.
 
 # Package org.maplibre.compose.map
 
-Core package containing the primary map composable and related components.
+Map composables and runtime configuration.
 
 # Package org.maplibre.compose.overlay
 
@@ -17,7 +17,7 @@ Camera controls and positioning utilities for the map view.
 
 # Package org.maplibre.compose.offline
 
-Functionality for managing offline map data and caching.
+Offline packs and ambient cache management.
 
 # Package org.maplibre.compose.layers
 
@@ -33,8 +33,7 @@ The abstract syntax tree (AST) for the expression language.
 
 # Package org.maplibre.compose.expressions.dsl
 
-The Kotlin DSL for creating MapLibre expressions. This is the primary API you'll
-be using to create expressions.
+The Kotlin DSL for creating MapLibre expressions.
 
 # Package org.maplibre.compose.expressions.value
 

--- a/lib/maplibre-compose/karma.config.d/timeout.js
+++ b/lib/maplibre-compose/karma.config.d/timeout.js
@@ -1,10 +1,9 @@
-// A test that hosts a real map waits on real work, none of which is on the test clock. Two seconds
-// is Mocha's default and is not enough for any of it.
+// Map rendering and network work run outside the test clock and can exceed Mocha's 2s default.
 
 config.client = config.client || {};
 config.client.mocha = Object.assign({}, config.client.mocha, { timeout: 60000 });
 
-// Karma hears nothing between two tests, so its own 30s idle timeout has to outlast Mocha's.
+// Keep Karma's idle timeout longer than Mocha's per-test timeout.
 config.browserNoActivityTimeout = 120000;
 // GL JS 6 workers stay busy after a map closes; the default 2s ping window then
 // reports a disconnect even when every test passed.

--- a/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/layers/LayerClickOrderTest.kt
+++ b/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/layers/LayerClickOrderTest.kt
@@ -33,14 +33,10 @@ import org.maplibre.compose.util.ClickResult
 import org.maplibre.spatialk.geojson.Position
 
 /**
- * Two overlapping fill layers cover the whole viewport, so a click at the centre hits both. Only
- * the order they sit in decides which handler runs first, and that order is the native style's, not
- * the composition's.
+ * Two overlapping fill layers cover the viewport. Click dispatch must follow native style order,
+ * not composition order. Anchors let the tests vary these orders independently.
  *
- * An anchor is what lets the two disagree: a layer composed first can be drawn in front of one
- * composed later. Dispatching in composition order was #69, fixed by #93, and nothing but a
- * rendered map can catch it coming back — the dispatch reads the live style's layer list and asks
- * the renderer what each layer actually covers.
+ * Regression coverage for #69, fixed by #93. A rendered map is required to query layer coverage.
  */
 @OptIn(ExperimentalTestApi::class)
 class LayerClickOrderTest {

--- a/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MlnFfiMapCompositionTest.kt
+++ b/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MlnFfiMapCompositionTest.kt
@@ -530,7 +530,7 @@ class MlnFfiMapCompositionTest {
     runtime.awaitClosed()
   }
 
-  /** Style loading needs no rendering, so no frame runs — and none is drawn — before a style. */
+  /** Style loading must not run or draw a frame before a style is available. */
   @Test
   fun an_unloaded_style_keeps_the_transparent_load_placeholder() = runFfiComposeUiTest {
     val errors = RecordingList<String>()

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/Viewport.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/Viewport.kt
@@ -6,7 +6,7 @@ import org.maplibre.compose.util.VisibleRegion
 import org.maplibre.spatialk.geojson.BoundingBox
 
 /**
- * What the map shows right now: the size of the map composable and the visible area.
+ * The map composable's size and visible area.
  *
  * Read a current instance from [org.maplibre.compose.map.MapState.viewport]. A new immutable
  * instance replaces it when the map has adopted a new camera or size. A composition that reads any
@@ -22,15 +22,13 @@ internal constructor(
   /**
    * The smallest bounding box that contains the currently visible area.
    *
-   * Note that the bounding box is always a north-aligned rectangle. I.e. if the map is rotated or
-   * tilted, the returned bounding box will always be larger than the actually visible area. See
-   * [visibleRegion].
+   * This north-aligned rectangle can include areas outside [visibleRegion] when the map is rotated
+   * or tilted.
    */
   public val visibleBoundingBox: BoundingBox,
 
   /**
-   * The currently visible area, which is a four-sided polygon spanned by the four points each at
-   * one corner of the map composable. If the camera has tilt (pitch), this polygon is a trapezoid
+   * The polygon formed by the map composable's four corners. Camera tilt makes it a trapezoid
    * instead of a rectangle.
    */
   public val visibleRegion: VisibleRegion,

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/ast/CompiledExpression.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/ast/CompiledExpression.kt
@@ -2,11 +2,7 @@ package org.maplibre.compose.expressions.ast
 
 import org.maplibre.compose.expressions.value.ExpressionValue
 
-/**
- * An [Expression] reduced to only those data types supported by the MapLibre SDKs. This can be
- * thought of as an intermediate representation between the high level expression DSL and the
- * platform-specific encoding.
- */
+/** An [Expression] reduced to the data types supported by MapLibre. */
 public sealed interface CompiledExpression<out T : ExpressionValue> : Expression<T> {
   override fun compile(context: ExpressionContext): CompiledExpression<T> = this
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/ast/CompiledFunctionCall.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/ast/CompiledFunctionCall.kt
@@ -2,7 +2,7 @@ package org.maplibre.compose.expressions.ast
 
 import org.maplibre.compose.expressions.value.ExpressionValue
 
-/** A [Literal] representing an function call with args all of [CompiledExpression] */
+/** A function call with compiled arguments. */
 public data class CompiledFunctionCall
 private constructor(
   val name: String,

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/ast/Expression.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/ast/Expression.kt
@@ -52,9 +52,9 @@ import org.maplibre.compose.expressions.value.ExpressionValue
  *   [atan][org.maplibre.compose.expressions.dsl.atan] - trigonometric functions
  * - [floor][org.maplibre.compose.expressions.dsl.floor], [ceil][org.maplibre.compose.expressions.dsl.ceil],
  *   [round][org.maplibre.compose.expressions.dsl.round],
- *   [abs][org.maplibre.compose.expressions.dsl.round] - coercing numbers
- * - [min][org.maplibre.compose.expressions.dsl.min], [max][org.maplibre.compose.expressions.dsl.max],
- *   [round][org.maplibre.compose.expressions.dsl.round] - rounding integers
+ *   [abs][org.maplibre.compose.expressions.dsl.abs] - rounding and absolute value
+ * - [min][org.maplibre.compose.expressions.dsl.min], [max][org.maplibre.compose.expressions.dsl.max] -
+ *   minimum and maximum
  * - [LN_2][org.maplibre.compose.expressions.dsl.LN_2], [PI][org.maplibre.compose.expressions.dsl.PI],
  *   [E][org.maplibre.compose.expressions.dsl.E] - constants
  *

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/ast/ExpressionContext.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/ast/ExpressionContext.kt
@@ -3,11 +3,9 @@ package org.maplibre.compose.expressions.ast
 import org.maplibre.compose.expressions.value.FloatValue
 
 /**
- * The context used while converting a high-level [Expression] to a low-level [CompiledExpression].
+ * Resolves text units and images when compiling an [Expression].
  *
- * It defines how to resolve certain expressions (TextUnit, bitmaps) to their MapLibre counterparts.
- * MapLibre Compose users should not need to implement this interface; it is used internally by the
- * MapLibre Compose library.
+ * The library supplies this context; applications do not need to implement it.
  */
 public interface ExpressionContext {
   /** The scale factor to convert EMs to the desired unit */

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/ast/TextUnitOffsetCalculation.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/ast/TextUnitOffsetCalculation.kt
@@ -22,7 +22,7 @@ public data class TextUnitOffsetCalculation private constructor(val x: TextUnit,
         else -> error("Unrecognized TextUnitType: ${x.type}")
       }
 
-    // some reasonably large number to bound the interpolation
+    // Interpolation clamps above this scale.
     val maxScale = 1000f
 
     return interpolate(

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/location/LocationState.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/location/LocationState.kt
@@ -266,13 +266,9 @@ public fun rememberLocationState(
 /**
  * Returns the most accurate bearing measurement available.
  *
- * This function considers bearings from two potential sources:
- * 1. The [LocationMeasurement] course indicates the direction of travel.
- * 2. The device [HeadingMeasurement] indicates the direction that the top of the device faces.
- *
- * It compares the accuracy of these two measurements and returns the one with the smallest accuracy
- * value (i.e., the most precise). If a measurement has no accuracy specified (`null`), it is
- * treated as having infinite (the worst possible) accuracy.
+ * Compares the travel course from [LocationMeasurement] with the device heading from
+ * [HeadingMeasurement]. Returns the measurement with the smallest estimated error, treating an
+ * unknown error as infinite.
  *
  * @return The bearing with the highest accuracy, or `null` when neither source provides a bearing.
  */

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapInput.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapInput.kt
@@ -69,7 +69,7 @@ import org.maplibre.compose.style.systemAnimatorDurationScale
  *
  * The map is a focus target while a key or rotary binding needs one, and the key handler exists
  * only while a keyboard gesture is enabled. [rotaryNotchPixels] is the scroll distance of one
- * rotary detent, from [rotaryNotchPixels]; zero disables rotary zoom.
+ * rotary detent; zero disables rotary zoom.
  */
 internal fun Modifier.mapInput(
   target: GestureTarget,
@@ -427,8 +427,8 @@ private class MapPointerGesture(
   private var pressRole = PressRole.First
 
   fun onPointerEvent(event: PointerEvent) {
-    // A wheel notch arrives here too, with nothing pressed, and would read as a release — closing
-    // the gesture scrollZoom is holding open for the rest of the burst.
+    // Wheel events have no pressed pointers. Treating one as a release would close the
+    // gesture scrollZoom keeps open for the rest of the burst.
     if (event.type == PointerEventType.Scroll) return
     val pressed = event.changes.filter { it.pressed }
     updateTwoFingerTap(event, pressed.size)

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLocals.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapLocals.kt
@@ -17,8 +17,5 @@ public val LocalViewport: ProvidableCompositionLocal<Viewport?> = compositionLoc
 /**
  * The interactive map whose style content is being evaluated, or null in the content of a
  * [MapSnapshotter].
- *
- * Content that requires the map checks for null at the read. Content that runs on both hosts
- * branches on it.
  */
 public val LocalMapState: ProvidableCompositionLocal<MapState?> = staticCompositionLocalOf { null }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/DisappearingScaleBar.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/DisappearingScaleBar.kt
@@ -20,10 +20,9 @@ import kotlinx.coroutines.delay
 
 /**
  * An animated scale bar that appears when the [zoom] level of the map changes, and then disappears
- * after [visibilityDuration]. This composable wraps [ScaleBar] with visibility animations.
+ * after [visibilityDuration].
  *
- * This component draws with Compose Foundation alone. The Material 3 module provides a themed
- * version of it.
+ * The Material 3 module provides a themed version.
  *
  * @param metersPerDp how many meters are displayed in one device independent pixel (dp), i.e. the
  *   scale. See
@@ -36,8 +35,7 @@ import kotlinx.coroutines.delay
  * @param haloColor halo for better visibility when displayed on top of the map
  * @param haloWidth scale bar and text halo width
  * @param barWidth scale bar width
- * @param textStyle the text style. The text size is the deciding factor how large the scale bar is
- *   is displayed.
+ * @param textStyle Text style. The font size determines the scale bar height.
  * @param alignment horizontal alignment of the scale bar and text
  * @param visibilityDuration how long it should be visible after the zoom changed
  * @param enterTransition EnterTransition(s) used for the appearing animation
@@ -62,10 +60,8 @@ public fun DisappearingScaleBar(
   val visible = remember { MutableTransitionState(true) }
 
   LaunchedEffect(zoom) {
-    // Show ScaleBar
     visible.targetState = true
     delay(visibilityDuration)
-    // Hide ScaleBar after timeout period
     visible.targetState = false
   }
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/ScaleBar.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/ScaleBar.kt
@@ -33,8 +33,7 @@ import org.maplibre.spatialk.units.extensions.meters
  * A scale bar composable that shows the current scale of the map in feet, meters or feet and meters
  * when zoomed in to the map, changing to miles and kilometers, respectively, when zooming out.
  *
- * This component draws with Compose Foundation alone. The Material 3 module provides a themed
- * version of it.
+ * The Material 3 module provides a themed version.
  *
  * @param metersPerDp how many meters are displayed in one device independent pixel (dp), i.e. the
  *   scale. See
@@ -46,8 +45,7 @@ import org.maplibre.spatialk.units.extensions.meters
  * @param haloColor halo for better visibility when displayed on top of the map
  * @param haloWidth scale bar and text halo width
  * @param barWidth scale bar width
- * @param textStyle the text style. The text size is the deciding factor how large the scale bar is
- *   is displayed.
+ * @param textStyle Text style. The font size determines the scale bar height.
  * @param alignment horizontal alignment of the scale bar and text
  */
 @Composable
@@ -75,13 +73,11 @@ public fun ScaleBar(
     }
   val maxTextSize = with(LocalDensity.current) { maxTextSizePx.toSize().toDpSize() }
 
-  // padding of text to bar stroke
   val textHorizontalPadding = 4.dp
   val textVerticalPadding = 0.dp
 
-  // multiplied by 2.5 because the next stop can be the x2.5 of a previous stop (e.g. 2km -> 5km),
-  // so the bar can end at approx 1/2.5th of the total width. We want to avoid that the bar
-  // intersects with the text, i.e. is drawn behind the text
+  // Adjacent stops can differ by a factor of 2.5, such as 2 km and 5 km. Reserve enough
+  // width to keep the text inside the bar at the shorter stop.
   val totalMaxWidth = maxTextSize.width * 2.5f + (textHorizontalPadding + barWidth) * 2f
 
   val fullStrokeWidth = haloWidth * 2 + barWidth
@@ -103,15 +99,14 @@ public fun ScaleBar(
       val textVerticalPaddingPx = textVerticalPadding.toPx()
 
       // bar ends should go to the vertical center of the text
-      val barEndsHeightPx = textHeightPx / 2f + textVerticalPadding.toPx() + fullStrokeWidthPx / 2f
+      val barEndsHeightPx = textHeightPx / 2f + textVerticalPaddingPx + fullStrokeWidthPx / 2f
 
-      var y = 0f
       val paths = ArrayList<List<Offset>>(2)
       val texts = ArrayList<Pair<Offset, TextLayoutResult>>(2)
 
       val alignmentSpacePx = ceil(size.width - fullStrokeWidthPx).toInt()
 
-      if (true) { // just want a scope here
+      run {
         val barLengthPx = params1.barWidth.toPx().roundToInt()
         val offsetX =
           alignment.align(
@@ -121,7 +116,7 @@ public fun ScaleBar(
           )
         paths.add(
           listOf(
-            Offset(offsetX + fullStrokeWidthPx / 2f, 0f + textHeightPx / 2f),
+            Offset(offsetX + fullStrokeWidthPx / 2f, textHeightPx / 2f),
             Offset(0f, barEndsHeightPx),
             Offset(barLengthPx.toFloat(), 0f),
             Offset(0f, -barEndsHeightPx),
@@ -133,11 +128,10 @@ public fun ScaleBar(
             textMeasurer.measure(params1.text, textStyle),
           )
         )
-
-        y += textHeightPx + textVerticalPaddingPx
       }
 
       if (params2 != null) {
+        val y = textHeightPx + textVerticalPaddingPx
         val barLengthPx = params2.barWidth.toPx().roundToInt()
         val offsetX =
           alignment.align(
@@ -150,7 +144,7 @@ public fun ScaleBar(
             Offset(offsetX + fullStrokeWidthPx / 2f, y + fullStrokeWidthPx / 2f + barEndsHeightPx),
             Offset(0f, -barEndsHeightPx),
             Offset(barLengthPx.toFloat(), 0f),
-            Offset(0f, +barEndsHeightPx),
+            Offset(0f, barEndsHeightPx),
           )
         )
         texts.add(
@@ -193,10 +187,10 @@ public fun ScaleBar(
 }
 
 public object ScaleBarDefaults {
-  /** Reads over both light and dark basemaps, in the absence of a theme to draw colors from. */
+  /** Default content color for light and dark basemaps. */
   public val ContentColor: Color = Color.Black.copy(alpha = 0.75f)
 
-  /** The halo stands in for a background, so it contrasts with [ContentColor]. */
+  /** Halo color that contrasts with [ContentColor]. */
   public val HaloColor: Color = Color.White.copy(alpha = 0.75f)
 
   public val ContentTextStyle: TextStyle = TextStyle(fontSize = 11.sp, color = ContentColor)
@@ -205,7 +199,7 @@ public object ScaleBarDefaults {
 
   public val BarWidth: Dp = 2.dp
 
-  /** The measures that the system settings ask for, or that the user's locale implies. */
+  /** Uses the system measurement settings, with the user's locale as a fallback. */
   @Composable
   public fun measures(): ScaleBarMeasures {
     val region = Locale.current.region
@@ -228,13 +222,9 @@ private fun scaleBarParameters(
   return ScaleBarParams(barWidth = (stopMeters / metersPerDp).dp, text = measure.getText(stop))
 }
 
-/**
- * find the largest stop in the list of stops (sorted in ascending order) that is below or equal
- * [max].
- */
+/** Finds the largest stop at or below [max], or the first stop if all are larger. */
 private fun findStop(max: Length, stops: List<Length>): Length {
   val i = stops.binarySearch { it.compareTo(max) }
-  // i is the inverted insertion point if the value is not found
-  // -i - 2 inverts it back
+  // A negative result encodes the insertion point; select the preceding stop.
   return if (i >= 0) stops[i] else stops[(-i - 2).coerceAtLeast(0)]
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/sources/SourceReferenceEffect.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/sources/SourceReferenceEffect.kt
@@ -10,18 +10,11 @@ internal fun SourceReferenceEffect(source: Source) {
   DisposableEffect(node, source) {
     when (node.sourceManager.getBaseSource(source.id)) {
       null -> {
-        // free to reference a new source
         node.sourceManager.addReference(source)
         onDispose { node.sourceManager.removeReference(source) }
       }
-      source -> {
-        // a base source was referenced; no-op
-        onDispose {}
-      }
-      else -> {
-        // not the base source, but conflicting id with a base source
-        error("Source id '${source.id}' conflicts with a base source")
-      }
+      source -> onDispose {}
+      else -> error("Source id '${source.id}' conflicts with a base source")
     }
   }
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/IncrementingIdMap.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/IncrementingIdMap.kt
@@ -1,6 +1,6 @@
 package org.maplibre.compose.style
 
-internal class IncrementingIdMap<in T>(private val name: String) {
+internal class IncrementingIdMap<in T>(name: String) {
   private val ids = IncrementingId(name)
   private val map = mutableMapOf<T, String>()
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleBinding.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleBinding.kt
@@ -439,11 +439,6 @@ internal interface StyleBinding {
 /** Stores one GeoJSON payload in an engine-specific installation form. [close] releases it. */
 internal interface PreparedGeoJson : AutoCloseable
 
-/** Represents a GeoJSON payload that requires no preparation. */
-internal object NoPreparedGeoJson : PreparedGeoJson {
-  override fun close() = Unit
-}
-
 /** Identifies the section of a layer object that contains a property. */
 internal enum class LayerPropertyKind {
   LAYOUT,

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/util/ExpressionJson.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/util/ExpressionJson.kt
@@ -19,16 +19,12 @@ import org.maplibre.compose.expressions.ast.OffsetLiteral
 import org.maplibre.compose.expressions.ast.ProjectionTransitionLiteral
 import org.maplibre.compose.expressions.ast.StringLiteral
 
-/**
- * Encodes a compiled expression as MapLibre style JSON. Must stay identical to the Android encoder,
- * including `literal` wrapping and colour format.
- */
+/** Encodes a compiled expression as MapLibre style JSON. */
 internal fun CompiledExpression<*>.toStyleJson(): JsonElement = normalizeJsonLike(inLiteral = false)
 
 /**
  * @param inLiteral whether this node is already inside a `["literal", ...]` wrapper. Arrays and
- *   objects are ambiguous in the style spec — `[1, 2]` reads as a function call — so they are
- *   wrapped unless something above already did it.
+ *   objects need literal context because the style spec reads `[1, 2]` as a function call.
  */
 private fun CompiledExpression<*>.normalizeJsonLike(inLiteral: Boolean): JsonElement =
   when (this) {
@@ -59,7 +55,7 @@ private fun CompiledExpression<*>.normalizeJsonLike(inLiteral: Boolean): JsonEle
       )
 
     is DpPaddingLiteral ->
-      // Style order is top, right, bottom, left — not the order DpPadding stores.
+      // Style order is top, right, bottom, left.
       literalArray(
         inLiteral,
         listOf(

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/util/AngleMathTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/util/AngleMathTest.kt
@@ -6,36 +6,29 @@ import kotlin.test.assertEquals
 class AngleMathTest {
   @Test
   fun testLeastPositiveResidue() {
-    // Test with positive numbers
     assertEquals(1.0, AngleMath.run { 1.0.leastPositiveResidue(5.0) })
     assertEquals(3.0, AngleMath.run { 8.0.leastPositiveResidue(5.0) })
 
-    // Test with negative numbers
     assertEquals(4.0, AngleMath.run { (-1.0).leastPositiveResidue(5.0) })
     assertEquals(2.0, AngleMath.run { (-3.0).leastPositiveResidue(5.0) })
 
-    // Test with zero
     assertEquals(0.0, AngleMath.run { 0.0.leastPositiveResidue(5.0) })
 
-    // Test with large numbers
     assertEquals(1.0, AngleMath.run { 361.0.leastPositiveResidue(360.0) })
     assertEquals(359.0, AngleMath.run { (-1.0).leastPositiveResidue(360.0) })
   }
 
   @Test
   fun testWrap() {
-    // Test with angles in range [0,360)
     assertEquals(0.0, AngleMath.run { 0.0.wrap() })
     assertEquals(90.0, AngleMath.run { 90.0.wrap() })
     assertEquals(180.0, AngleMath.run { 180.0.wrap() })
     assertEquals(270.0, AngleMath.run { 270.0.wrap() })
 
-    // Test with angles >= 360
     assertEquals(0.0, AngleMath.run { 360.0.wrap() })
     assertEquals(1.0, AngleMath.run { 361.0.wrap() })
     assertEquals(0.0, AngleMath.run { 720.0.wrap() })
 
-    // Test with negative angles
     assertEquals(359.0, AngleMath.run { (-1.0).wrap() })
     assertEquals(270.0, AngleMath.run { (-90.0).wrap() })
     assertEquals(180.0, AngleMath.run { (-180.0).wrap() })
@@ -45,23 +38,18 @@ class AngleMathTest {
 
   @Test
   fun testDiff() {
-    // Test with angles in the same quadrant
     assertEquals(-10.0, AngleMath.run { 80.0.diff(90.0) })
     assertEquals(10.0, AngleMath.run { 90.0.diff(80.0) })
 
-    // Test with angles in different quadrants
     assertEquals(-90.0, AngleMath.run { 0.0.diff(90.0) })
     assertEquals(90.0, AngleMath.run { 90.0.diff(0.0) })
 
-    // Test with angles on opposite sides
     assertEquals(180.0, AngleMath.run { 0.0.diff(180.0) })
     assertEquals(180.0, AngleMath.run { 180.0.diff(0.0) })
 
-    // Test with wrap-around cases
     assertEquals(-20.0, AngleMath.run { 350.0.diff(10.0) })
     assertEquals(20.0, AngleMath.run { 10.0.diff(350.0) })
 
-    // Test with negative angles
     assertEquals(-90.0, AngleMath.run { (-45.0).diff(45.0) })
     assertEquals(90.0, AngleMath.run { 45.0.diff(-45.0) })
   }

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/util/ExpressionJsonTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/util/ExpressionJsonTest.kt
@@ -35,8 +35,7 @@ class ExpressionJsonTest {
       .split(", ")
       .map { it.toDouble() }
 
-  private fun compiled(literal: org.maplibre.compose.expressions.ast.Expression<*>) =
-    literal.compile(ExpressionContext.None)
+  private fun compiled(literal: Expression<*>) = literal.compile(ExpressionContext.None)
 
   @Test
   fun encodes_scalars_as_bare_json_values() {

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsMapSurface.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsMapSurface.kt
@@ -70,7 +70,7 @@ internal fun GlJsMapSurface(
   }
 
   Canvas(modifier = modifier.onSizeChanged { physicalSize = it }) {
-    // Load-bearing read: it is what makes requestFrame() reschedule this Canvas.
+    // Observe frame requests so requestFrame() schedules another Canvas draw.
     frameRequest
 
     // The draw pass can run with an extent captured before the latest layout pass, e.g. when a

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsModule.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsModule.kt
@@ -183,7 +183,7 @@ internal external class LngLatBounds(sw: LngLat, ne: LngLat) {
 
 /**
  * MapLibre exposes no transition setter, and its style diff treats `setTransition` as a no-op, so
- * the only runtime lever is [stylesheet], a public field that [getTransition] reads every frame.
+ * update [stylesheet], the public field that [getTransition] reads every frame.
  */
 internal external class Style {
   var stylesheet: StyleSpecification

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsRuntime.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsRuntime.kt
@@ -8,8 +8,7 @@ import web.gl.WebGL2RenderingContext
  * bundler setup is needed for a map to render. Pass a different URL to [GlJsRuntime.pointAtWorker]
  * only to self-host the worker or pin a version other than the bundled one.
  *
- * The version is read from the bundled library rather than the version catalog so it can never
- * drift from the maplibre-gl the page actually links.
+ * Reads the version from the bundled MapLibre GL JS library.
  */
 internal val DEFAULT_WORKER_URL: String by lazy {
   "https://cdn.jsdelivr.net/npm/maplibre-gl@${getVersion()}/dist/maplibre-gl-worker.mjs"
@@ -20,7 +19,7 @@ internal val DEFAULT_WORKER_URL: String by lazy {
  * absolute form of that URL, which is what MapLibre GL JS 6 does for a CDN worker. Same-origin URLs
  * are returned as they are.
  *
- * MapLibre's own laundering uses `new URL(url, import.meta.url)`. Webpack rewrites that into a
+ * MapLibre wraps worker URLs with `new URL(url, import.meta.url)`. Webpack rewrites that into a
  * module lookup, which fails for an `https` URL with "Cannot find module". This path avoids
  * `import.meta.url` so the CDN default works when the library is bundled.
  */
@@ -49,8 +48,8 @@ internal fun sameOriginWorkerUrl(workerUrl: String): String =
     .unsafeCast<String>()
 
 /**
- * The places MapLibre GL JS is bent at runtime to be driven as a headless renderer. Each is pinned
- * to internals of one MapLibre version and fails loudly when a version bump moves them.
+ * Adapts MapLibre GL JS internals for rendering into Compose. Compatibility checks detect changes
+ * to the internals used here.
  */
 internal object GlJsRuntime {
 

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsTypes.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsTypes.kt
@@ -7,7 +7,7 @@ import kotlin.js.Promise
 import web.html.HTMLElement
 
 // The hand-written subset of MapLibre GL JS this platform binds against; GlJsDeclarationsTest
-// checks it against the MapLibre actually on the page.
+// checks it against the loaded MapLibre version.
 
 internal external interface Subscription {
   fun unsubscribe()
@@ -119,7 +119,7 @@ internal external interface GlJsGeoJsonSource : SourceHandle {
   ): Promise<Array<GeoJsonFeature>>
 }
 
-/** GeoJSON to read, or a URL to fetch it from — the style spec's own rule for `data`. */
+/** GeoJSON data or its URL, as defined by the style spec's `data` property. */
 internal external interface GeoJsonSourceData
 
 internal external interface GlJsImageSource : SourceHandle {

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/SkikoGpuBridge.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/SkikoGpuBridge.kt
@@ -51,10 +51,9 @@ internal object SkikoGpuBridge {
   }
 
   /**
-   * A stand-in for Compose's [DirectContext], carrying its native pointer. Built on a real managed
-   * object's prototype because an optimized build reads that pointer field directly where a
-   * development build goes through its accessor. It frees nothing — the pointer belongs to Compose
-   * — and no instance method may dispatch on it.
+   * Wraps Compose's [DirectContext] pointer using a managed object's prototype. Optimized builds
+   * read the pointer field directly; development builds use its accessor. Compose owns the pointer.
+   * Do not call instance methods or free the pointer through this wrapper.
    */
   fun directContext(context: EmscriptenGlContext): DirectContext? {
     val pointer = contextPointers[context.handle] ?: return null

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/style/GlJsStyleBinding.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/style/GlJsStyleBinding.kt
@@ -522,10 +522,7 @@ internal class GlJsStyleBinding(
     }
   }
 
-  /**
-   * GL JS fixes a layer's own keys at construction, except the zoom range, which moves as a pair —
-   * so the half that was not asked for is read back off the live layer.
-   */
+  /** GL JS sets both zoom bounds together, so preserve the bound that the caller did not change. */
   private fun setRootProperty(layerId: String, name: String, value: JsonElement) {
     val number = (value as? JsonPrimitive)?.takeUnless { it.isString }?.doubleOrNull
     val layer = map.getLayer(layerId)

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserGpu.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserGpu.kt
@@ -97,7 +97,7 @@ internal inline fun <T> BrowserGpu.withRecreatedSkiaContext(block: (DirectContex
   }
 }
 
-/** Reads [framebuffer] — null meaning the canvas itself — as tightly packed RGBA bytes. */
+/** Reads tightly packed RGBA bytes from [framebuffer], or the canvas when null. */
 internal fun readFramebuffer(gl: dynamic, framebuffer: Any?, width: Int, height: Int): ByteArray {
   val pixels = Uint8Array(width * height * 4)
   gl.bindFramebuffer(gl.FRAMEBUFFER, framebuffer)

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/ComposeGpuContext.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/ComposeGpuContext.kt
@@ -110,12 +110,10 @@ public interface ComposeMapPresentationHost {
     get() = OpenGlInterop.NATIVE
 
   /**
-   * The context Compose is currently drawing with, or null when it does not exist yet — Skia
-   * contexts are commonly created while producing the first frame, which the map reports as a
-   * skipped frame.
+   * The context Compose is drawing with, or null before it is available. The map skips frames while
+   * the context is unavailable, including during first-frame initialization.
    *
-   * Always called on the thread [runOnGpuThread] runs on, so this may read state confined to it and
-   * need not hop there itself.
+   * Called on the [runOnGpuThread] thread and may read state confined to that thread.
    */
   public fun gpuContext(): ComposeGpuContext?
 

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/skiko/AwtComposeMapPresentationHost.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/skiko/AwtComposeMapPresentationHost.kt
@@ -68,8 +68,8 @@ internal class AwtComposeMapPresentationHost(private val window: Window) :
     }
 
   /**
-   * Which backend Compose Desktop picks is decided by the operating system, so this is answerable
-   * before Skiko has built anything — unlike [gpuContext].
+   * The operating system determines the Compose Desktop backend, so it is available before Skiko
+   * initializes [gpuContext].
    */
   override val backend: ComposeRenderBackend
     get() =

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/skiko/SkikoReflection.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/skiko/SkikoReflection.kt
@@ -74,8 +74,8 @@ internal object SkikoReflection {
       ?: throw MlnFfiHostException("$redrawerClass.drawLock was null")
 
   /**
-   * The Direct3D device Compose renders with on Windows. Skiko keeps it on the redrawer, and only
-   * after the first frame has initialized the swap chain — until then this is null.
+   * The Direct3D device Compose renders with on Windows. Skiko stores it on the redrawer after the
+   * first frame initializes the swap chain. Returns null until then.
    */
   fun findDirect3DDevice(redrawer: Any): SkikoDirect3DDevice? {
     val ptr = redrawer.getField("device") as? Long ?: return null

--- a/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/desktop/skiko/SkikoMetalDeviceContractTest.kt
+++ b/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/desktop/skiko/SkikoMetalDeviceContractTest.kt
@@ -7,12 +7,10 @@ import org.lwjgl.system.MemoryUtil.NULL
 import org.lwjgl.system.macosx.ObjCRuntime
 
 /**
- * Pins the Objective-C members of Skiko's Metal device wrapper that the macOS host messages. That
- * class is private to Skiko's `MetalRedrawer.mm`, appears in no header, and would be renamed
- * silently by a Skiko upgrade — so a failure here means update [AwtComposeMapPresentationHost], not
- * a bug.
+ * Checks the Objective-C members used by [AwtComposeMapPresentationHost]. Skiko's private
+ * `MetalRedrawer.mm` wrapper has no header; an upgrade may require updating the host.
  *
- * The Objective-C runtime answers this without a GPU, a window, or a Skia context.
+ * The Objective-C runtime can check these members without a GPU, window, or Skia context.
  */
 class SkikoMetalDeviceContractTest {
 

--- a/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/resource/DesktopPackagedStyleTest.kt
+++ b/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/resource/DesktopPackagedStyleTest.kt
@@ -31,8 +31,8 @@ class DesktopPackagedStyleTest {
   }
 
   /**
-   * A `file:` style never reaches the provider — mbgl routes it to its own local file source — so
-   * this covers that source's handling of a percent-encoded non-ASCII path, not the provider's.
+   * mbgl routes `file:` styles to its local file source. This tests that source's handling of
+   * percent-encoded non-ASCII paths.
    */
   @Test
   fun `a style beside the application loads from a path with spaces and no ASCII`() {

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -256,10 +256,9 @@ internal class MlnFfiMapSession(
   private val reportedUrlAttribution = mutableSetOf<String>()
 
   /**
-   * Owner thread only. A URL source's TileJSON — and with it the server's attribution — arrives
-   * after its add returns, and the C API has no event for the arrival, so the only moment it can be
-   * observed is an idle. Add and remove report themselves from the binding; this reports the
-   * sources whose attribution newly appeared.
+   * Owner thread only. Checks for attribution received through a URL source's TileJSON after
+   * addSource returns. The C API has no TileJSON arrival event, so check on idle. The binding
+   * reports source addition and removal separately.
    */
   private fun reportNewlyArrivedAttribution() {
     val map = loop?.map ?: return
@@ -941,13 +940,9 @@ internal class MlnFfiMapSession(
     loop?.post(action)
   }
 
-  /** Test seam for intentionally backlogging owner-thread work without touching the native map. */
+  /** Queues test work on the owner thread without accessing the native map. */
   internal fun postOwnerTaskForTest(action: () -> Unit): Boolean =
     loop?.post(action = { action() }) ?: false
-
-  /** Test seam that runs [action] after the next native pump and event drain. */
-  internal fun postEventDrainBarrierForTest(action: () -> Unit): Boolean =
-    loop?.postEventDrainBarrier(action) ?: false
 
   private suspend fun updateOwnerThreadPresentation(action: () -> Unit) {
     val completion = CompletableDeferred<Result<Unit>>()

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapView.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapView.kt
@@ -257,8 +257,8 @@ internal fun loadRuntimeBackends(logger: MapLog?): Set<MapRenderBackend> =
   }
 
 /**
- * The MapLibre Compose producer backend this FFI backend corresponds to, or null when no host
- * bridge exists for it — WebGPU today, which the FFI builds only for the browser.
+ * The corresponding Compose producer backend, or null if no host supports it. WebGPU is currently
+ * supported only by the browser FFI runtime.
  */
 private fun RenderBackend.toComposeBackend(): MapRenderBackend? =
   when (this) {

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/mlnffi/MlnFfiRenderTarget.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/mlnffi/MlnFfiRenderTarget.kt
@@ -35,11 +35,10 @@ internal sealed interface MlnFfiRenderTarget {
   val extent: MapExtent
 
   /**
-   * Identifies the underlying target object.
+   * Identifies the underlying target allocation.
    *
-   * A host must bump this any time the handles it reports stop referring to the same allocation —
-   * after a reallocating resize, after surface loss, or when rotating through a pool — and must
-   * keep the retired allocation readable until it has been asked to draw a different one.
+   * Increment this when handles change allocation, including after resize, surface loss, or pool
+   * rotation. Keep the retired allocation readable until asked to draw a different one.
    */
   val generation: Long
 }

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/offline/MlnFfiOfflineManager.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/offline/MlnFfiOfflineManager.kt
@@ -34,8 +34,8 @@ internal class MlnFfiOfflineManager(
   private val logger = options.logger
 
   /**
-   * Compose state, written inline on the owner thread — never hopped to a dispatcher, which would
-   * both assume an AWT host and lose the production order of status updates.
+   * Compose state updated on the owner thread to preserve status update order and avoid depending
+   * on an AWT dispatcher.
    */
   private val packsState = mutableStateOf(emptySet<OfflinePack>())
 

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/resource/MlnFfiResourceProvider.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/resource/MlnFfiResourceProvider.kt
@@ -192,8 +192,8 @@ internal class MlnFfiResourceProvider(
   }
 
   /**
-   * Answers a request that arrived after [close], inline — safe on MapLibre's thread only because
-   * producing the failure blocks on nothing.
+   * Answers a request received after [close] on MapLibre's thread. Producing this failure does not
+   * block.
    */
   private fun refuse(request: TakenResourceRequest, url: String, requestedUrl: String) {
     try {

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/sources/StyleSpecTypes.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/sources/StyleSpecTypes.kt
@@ -5,9 +5,9 @@ import org.maplibre.nativeffi.style.SourceType
 import org.maplibre.nativeffi.style.VectorTileEncoding
 
 /**
- * The style spec's name for a source type, or null for one the spec cannot spell (annotation,
- * custom-vector, unknown). [SourceType.toString] is the FFI's generated default —
- * `SourceType(nativeValue=1)`, not `vector` — so it cannot be used here.
+ * The style spec name, or null for annotation, custom-vector, or unknown source types.
+ * [SourceType.toString] returns the generated FFI representation, such as
+ * `SourceType(nativeValue=1)`, instead of the style spec name.
  */
 internal fun SourceType.toStyleSpecType(): String? =
   when (this) {

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/util/conversions.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/util/conversions.kt
@@ -17,10 +17,6 @@ import org.maplibre.spatialk.geojson.Position
 // MapLibre Native works in logical pixels, the same units as Compose's dp, so these conversions are
 // unit-preserving; scaling by density here would double-apply it on a HiDPI display.
 
-// TODO: once maplibre-native-ffi covers every target this library does, the common public geometry
-// types should be typealiases for its own, and this file should go away rather than grow an
-// equivalent on each platform.
-
 internal fun LatLng.toPosition(): Position = Position(longitude = longitude, latitude = latitude)
 
 internal fun Position.toLatLng(): LatLng = LatLng(latitude = latitude, longitude = longitude)

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/MlnFfiMapRepaintTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/MlnFfiMapRepaintTest.kt
@@ -20,7 +20,7 @@ import org.maplibre.compose.style.uninstall
 import org.maplibre.spatialk.geojson.dsl.featureCollectionOf
 
 /**
- * Proves that a style change actually redraws, not just that it reaches MapLibre.
+ * Verifies that style changes request a rendered frame.
  *
  * `addSource`, `removeSource`, and `removeImage` publish no render update on their own, so the
  * style binding requests a repaint for them. A base style load can finish during a frame that

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/mlnffi/FakeMlnFfiMapHost.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/mlnffi/FakeMlnFfiMapHost.kt
@@ -211,10 +211,7 @@ internal class FakeMlnFfiMapHostFactory(
     RenderBackendPair(MapRenderBackend.VULKAN, ComposeRenderBackend.OPENGL),
   override val description: String = "fake test host",
   private val result: ((MapRenderBackend) -> MlnFfiMapHostResult)? = null,
-  /**
-   * Applied to each host before it is handed out — the only chance to arm a failure, since the
-   * first frame is acquired in the draw pass right after the host is created.
-   */
+  /** Configures failures before the draw pass acquires the new host's first frame. */
   private val configureHost: (FakeMlnFfiMapHost) -> Unit = {},
 ) : MlnFfiMapHostFactory {
 

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/offline/MlnFfiOfflinePackTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/offline/MlnFfiOfflinePackTest.kt
@@ -40,8 +40,7 @@ class MlnFfiOfflinePackTest {
 
   @AfterTest
   fun cleanUp() {
-    // Must precede the delete, so the database is closed rather than pulled out from under a live
-    // runtime.
+    // Close the runtime before deleting its database.
     managers.forEach { it.close() }
     FfiTestPlatform.deleteCacheFile(cacheFile)
   }
@@ -263,10 +262,7 @@ class MlnFfiOfflinePackTest {
     assertEquals(DownloadStatus.Paused, paused.status)
   }
 
-  /**
-   * The status a reopened manager publishes comes from the database rather than from the download
-   * that did the work — a different MapLibre code path, and the one every restart takes.
-   */
+  /** Reopening must restore status from the database through the same code path used on restart. */
   @Test
   fun a_finished_pack_still_reads_as_complete_after_a_reopen() = runBlocking {
     val first = manager()

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/offline/OfflineProgressMappingTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/offline/OfflineProgressMappingTest.kt
@@ -40,8 +40,8 @@ class OfflineProgressMappingTest {
   }
 
   /**
-   * MapLibre leaves a finished region marked active — it stops fetching without changing its
-   * download state — so completion has to win over the state.
+   * MapLibre stops fetching completed regions without changing their active download state.
+   * Completion must take precedence over that state.
    */
   @Test
   fun a_complete_region_is_complete_even_while_it_is_still_marked_active() {
@@ -53,7 +53,7 @@ class OfflineProgressMappingTest {
 
   /**
    * Download states are value classes over Int, so a newer native runtime can report one this build
-   * has never heard of. Paused is the honest answer; claiming a download is running is not.
+   * does not recognize. Treat unknown values as paused.
    */
   @Test
   fun an_unrecognized_download_state_is_reported_as_paused() {


### PR DESCRIPTION
## Description

Remove unused internal declarations, simplify scale-bar calculations and source-reference control flow, and trim redundant KDoc and platform comments. Public API contracts and lifecycle behavior are preserved.

## Validation

On the combined cleanup tree, static checks, style-spec parity, Android host tests, desktop tests, browser tests, and the documentation build passed. Browser tests required `mise run test:js -- --no-parallel -Pkotlin.daemon.jvmargs=-Xmx4g`. iOS, Android device tests, and direct scale-bar visual checks were not run. Each branch contains a disjoint portion of that validated tree and targets `main` independently.

## AI assistance

Codex (GPT-6), including subagents, performed the cleanup and source review. Draft pending human review.
