### PR TITLE
refactor: simplify location provider state and documentation

### DIFF
--- a/lib/location-runtime-gms/src/androidMain/kotlin/org/maplibre/compose/gms/FusedLocationProvider.kt
+++ b/lib/location-runtime-gms/src/androidMain/kotlin/org/maplibre/compose/gms/FusedLocationProvider.kt
@@ -32,29 +32,17 @@ import org.maplibre.compose.location.asMapLibreLocationUpdate
 import org.maplibre.spatialk.units.extensions.inMeters
 
 /**
- * A location provider backed by Google Play Services fused location.
+ * Foreground fused location from Google Play Services.
  *
- * Each collection requests fused updates, emits the last location when one exists, and removes its
- * callback when collection ends.
+ * Delivers the last known location when available, then applies the requested accuracy, interval,
+ * and minimum distance. [LocationAccuracy.Lowest] receives passive updates.
  *
- * [LocationAccuracy.BestForNavigation] and [LocationAccuracy.High] map to
- * [`Priority.PRIORITY_HIGH_ACCURACY`](https://developers.google.com/android/reference/com/google/android/gms/location/Priority#PRIORITY_HIGH_ACCURACY),
- * [LocationAccuracy.Balanced] maps to
- * [`Priority.PRIORITY_BALANCED_POWER_ACCURACY`](https://developers.google.com/android/reference/com/google/android/gms/location/Priority#PRIORITY_BALANCED_POWER_ACCURACY),
- * [LocationAccuracy.Low] maps to
- * [`Priority.PRIORITY_LOW_POWER`](https://developers.google.com/android/reference/com/google/android/gms/location/Priority#PRIORITY_LOW_POWER),
- * and [LocationAccuracy.Lowest] maps to
- * [`Priority.PRIORITY_PASSIVE`](https://developers.google.com/android/reference/com/google/android/gms/location/Priority#PRIORITY_PASSIVE).
+ * Unavailable locations report [LocationUnavailableReason.TemporarilyUnavailable]. Missing
+ * permission reports [LocationUnavailableReason.PermissionDenied]. Other exceptions propagate to
+ * the collector.
  *
- * [`LocationAvailability.isLocationAvailable`](https://developers.google.com/android/reference/com/google/android/gms/location/LocationAvailability#isLocationAvailable())
- * equal to `false` maps to [LocationUnavailableReason.TemporarilyUnavailable]. A
- * `SecurityException` maps to [LocationUnavailableReason.PermissionDenied]. Other exceptions escape
- * the flow, and the collector classifies them as [LocationUnavailableReason.UnexpectedFailure].
- *
- * The [Context] constructor delegates [permission] and [requestPermission] to an
- * [AndroidLocationProvider]. The [FusedLocationProviderClient] constructor keeps the default
- * [LocationProvider.permission], which is always granted, and its [updates] still surface a
- * `SecurityException` as [LocationUnavailableReason.PermissionDenied].
+ * The [Context] constructor handles permission requests. The [FusedLocationProviderClient]
+ * constructor reports permission as granted and requires the caller to manage authorization.
  */
 public class FusedLocationProvider
 internal constructor(

--- a/lib/location-runtime-hms/src/androidMain/kotlin/org/maplibre/compose/hms/FusedLocationProvider.kt
+++ b/lib/location-runtime-hms/src/androidMain/kotlin/org/maplibre/compose/hms/FusedLocationProvider.kt
@@ -28,28 +28,17 @@ import org.maplibre.compose.location.asMapLibreLocationUpdate
 import org.maplibre.spatialk.units.extensions.inMeters
 
 /**
- * A location provider backed by Huawei Mobile Services fused location.
+ * Foreground fused location from Huawei Mobile Services.
  *
- * Each collection requests fused updates, emits the last location when one exists, and removes its
- * callback when collection ends. Every update request explicitly selects
- * [`LocationRequest.COORDINATE_TYPE_WGS84`](https://developer.huawei.com/consumer/en/doc/HMSCore-References/locationrequest-0000001050986193),
- * which is the coordinate system that MapLibre expects.
+ * Delivers the last known location when available, then applies the requested accuracy, interval,
+ * and minimum distance. [LocationAccuracy.Lowest] receives passive updates.
  *
- * [LocationAccuracy.BestForNavigation] and [LocationAccuracy.High] map to
- * `LocationRequest.PRIORITY_HIGH_ACCURACY`, [LocationAccuracy.Balanced] maps to
- * `LocationRequest.PRIORITY_BALANCED_POWER_ACCURACY`, [LocationAccuracy.Low] maps to
- * `LocationRequest.PRIORITY_LOW_POWER`, and [LocationAccuracy.Lowest] maps to
- * `LocationRequest.PRIORITY_NO_POWER`.
+ * Unavailable locations report [LocationUnavailableReason.TemporarilyUnavailable]. Missing
+ * permission reports [LocationUnavailableReason.PermissionDenied]. Other exceptions propagate to
+ * the collector.
  *
- * [LocationAvailability.isLocationAvailable] equal to `false` maps to
- * [LocationUnavailableReason.TemporarilyUnavailable]. A `SecurityException` maps to
- * [LocationUnavailableReason.PermissionDenied]. Other exceptions escape the flow, and the collector
- * classifies them as [LocationUnavailableReason.UnexpectedFailure].
- *
- * The [Context] constructor delegates [permission] and [requestPermission] to an
- * [AndroidLocationProvider]. The [FusedLocationProviderClient] constructor keeps the default
- * [LocationProvider.permission], which is always granted, and its [updates] still surface a
- * `SecurityException` as [LocationUnavailableReason.PermissionDenied].
+ * The [Context] constructor handles permission requests. The [FusedLocationProviderClient]
+ * constructor reports permission as granted and requires the caller to manage authorization.
  */
 public class FusedLocationProvider
 internal constructor(

--- a/lib/location-runtime-linux/src/main/kotlin/org/maplibre/compose/location/desktop/linux/DbusLocationPortal.kt
+++ b/lib/location-runtime-linux/src/main/kotlin/org/maplibre/compose/location/desktop/linux/DbusLocationPortal.kt
@@ -214,9 +214,7 @@ internal class DbusLocationPortal(private val window: XdgPortalWindow? = null) :
     }
   }
 
-  // No distance-threshold: GeoClue emits nothing, not even the first measurement, when the position
-  // has
-  // not moved that far, and a GeoIP-located desktop never moves.
+  // A distance threshold suppresses even the first update for stationary GeoIP locations.
   private fun sessionOptions(request: LocationRequest): Map<String, Variant<*>> =
     mapOf(
       "session_handle_token" to Variant(newToken()),

--- a/lib/location-runtime-macos/src/main/kotlin/org/maplibre/compose/location/desktop/macos/MacosLocationBackend.kt
+++ b/lib/location-runtime-macos/src/main/kotlin/org/maplibre/compose/location/desktop/macos/MacosLocationBackend.kt
@@ -17,7 +17,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.maplibre.compose.location.DesktopLocationBackend
 import org.maplibre.compose.location.DesktopLocationProvider
-import org.maplibre.compose.location.LocationAccuracy
 import org.maplibre.compose.location.LocationAccuracyAuthorization
 import org.maplibre.compose.location.LocationBackendAvailability
 import org.maplibre.compose.location.LocationEvent
@@ -40,41 +39,16 @@ public class MacosLocationBackend : DesktopLocationBackend {
 }
 
 /**
- * A [LocationProvider] built on
- * [`CLLocationManager`](https://developer.apple.com/documentation/corelocation/cllocationmanager).
+ * Foreground location from macOS Core Location.
  *
- * [LocationProvider.permission] and [LocationProvider.requestPermission] delegate to a
- * [MacosLocationPermissionRequester] that shares the provider's Core Location client.
+ * The application's Info.plist must declare `NSLocationWhenInUseUsageDescription`. Applies the
+ * requested accuracy and minimum distance. [LocationRequest.minimumInterval] is ignored. See
+ * [MacosLocationPermissionRequester] for permission behavior.
  *
- * Each collection creates a
- * [`CLLocationManager`](https://developer.apple.com/documentation/corelocation/cllocationmanager)
- * on the AppKit main run loop, applies the request's accuracy and distance preferences, and stops
- * the manager when collection ends. Compose Desktop's `Dispatchers.Main` is the Swing
- * event-dispatch thread on the AWT host and does not pump that run loop, so Core Location work is
- * marshaled there explicitly. The process's app Info.plist must declare
- * `NSLocationWhenInUseUsageDescription`. [LocationRequest.minimumInterval] is ignored because Core
- * Location filters only by distance.
- *
- * [LocationAccuracy.BestForNavigation] maps to
- * [`kCLLocationAccuracyBestForNavigation`](https://developer.apple.com/documentation/corelocation/kcllocationaccuracybestfornavigation),
- * [LocationAccuracy.High] maps to
- * [`kCLLocationAccuracyBest`](https://developer.apple.com/documentation/corelocation/kcllocationaccuracybest),
- * [LocationAccuracy.Balanced] maps to
- * [`kCLLocationAccuracyHundredMeters`](https://developer.apple.com/documentation/corelocation/kcllocationaccuracyhundredmeters),
- * [LocationAccuracy.Low] maps to
- * [`kCLLocationAccuracyKilometer`](https://developer.apple.com/documentation/corelocation/kcllocationaccuracykilometer),
- * and [LocationAccuracy.Lowest] maps to
- * [`kCLLocationAccuracyReduced`](https://developer.apple.com/documentation/corelocation/kcllocationaccuracyreduced).
- *
- * [`kCLErrorDenied`](https://developer.apple.com/documentation/corelocation/clerror/denied) maps to
- * [LocationUnavailableReason.ServicesDisabled] when location services are disabled and to
- * [LocationUnavailableReason.PermissionDenied] otherwise.
- * [`kCLErrorPromptDeclined`](https://developer.apple.com/documentation/corelocation/clerror/promptdeclined)
- * also maps to [LocationUnavailableReason.PermissionDenied].
- * [`kCLErrorLocationUnknown`](https://developer.apple.com/documentation/corelocation/clerror/locationunknown)
- * and [`kCLErrorNetwork`](https://developer.apple.com/documentation/corelocation/clerror/network)
- * map to [LocationUnavailableReason.TemporarilyUnavailable]. Other Core Location errors map to
- * [LocationUnavailableReason.UnexpectedFailure].
+ * Disabled location services report [LocationUnavailableReason.ServicesDisabled]. Denied or
+ * declined permission reports [LocationUnavailableReason.PermissionDenied]. Network failures and
+ * unknown locations report [LocationUnavailableReason.TemporarilyUnavailable]. Other failures
+ * report [LocationUnavailableReason.UnexpectedFailure].
  */
 public class MacosLocationProvider
 internal constructor(
@@ -127,7 +101,6 @@ internal constructor(
       return@callbackFlow
     }
 
-    // Retaining the delegate in this closure is required because CLLocationManager does not.
     awaitClose { manager.close() }
   }
     .flowOn(dispatcher)

--- a/lib/location-runtime-windows/MODULE.md
+++ b/lib/location-runtime-windows/MODULE.md
@@ -1,5 +1,3 @@
 # Module location-runtime-windows
 
-Provides the Windows Runtime location backend for MapLibre Compose desktop
-applications. The backend uses `AppCapability` for permission and `Geolocator`
-for independent foreground update sessions.
+Windows location backend for MapLibre Compose desktop applications.

--- a/lib/location-runtime-windows/src/main/kotlin/org/maplibre/compose/location/desktop/windows/WinRtSupport.kt
+++ b/lib/location-runtime-windows/src/main/kotlin/org/maplibre/compose/location/desktop/windows/WinRtSupport.kt
@@ -29,18 +29,7 @@ internal class ComPtr(private var segment: MemorySegment) : AutoCloseable {
       return segment
     }
 
-  fun queryInterface(iid: String): ComPtr =
-    Arena.ofConfined().use { arena ->
-      val output = arena.allocate(ADDRESS)
-      WinRt.callHresult(
-        value,
-        0,
-        FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS, ADDRESS),
-        WinRt.guid(iid, arena),
-        output,
-      )
-      ComPtr(output.get(ADDRESS, 0))
-    }
+  fun queryInterface(iid: String): ComPtr = WinRt.queryInterface(value, iid)
 
   override fun close() {
     if (!closed.compareAndSet(false, true)) return

--- a/lib/location-runtime-windows/src/main/kotlin/org/maplibre/compose/location/desktop/windows/WindowsLocation.kt
+++ b/lib/location-runtime-windows/src/main/kotlin/org/maplibre/compose/location/desktop/windows/WindowsLocation.kt
@@ -127,27 +127,21 @@ internal class WindowsLocationFilter(
   private val minimumDistanceMeters: Double,
 ) {
   private var previousLocation: WindowsLocationMeasurement? = null
-  private var previousTimestampTicks: Long = 0
 
   fun shouldDeliver(measurement: WindowsLocationMeasurement): Boolean {
     val previous = previousLocation
     if (previous == null) {
-      remember(measurement)
+      previousLocation = measurement
       return true
     }
     val elapsed =
-      ((measurement.windowsTimestampTicks - previousTimestampTicks).coerceAtLeast(0) /
+      ((measurement.windowsTimestampTicks - previous.windowsTimestampTicks).coerceAtLeast(0) /
           TICKS_PER_MILLISECOND)
         .milliseconds
     if (elapsed < minimumInterval) return false
     if (haversineMeters(previous, measurement) < minimumDistanceMeters) return false
-    remember(measurement)
-    return true
-  }
-
-  private fun remember(measurement: WindowsLocationMeasurement) {
     previousLocation = measurement
-    previousTimestampTicks = measurement.windowsTimestampTicks
+    return true
   }
 }
 

--- a/lib/location-runtime-windows/src/main/kotlin/org/maplibre/compose/location/desktop/windows/WindowsLocationBackend.kt
+++ b/lib/location-runtime-windows/src/main/kotlin/org/maplibre/compose/location/desktop/windows/WindowsLocationBackend.kt
@@ -33,24 +33,18 @@ public class WindowsLocationBackend : DesktopLocationBackend {
 }
 
 /**
- * A [LocationProvider] backed by `Windows.Devices.Geolocation.Geolocator`.
+ * Foreground location from Windows geolocation.
  *
- * Each [updates] collector owns an independent `Geolocator`. The provider configures its scalar
- * desired accuracy to 1, 10, 100, 1,000, or 5,000 meters from [LocationAccuracy.BestForNavigation]
- * through [LocationAccuracy.Lowest], configures `ReportInterval`, and also enforces
- * [LocationRequest.minimumInterval] and [LocationRequest.minimumDistance] before delivery. The
- * first valid measurement is always delivered. Cancelling collection removes both native event
- * handlers and releases the geolocator.
+ * Requests accuracy of 1, 10, 100, 1,000, or 5,000 meters for [LocationAccuracy.BestForNavigation]
+ * through [LocationAccuracy.Lowest]. Applies [LocationRequest.minimumInterval] and
+ * [LocationRequest.minimumDistance] after the first valid measurement.
  *
- * `Initializing`, `NoData`, and `NotInitialized` report
- * [LocationUnavailableReason.TemporarilyUnavailable]. `Disabled` reports
- * [LocationUnavailableReason.PermissionDenied] when access is denied and
- * [LocationUnavailableReason.ServicesDisabled] when access remains granted. `NotAvailable` reports
- * [LocationUnavailableReason.Unsupported]. Unexpected native failures report
+ * An initializing service or missing data reports
+ * [LocationUnavailableReason.TemporarilyUnavailable]. A disabled service reports
+ * [LocationUnavailableReason.PermissionDenied] when access is denied, and
+ * [LocationUnavailableReason.ServicesDisabled] otherwise. Unavailable hardware reports
+ * [LocationUnavailableReason.Unsupported]. Other failures report
  * [LocationUnavailableReason.UnexpectedFailure].
- *
- * Ordinary Windows Runtime calls run in a dedicated multithreaded apartment. Permission requests
- * start on the AWT event-dispatch thread because Windows requires a foreground UI-thread request.
  */
 public class WindowsLocationProvider
 internal constructor(private val client: WindowsLocationClient) : DesktopLocationProvider {

--- a/lib/location/src/androidMain/kotlin/org/maplibre/compose/location/AndroidLocationBackend.kt
+++ b/lib/location/src/androidMain/kotlin/org/maplibre/compose/location/AndroidLocationBackend.kt
@@ -81,7 +81,7 @@ internal object AndroidLocationBackendResolver {
   }
 }
 
-internal class MisconfiguredLocationProvider(private val cause: Throwable) : LocationProvider {
+internal class MisconfiguredLocationProvider(cause: Throwable) : LocationProvider {
   override val backendAvailability: LocationBackendAvailability =
     LocationBackendAvailability.Misconfigured(cause)
 

--- a/lib/location/src/androidMain/kotlin/org/maplibre/compose/location/AndroidLocationProvider.kt
+++ b/lib/location/src/androidMain/kotlin/org/maplibre/compose/location/AndroidLocationProvider.kt
@@ -23,35 +23,19 @@ import kotlinx.coroutines.flow.callbackFlow
 import org.maplibre.spatialk.units.extensions.inMeters
 
 /**
- * A [LocationProvider] built on the [LocationManager] platform APIs.
+ * Foreground location from Android's location service.
  *
- * Each collection selects a provider and request settings from [LocationRequest], emits the last
- * known location when one exists, and removes its listener when collection ends.
+ * Uses fused location on Android 12 and later, and an available provider matching the requested
+ * accuracy on earlier versions. [LocationAccuracy.Lowest] receives passive updates.
  *
- * On Android 12 and newer, [LocationAccuracy.BestForNavigation] and [LocationAccuracy.High] map to
- * [`LocationRequest.QUALITY_HIGH_ACCURACY`](https://developer.android.com/reference/android/location/LocationRequest#QUALITY_HIGH_ACCURACY),
- * [LocationAccuracy.Balanced] maps to
- * [`LocationRequest.QUALITY_BALANCED_POWER_ACCURACY`](https://developer.android.com/reference/android/location/LocationRequest#QUALITY_BALANCED_POWER_ACCURACY),
- * and [LocationAccuracy.Low] maps to
- * [`LocationRequest.QUALITY_LOW_POWER`](https://developer.android.com/reference/android/location/LocationRequest#QUALITY_LOW_POWER).
- * Earlier versions use the corresponding
- * [`Criteria`](https://developer.android.com/reference/android/location/Criteria) accuracy and
- * power requirements. [LocationAccuracy.Lowest] uses
- * [`LocationManager.PASSIVE_PROVIDER`](https://developer.android.com/reference/android/location/LocationManager#PASSIVE_PROVIDER)
- * on every version.
+ * Disabled location services report [LocationUnavailableReason.ServicesDisabled]. Missing
+ * permission reports [LocationUnavailableReason.PermissionDenied]. Invalid provider registration
+ * reports [LocationUnavailableReason.UnexpectedFailure].
  *
- * A disabled location service or
- * [`LocationListener.onProviderDisabled`](https://developer.android.com/reference/android/location/LocationListener#onProviderDisabled(java.lang.String))
- * maps to [LocationUnavailableReason.ServicesDisabled]. A `SecurityException` maps to
- * [LocationUnavailableReason.PermissionDenied]. An `IllegalArgumentException` while registering the
- * selected provider maps to [LocationUnavailableReason.UnexpectedFailure], because this provider
- * constructs and validates every request argument itself.
+ * See [AndroidLocationPermissionRequester] for permission request requirements.
  *
- * [permission] and [requestPermission] delegate to an [AndroidLocationPermissionRequester]; see its
- * documentation for when the system permission dialog can be shown.
- *
- * @param context Context used to obtain the platform [LocationManager].
- * @param requester Permission requester that backs [permission] and [requestPermission].
+ * @param context Context used to access location services.
+ * @param requester Handles [permission] and [requestPermission].
  */
 public class AndroidLocationProvider
 internal constructor(context: Context, private val requester: AndroidLocationPermissionRequester) :

--- a/lib/location/src/commonMain/kotlin/org/maplibre/compose/location/LocationMeasurement.kt
+++ b/lib/location/src/commonMain/kotlin/org/maplibre/compose/location/LocationMeasurement.kt
@@ -10,9 +10,6 @@ import org.maplibre.spatialk.units.Rotation
 /**
  * One measured geographic location.
  *
- * [Position.altitude] is expressed in meters. [distancePerSecond] and [distancePerSecondAccuracy]
- * store the distance that corresponds to one second at the reported rate.
- *
  * @property position Geographic position, with an optional altitude in meters.
  * @property horizontalAccuracy Estimated horizontal error radius, or `null` when unknown.
  * @property altitudeAccuracy Estimated altitude error, or `null` when unknown or when [position]

--- a/lib/location/src/commonMain/kotlin/org/maplibre/compose/location/LocationProvider.kt
+++ b/lib/location/src/commonMain/kotlin/org/maplibre/compose/location/LocationProvider.kt
@@ -12,17 +12,10 @@ import org.maplibre.spatialk.units.extensions.inMeters
 import org.maplibre.spatialk.units.extensions.meters
 
 /**
- * This is an intentionally very limited abstraction over the various platform APIs for geolocation.
- * It is specialized to the use case of maplibre-compose.
+ * Supplies foreground location updates and permission status.
  *
- * If you have a more general use case, prefer using the platform APIs directly or using a more
- * powerful wrapper. In that case, you may want to provide your own [LocationProvider]
- * implementation to unify the API underneath. This is an explicitly supported use case:
- * [permission] defaults to granted, so a source where permission is not a concept needs no
- * permission handling.
- *
- * Each collector of [updates] starts an independent platform location request. Cancelling
- * collection must stop that request and unregister its callbacks.
+ * Implement this interface for custom location sources. Sources without permission handling can use
+ * the default [permission] and [requestPermission] implementations.
  */
 public interface LocationProvider {
   /** A stable implementation name for diagnostics, when the provider declares one. */
@@ -123,8 +116,7 @@ public data class LocationRequest(
 /**
  * Accuracy levels for [LocationRequest], which are mapped to platform accuracy and power levels.
  *
- * The recommended level for actively displaying the user location on screen is [High] or
- * [Balanced], if the location doesn't have to be perfectly accurate.
+ * Use [High] to display the user's location, or [Balanced] to reduce power usage.
  */
 public enum class LocationAccuracy {
   /**

--- a/lib/location/src/iosMain/kotlin/org/maplibre/compose/location/IosLocationProvider.kt
+++ b/lib/location/src/iosMain/kotlin/org/maplibre/compose/location/IosLocationProvider.kt
@@ -28,37 +28,15 @@ import platform.Foundation.NSError
 import platform.darwin.NSObject
 
 /**
- * A [LocationProvider] built on
- * [`CLLocationManager`](https://developer.apple.com/documentation/corelocation/cllocationmanager).
+ * Foreground location from Core Location.
  *
- * [LocationProvider.permission] and [LocationProvider.requestPermission] delegate to an
- * [IosLocationPermissionRequester].
+ * Applies the requested accuracy and minimum distance. [LocationRequest.minimumInterval] is
+ * ignored. See [IosLocationPermissionRequester] for permission behavior.
  *
- * Each collection creates a
- * [`CLLocationManager`](https://developer.apple.com/documentation/corelocation/cllocationmanager)
- * on the main dispatcher, applies the request's accuracy and distance preferences, and stops the
- * manager when collection ends.
- *
- * [LocationAccuracy.BestForNavigation] maps to
- * [`kCLLocationAccuracyBestForNavigation`](https://developer.apple.com/documentation/corelocation/kcllocationaccuracybestfornavigation),
- * [LocationAccuracy.High] maps to
- * [`kCLLocationAccuracyBest`](https://developer.apple.com/documentation/corelocation/kcllocationaccuracybest),
- * [LocationAccuracy.Balanced] maps to
- * [`kCLLocationAccuracyHundredMeters`](https://developer.apple.com/documentation/corelocation/kcllocationaccuracyhundredmeters),
- * [LocationAccuracy.Low] maps to
- * [`kCLLocationAccuracyKilometer`](https://developer.apple.com/documentation/corelocation/kcllocationaccuracykilometer),
- * and [LocationAccuracy.Lowest] maps to
- * [`kCLLocationAccuracyReduced`](https://developer.apple.com/documentation/corelocation/kcllocationaccuracyreduced).
- *
- * [`kCLErrorDenied`](https://developer.apple.com/documentation/corelocation/clerror/denied) maps to
- * [LocationUnavailableReason.ServicesDisabled] when location services are disabled and to
- * [LocationUnavailableReason.PermissionDenied] otherwise.
- * [`kCLErrorPromptDeclined`](https://developer.apple.com/documentation/corelocation/clerror/promptdeclined)
- * also maps to [LocationUnavailableReason.PermissionDenied].
- * [`kCLErrorLocationUnknown`](https://developer.apple.com/documentation/corelocation/clerror/locationunknown)
- * and [`kCLErrorNetwork`](https://developer.apple.com/documentation/corelocation/clerror/network)
- * map to [LocationUnavailableReason.TemporarilyUnavailable]. Other Core Location errors map to
- * [LocationUnavailableReason.UnexpectedFailure].
+ * Disabled location services report [LocationUnavailableReason.ServicesDisabled]. Denied or
+ * declined permission reports [LocationUnavailableReason.PermissionDenied]. Network failures and
+ * unknown locations report [LocationUnavailableReason.TemporarilyUnavailable]. Other failures
+ * report [LocationUnavailableReason.UnexpectedFailure].
  */
 public class IosLocationProvider : LocationProvider {
   private val requester = IosLocationPermissionRequester()

--- a/lib/location/src/jsMain/kotlin/org/maplibre/compose/location/BrowserLocationProvider.kt
+++ b/lib/location/src/jsMain/kotlin/org/maplibre/compose/location/BrowserLocationProvider.kt
@@ -38,29 +38,15 @@ import web.permissions.prompt
 import web.permissions.query
 
 /**
- * A browser location provider backed by the
- * [Geolocation API](https://developer.mozilla.org/en-US/docs/Web/API/Geolocation_API).
+ * Foreground location from the browser's Geolocation API.
  *
- * [LocationAccuracy.BestForNavigation] and [LocationAccuracy.High] set
- * [`PositionOptions.enableHighAccuracy`](https://developer.mozilla.org/en-US/docs/Web/API/Geolocation/getCurrentPosition#enablehighaccuracy)
- * to `true`. The remaining accuracy values set it to `false`. The provider applies
- * [LocationRequest.minimumInterval] after delivery. It ignores [LocationRequest.minimumDistance]
- * because [`PositionOptions`](https://developer.mozilla.org/en-US/docs/Web/API/PositionOptions) has
- * no distance threshold.
+ * [LocationAccuracy.BestForNavigation] and [LocationAccuracy.High] request high accuracy. Applies
+ * [LocationRequest.minimumInterval] and ignores [LocationRequest.minimumDistance].
  *
- * A missing Geolocation API maps [LocationProvider.backendAvailability] to
- * [LocationBackendAvailability.Unsupported].
- * [`GeolocationPositionError.PERMISSION_DENIED`](https://developer.mozilla.org/en-US/docs/Web/API/GeolocationPositionError/code#geolocationpositionerror.permission_denied)
- * maps to [LocationUnavailableReason.PermissionDenied].
- * [`POSITION_UNAVAILABLE`](https://developer.mozilla.org/en-US/docs/Web/API/GeolocationPositionError/code#geolocationpositionerror.position_unavailable)
- * and
- * [`TIMEOUT`](https://developer.mozilla.org/en-US/docs/Web/API/GeolocationPositionError/code#geolocationpositionerror.timeout)
- * map to [LocationUnavailableReason.TemporarilyUnavailable]. An exception thrown while starting the
- * live watch maps to [LocationUnavailableReason.UnexpectedFailure].
- *
- * [LocationProvider.permission] and [LocationProvider.requestPermission] delegate to a
- * [BrowserLocationPermissionRequester] that shares the provider's boundary, so a permission denial
- * during an active watch updates [LocationProvider.permission].
+ * A missing Geolocation API reports [LocationBackendAvailability.Unsupported]. Permission denial
+ * reports [LocationUnavailableReason.PermissionDenied] and updates [permission]. Timeouts and
+ * unavailable positions report [LocationUnavailableReason.TemporarilyUnavailable]. Failure to start
+ * location updates reports [LocationUnavailableReason.UnexpectedFailure].
  */
 public class BrowserLocationProvider
 internal constructor(
@@ -68,8 +54,8 @@ internal constructor(
   coroutineScope: CoroutineScope,
 ) : LocationProvider {
   /**
-   * Creates a provider that observes permission in a coroutine scope that lives as long as the
-   * provider.
+   * Creates a provider with independent permission observation. Use the [CoroutineScope]
+   * constructor to control the observation lifetime.
    */
   public constructor() :
     this(BrowserGeolocation, CoroutineScope(SupervisorJob() + Dispatchers.Default))
@@ -100,10 +86,8 @@ internal constructor(
       when (result) {
         is BrowserResult.Position -> {
           val current = result.value
-          if (
-            previous == null ||
-              current.capturedAt - previous!!.capturedAt >= request.minimumInterval
-          ) {
+          val last = previous
+          if (last == null || current.capturedAt - last.capturedAt >= request.minimumInterval) {
             previous = current
             trySend(
               LocationEvent.Update(


### PR DESCRIPTION
## Description

Reuse the previous Windows fix timestamp instead of storing it twice, delegate COM interface lookup to the existing helper, and remove redundant state and assertions. Shorten provider documentation while retaining lifetime and platform constraints.

## Validation

On the combined cleanup tree, static checks and Android host, desktop, and browser tests passed. Windows and Linux location services and iOS were not exercised on their target operating systems. Each branch contains a disjoint portion of that validated tree and targets `main` independently.

## AI assistance

Codex (GPT-6), including subagents, performed the cleanup and source review. Draft pending human review.
