### PR TITLE
fix: refresh offline icons when content slots change

### DIFF
--- a/lib/maplibre-compose-material3/MODULE.md
+++ b/lib/maplibre-compose-material3/MODULE.md
@@ -4,6 +4,4 @@ Material 3 extensions for MapLibre Compose.
 
 # Package org.maplibre.compose.material3
 
-Map controls themed from the Material 3 color scheme and typography, replacing
-the ones that `org.maplibre.compose.overlay` draws with Compose Foundation
-alone.
+Map controls using the Material 3 color scheme and typography.

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/org/maplibre/compose/material3/AttributionButton.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/org/maplibre/compose/material3/AttributionButton.kt
@@ -24,8 +24,7 @@ import org.maplibre.compose.overlay.ExpandingAttributionButton as BaseExpandingA
 import org.maplibre.compose.overlay.MapOverlayScope
 
 /**
- * Info button from which an attribution popup text is expanded. This version retracts when the user
- * interacts with the map.
+ * An attribution popup that collapses when the user interacts with the map.
  *
  * This is [org.maplibre.compose.overlay.ExpandingAttributionButton] with its colors, typography,
  * and widgets taken from the Material 3 theme.
@@ -67,11 +66,10 @@ public fun MapOverlayScope.ExpandingAttributionButton(
 }
 
 /**
- * A composable function that displays a collection of attribution links as a flow layout, styled
- * from the Material 3 theme.
+ * Attribution links in a flow layout using the Material 3 theme.
  *
- * @param attributions A list of HTML strings representing the attributions that need to be
- *   displayed as links. See: [org.maplibre.compose.sources.Source.attributionHtml].
+ * @param attributions HTML attribution strings. See
+ *   [org.maplibre.compose.sources.Source.attributionHtml].
  * @param textStyle Style of the attribution text.
  * @param linkStyles Optional style for hyperlinks. Default is primary color and underlined.
  * @param spacing The horizontal spacing between items in the flow layout.
@@ -118,10 +116,7 @@ public object AttributionButtonDefaults {
       AttributionLinks(attributions, textStyle = textStyle)
     }
 
-  /**
-   * @param tonalElevation Resolved into the container color, because the base component draws no
-   *   Material surface of its own.
-   */
+  /** @param tonalElevation Tonal elevation applied to the container color. */
   @Composable
   public fun expandedStyle(
     tonalElevation: Dp = 0.dp,

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/org/maplibre/compose/material3/MapOverlay.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/org/maplibre/compose/material3/MapOverlay.kt
@@ -40,8 +40,7 @@ private val Material3FullOverlay = MapOverlay {
 
 /**
  * Applies the Material 3 color scheme and typography to the controls from
- * [MapOverlay.AttributionOnly]. The empty overlay has no colors to theme, so it stays
- * [MapOverlay.None].
+ * [MapOverlay.AttributionOnly].
  *
  * The Material 3 theme does not change the MapLibre logo colors.
  */

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/org/maplibre/compose/material3/PointerPinButton.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/org/maplibre/compose/material3/PointerPinButton.kt
@@ -91,9 +91,7 @@ public fun MapOverlayScope.PointerPinButton(
         Modifier
           // Counter-rotation keeps the content upright inside the rotated pin.
           .graphicsLayer { rotationZ = -placement.angleDegrees }
-          // padding to place the content within the pin correctly, taking into account that the
-          // center of the pointer shape is not the center of to-be-placed icon (due to the
-          // pointy side)
+          // Offset the content from the pin tip to center it in the rounded part.
           .proportionalPadding(PointerPinShape.POINTY_SIZE)
           .padding(contentPadding)
     ) {

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/org/maplibre/compose/material3/util/ColorScheme.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/org/maplibre/compose/material3/util/ColorScheme.kt
@@ -8,13 +8,7 @@ import androidx.compose.runtime.Stable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.takeOrElse
 
-// The scalebar uses `LocalContentColor` as its default color to be consistent with other elements
-// shown alongside it, such as the attribution button, static text, etc.. So, usually it is the
-// other way round - the background color decides which content color is used. For the scalebar, we
-// look at which content color is used, and derive the scalebar's halo from that, as the halo should
-// mimic a background. See also #290.
-
-/** Like [contentColorFor][androidx.compose.material3.contentColorFor] but the other way round */
+/** Chooses the scale bar halo from its content color. See #290. */
 @Composable
 @ReadOnlyComposable
 internal fun backgroundColorFor(contentColor: Color) =

--- a/lib/maplibre-compose-material3/src/maplibreNativeMain/kotlin/org/maplibre/compose/material3/OfflinePackListItem.kt
+++ b/lib/maplibre-compose-material3/src/maplibreNativeMain/kotlin/org/maplibre/compose/material3/OfflinePackListItem.kt
@@ -68,8 +68,7 @@ import org.maplibre.compose.offline.OfflinePack
  * By default, it includes controls to pause, resume, invalidate, and delete the pack, and a
  * [CircularProgressIndicator] for download progress.
  *
- * You must supply a [headlineContent] for the list item. Typically, this will be a suitable name
- * for the pack, parsed from [OfflinePack.metadata].
+ * Supply [headlineContent] with a pack name, for example from [OfflinePack.metadata].
  *
  * Swipe the item from end to start to request deletion. The default trailing delete button and the
  * swipe gesture both require confirmation before deleting the pack.
@@ -191,7 +190,7 @@ public object OfflinePackListItemDefaults {
     },
   ) {
     val icon by
-      remember(pack) {
+      remember(pack, completedIcon, pausedIcon, downloadingIcon, errorIcon, warningIcon) {
         derivedStateOf {
           val progress = pack.downloadProgress
           when (progress) {
@@ -225,11 +224,7 @@ public object OfflinePackListItemDefaults {
     DeleteButton(pack, offlineManager)
   }
 
-  /**
-   * The default supporting content for an [OfflinePackListItem]. It includes a [Text] describing
-   * the status of the pack; typically the download status and size. If the pack is in an error or
-   * other unhealthy state, it'll be indicated here.
-   */
+  /** Displays the pack's download status and size, or its error or tile limit status. */
   @Composable
   public fun SupportingContent(
     progress: DownloadProgress,


### PR DESCRIPTION
## Description

Changing an offline pack icon slot while retaining the same pack could keep displaying the old content. Include the icon slots in the remembered state keys so the item uses the replacement content. Also shorten Material3 control documentation and comments.

## Validation

On the combined cleanup tree, static checks, Android host and desktop test tasks, and the documentation build passed. Icon replacement was reviewed in source; recomposition behavior was not directly exercised in a UI test. Each branch contains a disjoint portion of that validated tree and targets `main` independently.

## AI assistance

Codex (GPT-6), including subagents, performed the cleanup and source review. Draft pending human review.
