### PR TITLE
chore: remove redundant tooling code and commentary

### DIFF
--- a/.agents/skills/bump-maplibre-gl-js/SKILL.md
+++ b/.agents/skills/bump-maplibre-gl-js/SKILL.md
@@ -49,11 +49,11 @@ cover only the members they exercise.
   here and fails at runtime with `undefined is not a function`.
 - **Did a type widen or narrow?** A field that became optional, a return that
   gained `| undefined`, an argument that stopped accepting the shape passed. The
-  declarations deliberately state narrower types than MapLibre's `*Like` unions
-  — `LngLat` for `LngLatLike`, `Point` for `PointLike` — so check the narrowing
-  still holds rather than that the signature matches.
+  declarations deliberately state narrower types than MapLibre's `*Like` unions.
+  For example, they use `LngLat` for `LngLatLike` and `Point` for `PointLike`.
+  Check that these narrower types remain valid.
 - **Is anything declared that upstream never had?** Left over from an earlier
-  version, or mistyped. Grep the `.d.ts` for it.
+  version, or mistyped. Search the `.d.ts` for it.
 
 ## 4. Look for new capability worth binding
 
@@ -67,8 +67,8 @@ between the two versions for:
 - **TODOs waiting on upstream.**
   `git grep -n TODO lib/maplibre-compose/src/jsMain` finds the ones parked
   against a MapLibre GL JS limitation.
-- **New API surface.** New `Map` methods, style-spec properties, and source or
-  layer types that the common API could expose. Style-spec gaps go through the
+- **New APIs.** New `Map` methods, style-spec properties, and source or layer
+  types that the common API could expose. Style-spec gaps go through the
   `style-spec-parity` skill.
 
 An upgrade includes adopting useful new capabilities from these categories,
@@ -86,13 +86,13 @@ Browser-only implementation tests belong in `jsTest`.
 `GlJsRuntime.kt` and `GlJsStyleBinding.setTransition` depend on MapLibre
 internals. Compare the upstream sources to verify these assumptions:
 
-| Shim                           | Upstream anchor                                                                                                                                                                                        |
-| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `lendingContext`               | `src/ui/map.ts` — `Map` must call `canvas.getContext` exactly once, synchronously, in its constructor                                                                                                  |
-| `redirectDefaultFramebuffer`   | `src/gl/value.ts` — `class BindFramebuffer`'s `set(v)`, whose body this replaces (`current`/`dirty`/`gl` fields)                                                                                       |
-| `interceptRepaintRequests`     | `src/ui/map.ts` — `triggerRepaint()` must stay MapLibre's only caller of `browser.frame`                                                                                                               |
-| `removingWithoutLosingContext` | `src/ui/map.ts` — `remove()` must still reach the context only through `getExtension('WEBGL_lose_context')`                                                                                            |
-| `setTransition`                | `src/style/style.ts` — `getTransition()` must still read `this.stylesheet.transition`; if `setTransition` in `_getOperationsToPerform` stops being a no-op, MapLibre has a real setter to call instead |
+| Shim                           | Upstream anchor                                                                                                                                                                                       |
+| ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `lendingContext`               | `src/ui/map.ts`. `Map` must call `canvas.getContext` exactly once, synchronously, in its constructor                                                                                                  |
+| `redirectDefaultFramebuffer`   | `src/gl/value.ts`. `class BindFramebuffer`'s `set(v)`, whose body this replaces (`current`/`dirty`/`gl` fields)                                                                                       |
+| `interceptRepaintRequests`     | `src/ui/map.ts`. `triggerRepaint()` must stay MapLibre's only caller of `browser.frame`                                                                                                               |
+| `removingWithoutLosingContext` | `src/ui/map.ts`. `remove()` must still reach the context only through `getExtension('WEBGL_lose_context')`                                                                                            |
+| `setTransition`                | `src/style/style.ts`. `getTransition()` must still read `this.stylesheet.transition`; if `setTransition` in `_getOperationsToPerform` stops being a no-op, MapLibre has a real setter to call instead |
 
 ```sh
 diff -u "$upgrade_dir/src/gl/value.ts" build/js/node_modules/maplibre-gl/src/gl/value.ts

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -22,7 +22,6 @@ reviews:
       enabled: false
 
 chat:
-  # free OSS plan, should be fine
   allow_non_org_members: true
 
   # reduce noisy defaults

--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -1,9 +1,4 @@
 body:
-  - type: markdown
-    attributes:
-      value: |
-        Thanks for asking a question! Please provide as much detail as possible to help us understand your issue.
-
   - type: textarea
     id: question
     attributes:
@@ -18,7 +13,7 @@ body:
   - type: checkboxes
     id: platform
     attributes:
-      label: Affected Platform(s)
+      label: Affected platforms
       description: Which platform(s) are you working with?
       options:
         - label: Android
@@ -34,7 +29,7 @@ body:
   - type: input
     id: library-version
     attributes:
-      label: Library Version
+      label: Library version
       description: What version of MapLibre Compose are you using?
       placeholder: e.g. 0.12.0
     validations:
@@ -45,8 +40,7 @@ body:
     attributes:
       label: What have you tried?
       description: |
-        Please describe what approaches you've already attempted and what happened.
-        Include code samples if possible. This helps us understand where you're stuck.
+        Describe what you tried and what happened. Include code samples.
       placeholder: |
         Example:
         I tried using a SymbolLayer but I'm not sure how to update the marker position.

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -2,10 +2,6 @@ name: Bug Report
 description: File a bug report
 type: bug
 body:
-  - type: markdown
-    attributes:
-      value: |
-        Thanks for taking the time to fill out this bug report!
   - type: textarea
     id: what-happened
     attributes:
@@ -17,7 +13,7 @@ body:
   - type: checkboxes
     id: platform
     attributes:
-      label: Affected Platforms
+      label: Affected platforms
       description: On which platforms have you seen this bug?
       options:
         - label: Android
@@ -32,7 +28,7 @@ body:
   - type: input
     id: platform-version
     attributes:
-      label: Platform Version
+      label: Platform version
       description: What version of the platform(s) are you using?
       placeholder: e.g. Android 14, iOS 17.2, macOS 14.2
     validations:
@@ -40,7 +36,7 @@ body:
   - type: input
     id: library-version
     attributes:
-      label: Library Version
+      label: Library version
       description: What version of MapLibre Compose are you using?
       placeholder: e.g. 1.0.0
     validations:
@@ -48,9 +44,9 @@ body:
   - type: textarea
     id: sample-code
     attributes:
-      label: Sample Code
+      label: Sample code
       description:
-        Please provide a minimal code sample that demonstrates the issue
+        Provide a minimal code sample that demonstrates the issue
       placeholder: |
         @Composable
         fun MyMap() {

--- a/.github/workflows/action-pins.yml
+++ b/.github/workflows/action-pins.yml
@@ -1,6 +1,5 @@
-# Single source of truth for third-party action pins, so that Dependabot — which
-# scans only `.github/workflows` — also updates the ones the composite actions
-# use. `mise run ci:check-action-pins` verifies every reference agrees.
+# Third-party action pins live here so Dependabot also updates composite actions.
+# `mise run ci:check-action-pins` checks their references against this file.
 name: Action pins
 
 # Never runs: the branch is never created, and `!always()` is false by

--- a/.mise/bin/dprint-ktfmt
+++ b/.mise/bin/dprint-ktfmt
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
-# dprint's exec plugin runs a formatter once per file, so this resolves ktfmt
-# straight off PATH and hands it to the JVM. Routing through `mise run` instead
-# would pay mise's startup cost on every Kotlin file in the repository.
+# Resolve ktfmt from PATH to avoid starting mise for every file.
 
 set -euo pipefail
 
@@ -10,9 +8,7 @@ if ! ktfmt_path="$(command -v ktfmt)"; then
   exit 1
 fi
 
-# One JVM per file means startup dominates the run, so ask for the settings that
-# suit a short-lived process: no tiered compilation past C1, and a collector that
-# does not size a heap it will never fill.
+# Reduce JVM startup and heap overhead for these short-lived processes.
 jvm_options=(-XX:+UseSerialGC -XX:TieredStopAtLevel=1)
 
 # The aqua package installs the distribution jar under the name `ktfmt`.

--- a/.mise/tasks/install-xcode
+++ b/.mise/tasks/install-xcode
@@ -2,9 +2,7 @@
 # [MISE] description="Install and select the Xcode version this repository pins."
 # [MISE] shell="bash"
 
-# Xcode is a multi-gigabyte download, so this is a task rather than a postinstall
-# hook: a contributor who never builds for Apple platforms never pays for it, and
-# a machine that cannot install it can still run every other task.
+# Keep the multi-gigabyte Xcode download optional for non-Apple development.
 
 set -euo pipefail
 

--- a/buildSrc/src/main/kotlin/catalog.kt
+++ b/buildSrc/src/main/kotlin/catalog.kt
@@ -2,12 +2,7 @@ import org.gradle.api.Project
 import org.gradle.api.artifacts.VersionCatalogsExtension
 import org.gradle.kotlin.dsl.getByType
 
-/**
- * Reads a version out of `gradle/libs.versions.toml`.
- *
- * Precompiled script plugins get no typesafe `libs` accessor, so the convention plugins in this
- * directory go through here. Ordinary project build scripts use `libs` directly.
- */
+/** Reads a catalog version for precompiled plugins, which have no typesafe `libs` accessor. */
 fun Project.catalogVersion(name: String): String =
   extensions
     .getByType<VersionCatalogsExtension>()

--- a/buildSrc/src/main/kotlin/ffi.kt
+++ b/buildSrc/src/main/kotlin/ffi.kt
@@ -1,9 +1,6 @@
 /**
- * The desktop platforms MapLibre Native FFI publishes a native runtime for.
- *
- * The FFI ships one artifact per render backend, each carrying per-platform natives under a
- * classifier; an application picks exactly one. Which backends a platform can run is a property of
- * the platform; which one runs is the application's choice of runtime artifact.
+ * Desktop platforms with published MapLibre Native FFI runtimes. Applications select one supported
+ * render backend.
  */
 enum class DesktopHostPlatform(
   private val os: String,
@@ -51,10 +48,7 @@ enum class DesktopHostPlatform(
   fun runtimeModule(backend: RenderBackend): String =
     "org.maplibre.nativeffi:maplibre-native-ffi-runtime-${backend.artifactInfix}-jvm"
 
-  /**
-   * Whether the Compose side of the handoff presents through OpenGL, and so needs LWJGL's OpenGL
-   * natives. This follows the platform rather than the map's backend.
-   */
+  /** Whether Compose presentation needs LWJGL OpenGL natives, regardless of the map backend. */
   private val presentsThroughOpenGl: Boolean
     get() = os == "linux"
 

--- a/ci/action_pins.py
+++ b/ci/action_pins.py
@@ -29,7 +29,7 @@ class Pin(NamedTuple):
 
 
 def _parse(path: pathlib.Path) -> list[tuple[int, Pin | str]]:
-    """Yield (line number, Pin) for pinned uses and (line number, raw) otherwise."""
+    """Return line numbers paired with pins or unpinned references."""
     found: list[tuple[int, Pin | str]] = []
     for number, line in enumerate(path.read_text().splitlines(), 1):
         pinned = PINNED.match(line)

--- a/ci/style_spec_parity.py
+++ b/ci/style_spec_parity.py
@@ -1,9 +1,7 @@
 """Compare this repository's style API with the pinned style spec release.
 
-The spec is one document. Each engine implements a versioned slice of it.
-This catalog asks: for the engines this repository pins, is every in-scope
-layer type and paint or layout property written in the right source set,
-with the matching paint or layout setter?
+Check layer types, source types, properties, transitions, and setter calls
+against the repository's engine versions.
 """
 
 from __future__ import annotations
@@ -571,7 +569,7 @@ def _audit_properties(
             for kind, engines in api.kinds_written(prop.layer, prop.name).items()
             if kind not in {target[1], "root"} and engines
         ]
-        if other_kinds and "js" not in written and "native" not in written:
+        if other_kinds and not written:
             report.error(
                 f"{_label(*prop.key)} written as {other_kinds[0]}, "
                 f"spec says {prop.kind}"

--- a/ci/style_spec_parity_test.py
+++ b/ci/style_spec_parity_test.py
@@ -224,23 +224,6 @@ class AuditTest(unittest.TestCase):
             )
         self.assertEqual(report.errors, [])
 
-    def test_a_js_only_layer_in_js_main_counts(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            root = pathlib.Path(tmp)
-            _layer_file(
-                root,
-                "jsMain",
-                "FillLayer.kt",
-                "fill",
-                'setPaintProperty("fill-opacity", value)',
-            )
-            report = audit(
-                _spec(js="1.0.0", android=None, ios=None),
-                root,
-                Pins(js=Version.parse("6.2.0")),
-            )
-        self.assertEqual(report.errors, [])
-
     def test_a_native_only_property_in_native_main_counts(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = pathlib.Path(tmp)

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,7 @@ org.jetbrains.compose.experimental.jscanvas.enabled=true
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.configuration-cache=false
-# Linking an iOS release framework runs the whole Kotlin/Native optimizer over
-# one binary, which is the heaviest thing this build does. It runs in the Gradle
-# daemon, so this is the setting that governs it rather than
-# kotlin.daemon.jvmargs, which was measured and made no difference. 2048M was
-# measured as too little: linkReleaseFrameworkIosArm64 and its simulator sibling
-# both died with an OutOfMemoryError.
+# iOS release linking runs in the Gradle daemon and exhausts a 2 GiB heap.
 org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
 android.nonTransitiveRClass=true
 android.useAndroidX=true


### PR DESCRIPTION
## Description

Remove a duplicate style-parity test and simplify its engine-selection condition. Trim redundant build, CI, template, and tool comments, and correct a helper docstring that described returning a list as yielding values.

## Validation

On the combined cleanup tree, `mise run ci:test-scripts` passed all 40 tests, `mise run style-spec:parity -- --check` passed, and `mise run check` passed, including action-pin validation. Each branch contains a disjoint portion of that validated tree and targets `main` independently.

## AI assistance

Codex (GPT-6), including subagents, performed the cleanup and source review. Draft pending human review.
