### PR TITLE
refactor: simplify demo code and descriptions

### DIFF
--- a/demo-app/common/build.gradle.kts
+++ b/demo-app/common/build.gradle.kts
@@ -23,8 +23,7 @@ kotlin {
   jvm { compilerOptions { jvmTarget = project.getDesktopJvmTarget() } }
 
   js {
-    // maplibre-compose's MapLibre GL JS declarations are @file:JsModule with no global to fall
-    // back to, which UMD output rejects; every consumer down the chain has to match.
+    // MapLibre GL JS bindings require ES modules in every consumer.
     useEsModules()
     browser { commonWebpackConfig { outputFileName = "app.js" } }
     binaries.executable()

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/Demo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/Demo.kt
@@ -30,10 +30,8 @@ interface Demo {
   /**
    * Replaces the user's chosen light style while this demo is selected. See [DemoStyle].
    *
-   * Declare this only when the demo genuinely depends on its base style: it reads the style's own
-   * data or glyph endpoint, or its data visualization only reads against a deliberately muted
-   * canvas. Demos whose content is self-contained should stay agnostic and honor the user's chosen
-   * style and theme.
+   * Override only when the demo requires the style's data, fonts, or colors. Otherwise, use the
+   * user's chosen style.
    */
   val preferredLightStyle: DemoStyle?
     get() = null

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoAppState.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoAppState.kt
@@ -21,7 +21,7 @@ import org.maplibre.compose.map.rememberMapState
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.spatialk.geojson.Position
 
-/** New York City at a metro-area zoom, so every demo's fly-in has somewhere to go. */
+/** New York City, zoomed out before selecting a demo. */
 private val StartPosition =
   CameraPosition(target = Position(longitude = -74.006, latitude = 40.7128), zoom = 9.5)
 
@@ -121,10 +121,8 @@ internal class DemoMapConfiguration {
 
 internal data class StyleLoad(val count: Int, val base: BaseStyle?)
 
-// Pin the composition target to UI. Without it, the @MaplibreComposable content lambda below lets
-// the compiler's target inference mark this function as map content. The compiler then propagates
-// that target to target-inferred calling scopes (the Nucleus window host) and rejects their UI
-// composables.
+// Prevent the map-content lambda from making callers infer a map composition target.
+// The Nucleus window host needs a UI target.
 @UiComposable
 @Composable
 fun rememberDemoAppState(): DemoAppState {

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoPanel.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoPanel.kt
@@ -49,7 +49,6 @@ import org.maplibre.compose.demoapp.generated.arrow_back_24px
 import org.maplibre.compose.demoapp.generated.settings_24px
 import org.maplibre.compose.demoapp.generated.speed_24px
 
-/** The demo list, the style knob, and the selected demo's controls — or the settings page. */
 @Composable
 fun DemoPanel(
   state: DemoAppState,
@@ -85,7 +84,6 @@ fun DemoPanel(
   ) {
     composable("demos") {
       DemosScreen(
-        state,
         onOpenSettings = { navController.navigate("settings") },
         onOpenDemo = { demo ->
           flightJob?.cancel()
@@ -184,7 +182,6 @@ private fun sharedAxisExit(slideDistance: Int): ExitTransition =
 
 @Composable
 private fun DemosScreen(
-  state: DemoAppState,
   onOpenSettings: () -> Unit,
   onOpenDemo: (Demo) -> Unit,
   onOpenBenchmarks: () -> Unit,

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoSettings.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoSettings.kt
@@ -40,10 +40,7 @@ enum class MapStyleMode(val displayName: String) {
       }
 }
 
-/**
- * How the Material 3 chrome colors are generated: Android Material You, or a MapLibre brand palette
- * style.
- */
+/** Material You on Android or a palette based on the MapLibre brand color. */
 enum class PaletteMode {
   System,
   Tonal,
@@ -76,13 +73,9 @@ class DemoSettings {
 
 @Composable fun rememberDemoSettings() = remember { DemoSettings() }
 
-/**
- * The rendering toggles this platform's [RenderOptions] offers — debug flags, the frame rate cap,
- * and on Android the texture-versus-surface choice — as settings list items.
- */
+/** Settings for the platform's debug flags, frame rate cap, and render mode. */
 @Composable expect fun RenderSettingsItems(settings: DemoSettings)
 
-/** Presets for [TileLodOptions], shared because every platform exposes the same three. */
 @Composable
 fun TileLodSettingsItems(settings: DemoSettings) {
   SectionHeader("Tile level of detail")

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoStyle.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoStyle.kt
@@ -5,9 +5,8 @@ import org.maplibre.compose.layers.Anchor
 import org.maplibre.compose.style.BaseStyle
 
 /**
- * The demo key for api.protomaps.com, shared by the Protomaps styles and MaterialStyleDemo.
- * Protomaps tiles are free for light use — if you copy any of this code, please get your own key at
- * https://app.protomaps.com/ rather than reusing this one.
+ * The demo key for api.protomaps.com, shared by the Protomaps styles and MaterialStyleDemo. Get
+ * your own key at https://app.protomaps.com/ when copying this code.
  */
 internal const val PROTOMAPS_API_KEY = "73c45a97eddd43fb"
 
@@ -15,9 +14,8 @@ internal const val PROTOMAPS_API_KEY = "73c45a97eddd43fb"
  * A base map style plus the metadata a demo needs to draw on it.
  *
  * The enums in this file are the styles the user can pick from the settings, independent of the
- * selected demo. A demo can instead define its own private implementation and apply it with
- * [Demo.preferredLightStyle]; it then stays out of the pickers, which is the right call when the
- * style is meaningless without the demo's layers. See MaterialStyleDemo for an example.
+ * selected demo. Define a private style with [Demo.preferredLightStyle] when it requires the demo's
+ * layers and should not appear in settings. See MaterialStyleDemo for an example.
  */
 interface DemoStyle {
   val displayName: String

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/FrameRateState.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/FrameRateState.kt
@@ -9,11 +9,10 @@ import kotlin.time.DurationUnit
 import kotlin.time.TimeSource
 import kotlinx.coroutines.delay
 
-/** How often the rate is recomputed. Short enough to react, long enough to read. */
 private const val SAMPLE_MILLIS = 500L
 
 /**
- * How many frames the map has actually drawn, sampled over time.
+ * Samples the rendered frame count to calculate frames per second.
  *
  * [record] counts one [org.maplibre.compose.map.MapEvent.FrameRendered] event. The counter is
  * deliberately not snapshot state: it advances once per frame, and writing state there would
@@ -31,9 +30,7 @@ class FrameRateState {
   var framesPerSecond by mutableDoubleStateOf(0.0)
     private set
 
-  /**
-   * Called once per rendered frame. One collector calls this, so a plain increment loses nothing.
-   */
+  /** Called once per rendered frame by a single collector. */
   fun record() {
     frames++
   }

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/benchmark/BenchmarkMap.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/benchmark/BenchmarkMap.kt
@@ -147,7 +147,7 @@ internal fun BenchmarkMap(state: DemoAppState, viewportInsets: MapViewportInsets
       }
       val durationMs = started.elapsedNow().inWholeMilliseconds.toDouble()
       val frames = session.frames.stop()
-      val gesture = if (session.gestures.stats().samples > 0) session.gestures.stats() else null
+      val gesture = session.gestures.stats().takeIf { it.samples > 0 }
       val report =
         BenchmarkReport(
           scenario = running.id,

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/CastelloPlanDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/CastelloPlanDemo.kt
@@ -27,7 +27,7 @@ import org.maplibre.spatialk.geojson.Position
 
 object CastelloPlanDemo : Demo {
   override val name = "Castello Plan"
-  override val description = "The 1660 map of New Amsterdam draped over lower Manhattan."
+  override val description = "The 1660 map of New Amsterdam overlaid on lower Manhattan."
 
   private val imageRegion =
     BoundingBox(west = -74.018, south = 40.7005, east = -74.006, north = 40.710)

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/DragDropDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/DragDropDemo.kt
@@ -52,7 +52,6 @@ object DragDropDemo : Demo {
   override val name = "Drag & drop"
   override val description = "Drag a location-picker pin or the corner handles of a bounding box."
 
-  // A neighborhood view gives both modes room to drag in without a detour through the camera.
   override val destination =
     DemoDestination.FitBounds(
       BoundingBox(west = -122.3452, south = 47.6155, east = -122.3252, north = 47.6255)
@@ -69,11 +68,8 @@ object DragDropDemo : Demo {
   private var southeast by mutableStateOf(Position(longitude = -122.3327, latitude = 47.6185))
 
   /**
-   * Moves the overlay child with the pointer. The screen offset of [position] is captured on drag
-   * start and pointer deltas are accumulated onto it, so the child never has to be read back while
-   * it moves under the pointer. Pointer events report pixels, so the anchor captured from
-   * [MapState.screenLocationFromPosition] is scaled up before the px-based projection receives the
-   * sum.
+   * Accumulates pointer deltas from the initial screen position to avoid feedback from the moving
+   * child. Converts between pointer pixels and the map's Dp coordinates.
    */
   private fun Modifier.draggablePosition(
     mapState: MapState,

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/LiveTrackingDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/LiveTrackingDemo.kt
@@ -123,7 +123,7 @@ object LiveTrackingDemo : Demo {
       while (true) {
         withFrameMillis { frameMillis ->
           val traveled = (frameMillis - startMillis) / 1000.0 * SPEED_METERS_PER_SECOND
-          // Ping-pong between the terminals, like the ferry itself.
+          // Reverse direction at each terminal.
           val phase = traveled % (2 * routeLength)
           vehiclePosition = positionAt(routeLength - abs(phase - routeLength))
         }

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/MagnifyingLensDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/MagnifyingLensDemo.kt
@@ -66,7 +66,8 @@ import org.maplibre.spatialk.geojson.BoundingBox
  */
 object MagnifyingLensDemo : Demo {
   override val name = "Magnifying lens"
-  override val description = "A second map composited into a draggable lens with Compose modifiers."
+  override val description =
+    "Drag a magnifying lens over the map. Change its size, shape, and magnification."
 
   private val lensRegion =
     BoundingBox(west = -74.002, south = 40.748, east = -73.968, north = 40.768)

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/Manhattan3dDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/Manhattan3dDemo.kt
@@ -13,7 +13,7 @@ import org.maplibre.spatialk.geojson.Position
 
 object Manhattan3dDemo : Demo {
   override val name = "3D Manhattan"
-  override val description = "Liberty's building extrusions pitched over the financial district."
+  override val description = "View 3D buildings in Manhattan's financial district."
   override val preferredLightStyle = OpenFreeMap.Liberty
 
   private val offlineRegion =

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/MapSnapshotterDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/MapSnapshotterDemo.kt
@@ -57,10 +57,9 @@ import org.maplibre.spatialk.geojson.Position
 private val SnapshotTarget = Position(longitude = -122.3358, latitude = 47.6086)
 private val SnapshotMarkerColor = Color(0xFF00897B)
 
-/** Captures the current map camera into an image through an independent non-UI map. */
 object MapSnapshotterDemo : Demo {
   override val name = "Map snapshotter"
-  override val description = "Capture the current camera and style with an independent non-UI map."
+  override val description = "Capture an image of the current map view."
   override val destination =
     DemoDestination.ExactCamera(CameraPosition(target = SnapshotTarget, zoom = 13.5))
   override val pointerPin = DemoPointerPin(SnapshotTarget, destination)

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/MaterialStyleDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/MaterialStyleDemo.kt
@@ -91,10 +91,9 @@ private enum class Material(override val isDark: Boolean = false) : DemoStyle {
 }
 
 /**
- * A complete basemap — land, water, roads, buildings, and labels — composed in Kotlin from
- * MaterialTheme color tokens. The layer structure follows Protomaps Light; the street and building
- * shading follows Protomaps White and Black. The only style JSON is an empty base style, so the
- * whole map re-tints by recomposition when the theme changes.
+ * A basemap using MaterialTheme colors. The layers follow Protomaps Light, and street and building
+ * shading follows Protomaps White and Black. Theme changes update the layers without reloading the
+ * base style.
  */
 object MaterialStyleDemo : Demo {
   override val name = "Material 3 style"

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Location.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Location.kt
@@ -3,7 +3,6 @@
 package org.maplibre.compose.docsnippets
 
 import androidx.compose.runtime.Composable
-import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.location.LocationPuck
 import org.maplibre.compose.location.LocationTrackingEffect
@@ -15,9 +14,7 @@ import org.maplibre.compose.map.MaplibreMap
 import org.maplibre.compose.map.rememberMapState
 
 @Composable
-@OptIn(ExperimentalResourceApi::class)
-// The snippet below shows the calls alone. Requesting the permission belongs to the surrounding
-// app, which the documentation covers in prose.
+// The application requests location permission separately.
 fun Location() {
   // #region puck
   val locationProvider = rememberDefaultLocationProvider()

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/README.md
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/README.md
@@ -1,3 +1,2 @@
-The files in this package are not used by the demo app; they're just here to be
-included as snippets in the documentation. By including them in the demo app
-build, we can ensure that they're always up-to-date with the latest code.
+These documentation snippets compile with the demo app but are not called by it.
+Compilation checks API usage; it does not verify runtime behavior or resources.

--- a/demo-app/desktop/build.gradle.kts
+++ b/demo-app/desktop/build.gradle.kts
@@ -33,9 +33,7 @@ compose.desktop {
     jvmArgs += NATIVE_ACCESS_JVM_ARGS
 
     nativeDistributions {
-      // jpackage runs jlink against this JDK, so it decides the Java version inside the installed
-      // application; without it the packaged app takes whatever JDK Gradle runs on, which can be
-      // older than the 24 the MapLibre Native FFI binding requires.
+      // Package the configured toolchain, even when Gradle runs on an older JDK.
       javaHome =
         javaToolchains
           .launcherFor {
@@ -54,7 +52,6 @@ compose.desktop {
       targetFormats(TargetFormat.Dmg, TargetFormat.Msi)
       packageName = "org.maplibre.compose.demoapp"
       // https://youtrack.jetbrains.com/issue/CMP-2360
-      // packageVersion = providers.gradleProperty("maplibreReleaseVersion").get()
       packageVersion = "1.0.0"
 
       macOS {
@@ -66,9 +63,9 @@ compose.desktop {
           extraKeysRawXml =
             """
             <key>NSLocationWhenInUseUsageDescription</key>
-            <string>Example</string>
+            <string>The My location demo draws your position on the map.</string>
             <key>NSLocationUsageDescription</key>
-            <string>Example</string>
+            <string>The My location demo draws your position on the map.</string>
             """
               .trimIndent()
         }


### PR DESCRIPTION
## Description

Remove an unused demo-screen parameter and an unnecessary opt-in, compute benchmark gesture statistics once, and simplify demo descriptions and comments. Replace placeholder desktop location permission text with the reason the demo requests location.

## Validation

On the combined cleanup tree, static checks, Android host, desktop, and browser test tasks and the documentation build passed. Interactive demo behavior and the desktop permission prompt were not directly exercised. Each branch contains a disjoint portion of that validated tree and targets `main` independently.

## AI assistance

Codex (GPT-6), including subagents, performed the cleanup and source review. Draft pending human review.
