### PR TITLE
Fix location provider lifetimes and unknown permission recovery

### DIFF
--- a/demo-app/common/src/androidMain/kotlin/org/maplibre/compose/demoapp/demos/LocationEngine.android.kt
+++ b/demo-app/common/src/androidMain/kotlin/org/maplibre/compose/demoapp/demos/LocationEngine.android.kt
@@ -1,6 +1,7 @@
 package org.maplibre.compose.demoapp.demos
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import org.maplibre.compose.gms.GmsLocationBackend
@@ -17,7 +18,9 @@ private object GmsLocationEngine : DemoLocationEngine {
   @Composable
   override fun rememberLocationProvider(): LocationProvider {
     val context = LocalContext.current
-    return remember(context) { GmsLocationBackend().createLocationProvider(context) }
+    val provider = remember(context) { GmsLocationBackend().createLocationProvider(context) }
+    DisposableEffect(provider) { onDispose { provider.close() } }
+    return provider
   }
 
   @Composable
@@ -34,7 +37,9 @@ private object HmsLocationEngine : DemoLocationEngine {
   @Composable
   override fun rememberLocationProvider(): LocationProvider {
     val context = LocalContext.current
-    return remember(context) { HmsLocationBackend().createLocationProvider(context) }
+    val provider = remember(context) { HmsLocationBackend().createLocationProvider(context) }
+    DisposableEffect(provider) { onDispose { provider.close() } }
+    return provider
   }
 
   @Composable
@@ -51,7 +56,9 @@ private object FrameworkLocationEngine : DemoLocationEngine {
   @Composable
   override fun rememberLocationProvider(): LocationProvider {
     val context = LocalContext.current
-    return remember(context) { AndroidLocationProvider(context) }
+    val provider = remember(context) { AndroidLocationProvider(context) }
+    DisposableEffect(provider) { onDispose { provider.close() } }
+    return provider
   }
 
   @Composable

--- a/docs/src/content/docs/location.mdx
+++ b/docs/src/content/docs/location.mdx
@@ -44,7 +44,7 @@ if (locationState.permission !is LocationPermission.Granted) {
 }
 ```
 
-When permission is not granted, <Api of="LocationPermission.NotGranted" />
+When authorization is absent, <Api of="LocationPermission.NotGranted" />
 reports the next step: explain first when `shouldShowRationale` is set
 (Android only), request when `canRequest` is not `false`, and send the user to
 the system settings otherwise. <Api of="rememberSystemSettingsLauncher" />
@@ -64,6 +64,12 @@ if (permission is LocationPermission.NotGranted) {
   }
 }
 ```
+
+<Api of="LocationPermission.Unknown" /> means the permission check has not
+completed. Location collection retries the check without prompting. If the
+check fails, <Api of="LocationState.status" /> reports
+<Api of="LocationTrackingStatus.Unavailable" /> with the cause. Call
+<Api of="LocationState.retry" /> to try again.
 
 ## Platform requirements
 

--- a/lib/location-runtime-gms/src/androidMain/kotlin/org/maplibre/compose/gms/FusedLocationProvider.kt
+++ b/lib/location-runtime-gms/src/androidMain/kotlin/org/maplibre/compose/gms/FusedLocationProvider.kt
@@ -82,6 +82,10 @@ internal constructor(
     }
   }
 
+  override fun close() {
+    permissionDelegate?.close()
+  }
+
   @RequiresPermission(
     anyOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION]
   )

--- a/lib/location-runtime-gms/src/androidMain/kotlin/org/maplibre/compose/gms/FusedLocationProvider.kt
+++ b/lib/location-runtime-gms/src/androidMain/kotlin/org/maplibre/compose/gms/FusedLocationProvider.kt
@@ -2,6 +2,7 @@ package org.maplibre.compose.gms
 
 import android.Manifest
 import android.content.Context
+import androidx.annotation.MainThread
 import androidx.annotation.RequiresPermission
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.Granularity
@@ -43,6 +44,8 @@ import org.maplibre.spatialk.units.extensions.inMeters
  *
  * The [Context] constructor handles permission requests. The [FusedLocationProviderClient]
  * constructor reports permission as granted and requires the caller to manage authorization.
+ *
+ * Create the provider, request permission, and close it on the main thread.
  */
 public class FusedLocationProvider
 internal constructor(
@@ -58,12 +61,14 @@ internal constructor(
    *
    * Permission keeps the [LocationProvider.permission] default, which is always granted.
    */
+  @MainThread
   public constructor(locationClient: FusedLocationProviderClient) : this(locationClient, null)
 
   /**
    * Creates a provider with its own fused client and an [AndroidLocationProvider] as its permission
    * delegate.
    */
+  @MainThread
   public constructor(
     context: Context
   ) : this(
@@ -74,6 +79,7 @@ internal constructor(
   override val permission: StateFlow<LocationPermission>
     get() = permissionDelegate?.permission ?: super.permission
 
+  @MainThread
   override fun requestPermission() {
     if (permissionDelegate != null) {
       permissionDelegate.requestPermission()
@@ -82,6 +88,7 @@ internal constructor(
     }
   }
 
+  @MainThread
   override fun close() {
     permissionDelegate?.close()
   }

--- a/lib/location-runtime-hms/src/androidMain/kotlin/org/maplibre/compose/hms/FusedLocationProvider.kt
+++ b/lib/location-runtime-hms/src/androidMain/kotlin/org/maplibre/compose/hms/FusedLocationProvider.kt
@@ -77,6 +77,10 @@ internal constructor(
     }
   }
 
+  override fun close() {
+    permissionDelegate?.close()
+  }
+
   @RequiresPermission(
     anyOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION]
   )

--- a/lib/location-runtime-hms/src/androidMain/kotlin/org/maplibre/compose/hms/FusedLocationProvider.kt
+++ b/lib/location-runtime-hms/src/androidMain/kotlin/org/maplibre/compose/hms/FusedLocationProvider.kt
@@ -3,6 +3,7 @@ package org.maplibre.compose.hms
 import android.Manifest
 import android.content.Context
 import android.os.HandlerThread
+import androidx.annotation.MainThread
 import androidx.annotation.RequiresPermission
 import com.huawei.hmf.tasks.Task
 import com.huawei.hmf.tasks.TaskExecutors
@@ -39,6 +40,8 @@ import org.maplibre.spatialk.units.extensions.inMeters
  *
  * The [Context] constructor handles permission requests. The [FusedLocationProviderClient]
  * constructor reports permission as granted and requires the caller to manage authorization.
+ *
+ * Create the provider, request permission, and close it on the main thread.
  */
 public class FusedLocationProvider
 internal constructor(
@@ -53,12 +56,14 @@ internal constructor(
    *
    * Permission keeps the [LocationProvider.permission] default, which is always granted.
    */
+  @MainThread
   public constructor(locationClient: FusedLocationProviderClient) : this(locationClient, null)
 
   /**
    * Creates a provider with its own fused client and an [AndroidLocationProvider] as its permission
    * delegate.
    */
+  @MainThread
   public constructor(
     context: Context
   ) : this(
@@ -69,6 +74,7 @@ internal constructor(
   override val permission: StateFlow<LocationPermission>
     get() = permissionDelegate?.permission ?: super.permission
 
+  @MainThread
   override fun requestPermission() {
     if (permissionDelegate != null) {
       permissionDelegate.requestPermission()
@@ -77,6 +83,7 @@ internal constructor(
     }
   }
 
+  @MainThread
   override fun close() {
     permissionDelegate?.close()
   }

--- a/lib/location-runtime-linux/src/main/kotlin/org/maplibre/compose/location/desktop/linux/LinuxPortalLocationBackend.kt
+++ b/lib/location-runtime-linux/src/main/kotlin/org/maplibre/compose/location/desktop/linux/LinuxPortalLocationBackend.kt
@@ -3,14 +3,21 @@ package org.maplibre.compose.location.desktop.linux
 import java.util.Locale
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.maplibre.compose.location.DesktopLocationBackend
 import org.maplibre.compose.location.DesktopLocationProvider
 import org.maplibre.compose.location.LocationAccuracy
@@ -82,7 +89,13 @@ internal constructor(
 ) : DesktopLocationProvider {
   public constructor(window: XdgPortalWindow? = null) : this(DbusLocationPortal(window))
 
-  private val requester = LinuxPortalLocationPermissionRequester(portal, coroutineScope)
+  private val job = SupervisorJob(coroutineScope.coroutineContext[Job])
+  private val scope = CoroutineScope(coroutineScope.coroutineContext + job)
+  private val requester = LinuxPortalLocationPermissionRequester(portal, scope, ownsPortal = false)
+
+  init {
+    job.invokeOnCompletion { portal.close() }
+  }
 
   override val backendAvailability: LocationBackendAvailability =
     if (portal.available) {
@@ -94,18 +107,35 @@ internal constructor(
   override val permission: StateFlow<LocationPermission>
     get() = requester.status
 
-  override fun requestPermission(): Unit = requester.requestForegroundPermission()
+  override fun requestPermission() {
+    check(job.isActive) { "The Linux location provider is closed" }
+    requester.requestForegroundPermission()
+  }
 
-  override fun updates(request: LocationRequest): Flow<LocationEvent> = flow {
+  override fun updates(request: LocationRequest): Flow<LocationEvent> = callbackFlow {
     check(backendAvailability == LocationBackendAvailability.Available) {
       "Location updates require an available backend: $backendAvailability"
     }
-    portal.updates(request).collect { emit(it) }
+    check(job.isActive) { "The Linux location provider is closed" }
+    val collection =
+      scope.launch(start = CoroutineStart.UNDISPATCHED) {
+        try {
+          currentCoroutineContext().ensureActive()
+          portal.updates(request).collect { send(it) }
+        } catch (error: Throwable) {
+          if (job.isActive) channel.close(error)
+        }
+      }
+    collection.invokeOnCompletion { channel.close() }
+    try {
+      awaitClose()
+    } finally {
+      withContext(NonCancellable) { collection.cancelAndJoin() }
+    }
   }
 
   override fun close() {
-    requester.close()
-    portal.close()
+    job.cancel()
   }
 }
 
@@ -128,6 +158,7 @@ internal constructor(
   private val portal: LinuxLocationPortal,
   private val coroutineScope: CoroutineScope =
     CoroutineScope(SupervisorJob() + Dispatchers.Default),
+  private val ownsPortal: Boolean = true,
 ) : AutoCloseable {
   public constructor(window: XdgPortalWindow? = null) : this(DbusLocationPortal(window))
 
@@ -148,11 +179,16 @@ internal constructor(
   public val status: StateFlow<LocationPermission> = mutableStatus
   private val requestPending = AtomicBoolean()
 
+  init {
+    job.invokeOnCompletion { if (ownsPortal) portal.close() }
+  }
+
   /**
    * Starts a foreground permission request and returns immediately. The result is published to
    * [status].
    */
   public fun requestForegroundPermission() {
+    check(job.isActive) { "The Linux permission requester is closed" }
     if (
       backendAvailability != LocationBackendAvailability.Available ||
         status.value is LocationPermission.Granted ||
@@ -179,7 +215,6 @@ internal constructor(
   /** Cancels pending requests and closes the portal. */
   override fun close() {
     job.cancel()
-    portal.close()
   }
 }
 

--- a/lib/location-runtime-linux/src/test/kotlin/org/maplibre/compose/location/desktop/linux/LinuxPortalLocationProviderTest.kt
+++ b/lib/location-runtime-linux/src/test/kotlin/org/maplibre/compose/location/desktop/linux/LinuxPortalLocationProviderTest.kt
@@ -11,15 +11,21 @@ import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import org.freedesktop.dbus.types.UInt64
 import org.freedesktop.dbus.types.Variant
@@ -185,10 +191,75 @@ class LinuxPortalLocationProviderTest {
   }
 
   @Test
+  fun cancellingCollectorWaitsForPortalSessionCleanup() = runTest {
+    val portal = FakeLinuxLocationPortal()
+    var cleanedUp = false
+    portal.events = flow {
+      try {
+        awaitCancellation()
+      } finally {
+        withContext(NonCancellable) { delay(1) }
+        cleanedUp = true
+      }
+    }
+    val provider = LinuxPortalLocationProvider(portal, backgroundScope)
+    val collection = launch { provider.updates().collect {} }
+    runCurrent()
+
+    collection.cancelAndJoin()
+
+    assertTrue(cleanedUp)
+    assertEquals(0, portal.closeCount)
+    provider.close()
+    assertEquals(1, portal.closeCount)
+  }
+
+  @Test
+  fun providerCloseStopsUpdatesAndPermissionBeforeClosingPortal() = runTest {
+    val events = mutableListOf<String>()
+    val portal = FakeLinuxLocationPortal()
+    portal.events = flow {
+      try {
+        awaitCancellation()
+      } finally {
+        events += "updates stopped"
+      }
+    }
+    portal.permissionResult = {
+      try {
+        awaitCancellation()
+      } finally {
+        events += "permission stopped"
+      }
+    }
+    portal.onClose = { events += "portal closed" }
+    val provider = LinuxPortalLocationProvider(portal, backgroundScope)
+    val collection = launch { provider.updates().collect {} }
+    provider.requestPermission()
+    runCurrent()
+    assertEquals(1, portal.updateCollections)
+    assertEquals(1, portal.permissionRequests)
+
+    provider.close()
+    provider.close()
+    collection.join()
+    runCurrent()
+
+    assertEquals(1, portal.closeCount)
+    assertEquals("portal closed", events.last())
+    assertEquals(setOf("updates stopped", "permission stopped", "portal closed"), events.toSet())
+    assertTrue(backgroundScope.isActive)
+    assertFailsWith<IllegalStateException> { provider.updates().first() }
+    assertFailsWith<IllegalStateException> { provider.requestPermission() }
+  }
+
+  @Test
   fun closeDoesNotCancelCallerScope() {
     val callerScope = CoroutineScope(SupervisorJob())
     val requester = LinuxPortalLocationPermissionRequester(FakeLinuxLocationPortal(), callerScope)
     requester.close()
+    requester.close()
+    assertFailsWith<IllegalStateException> { requester.requestForegroundPermission() }
     assertTrue(callerScope.isActive)
   }
 }
@@ -208,6 +279,8 @@ private class FakeWaylandWindow(private val handle: String?) : XdgPortalWindow.W
 
 private class FakeLinuxLocationPortal(override val available: Boolean = true) :
   LinuxLocationPortal {
+  var closeCount = 0
+  var onClose: () -> Unit = {}
   var closed = false
   var updateCollections = 0
   var permissionRequests = 0
@@ -233,6 +306,8 @@ private class FakeLinuxLocationPortal(override val available: Boolean = true) :
   }
 
   override fun close() {
+    closeCount += 1
+    onClose()
     closed = true
   }
 }

--- a/lib/location-runtime-macos/src/main/kotlin/org/maplibre/compose/location/desktop/macos/CoreLocation.kt
+++ b/lib/location-runtime-macos/src/main/kotlin/org/maplibre/compose/location/desktop/macos/CoreLocation.kt
@@ -87,6 +87,9 @@ internal interface CoreLocationClient : AutoCloseable {
     get() = LocationBackendAvailability.Available
 
   fun createManager(): CoreLocationManager
+
+  /** Runs on Core Location's owning thread, executing inline when already there. */
+  fun <T> onLocationThread(action: () -> T): T
 }
 
 internal fun LocationAccuracy.toDesiredAccuracy(): Double =

--- a/lib/location-runtime-macos/src/main/kotlin/org/maplibre/compose/location/desktop/macos/MacosLocationBackend.kt
+++ b/lib/location-runtime-macos/src/main/kotlin/org/maplibre/compose/location/desktop/macos/MacosLocationBackend.kt
@@ -232,6 +232,8 @@ internal constructor(private val client: CoreLocationClient) : AutoCloseable {
   private var closed = false
   private var activeOperations = 0
   private var disposed = false
+  private var permissionRevision = 0L
+  private var permissionFailure: Throwable? = null
 
   private fun withClient(ifClosed: () -> Unit = {}, action: () -> Unit) {
     val accepted =
@@ -300,13 +302,17 @@ internal constructor(private val client: CoreLocationClient) : AutoCloseable {
       }
 
       override fun didChangeAuthorization() = withClient {
-        if (synchronized(lock) { manager !== source }) return@withClient
-        val permission = readPermission(source.authorizationStatus, source.accuracyAuthorization)
-        mutableStatus.value = permission
-        if (permission != LocationPermission.NotGranted(canRequest = true)) {
-          source.stopUpdatingLocation()
+        client.onLocationThread {
+          if (synchronized(lock) { manager !== source }) return@onLocationThread
+          val permission = runCatching {
+            readAndPublishPermission(source)
+          }
+            .getOrDefault(LocationPermission.Unknown)
+          if (permission != LocationPermission.NotGranted(canRequest = true)) {
+            source.stopUpdatingLocation()
+          }
+          requestPending.set(false)
         }
-        requestPending.set(false)
       }
     }
 
@@ -317,16 +323,42 @@ internal constructor(private val client: CoreLocationClient) : AutoCloseable {
   internal fun refreshPermission(): LocationPermission {
     var permission: LocationPermission = LocationPermission.Unknown
     withClient(ifClosed = { error("The macOS permission requester is closed") }) {
-      try {
-        val manager = manager()
-        permission = readPermission(manager.authorizationStatus, manager.accuracyAuthorization)
-        mutableStatus.value = permission
-      } catch (error: Throwable) {
-        mutableStatus.value = LocationPermission.Unknown
-        throw error
-      }
+      val revisionBeforeAllocation = synchronized(lock) { permissionRevision }
+      val manager =
+        try {
+          manager()
+        } catch (error: Throwable) {
+          permission = client.onLocationThread {
+            synchronized(lock) {
+              if (permissionRevision == revisionBeforeAllocation) {
+                permissionRevision += 1
+                permissionFailure = error
+                mutableStatus.value = LocationPermission.Unknown
+              }
+              permissionFailure?.let { throw it }
+              mutableStatus.value
+            }
+          }
+          return@withClient
+        }
+      permission = client.onLocationThread { readAndPublishPermission(manager) }
     }
     return permission
+  }
+
+  private fun readAndPublishPermission(source: CoreLocationManager): LocationPermission {
+    val revision = synchronized(lock) { ++permissionRevision }
+    val result = runCatching {
+      readPermission(source.authorizationStatus, source.accuracyAuthorization)
+    }
+    return synchronized(lock) {
+      if (revision == permissionRevision) {
+        permissionFailure = result.exceptionOrNull()
+        mutableStatus.value = result.getOrDefault(LocationPermission.Unknown)
+      }
+      permissionFailure?.let { throw it }
+      mutableStatus.value
+    }
   }
 
   /**

--- a/lib/location-runtime-macos/src/main/kotlin/org/maplibre/compose/location/desktop/macos/MacosLocationBackend.kt
+++ b/lib/location-runtime-macos/src/main/kotlin/org/maplibre/compose/location/desktop/macos/MacosLocationBackend.kt
@@ -5,9 +5,15 @@ import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.coroutines.CoroutineContext
 import kotlin.time.TimeSource
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -58,16 +64,44 @@ internal constructor(
 ) : DesktopLocationProvider {
   public constructor() : this(SystemCoreLocationClient())
 
+  private val job = SupervisorJob()
+  private val scope = CoroutineScope(dispatcher + job)
   private val requester = MacosLocationPermissionRequester(client)
+
+  init {
+    job.invokeOnCompletion { requester.close() }
+  }
 
   override val backendAvailability: LocationBackendAvailability = client.backendAvailability
 
   override val permission: StateFlow<LocationPermission>
     get() = requester.status
 
-  override fun requestPermission(): Unit = requester.requestForegroundPermission()
+  override fun requestPermission() {
+    check(job.isActive) { "The macOS location provider is closed" }
+    requester.requestForegroundPermission()
+  }
 
   override fun updates(request: LocationRequest): Flow<LocationEvent> = callbackFlow {
+    check(job.isActive) { "The macOS location provider is closed" }
+    val collection =
+      scope.launch(start = CoroutineStart.UNDISPATCHED) {
+        try {
+          currentCoroutineContext().ensureActive()
+          collectUpdates(request).collect { send(it) }
+        } catch (error: Throwable) {
+          if (job.isActive) channel.close(error)
+        }
+      }
+    collection.invokeOnCompletion { channel.close() }
+    try {
+      awaitClose()
+    } finally {
+      withContext(NonCancellable) { collection.cancelAndJoin() }
+    }
+  }
+
+  private fun collectUpdates(request: LocationRequest): Flow<LocationEvent> = callbackFlow {
     check(backendAvailability == LocationBackendAvailability.Available) {
       "Location updates require an available backend: $backendAvailability"
     }
@@ -106,8 +140,7 @@ internal constructor(
     .flowOn(dispatcher)
 
   override fun close() {
-    requester.close()
-    client.close()
+    job.cancel()
   }
 
   private class UpdateDelegate(
@@ -179,6 +212,47 @@ internal constructor(private val client: CoreLocationClient) : AutoCloseable {
   /** Current foreground location permission, updated when Core Location reports a change. */
   public val status: StateFlow<LocationPermission> = mutableStatus
   private val requestPending = AtomicBoolean()
+  private val lock = Any()
+  private var closed = false
+  private var activeOperations = 0
+  private var disposed = false
+
+  private fun withClient(ifClosed: () -> Unit = {}, action: () -> Unit) {
+    val accepted =
+      synchronized(lock) {
+        if (closed) false
+        else {
+          activeOperations += 1
+          true
+        }
+      }
+    if (!accepted) return ifClosed()
+    try {
+      action()
+    } finally {
+      val dispose =
+        synchronized(lock) {
+          activeOperations -= 1
+          claimDisposal()
+        }
+      if (dispose) disposeClient()
+    }
+  }
+
+  private fun claimDisposal(): Boolean =
+    if (closed && activeOperations == 0 && !disposed) {
+      disposed = true
+      true
+    } else false
+
+  private fun disposeClient() {
+    try {
+      manager?.close()
+    } finally {
+      manager = null
+      client.close()
+    }
+  }
 
   // Allocation is fallible and must not throw from construction, so the manager is created through
   // manager() and retried on each access until an attempt succeeds. A failed attempt reports
@@ -202,12 +276,12 @@ internal constructor(private val client: CoreLocationClient) : AutoCloseable {
     object : CoreLocationDelegate {
       override fun didUpdateLocations(locations: List<CoreLocationMeasurement>) = Unit
 
-      override fun didFailWithError(error: CoreLocationError) {
+      override fun didFailWithError(error: CoreLocationError) = withClient {
         manager?.stopUpdatingLocation()
         requestPending.set(false)
       }
 
-      override fun didChangeAuthorization() {
+      override fun didChangeAuthorization() = withClient {
         val permission = currentPermission()
         mutableStatus.value = permission
         if (permission != LocationPermission.NotGranted(canRequest = true)) {
@@ -227,22 +301,35 @@ internal constructor(private val client: CoreLocationClient) : AutoCloseable {
    * Starts a foreground permission request and returns immediately. The result is published to
    * [status].
    */
-  public fun requestForegroundPermission() {
-    if (backendAvailability != LocationBackendAvailability.Available) return
-    val manager = manager() ?: return
-    val current = currentPermission()
-    if (current != LocationPermission.NotGranted(canRequest = true)) return
-    if (!requestPending.compareAndSet(false, true)) return
-    manager.requestWhenInUseAuthorization()
-    // macOS presents the system prompt when a location service starts, not from the
-    // authorization request alone.
-    manager.startUpdatingLocation()
-  }
+  public fun requestForegroundPermission(): Unit =
+    withClient(ifClosed = { error("The macOS permission requester is closed") }) {
+      if (backendAvailability != LocationBackendAvailability.Available) return@withClient
+      if (!requestPending.compareAndSet(false, true)) return@withClient
+      val manager = manager()
+      if (
+        manager == null || currentPermission() != LocationPermission.NotGranted(canRequest = true)
+      ) {
+        requestPending.set(false)
+        return@withClient
+      }
+      try {
+        manager.requestWhenInUseAuthorization()
+        // macOS presents the prompt when location updates start.
+        manager.startUpdatingLocation()
+      } catch (error: Throwable) {
+        requestPending.set(false)
+        throw error
+      }
+    }
 
-  /** Releases the Core Location manager and client. */
+  /** Releases the Core Location manager and client after active calls finish. */
   override fun close() {
-    manager?.close()
-    client.close()
+    val dispose =
+      synchronized(lock) {
+        closed = true
+        claimDisposal()
+      }
+    if (dispose) disposeClient()
   }
 
   private fun currentPermission(): LocationPermission =

--- a/lib/location-runtime-macos/src/main/kotlin/org/maplibre/compose/location/desktop/macos/MacosLocationBackend.kt
+++ b/lib/location-runtime-macos/src/main/kotlin/org/maplibre/compose/location/desktop/macos/MacosLocationBackend.kt
@@ -4,6 +4,7 @@ import java.util.Locale
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.coroutines.CoroutineContext
 import kotlin.time.TimeSource
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
@@ -23,7 +24,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.maplibre.compose.location.DesktopLocationBackend
 import org.maplibre.compose.location.DesktopLocationProvider
-import org.maplibre.compose.location.LocationAccuracyAuthorization
 import org.maplibre.compose.location.LocationBackendAvailability
 import org.maplibre.compose.location.LocationEvent
 import org.maplibre.compose.location.LocationPermission
@@ -112,30 +112,48 @@ internal constructor(
       return@callbackFlow
     }
 
+    val permission =
+      try {
+        requester.refreshPermission()
+      } catch (error: Throwable) {
+        if (error is CancellationException) throw error
+        trySend(LocationEvent.Unavailable(LocationUnavailableReason.UnexpectedFailure, error))
+        close()
+        return@callbackFlow
+      }
+    currentCoroutineContext().ensureActive()
+    if (permission !is LocationPermission.Granted) {
+      trySend(LocationEvent.Unavailable(LocationUnavailableReason.PermissionDenied))
+      close()
+      return@callbackFlow
+    }
+
     val manager =
       try {
         client.createManager()
       } catch (error: Throwable) {
+        if (error is CancellationException) throw error
         trySend(LocationEvent.Unavailable(LocationUnavailableReason.UnexpectedFailure, error))
         close()
         return@callbackFlow
       }
 
     try {
+      currentCoroutineContext().ensureActive()
       val delegate = UpdateDelegate(this, channel, client, ioDispatcher)
       manager.setDelegate(delegate)
       manager.desiredAccuracy = request.accuracy.toDesiredAccuracy()
       manager.distanceFilter = request.minimumDistance.inMeters
       manager.location?.let(delegate::sendLocation)
       manager.startUpdatingLocation()
+      awaitClose()
     } catch (error: Throwable) {
-      manager.close()
+      if (error is CancellationException) throw error
       trySend(LocationEvent.Unavailable(LocationUnavailableReason.UnexpectedFailure, error))
       close()
-      return@callbackFlow
+    } finally {
+      manager.close()
     }
-
-    awaitClose { manager.close() }
   }
     .flowOn(dispatcher)
 
@@ -195,9 +213,8 @@ internal constructor(
  * [`requestWhenInUseAuthorization()`](https://developer.apple.com/documentation/corelocation/cllocationmanager/requestwheninuseauthorization())
  * and starts location updates so macOS can present the system prompt.
  *
- * If the manager cannot be allocated, [status] reports [LocationPermission.Granted] at
- * [LocationAccuracyAuthorization.Unknown] so that collection still reaches the provider's guarded
- * update path, which retries the allocation and reports a persistent failure as
+ * If permission initialization fails, [status] reports [LocationPermission.Unknown]. Collecting
+ * location updates retries initialization without requesting permission. Persistent failures report
  * [LocationUnavailableReason.UnexpectedFailure].
  */
 public class MacosLocationPermissionRequester
@@ -206,8 +223,7 @@ internal constructor(private val client: CoreLocationClient) : AutoCloseable {
 
   /** Whether the process has a usable Core Location implementation. */
   public val backendAvailability: LocationBackendAvailability = client.backendAvailability
-  private val mutableStatus =
-    MutableStateFlow<LocationPermission>(LocationPermission.NotGranted(canRequest = null))
+  private val mutableStatus = MutableStateFlow<LocationPermission>(LocationPermission.Unknown)
 
   /** Current foreground location permission, updated when Core Location reports a change. */
   public val status: StateFlow<LocationPermission> = mutableStatus
@@ -254,47 +270,63 @@ internal constructor(private val client: CoreLocationClient) : AutoCloseable {
     }
   }
 
-  // Allocation is fallible and must not throw from construction, so the manager is created through
-  // manager() and retried on each access until an attempt succeeds. A failed attempt reports
-  // permission as granted at unknown accuracy, so that rememberLocationState still collects updates
-  // and the provider's own guarded allocation retries or reports UnexpectedFailure.
   private var manager: CoreLocationManager? = null
 
-  private fun manager(): CoreLocationManager? =
-    manager
-      ?: try {
-        client.createManager().also {
-          it.setDelegate(delegate)
-          manager = it
-          mutableStatus.value = readPermission(it.authorizationStatus, it.accuracyAuthorization)
-        }
-      } catch (error: Throwable) {
-        null
+  private fun manager(): CoreLocationManager {
+    synchronized(lock) { manager }
+      ?.let {
+        return it
       }
+    val candidate = client.createManager()
+    try {
+      candidate.setDelegate(delegate(candidate))
+    } catch (error: Throwable) {
+      candidate.close()
+      throw error
+    }
+    val selected = synchronized(lock) { manager ?: candidate.also { manager = it } }
+    if (selected !== candidate) candidate.close()
+    return selected
+  }
 
-  private val delegate =
+  private fun delegate(source: CoreLocationManager): CoreLocationDelegate =
     object : CoreLocationDelegate {
       override fun didUpdateLocations(locations: List<CoreLocationMeasurement>) = Unit
 
       override fun didFailWithError(error: CoreLocationError) = withClient {
-        manager?.stopUpdatingLocation()
+        if (synchronized(lock) { manager !== source }) return@withClient
+        source.stopUpdatingLocation()
         requestPending.set(false)
       }
 
       override fun didChangeAuthorization() = withClient {
-        val permission = currentPermission()
+        if (synchronized(lock) { manager !== source }) return@withClient
+        val permission = readPermission(source.authorizationStatus, source.accuracyAuthorization)
         mutableStatus.value = permission
         if (permission != LocationPermission.NotGranted(canRequest = true)) {
-          manager?.stopUpdatingLocation()
+          source.stopUpdatingLocation()
         }
         requestPending.set(false)
       }
     }
 
   init {
-    if (manager() == null) {
-      mutableStatus.value = LocationPermission.Granted(LocationAccuracyAuthorization.Unknown)
+    runCatching { refreshPermission() }
+  }
+
+  internal fun refreshPermission(): LocationPermission {
+    var permission: LocationPermission = LocationPermission.Unknown
+    withClient(ifClosed = { error("The macOS permission requester is closed") }) {
+      try {
+        val manager = manager()
+        permission = readPermission(manager.authorizationStatus, manager.accuracyAuthorization)
+        mutableStatus.value = permission
+      } catch (error: Throwable) {
+        mutableStatus.value = LocationPermission.Unknown
+        throw error
+      }
     }
+    return permission
   }
 
   /**
@@ -305,13 +337,18 @@ internal constructor(private val client: CoreLocationClient) : AutoCloseable {
     withClient(ifClosed = { error("The macOS permission requester is closed") }) {
       if (backendAvailability != LocationBackendAvailability.Available) return@withClient
       if (!requestPending.compareAndSet(false, true)) return@withClient
-      val manager = manager()
-      if (
-        manager == null || currentPermission() != LocationPermission.NotGranted(canRequest = true)
-      ) {
+      val permission =
+        try {
+          refreshPermission()
+        } catch (error: Throwable) {
+          requestPending.set(false)
+          return@withClient
+        }
+      if (permission != LocationPermission.NotGranted(canRequest = true)) {
         requestPending.set(false)
         return@withClient
       }
+      val manager = manager()
       try {
         manager.requestWhenInUseAuthorization()
         // macOS presents the prompt when location updates start.
@@ -331,8 +368,4 @@ internal constructor(private val client: CoreLocationClient) : AutoCloseable {
       }
     if (dispose) disposeClient()
   }
-
-  private fun currentPermission(): LocationPermission =
-    manager?.let { readPermission(it.authorizationStatus, it.accuracyAuthorization) }
-      ?: LocationPermission.NotGranted(canRequest = null)
 }

--- a/lib/location-runtime-macos/src/main/kotlin/org/maplibre/compose/location/desktop/macos/SystemCoreLocation.kt
+++ b/lib/location-runtime-macos/src/main/kotlin/org/maplibre/compose/location/desktop/macos/SystemCoreLocation.kt
@@ -31,6 +31,8 @@ internal class SystemCoreLocationClient : CoreLocationClient {
 
   override fun createManager(): CoreLocationManager = SystemCoreLocationManager()
 
+  override fun <T> onLocationThread(action: () -> T): T = onMain(action)
+
   override fun close() = Unit
 }
 

--- a/lib/location-runtime-macos/src/test/kotlin/org/maplibre/compose/location/desktop/macos/MacosLocationProviderTest.kt
+++ b/lib/location-runtime-macos/src/test/kotlin/org/maplibre/compose/location/desktop/macos/MacosLocationProviderTest.kt
@@ -11,9 +11,12 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.maplibre.compose.location.DesktopLocationBackend
 import org.maplibre.compose.location.LocationAccuracy
@@ -28,6 +31,7 @@ import org.maplibre.spatialk.units.extensions.degrees
 import org.maplibre.spatialk.units.extensions.inMeters
 import org.maplibre.spatialk.units.extensions.meters
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class MacosLocationProviderTest {
   @Test
   fun serviceLoaderFindsMacosBackend() {
@@ -163,6 +167,55 @@ class MacosLocationProviderTest {
     assertNull(location.altitudeAccuracy)
     assertNull(location.course)
     assertNull(location.distancePerSecond)
+  }
+
+  @Test
+  fun closeStopsCollectorsAndClosesResourcesOnce() = runTest {
+    val client = FakeCoreLocationClient()
+    val provider = MacosLocationProvider(client, Dispatchers.Unconfined, Dispatchers.Unconfined)
+    val first = launch(start = CoroutineStart.UNDISPATCHED) { provider.updates().collect {} }
+    val second = launch(start = CoroutineStart.UNDISPATCHED) { provider.updates().collect {} }
+    runCurrent()
+    assertEquals(3, client.managers.size)
+
+    provider.close()
+    provider.close()
+    first.join()
+    second.join()
+
+    assertTrue(client.managers.all { it.closeCount == 1 })
+    assertEquals(1, client.closeCount)
+    assertFailsWith<IllegalStateException> { provider.updates().first() }
+    assertFailsWith<IllegalStateException> { provider.requestPermission() }
+    assertEquals(3, client.managers.size)
+  }
+
+  @Test
+  fun reentrantCloseWaitsForPermissionCallToFinish() {
+    val client = FakeCoreLocationClient()
+    val requester = MacosLocationPermissionRequester(client)
+    client.managers.single().onRequest = {
+      requester.close()
+      assertFalse(client.closed)
+      assertFalse(client.managers.single().closed)
+    }
+
+    requester.requestForegroundPermission()
+
+    assertEquals(1, client.closeCount)
+    assertEquals(1, client.managers.single().closeCount)
+    assertFalse(client.managers.single().updating)
+  }
+
+  @Test
+  fun standaloneRequesterOwnsClientAndClosesOnce() {
+    val client = FakeCoreLocationClient()
+    val requester = MacosLocationPermissionRequester(client)
+    requester.close()
+    requester.close()
+    assertEquals(1, client.closeCount)
+    assertEquals(1, client.managers.single().closeCount)
+    assertFailsWith<IllegalStateException> { requester.requestForegroundPermission() }
   }
 
   @Test
@@ -439,6 +492,7 @@ private class FakeCoreLocationClient(
       LocationBackendAvailability.Misconfigured(IllegalStateException("missing usage description"))
     }
   val managers = mutableListOf<FakeCoreLocationManager>()
+  var closeCount = 0
   var closed = false
   var nextLocation: CoreLocationMeasurement? = null
   var createFailure: Throwable? = null
@@ -449,6 +503,7 @@ private class FakeCoreLocationClient(
   }
 
   override fun close() {
+    closeCount += 1
     closed = true
   }
 }
@@ -462,6 +517,8 @@ private class FakeCoreLocationManager(override var location: CoreLocationMeasure
   var boundDelegate: CoreLocationDelegate? = null
   var updating = false
   var whenInUseRequests = 0
+  var onRequest: () -> Unit = {}
+  var closeCount = 0
   var closed = false
 
   override fun setDelegate(delegate: CoreLocationDelegate?) {
@@ -478,9 +535,11 @@ private class FakeCoreLocationManager(override var location: CoreLocationMeasure
 
   override fun requestWhenInUseAuthorization() {
     whenInUseRequests += 1
+    onRequest()
   }
 
   override fun close() {
+    closeCount += 1
     closed = true
     stopUpdatingLocation()
     boundDelegate = null

--- a/lib/location-runtime-macos/src/test/kotlin/org/maplibre/compose/location/desktop/macos/MacosLocationProviderTest.kt
+++ b/lib/location-runtime-macos/src/test/kotlin/org/maplibre/compose/location/desktop/macos/MacosLocationProviderTest.kt
@@ -1,7 +1,11 @@
 package org.maplibre.compose.location.desktop.macos
 
+import java.util.Collections
 import java.util.Locale
 import java.util.ServiceLoader
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -15,9 +19,11 @@ import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
 import org.maplibre.compose.location.DesktopLocationBackend
 import org.maplibre.compose.location.LocationAccuracy
 import org.maplibre.compose.location.LocationAccuracyAuthorization
@@ -192,7 +198,7 @@ class MacosLocationProviderTest {
 
   @Test
   fun reentrantCloseWaitsForPermissionCallToFinish() {
-    val client = FakeCoreLocationClient()
+    val client = FakeCoreLocationClient(authorizationStatus = CL_AUTHORIZATION_NOT_DETERMINED)
     val requester = MacosLocationPermissionRequester(client)
     client.managers.single().onRequest = {
       requester.close()
@@ -345,12 +351,7 @@ class MacosLocationProviderTest {
 
     val provider = MacosLocationProvider(client, Dispatchers.Unconfined)
 
-    // Permission reports granted at unknown accuracy so that collection reaches the guarded update
-    // path, which retries the allocation and reports the persistent failure.
-    assertEquals(
-      LocationPermission.Granted(LocationAccuracyAuthorization.Unknown),
-      provider.permission.value,
-    )
+    assertEquals(LocationPermission.Unknown, provider.permission.value)
     provider.requestPermission()
     val event = assertIs<LocationEvent.Unavailable>(provider.updates(LocationRequest()).first())
     assertEquals(LocationUnavailableReason.UnexpectedFailure, event.reason)
@@ -358,8 +359,151 @@ class MacosLocationProviderTest {
   }
 
   @Test
+  fun collectionRetriesPermissionInitializationWithoutPrompting() = runTest {
+    val failure = IllegalStateException("native failed")
+    val client = FakeCoreLocationClient().apply { createFailure = failure }
+    val provider = MacosLocationProvider(client, Dispatchers.Unconfined, Dispatchers.Unconfined)
+
+    val failed = assertIs<LocationEvent.Unavailable>(provider.updates().first())
+    assertEquals(LocationUnavailableReason.UnexpectedFailure, failed.reason)
+    assertEquals(failure, failed.cause)
+    assertEquals(LocationPermission.Unknown, provider.permission.value)
+
+    client.createFailure = null
+    client.nextLocation = sampleMeasurement()
+    assertIs<LocationEvent.Update>(provider.updates().first())
+    assertEquals(
+      LocationPermission.Granted(LocationAccuracyAuthorization.Precise),
+      provider.permission.value,
+    )
+    assertEquals(2, client.managers.size)
+    assertTrue(client.managers.all { it.whenInUseRequests == 0 })
+    provider.close()
+    assertTrue(client.managers.all { it.closeCount == 1 })
+    assertEquals(1, client.closeCount)
+  }
+
+  @Test
+  fun initializationRetryDoesNotStartUpdatesWithoutAuthorization() = runTest {
+    for (authorization in listOf(CL_AUTHORIZATION_DENIED, CL_AUTHORIZATION_NOT_DETERMINED)) {
+      val client = FakeCoreLocationClient(authorizationStatus = authorization)
+      client.createFailure = IllegalStateException("native failed")
+      val provider = MacosLocationProvider(client, Dispatchers.Unconfined, Dispatchers.Unconfined)
+      client.createFailure = null
+
+      val event = assertIs<LocationEvent.Unavailable>(provider.updates().first())
+
+      assertEquals(LocationUnavailableReason.PermissionDenied, event.reason)
+      assertEquals(
+        LocationPermission.NotGranted(
+          canRequest = authorization == CL_AUTHORIZATION_NOT_DETERMINED
+        ),
+        provider.permission.value,
+      )
+      val manager = client.managers.single()
+      assertEquals(0, manager.whenInUseRequests)
+      assertEquals(0, manager.startCount)
+      provider.close()
+      assertEquals(1, manager.closeCount)
+    }
+  }
+
+  @Test
+  fun closeDuringInitializationRetryDoesNotStartDeliveryOrLeakManager() = runTest {
+    val client =
+      FakeCoreLocationClient().apply { createFailure = IllegalStateException("native failed") }
+    val provider = MacosLocationProvider(client, Dispatchers.Unconfined, Dispatchers.Unconfined)
+    client.createFailure = null
+    client.onCreate = { provider.close() }
+
+    assertTrue(provider.updates().toList().isEmpty())
+
+    val manager = client.managers.single()
+    assertEquals(0, manager.whenInUseRequests)
+    assertEquals(0, manager.startCount)
+    assertEquals(1, manager.closeCount)
+    assertEquals(1, client.closeCount)
+  }
+
+  @Test
+  fun cancellingCollectorDuringPermissionRetryDoesNotStartDelivery() = runTest {
+    val client =
+      FakeCoreLocationClient().apply { createFailure = IllegalStateException("native failed") }
+    val provider = MacosLocationProvider(client, Dispatchers.IO, Dispatchers.IO)
+    client.createFailure = null
+    val creating = CountDownLatch(1)
+    val resume = CountDownLatch(1)
+    client.onCreate = {
+      creating.countDown()
+      check(resume.await(5, TimeUnit.SECONDS))
+    }
+    val collection = launch { provider.updates().collect {} }
+    try {
+      withContext(Dispatchers.IO) { check(creating.await(5, TimeUnit.SECONDS)) }
+      collection.cancel()
+      runCurrent()
+    } finally {
+      resume.countDown()
+    }
+    collection.join()
+
+    val manager = client.managers.single()
+    assertEquals(0, manager.startCount)
+    assertEquals(0, manager.whenInUseRequests)
+    assertEquals(0, client.closeCount)
+    provider.close()
+    assertEquals(1, manager.closeCount)
+    assertEquals(1, client.closeCount)
+  }
+
+  @Test
+  fun failedPermissionDelegateSetupClosesManagerAndCanRetry() = runTest {
+    val failure = IllegalStateException("delegate failed")
+    val client = FakeCoreLocationClient().apply { delegateFailure = failure }
+    val provider = MacosLocationProvider(client, Dispatchers.Unconfined, Dispatchers.Unconfined)
+    assertEquals(LocationPermission.Unknown, provider.permission.value)
+    assertEquals(1, client.managers.single().closeCount)
+
+    val event = assertIs<LocationEvent.Unavailable>(provider.updates().first())
+    assertEquals(failure, event.cause)
+    assertTrue(client.managers.all { it.closeCount == 1 })
+    client.delegateFailure = null
+    client.nextLocation = sampleMeasurement()
+    assertIs<LocationEvent.Update>(provider.updates().first())
+    provider.close()
+    assertTrue(client.managers.all { it.closeCount == 1 })
+  }
+
+  @Test
+  fun concurrentInitializationRetriesKeepOnePermissionManager() {
+    val client =
+      FakeCoreLocationClient().apply { createFailure = IllegalStateException("native failed") }
+    val requester = MacosLocationPermissionRequester(client)
+    client.createFailure = null
+    val creating = CountDownLatch(2)
+    client.onCreate = {
+      creating.countDown()
+      check(creating.await(5, TimeUnit.SECONDS))
+    }
+
+    Executors.newFixedThreadPool(2).use { executor ->
+      val attempts =
+        (1..2).map { executor.submit<LocationPermission> { requester.refreshPermission() } }
+      attempts.forEach {
+        assertIs<LocationPermission.Granted>(it.get(5, TimeUnit.SECONDS))
+      }
+    }
+
+    assertEquals(2, client.managers.size)
+    assertEquals(1, client.managers.count { it.closed })
+    requester.close()
+    assertTrue(client.managers.all { it.closeCount == 1 })
+    assertEquals(1, client.closeCount)
+  }
+
+  @Test
   fun overlappingPermissionRequestsStartOneAuthorizationRequest() {
-    val client = FakeCoreLocationClient()
+    val client = FakeCoreLocationClient(authorizationStatus = CL_AUTHORIZATION_NOT_DETERMINED)
     val provider = MacosLocationProvider(client, Dispatchers.Unconfined)
     val manager = client.managers.single()
 
@@ -388,7 +532,7 @@ class MacosLocationProviderTest {
 
   @Test
   fun permissionFailureClearsPendingRequest() {
-    val client = FakeCoreLocationClient()
+    val client = FakeCoreLocationClient(authorizationStatus = CL_AUTHORIZATION_NOT_DETERMINED)
     val provider = MacosLocationProvider(client, Dispatchers.Unconfined)
     val manager = client.managers.single()
 
@@ -484,6 +628,7 @@ private fun sampleMeasurement(): CoreLocationMeasurement =
 private class FakeCoreLocationClient(
   override var locationServicesEnabled: Boolean = true,
   hasUsageDescription: Boolean = true,
+  val authorizationStatus: Long = CL_AUTHORIZATION_AUTHORIZED_WHEN_IN_USE,
 ) : CoreLocationClient {
   override val backendAvailability: LocationBackendAvailability =
     if (hasUsageDescription) {
@@ -491,15 +636,22 @@ private class FakeCoreLocationClient(
     } else {
       LocationBackendAvailability.Misconfigured(IllegalStateException("missing usage description"))
     }
-  val managers = mutableListOf<FakeCoreLocationManager>()
+  val managers: MutableList<FakeCoreLocationManager> = Collections.synchronizedList(mutableListOf())
   var closeCount = 0
   var closed = false
   var nextLocation: CoreLocationMeasurement? = null
   var createFailure: Throwable? = null
+  var delegateFailure: Throwable? = null
+  var onCreate: () -> Unit = {}
 
   override fun createManager(): CoreLocationManager {
     createFailure?.let { throw it }
-    return FakeCoreLocationManager(nextLocation).also { managers += it }
+    return FakeCoreLocationManager(nextLocation).also {
+      it.authorizationStatus = authorizationStatus
+      it.delegateFailure = delegateFailure
+      managers += it
+      onCreate()
+    }
   }
 
   override fun close() {
@@ -517,15 +669,19 @@ private class FakeCoreLocationManager(override var location: CoreLocationMeasure
   var boundDelegate: CoreLocationDelegate? = null
   var updating = false
   var whenInUseRequests = 0
+  var startCount = 0
+  var delegateFailure: Throwable? = null
   var onRequest: () -> Unit = {}
   var closeCount = 0
   var closed = false
 
   override fun setDelegate(delegate: CoreLocationDelegate?) {
+    delegateFailure?.let { throw it }
     boundDelegate = delegate
   }
 
   override fun startUpdatingLocation() {
+    startCount += 1
     updating = true
   }
 

--- a/lib/location-runtime-macos/src/test/kotlin/org/maplibre/compose/location/desktop/macos/MacosLocationProviderTest.kt
+++ b/lib/location-runtime-macos/src/test/kotlin/org/maplibre/compose/location/desktop/macos/MacosLocationProviderTest.kt
@@ -502,6 +502,101 @@ class MacosLocationProviderTest {
   }
 
   @Test
+  fun denialCallbackDuringRefreshPreventsDelivery() = runTest {
+    val client = FakeCoreLocationClient()
+    val provider = MacosLocationProvider(client, Dispatchers.Unconfined, Dispatchers.Unconfined)
+    val manager = client.managers.single()
+    manager.onAuthorizationRead = {
+      manager.onAuthorizationRead = {}
+      manager.authorizationStatus = CL_AUTHORIZATION_DENIED
+      manager.boundDelegate?.didChangeAuthorization()
+    }
+
+    val event = assertIs<LocationEvent.Unavailable>(provider.updates().first())
+
+    assertEquals(LocationUnavailableReason.PermissionDenied, event.reason)
+    assertEquals(LocationPermission.NotGranted(canRequest = false), provider.permission.value)
+    assertEquals(1, client.managers.size)
+    assertEquals(0, manager.startCount)
+    provider.close()
+  }
+
+  @Test
+  fun grantCallbackDuringRefreshAllowsDelivery() = runTest {
+    val client = FakeCoreLocationClient()
+    val provider = MacosLocationProvider(client, Dispatchers.Unconfined, Dispatchers.Unconfined)
+    val manager = client.managers.single()
+    manager.authorizationStatus = CL_AUTHORIZATION_DENIED
+    manager.onAuthorizationRead = {
+      manager.onAuthorizationRead = {}
+      manager.authorizationStatus = CL_AUTHORIZATION_AUTHORIZED_WHEN_IN_USE
+      manager.boundDelegate?.didChangeAuthorization()
+    }
+    client.nextLocation = sampleMeasurement()
+
+    assertIs<LocationEvent.Update>(provider.updates().first())
+
+    assertIs<LocationPermission.Granted>(provider.permission.value)
+    assertEquals(2, client.managers.size)
+    provider.close()
+  }
+
+  @Test
+  fun newerAuthorizationReadFailureDuringRefreshReportsItsCause() = runTest {
+    val client = FakeCoreLocationClient()
+    val provider = MacosLocationProvider(client, Dispatchers.Unconfined, Dispatchers.Unconfined)
+    val manager = client.managers.single()
+    val failure = IllegalStateException("new permission read failed")
+    manager.onAuthorizationRead = {
+      manager.onAuthorizationRead = { throw failure }
+      manager.boundDelegate?.didChangeAuthorization()
+      manager.onAuthorizationRead = {}
+    }
+
+    val event = assertIs<LocationEvent.Unavailable>(provider.updates().first())
+
+    assertEquals(LocationUnavailableReason.UnexpectedFailure, event.reason)
+    assertEquals(failure, event.cause)
+    assertEquals(LocationPermission.Unknown, provider.permission.value)
+    assertEquals(1, client.managers.size)
+    provider.close()
+  }
+
+  @Test
+  fun staleRefreshFailurePreservesNewerAuthorization() {
+    val client = FakeCoreLocationClient()
+    val requester = MacosLocationPermissionRequester(client)
+    val manager = client.managers.single()
+    manager.onAuthorizationRead = {
+      manager.onAuthorizationRead = {}
+      manager.authorizationStatus = CL_AUTHORIZATION_DENIED
+      manager.boundDelegate?.didChangeAuthorization()
+      error("old permission read failed")
+    }
+
+    assertEquals(LocationPermission.NotGranted(canRequest = false), requester.refreshPermission())
+    assertEquals(LocationPermission.NotGranted(canRequest = false), requester.status.value)
+    requester.close()
+  }
+
+  @Test
+  fun staleAuthorizationCallbackPreservesNewerRefreshFailure() {
+    val client = FakeCoreLocationClient()
+    val requester = MacosLocationPermissionRequester(client)
+    val manager = client.managers.single()
+    manager.onAuthorizationRead = {
+      manager.onAuthorizationRead = { error("new permission read failed") }
+      assertFailsWith<IllegalStateException> { requester.refreshPermission() }
+      manager.onAuthorizationRead = {}
+    }
+
+    manager.boundDelegate?.didChangeAuthorization()
+
+    assertEquals(LocationPermission.Unknown, requester.status.value)
+    requester.close()
+  }
+
+  @Test
   fun overlappingPermissionRequestsStartOneAuthorizationRequest() {
     val client = FakeCoreLocationClient(authorizationStatus = CL_AUTHORIZATION_NOT_DETERMINED)
     val provider = MacosLocationProvider(client, Dispatchers.Unconfined)
@@ -643,6 +738,9 @@ private class FakeCoreLocationClient(
   var createFailure: Throwable? = null
   var delegateFailure: Throwable? = null
   var onCreate: () -> Unit = {}
+  private val locationThread = Any()
+
+  override fun <T> onLocationThread(action: () -> T): T = synchronized(locationThread, action)
 
   override fun createManager(): CoreLocationManager {
     createFailure?.let { throw it }
@@ -665,6 +763,13 @@ private class FakeCoreLocationManager(override var location: CoreLocationMeasure
   override var desiredAccuracy: Double = 0.0
   override var distanceFilter: Double = 0.0
   override var authorizationStatus: Long = CL_AUTHORIZATION_NOT_DETERMINED
+    get() {
+      val value = field
+      onAuthorizationRead()
+      return value
+    }
+
+  var onAuthorizationRead: () -> Unit = {}
   override var accuracyAuthorization: Long = CL_ACCURACY_AUTHORIZATION_FULL
   var boundDelegate: CoreLocationDelegate? = null
   var updating = false

--- a/lib/location-runtime-windows/src/main/kotlin/org/maplibre/compose/location/desktop/windows/WindowsLocationBackend.kt
+++ b/lib/location-runtime-windows/src/main/kotlin/org/maplibre/compose/location/desktop/windows/WindowsLocationBackend.kt
@@ -1,7 +1,6 @@
 package org.maplibre.compose.location.desktop.windows
 
 import java.util.Locale
-import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.time.TimeSource
 import kotlinx.coroutines.channels.awaitClose
@@ -51,29 +50,33 @@ internal constructor(private val client: WindowsLocationClient) : DesktopLocatio
   public constructor() : this(SystemWindowsLocationClient())
 
   private val requester = WindowsLocationPermissionRequester(client, ownsClient = false)
-  private val sessions = ConcurrentHashMap.newKeySet<WindowsCloseable>()
-  private val closed = AtomicBoolean()
+  private val lifecycleLock = Any()
+  private val sessions = mutableSetOf<Session>()
+  private var closed = false
+  // Keep the client alive across native calls without holding the lifecycle lock in callbacks.
+  private var activeOperations = 0
+  private var clientClosed = false
 
   override val backendAvailability: LocationBackendAvailability = client.backendAvailability
 
   override val permission: StateFlow<LocationPermission>
     get() = requester.status
 
-  override fun requestPermission(): Unit = requester.requestForegroundPermission()
+  override fun requestPermission() {
+    synchronized(lifecycleLock) {
+      check(!closed) { "The Windows location provider is closed" }
+      activeOperations++
+    }
+    try {
+      requester.requestForegroundPermission()
+    } finally {
+      finishOperation()
+    }
+  }
 
   override fun updates(request: LocationRequest): Flow<LocationEvent> = callbackFlow {
     check(backendAvailability == LocationBackendAvailability.Available) {
       "Location updates require an available backend: $backendAvailability"
-    }
-    if (closed.get()) {
-      trySend(
-        LocationEvent.Unavailable(
-          LocationUnavailableReason.UnexpectedFailure,
-          IllegalStateException("The Windows location provider is closed"),
-        )
-      )
-      close()
-      return@callbackFlow
     }
 
     val filter = WindowsLocationFilter(request.minimumInterval, request.minimumDistance.inMeters)
@@ -103,8 +106,14 @@ internal constructor(private val client: WindowsLocationClient) : DesktopLocatio
           trySend(LocationEvent.Unavailable(LocationUnavailableReason.UnexpectedFailure, error))
         }
       }
-    val session =
-      try {
+    val session = Session { close() }
+    synchronized(lifecycleLock) {
+      check(!closed) { "The Windows location provider is closed" }
+      sessions += session
+      activeOperations++
+    }
+    try {
+      val nativeSession =
         client.createSession(
           WindowsLocationConfiguration(
             desiredAccuracyMeters = request.accuracy.toDesiredAccuracyMeters(),
@@ -112,24 +121,74 @@ internal constructor(private val client: WindowsLocationClient) : DesktopLocatio
           ),
           listener,
         )
-      } catch (error: Throwable) {
-        trySend(LocationEvent.Unavailable(LocationUnavailableReason.UnexpectedFailure, error))
-        close()
-        return@callbackFlow
-      }
-    sessions += session
-    awaitClose {
-      if (sessions.remove(session)) session.close()
+      val retained =
+        synchronized(lifecycleLock) {
+          if (session in sessions) {
+            session.nativeSession = nativeSession
+            true
+          } else {
+            false
+          }
+        }
+      if (!retained) nativeSession.close()
+    } catch (error: Throwable) {
+      trySend(LocationEvent.Unavailable(LocationUnavailableReason.UnexpectedFailure, error))
+      closeSession(session)
+    } finally {
+      finishOperation()
     }
+    awaitClose { closeSession(session) }
   }
 
   override fun close() {
-    if (!closed.compareAndSet(false, true)) return
-    sessions.toList().forEach {
-      if (sessions.remove(it)) runCatching(it::close)
+    val activeSessions =
+      synchronized(lifecycleLock) {
+        if (closed) return
+        closed = true
+        activeOperations++
+        sessions.toList()
+      }
+    try {
+      activeSessions.forEach(::closeSession)
+    } finally {
+      finishOperation()
     }
-    runCatching(requester::close)
-    runCatching(client::close)
+  }
+
+  private fun closeSession(session: Session) {
+    val nativeSession =
+      synchronized(lifecycleLock) {
+        if (!sessions.remove(session)) return
+        activeOperations++
+        session.nativeSession
+      }
+    try {
+      session.closeFlow()
+      nativeSession?.let { runCatching(it::close) }
+    } finally {
+      finishOperation()
+    }
+  }
+
+  private fun finishOperation() {
+    val releaseClient =
+      synchronized(lifecycleLock) {
+        activeOperations--
+        if (closed && activeOperations == 0 && sessions.isEmpty() && !clientClosed) {
+          clientClosed = true
+          true
+        } else {
+          false
+        }
+      }
+    if (releaseClient) {
+      runCatching(requester::close)
+      runCatching(client::close)
+    }
+  }
+
+  private class Session(val closeFlow: () -> Unit) {
+    var nativeSession: WindowsCloseable? = null
   }
 }
 

--- a/lib/location-runtime-windows/src/test/kotlin/org/maplibre/compose/location/desktop/windows/WindowsLocationProviderTest.kt
+++ b/lib/location-runtime-windows/src/test/kotlin/org/maplibre/compose/location/desktop/windows/WindowsLocationProviderTest.kt
@@ -1,6 +1,8 @@
 package org.maplibre.compose.location.desktop.windows
 
 import java.util.ServiceLoader
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -291,9 +293,106 @@ class WindowsLocationProviderTest {
     assertEquals(1, client.observationCloses)
     assertEquals(1, client.closeCount)
 
-    first.cancelAndJoin()
-    second.cancelAndJoin()
+    first.join()
+    second.join()
+    assertTrue(first.isCompleted)
+    assertTrue(second.isCompleted)
     assertTrue(client.sessions.all { it.closeCount == 1 })
+  }
+
+  @Test
+  fun closeDuringSessionCreationDefersClientRelease() = runTest {
+    val creationStarted = CountDownLatch(1)
+    val finishCreation = CountDownLatch(1)
+    val client = FakeWindowsLocationClient(access = WindowsAccessStatus.Allowed)
+    client.onCreateSession = {
+      creationStarted.countDown()
+      check(finishCreation.await(5, TimeUnit.SECONDS))
+      assertEquals(0, client.closeCount)
+    }
+    val provider = WindowsLocationProvider(client)
+    val collector =
+      backgroundScope.launch(Dispatchers.Default) {
+        provider.updates(LocationRequest()).collect {}
+      }
+
+    try {
+      assertTrue(creationStarted.await(5, TimeUnit.SECONDS))
+      provider.close()
+      provider.close()
+      assertEquals(0, client.closeCount)
+      assertEquals(0, client.observationCloses)
+    } finally {
+      finishCreation.countDown()
+    }
+    collector.join()
+
+    assertFalse(collector.isCancelled)
+    assertEquals(1, client.sessions.single().closeCount)
+    assertEquals(1, client.observationCloses)
+    assertEquals(1, client.closeCount)
+  }
+
+  @Test
+  fun cancellationDuringSessionCreationClosesTheReturnedSession() = runTest {
+    val creationStarted = CountDownLatch(1)
+    val finishCreation = CountDownLatch(1)
+    val client = FakeWindowsLocationClient(access = WindowsAccessStatus.Allowed)
+    client.onCreateSession = {
+      creationStarted.countDown()
+      check(finishCreation.await(5, TimeUnit.SECONDS))
+    }
+    val provider = WindowsLocationProvider(client)
+    val collector =
+      backgroundScope.launch(Dispatchers.Default) {
+        provider.updates(LocationRequest()).collect {}
+      }
+
+    try {
+      assertTrue(creationStarted.await(5, TimeUnit.SECONDS))
+      collector.cancel()
+    } finally {
+      finishCreation.countDown()
+    }
+    collector.join()
+
+    assertEquals(1, client.sessions.single().closeCount)
+    assertEquals(0, client.closeCount)
+    provider.close()
+    assertEquals(1, client.sessions.single().closeCount)
+    assertEquals(1, client.closeCount)
+  }
+
+  @Test
+  fun sessionCreationCanCloseProviderReentrantly() = runTest {
+    val client = FakeWindowsLocationClient(access = WindowsAccessStatus.Allowed)
+    val provider = WindowsLocationProvider(client)
+    client.onCreateSession = {
+      provider.close()
+      assertEquals(0, client.closeCount)
+    }
+    val collector =
+      backgroundScope.launch(Dispatchers.Unconfined) {
+        provider.updates(LocationRequest()).collect {}
+      }
+    collector.join()
+
+    assertFalse(collector.isCancelled)
+    assertEquals(1, client.sessions.single().closeCount)
+    assertEquals(1, client.closeCount)
+  }
+
+  @Test
+  fun closedProviderRejectsNewWork() = runTest {
+    val client = FakeWindowsLocationClient()
+    val provider = WindowsLocationProvider(client)
+    provider.close()
+
+    assertFailsWith<IllegalStateException> { provider.requestPermission() }
+    assertFailsWith<IllegalStateException> { provider.updates(LocationRequest()).first() }
+    assertEquals(0, client.accessRequests)
+    assertTrue(client.sessions.isEmpty())
+    assertEquals(1, client.closeCount)
   }
 
   @Test
@@ -332,6 +431,7 @@ private class FakeWindowsLocationClient(
   var closeCount = 0
   var checkFailure: Throwable? = null
   var sessionFailure: Throwable? = null
+  var onCreateSession: (() -> Unit)? = null
   private var accessObserver: ((WindowsAccessStatus) -> Unit)? = null
   private var accessCompletion: ((WindowsAccessStatus) -> Unit)? = null
 
@@ -361,6 +461,7 @@ private class FakeWindowsLocationClient(
     configuration: WindowsLocationConfiguration,
     listener: WindowsLocationListener,
   ): WindowsCloseable {
+    onCreateSession?.invoke()
     sessionFailure?.let { throw it }
     val session = FakeWindowsSession(configuration, listener)
     sessions += session

--- a/lib/location/src/androidDeviceTest/kotlin/org/maplibre/compose/location/AndroidLocationPermissionRequestTest.kt
+++ b/lib/location/src/androidDeviceTest/kotlin/org/maplibre/compose/location/AndroidLocationPermissionRequestTest.kt
@@ -1,0 +1,70 @@
+package org.maplibre.compose.location
+
+import androidx.activity.result.ActivityResultRegistry
+import androidx.activity.result.contract.ActivityResultContract
+import androidx.core.app.ActivityOptionsCompat
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class AndroidLocationPermissionRequestTest {
+  @Test
+  fun closeUnregistersPendingRequestBeforeResultArrives() {
+    val registry = TestResultRegistry()
+    var reads = 0
+    val requester =
+      AndroidLocationPermissionRequester(
+        null,
+        registry,
+        {
+          reads++
+          null
+        },
+        { false },
+      )
+    requester.requestForegroundPermission()
+    requester.requestForegroundPermission()
+    assertEquals(1, registry.launches)
+    val readsBeforeClose = reads
+    val permissionBeforeClose = requester.status.value
+
+    requester.close()
+    registry.dispatchResult(registry.requestCode, mapOf("fine" to false))
+
+    assertEquals(readsBeforeClose, reads)
+    assertEquals(permissionBeforeClose, requester.status.value)
+  }
+
+  @Test
+  fun failedLaunchAllowsAnotherRequest() {
+    val registry = TestResultRegistry()
+    val requester = AndroidLocationPermissionRequester(null, registry, { null }, { false })
+    registry.failLaunch = true
+    assertFailsWith<IllegalStateException> { requester.requestForegroundPermission() }
+    registry.failLaunch = false
+
+    requester.requestForegroundPermission()
+    registry.dispatchResult(registry.requestCode, mapOf("fine" to false))
+
+    assertEquals(2, registry.launches)
+    assertEquals(LocationPermission.NotGranted(canRequest = false), requester.status.value)
+    requester.close()
+  }
+
+  private class TestResultRegistry : ActivityResultRegistry() {
+    var launches = 0
+    var requestCode = 0
+    var failLaunch = false
+
+    override fun <I, O> onLaunch(
+      requestCode: Int,
+      contract: ActivityResultContract<I, O>,
+      input: I,
+      options: ActivityOptionsCompat?,
+    ) {
+      launches++
+      this.requestCode = requestCode
+      check(!failLaunch) { "Launch failed" }
+    }
+  }
+}

--- a/lib/location/src/androidDeviceTest/kotlin/org/maplibre/compose/location/AndroidLocationPermissionRequestTest.kt
+++ b/lib/location/src/androidDeviceTest/kotlin/org/maplibre/compose/location/AndroidLocationPermissionRequestTest.kt
@@ -3,11 +3,59 @@ package org.maplibre.compose.location
 import androidx.activity.result.ActivityResultRegistry
 import androidx.activity.result.contract.ActivityResultContract
 import androidx.core.app.ActivityOptionsCompat
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import androidx.test.platform.app.InstrumentationRegistry
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.launch
 
 class AndroidLocationPermissionRequestTest {
+  @Test
+  fun reentrantCloseDuringPermissionRefreshPreventsLaunch() {
+    val registry = TestResultRegistry()
+    var rationale = false
+    val requester = AndroidLocationPermissionRequester(null, registry, { null }, { rationale })
+    val observer =
+      CoroutineScope(Dispatchers.Unconfined).launch {
+        requester.status.drop(1).collect { requester.close() }
+      }
+    try {
+      rationale = true
+      requester.requestForegroundPermission()
+      assertEquals(0, registry.launches)
+      assertFailsWith<IllegalStateException> { requester.refresh() }
+    } finally {
+      observer.cancel()
+      requester.close()
+    }
+  }
+
+  @Test
+  fun failedOffMainCloseCanStillDisposeOnMain() {
+    val instrumentation = InstrumentationRegistry.getInstrumentation()
+    val owner =
+      object : LifecycleOwner {
+        override val lifecycle = LifecycleRegistry(this)
+      }
+    lateinit var requester: AndroidLocationPermissionRequester
+    instrumentation.runOnMainSync {
+      requester = AndroidLocationPermissionRequester(owner.lifecycle, null, { null }, { false })
+      assertEquals(1, owner.lifecycle.observerCount)
+    }
+
+    assertFailsWith<IllegalStateException> { requester.close() }
+
+    instrumentation.runOnMainSync {
+      requester.close()
+      assertEquals(0, owner.lifecycle.observerCount)
+    }
+  }
+
   @Test
   fun closeUnregistersPendingRequestBeforeResultArrives() {
     val registry = TestResultRegistry()

--- a/lib/location/src/androidHostTest/kotlin/org/maplibre/compose/location/AndroidLocationPermissionRequesterTest.kt
+++ b/lib/location/src/androidHostTest/kotlin/org/maplibre/compose/location/AndroidLocationPermissionRequesterTest.kt
@@ -1,0 +1,54 @@
+package org.maplibre.compose.location
+
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class AndroidLocationPermissionRequesterTest {
+  @Test
+  fun `close removes the observer and prevents later refreshes`() {
+    val owner = TestLifecycleOwner()
+    var reads = 0
+    val requester =
+      AndroidLocationPermissionRequester(
+        owner.lifecycle,
+        null,
+        {
+          reads++
+          null
+        },
+        { false },
+      )
+    owner.lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_CREATE)
+    owner.lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START)
+    owner.lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_RESUME)
+    assertEquals(2, reads)
+    assertEquals(1, owner.lifecycle.observerCount)
+
+    requester.close()
+    requester.close()
+    assertEquals(0, owner.lifecycle.observerCount)
+    owner.lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE)
+    owner.lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_RESUME)
+    assertEquals(2, reads)
+    assertFailsWith<IllegalStateException> { requester.requestForegroundPermission() }
+  }
+
+  @Test
+  fun `activity destruction closes the requester`() {
+    val owner = TestLifecycleOwner()
+    val requester = AndroidLocationPermissionRequester(owner.lifecycle, null, { null }, { false })
+    owner.lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_CREATE)
+    owner.lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+
+    assertEquals(0, owner.lifecycle.observerCount)
+    assertFailsWith<IllegalStateException> { requester.refresh() }
+  }
+
+  private class TestLifecycleOwner : LifecycleOwner {
+    override val lifecycle = LifecycleRegistry.createUnsafe(this)
+  }
+}

--- a/lib/location/src/androidMain/kotlin/org/maplibre/compose/location/AndroidLocationBackend.kt
+++ b/lib/location/src/androidMain/kotlin/org/maplibre/compose/location/AndroidLocationBackend.kt
@@ -1,6 +1,7 @@
 package org.maplibre.compose.location
 
 import android.content.Context
+import androidx.annotation.MainThread
 import java.util.ServiceConfigurationError
 import java.util.ServiceLoader
 import kotlinx.coroutines.flow.Flow
@@ -33,7 +34,7 @@ public interface AndroidLocationBackend {
   public fun isAvailable(context: Context): Boolean
 
   /** Creates this backend's location provider. */
-  public fun createLocationProvider(context: Context): LocationProvider
+  @MainThread public fun createLocationProvider(context: Context): LocationProvider
 
   /**
    * Creates this backend's heading provider, or returns null so the default framework heading

--- a/lib/location/src/androidMain/kotlin/org/maplibre/compose/location/AndroidLocationPermissionRequester.kt
+++ b/lib/location/src/androidMain/kotlin/org/maplibre/compose/location/AndroidLocationPermissionRequester.kt
@@ -7,7 +7,9 @@ import android.content.ContextWrapper
 import android.content.pm.PackageManager
 import androidx.activity.ComponentActivity
 import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.ActivityResultRegistry
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.annotation.MainThread
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
@@ -21,10 +23,40 @@ import kotlinx.coroutines.flow.StateFlow
  * Android [LocationProvider] implementations hold a requester and expose it through
  * [LocationProvider.permission] and [LocationProvider.requestPermission].
  *
- * @param context Any [Context]; the permission status is read from the application package. A
- *   context that cannot reach an [Activity] cannot answer the rationale check or launch a request.
+ * Call [close] when the requester is no longer needed. The resolved activity also closes it when
+ * destroyed. Construct and use the requester on the main thread.
  */
-public class AndroidLocationPermissionRequester(private val context: Context) {
+@MainThread
+public class AndroidLocationPermissionRequester
+internal constructor(
+  private val lifecycle: Lifecycle?,
+  private val registry: ActivityResultRegistry?,
+  private val readGrantedAccuracy: () -> LocationAccuracyAuthorization?,
+  private val readRationale: () -> Boolean?,
+) : AutoCloseable {
+
+  /**
+   * Reads permission from [context]. A context that cannot reach an activity cannot answer the
+   * rationale check or launch a request.
+   */
+  public constructor(
+    context: Context
+  ) : this(
+    lifecycle = (context.findActivityOrNull() as? LifecycleOwner)?.lifecycle,
+    registry = (context.findActivityOrNull() as? ComponentActivity)?.activityResultRegistry,
+    readGrantedAccuracy = { context.readGrantedAccuracy() },
+    readRationale = { context.readRationale() },
+  )
+
+  private var closed = false
+  private var pendingLauncher: ActivityResultLauncher<Array<String>>? = null
+  private val observer = LifecycleEventObserver { _, event ->
+    when (event) {
+      Lifecycle.Event.ON_RESUME -> refresh()
+      Lifecycle.Event.ON_DESTROY -> close()
+      else -> Unit
+    }
+  }
 
   // In-memory only: Android can silently make the permission requestable again (auto-reset,
   // revocation in settings), and no API distinguishes that from a permanent denial, so a
@@ -40,23 +72,29 @@ public class AndroidLocationPermissionRequester(private val context: Context) {
    * approximate. Otherwise the status is [LocationPermission.NotGranted]:
    * - `shouldShowRationale = true` when Android advises explaining the request first.
    * - `canRequest = false` after a permanent denial that [requestForegroundPermission] recorded.
-   * - `canRequest = null` when [context] cannot reach an activity for the rationale check.
+   * - `canRequest = null` when the supplied context cannot reach an activity for the rationale
+   *   check.
    * - `canRequest = true` otherwise.
    *
    * The value refreshes when the resolved activity resumes.
    */
   public val status: StateFlow<LocationPermission> = mutableStatus
 
-  private var requestPending = false
-
   init {
-    (context.findActivityOrNull() as? LifecycleOwner)
-      ?.lifecycle
-      ?.addObserver(
-        LifecycleEventObserver { _, event ->
-          if (event == Lifecycle.Event.ON_RESUME) refresh()
-        }
-      )
+    if (lifecycle?.currentState == Lifecycle.State.DESTROYED) {
+      closed = true
+    } else {
+      lifecycle?.addObserver(observer)
+    }
+  }
+
+  /** Removes the activity observer and unregisters any pending permission callback. */
+  override fun close() {
+    if (closed) return
+    closed = true
+    lifecycle?.removeObserver(observer)
+    pendingLauncher?.unregister()
+    pendingLauncher = null
   }
 
   /**
@@ -64,34 +102,37 @@ public class AndroidLocationPermissionRequester(private val context: Context) {
    * [status].
    *
    * The launcher registers on the activity's result registry at request time, so a directly
-   * constructed requester works when [context] can reach a [ComponentActivity]. With a context that
-   * cannot, such as a service context, this call does nothing and [status] stays accurate.
+   * constructed requester works when the supplied context can reach a [ComponentActivity]. With a
+   * context that cannot, such as a service context, this call does nothing and [status] stays
+   * accurate.
    *
    * Android's rationale check returns `false` both before the first request and after a permanent
    * denial. This requester tells the two apart by recording a denial that arrives while the check
    * stays `false`. The record lives only in memory and clears once permission is granted or the
    * check returns `true`, so the first request in a fresh process may silently return a denial
    * before [status] reports `canRequest = false` again.
+   *
+   * @throws IllegalStateException if the requester is closed.
    */
   public fun requestForegroundPermission() {
     val current = refresh()
-    if (current is LocationPermission.Granted || requestPending) return
-    val activity = context.findActivityOrNull() as? ComponentActivity ?: return
-    requestPending = true
-    lateinit var launcher: ActivityResultLauncher<Array<String>>
-    launcher =
-      activity.activityResultRegistry.register(
+    if (current is LocationPermission.Granted || pendingLauncher != null) return
+    val registry = registry ?: return
+    val launcher =
+      registry.register(
         "org.maplibre.compose.location.permission.${nextKey.getAndIncrement()}",
         ActivityResultContracts.RequestMultiplePermissions(),
       ) { results ->
-        requestPending = false
+        val completedLauncher = pendingLauncher ?: return@register
+        pendingLauncher = null
+        completedLauncher.unregister()
         // The map holds one granted flag per permission; a fine request can still return a coarse
         // grant. An empty map is a cancelled request, not a user denial.
         val nothingGranted = results.isNotEmpty() && results.values.none { granted -> granted }
         if (nothingGranted && readRationale() == false) permanentlyDenied = true
         refresh()
-        launcher.unregister()
       }
+    pendingLauncher = launcher
     try {
       launcher.launch(
         arrayOf(
@@ -100,14 +141,19 @@ public class AndroidLocationPermissionRequester(private val context: Context) {
         )
       )
     } catch (error: Throwable) {
-      requestPending = false
+      pendingLauncher = null
       launcher.unregister()
       throw error
     }
   }
 
-  /** Re-reads the permission status, publishes it to [status], and returns it. */
+  /**
+   * Re-reads the permission status, publishes it to [status], and returns it.
+   *
+   * @throws IllegalStateException if the requester is closed.
+   */
   public fun refresh(): LocationPermission {
+    check(!closed) { "Location permission requester is closed" }
     val result = readStatus()
     mutableStatus.value = result
     return result
@@ -120,21 +166,6 @@ public class AndroidLocationPermissionRequester(private val context: Context) {
     if (granted != null || shouldShowRationale == true) permanentlyDenied = false
     return resolveAndroidLocationPermission(granted, shouldShowRationale, permanentlyDenied)
   }
-
-  private fun readGrantedAccuracy(): LocationAccuracyAuthorization? =
-    when {
-      context.checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION) ==
-        PackageManager.PERMISSION_GRANTED -> LocationAccuracyAuthorization.Precise
-      context.checkSelfPermission(Manifest.permission.ACCESS_COARSE_LOCATION) ==
-        PackageManager.PERMISSION_GRANTED -> LocationAccuracyAuthorization.Approximate
-      else -> null
-    }
-
-  private fun readRationale(): Boolean? =
-    context.findActivityOrNull()?.let { activity ->
-      activity.shouldShowRequestPermissionRationale(Manifest.permission.ACCESS_FINE_LOCATION) ||
-        activity.shouldShowRequestPermissionRationale(Manifest.permission.ACCESS_COARSE_LOCATION)
-    }
 
   private companion object {
     private val nextKey = AtomicInteger()
@@ -164,4 +195,19 @@ internal tailrec fun Context.findActivityOrNull(): Activity? =
     is Activity -> this
     is ContextWrapper -> baseContext.findActivityOrNull()
     else -> null
+  }
+
+private fun Context.readGrantedAccuracy(): LocationAccuracyAuthorization? =
+  when {
+    checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION) ==
+      PackageManager.PERMISSION_GRANTED -> LocationAccuracyAuthorization.Precise
+    checkSelfPermission(Manifest.permission.ACCESS_COARSE_LOCATION) ==
+      PackageManager.PERMISSION_GRANTED -> LocationAccuracyAuthorization.Approximate
+    else -> null
+  }
+
+private fun Context.readRationale(): Boolean? =
+  findActivityOrNull()?.let { activity ->
+    activity.shouldShowRequestPermissionRationale(Manifest.permission.ACCESS_FINE_LOCATION) ||
+      activity.shouldShowRequestPermissionRationale(Manifest.permission.ACCESS_COARSE_LOCATION)
   }

--- a/lib/location/src/androidMain/kotlin/org/maplibre/compose/location/AndroidLocationPermissionRequester.kt
+++ b/lib/location/src/androidMain/kotlin/org/maplibre/compose/location/AndroidLocationPermissionRequester.kt
@@ -91,8 +91,8 @@ internal constructor(
   /** Removes the activity observer and unregisters any pending permission callback. */
   override fun close() {
     if (closed) return
-    closed = true
     lifecycle?.removeObserver(observer)
+    closed = true
     pendingLauncher?.unregister()
     pendingLauncher = null
   }
@@ -116,7 +116,7 @@ internal constructor(
    */
   public fun requestForegroundPermission() {
     val current = refresh()
-    if (current is LocationPermission.Granted || pendingLauncher != null) return
+    if (closed || current is LocationPermission.Granted || pendingLauncher != null) return
     val registry = registry ?: return
     val launcher =
       registry.register(

--- a/lib/location/src/androidMain/kotlin/org/maplibre/compose/location/AndroidLocationProvider.kt
+++ b/lib/location/src/androidMain/kotlin/org/maplibre/compose/location/AndroidLocationProvider.kt
@@ -14,6 +14,7 @@ import android.location.LocationRequest as AndroidLocationRequest
 import android.os.Build
 import android.os.Handler
 import android.os.HandlerThread
+import androidx.annotation.MainThread
 import androidx.annotation.RequiresApi
 import androidx.annotation.RequiresPermission
 import kotlinx.coroutines.channels.awaitClose
@@ -34,6 +35,8 @@ import org.maplibre.spatialk.units.extensions.inMeters
  *
  * See [AndroidLocationPermissionRequester] for permission request requirements.
  *
+ * Create the provider, request permission, and close it on the main thread.
+ *
  * @param context Context used to access location services.
  * @param requester Handles [permission] and [requestPermission].
  */
@@ -45,14 +48,15 @@ internal constructor(context: Context, private val requester: AndroidLocationPer
   override val backendId: String = "android-framework"
 
   /** Creates a provider with its own [AndroidLocationPermissionRequester]. */
+  @MainThread
   public constructor(context: Context) : this(context, AndroidLocationPermissionRequester(context))
 
   override val permission: StateFlow<LocationPermission>
     get() = requester.status
 
-  override fun requestPermission(): Unit = requester.requestForegroundPermission()
+  @MainThread override fun requestPermission(): Unit = requester.requestForegroundPermission()
 
-  override fun close(): Unit = requester.close()
+  @MainThread override fun close(): Unit = requester.close()
 
   @RequiresPermission(
     anyOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION]
@@ -215,6 +219,7 @@ internal constructor(context: Context, private val requester: AndroidLocationPer
  * available, a provider that reports the failure when discovery is misconfigured, and the framework
  * [AndroidLocationProvider] otherwise.
  */
+@MainThread
 public fun createDefaultLocationProvider(context: Context): LocationProvider =
   when (val resolution = AndroidLocationBackendResolver.discover(context)) {
     is AndroidBackendResolution.Discovered ->

--- a/lib/location/src/androidMain/kotlin/org/maplibre/compose/location/AndroidLocationProvider.kt
+++ b/lib/location/src/androidMain/kotlin/org/maplibre/compose/location/AndroidLocationProvider.kt
@@ -52,6 +52,8 @@ internal constructor(context: Context, private val requester: AndroidLocationPer
 
   override fun requestPermission(): Unit = requester.requestForegroundPermission()
 
+  override fun close(): Unit = requester.close()
+
   @RequiresPermission(
     anyOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION]
   )

--- a/lib/location/src/commonMain/kotlin/org/maplibre/compose/location/LocationProvider.kt
+++ b/lib/location/src/commonMain/kotlin/org/maplibre/compose/location/LocationProvider.kt
@@ -230,6 +230,13 @@ public enum class LocationAccuracyAuthorization {
 
 /** Current foreground location authorization. */
 public sealed interface LocationPermission {
+  /**
+   * Authorization has not been determined. Collecting [LocationProvider.updates] retries the
+   * permission check without prompting. The provider must determine authorization before delivering
+   * measurements and report check failures through [LocationEvent.Unavailable].
+   */
+  public data object Unknown : LocationPermission
+
   /** Foreground authorization is granted at [accuracy]. */
   public data class Granted(val accuracy: LocationAccuracyAuthorization) : LocationPermission
 

--- a/lib/location/src/commonMain/kotlin/org/maplibre/compose/location/LocationProvider.kt
+++ b/lib/location/src/commonMain/kotlin/org/maplibre/compose/location/LocationProvider.kt
@@ -17,7 +17,7 @@ import org.maplibre.spatialk.units.extensions.meters
  * Implement this interface for custom location sources. Sources without permission handling can use
  * the default [permission] and [requestPermission] implementations.
  */
-public interface LocationProvider {
+public interface LocationProvider : AutoCloseable {
   /** A stable implementation name for diagnostics, when the provider declares one. */
   public val backendId: String?
     get() = null
@@ -59,6 +59,14 @@ public interface LocationProvider {
    * that request and unregisters its callbacks.
    */
   public fun updates(request: LocationRequest = LocationRequest()): Flow<LocationEvent>
+
+  /**
+   * Releases resources owned by this provider. Repeated calls have no effect.
+   *
+   * Cancel update collectors when disposing the provider. Implementations that own permission
+   * observers or platform clients release them here. The default does nothing.
+   */
+  override fun close(): Unit = Unit
 }
 
 private val AlwaysGrantedLocationPermission: StateFlow<LocationPermission> =

--- a/lib/location/src/commonMain/kotlin/org/maplibre/compose/location/LocationProvider.kt
+++ b/lib/location/src/commonMain/kotlin/org/maplibre/compose/location/LocationProvider.kt
@@ -64,7 +64,8 @@ public interface LocationProvider : AutoCloseable {
    * Releases resources owned by this provider. Repeated calls have no effect.
    *
    * Cancel update collectors when disposing the provider. Implementations that own permission
-   * observers or platform clients release them here. The default does nothing.
+   * observers or platform clients release them here. Android providers require the main thread. The
+   * default does nothing.
    */
   override fun close(): Unit = Unit
 }

--- a/lib/location/src/commonMain/kotlin/org/maplibre/compose/location/LocationProvider.kt
+++ b/lib/location/src/commonMain/kotlin/org/maplibre/compose/location/LocationProvider.kt
@@ -64,8 +64,8 @@ public interface LocationProvider : AutoCloseable {
    * Releases resources owned by this provider. Repeated calls have no effect.
    *
    * Cancel update collectors when disposing the provider. Implementations that own permission
-   * observers or platform clients release them here. Android providers require the main thread. The
-   * default does nothing.
+   * observers or platform clients release them here. Android and iOS providers require the main
+   * thread. The default does nothing.
    */
   override fun close(): Unit = Unit
 }

--- a/lib/location/src/iosMain/kotlin/org/maplibre/compose/location/IosLocationPermissionRequester.kt
+++ b/lib/location/src/iosMain/kotlin/org/maplibre/compose/location/IosLocationPermissionRequester.kt
@@ -10,6 +10,7 @@ import platform.CoreLocation.kCLAuthorizationStatusAuthorizedWhenInUse
 import platform.CoreLocation.kCLAuthorizationStatusDenied
 import platform.CoreLocation.kCLAuthorizationStatusNotDetermined
 import platform.CoreLocation.kCLAuthorizationStatusRestricted
+import platform.Foundation.NSThread
 import platform.darwin.NSObject
 
 /**
@@ -19,6 +20,9 @@ import platform.darwin.NSObject
  * [LocationProvider.requestPermission] to an instance of this class. Use it directly when a custom
  * provider needs the same Core Location permission behavior.
  *
+ * Construct, request permission, and [close] on the main thread. Closing detaches the permission
+ * observer and releases the manager.
+ *
  * [`CLAuthorizationStatus`](https://developer.apple.com/documentation/corelocation/clauthorizationstatus)
  * maps an authorized status to [LocationPermission.Granted], `notDetermined` to
  * [LocationPermission.NotGranted] with `canRequest = true`, `denied` or `restricted` to `canRequest
@@ -26,7 +30,12 @@ import platform.darwin.NSObject
  * [`CLLocationManager.accuracyAuthorization`](https://developer.apple.com/documentation/corelocation/cllocationmanager/accuracyauthorization)
  * distinguishes precise from approximate grants.
  */
-public class IosLocationPermissionRequester {
+public class IosLocationPermissionRequester internal constructor(manager: CLLocationManager) :
+  AutoCloseable {
+  /** Creates a requester with its own Core Location manager. */
+  public constructor() : this(CLLocationManager())
+
+  private var manager: CLLocationManager? = manager
   private val mutableStatus =
     MutableStateFlow<LocationPermission>(LocationPermission.NotGranted(canRequest = null))
 
@@ -37,23 +46,37 @@ public class IosLocationPermissionRequester {
   private val delegate =
     object : NSObject(), CLLocationManagerDelegateProtocol {
       override fun locationManagerDidChangeAuthorization(manager: CLLocationManager) {
+        if (manager !== this@IosLocationPermissionRequester.manager) return
         val value = readStatus(manager)
         mutableStatus.value = value
         requestPending = false
       }
     }
 
-  private val manager = CLLocationManager().also { it.delegate = delegate }
-
   init {
+    check(NSThread.isMainThread) { "Location permission requester requires the main thread" }
+    manager.delegate = delegate
     mutableStatus.value = readStatus(manager)
+  }
+
+  /** Detaches the permission observer and releases the manager. Repeated calls have no effect. */
+  override fun close() {
+    check(NSThread.isMainThread) { "Location permission requester requires the main thread" }
+    val manager = manager ?: return
+    this.manager = null
+    manager.delegate = null
+    requestPending = false
   }
 
   /**
    * Starts a foreground permission request and returns immediately. The result is published to
    * [status].
+   *
+   * @throws IllegalStateException if the requester is closed or called off the main thread.
    */
   public fun requestForegroundPermission() {
+    check(NSThread.isMainThread) { "Location permission requester requires the main thread" }
+    val manager = checkNotNull(manager) { "Location permission requester is closed" }
     val current = readStatus(manager)
     if (current !is LocationPermission.NotGranted || current.canRequest != true || requestPending)
       return

--- a/lib/location/src/iosMain/kotlin/org/maplibre/compose/location/IosLocationPermissionRequester.kt
+++ b/lib/location/src/iosMain/kotlin/org/maplibre/compose/location/IosLocationPermissionRequester.kt
@@ -72,7 +72,7 @@ public class IosLocationPermissionRequester internal constructor(manager: CLLoca
    * Starts a foreground permission request and returns immediately. The result is published to
    * [status].
    *
-   * @throws IllegalStateException if the requester is closed or called off the main thread.
+   * Throws `IllegalStateException` if the requester is closed or called off the main thread.
    */
   public fun requestForegroundPermission() {
     check(NSThread.isMainThread) { "Location permission requester requires the main thread" }

--- a/lib/location/src/iosMain/kotlin/org/maplibre/compose/location/IosLocationProvider.kt
+++ b/lib/location/src/iosMain/kotlin/org/maplibre/compose/location/IosLocationProvider.kt
@@ -33,18 +33,24 @@ import platform.darwin.NSObject
  * Applies the requested accuracy and minimum distance. [LocationRequest.minimumInterval] is
  * ignored. See [IosLocationPermissionRequester] for permission behavior.
  *
+ * Create the provider, request permission, and close it on the main thread.
+ *
  * Disabled location services report [LocationUnavailableReason.ServicesDisabled]. Denied or
  * declined permission reports [LocationUnavailableReason.PermissionDenied]. Network failures and
  * unknown locations report [LocationUnavailableReason.TemporarilyUnavailable]. Other failures
  * report [LocationUnavailableReason.UnexpectedFailure].
  */
-public class IosLocationProvider : LocationProvider {
-  private val requester = IosLocationPermissionRequester()
+public class IosLocationProvider
+internal constructor(private val requester: IosLocationPermissionRequester) : LocationProvider {
+  /** Creates a provider with its own permission requester. */
+  public constructor() : this(IosLocationPermissionRequester())
 
   override val permission: StateFlow<LocationPermission>
     get() = requester.status
 
   override fun requestPermission(): Unit = requester.requestForegroundPermission()
+
+  override fun close(): Unit = requester.close()
 
   override fun updates(request: LocationRequest): Flow<LocationEvent> =
     callbackFlow<IosLocationCallback> {

--- a/lib/location/src/iosTest/kotlin/org/maplibre/compose/location/IosLocationProviderTest.kt
+++ b/lib/location/src/iosTest/kotlin/org/maplibre/compose/location/IosLocationProviderTest.kt
@@ -2,9 +2,15 @@ package org.maplibre.compose.location
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import platform.CoreLocation.CLLocationManager
 import platform.CoreLocation.kCLErrorDenied
 import platform.CoreLocation.kCLErrorDomain
 import platform.CoreLocation.kCLErrorLocationUnknown
@@ -15,10 +21,41 @@ import platform.Foundation.NSThread
 class IosLocationProviderTest {
   @Test
   fun exposesPermissionFromItsRequester() {
-    assertEquals(
-      IosLocationPermissionRequester().status.value,
-      IosLocationProvider().permission.value,
-    )
+    IosLocationPermissionRequester().use { requester ->
+      IosLocationProvider().use { provider ->
+        assertEquals(requester.status.value, provider.permission.value)
+      }
+    }
+  }
+
+  @Test
+  fun closeDetachesPermissionObserverAndRejectsRequests() {
+    val manager = CLLocationManager()
+    val requester = IosLocationPermissionRequester(manager)
+    val provider = IosLocationProvider(requester)
+    assertNotNull(manager.delegate)
+
+    provider.close()
+    provider.close()
+
+    assertNull(manager.delegate)
+    assertFailsWith<IllegalStateException> { provider.requestPermission() }
+    assertFailsWith<IllegalStateException> { requester.requestForegroundPermission() }
+  }
+
+  @Test
+  fun failedOffMainCloseCanStillDisposeOnMain() = runTest {
+    val manager = CLLocationManager()
+    val requester = IosLocationPermissionRequester(manager)
+    try {
+      withContext(Dispatchers.Default) {
+        assertFailsWith<IllegalStateException> { requester.close() }
+      }
+      assertNotNull(manager.delegate)
+    } finally {
+      requester.close()
+    }
+    assertNull(manager.delegate)
   }
 
   @Test

--- a/lib/location/src/jsMain/kotlin/org/maplibre/compose/location/BrowserLocationProvider.kt
+++ b/lib/location/src/jsMain/kotlin/org/maplibre/compose/location/BrowserLocationProvider.kt
@@ -8,8 +8,6 @@ import kotlin.time.Instant
 import kotlin.time.TimeSource
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
@@ -53,13 +51,6 @@ internal constructor(
   private val boundary: BrowserGeolocationBoundary,
   coroutineScope: CoroutineScope,
 ) : LocationProvider {
-  /**
-   * Creates a provider with independent permission observation. Use the [CoroutineScope]
-   * constructor to control the observation lifetime.
-   */
-  public constructor() :
-    this(BrowserGeolocation, CoroutineScope(SupervisorJob() + Dispatchers.Default))
-
   /** Creates a provider that observes permission in [coroutineScope]. */
   public constructor(coroutineScope: CoroutineScope) : this(BrowserGeolocation, coroutineScope)
 

--- a/lib/location/src/jvmMain/kotlin/org/maplibre/compose/location/DesktopLocationProvider.kt
+++ b/lib/location/src/jvmMain/kotlin/org/maplibre/compose/location/DesktopLocationProvider.kt
@@ -27,7 +27,7 @@ public interface DesktopLocationBackend {
 }
 
 /** A desktop provider whose process resources can be released with [close]. */
-public interface DesktopLocationProvider : LocationProvider, AutoCloseable
+public interface DesktopLocationProvider : LocationProvider
 
 /**
  * Creates the default desktop location provider from the installed backend. The provider's system
@@ -90,6 +90,4 @@ private class UnavailableDesktopLocationProvider(
       "Location updates require an available backend: $backendAvailability"
     }
   }
-
-  override fun close() = Unit
 }

--- a/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/location/RememberDefaults.android.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/location/RememberDefaults.android.kt
@@ -1,13 +1,16 @@
 package org.maplibre.compose.location
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 
 @Composable
 public actual fun rememberDefaultLocationProvider(): LocationProvider {
   val context = LocalContext.current
-  return remember(context) { createDefaultLocationProvider(context) }
+  val provider = remember(context) { createDefaultLocationProvider(context) }
+  DisposableEffect(provider) { onDispose { provider.close() } }
+  return provider
 }
 
 @Composable

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/location/LocationState.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/location/LocationState.kt
@@ -32,7 +32,7 @@ import org.maplibre.spatialk.units.extensions.degrees
 public class LocationState
 internal constructor(
   initialAvailability: LocationBackendAvailability = LocationBackendAvailability.Available,
-  initialPermission: LocationPermission = LocationPermission.NotGranted(null),
+  initialPermission: LocationPermission = LocationPermission.Unknown,
 ) {
   /** The user's last known location measurement. */
   public var lastLocation: LocationMeasurement? by mutableStateOf(null)
@@ -132,6 +132,9 @@ public sealed interface LocationTrackingStatus {
  * provider setup, [LocationState.permission] reports foreground authorization, and
  * [LocationState.status] reports only the tracking session.
  *
+ * Unknown permission allows collection to retry a non-prompting permission check. A known denial
+ * stops location collection. Heading collection requires granted permission.
+ *
  * @param provider The [LocationProvider] to use for obtaining location updates and for observing
  *   and requesting foreground location permission. A custom provider whose
  *   [LocationProvider.permission] keeps the granted default needs no permission handling.
@@ -164,6 +167,12 @@ public fun rememberLocationState(
       )
     }
   val permission by provider.permission.collectAsState()
+  val canCollectLocation =
+    when (permission) {
+      LocationPermission.Unknown,
+      is LocationPermission.Granted -> true
+      is LocationPermission.NotGranted -> false
+    }
   SideEffect {
     state.permission = permission
     state.requestPermissionAction = provider::requestPermission
@@ -173,16 +182,14 @@ public fun rememberLocationState(
     enabled,
     provider,
     request,
-    permission,
+    canCollectLocation,
     state,
     state.retryKey,
     lifecycleOwner.lifecycle,
     minActiveState,
   ) {
     if (
-      !enabled ||
-        state.availability != LocationBackendAvailability.Available ||
-        permission !is LocationPermission.Granted
+      !enabled || state.availability != LocationBackendAvailability.Available || !canCollectLocation
     ) {
       state.status = LocationTrackingStatus.Stopped
       return@LaunchedEffect

--- a/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/location/RememberDefaults.ios.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/location/RememberDefaults.ios.kt
@@ -1,11 +1,14 @@
 package org.maplibre.compose.location
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.remember
 
 @Composable
-public actual fun rememberDefaultLocationProvider(): LocationProvider = remember {
-  IosLocationProvider()
+public actual fun rememberDefaultLocationProvider(): LocationProvider {
+  val provider = remember { IosLocationProvider() }
+  DisposableEffect(provider) { onDispose { provider.close() } }
+  return provider
 }
 
 @Composable

--- a/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/location/LocationStateTest.kt
+++ b/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/location/LocationStateTest.kt
@@ -11,6 +11,8 @@ import androidx.lifecycle.LifecycleRegistry
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 import kotlin.time.Clock
 import kotlin.time.TimeSource
@@ -52,6 +54,100 @@ class LocationStateTest {
       waitUntil { state?.availability == LocationBackendAvailability.Misconfigured(cause) }
       assertEquals(LocationTrackingStatus.Stopped, state?.status)
       assertFalse(provider.active)
+    }
+  }
+
+  @Test
+  fun unknownPermissionRetriesFailureWithoutRestartingOnGrant() = withMainDispatcher {
+    runComposeUiTest {
+      val failure = IllegalStateException("permission initialization failed")
+      val permissionState = MutableStateFlow<LocationPermission>(LocationPermission.Unknown)
+      val locationProvider = ActiveLocationProvider(location(13.0))
+      var attempts = 0
+      var permissionRequests = 0
+      val provider =
+        object : LocationProvider {
+          override val permission = permissionState
+
+          override fun requestPermission() {
+            permissionRequests++
+          }
+
+          override fun updates(request: LocationRequest): Flow<LocationEvent> = flow {
+            attempts++
+            if (attempts == 1) {
+              emit(LocationEvent.Unavailable(LocationUnavailableReason.UnexpectedFailure, failure))
+            } else {
+              permission.value = LocationPermission.Granted(LocationAccuracyAuthorization.Precise)
+              emitAll(locationProvider.updates(request))
+            }
+          }
+        }
+      val headingProvider = MutableHeadingProvider()
+      val lifecycleOwner = ResumedLifecycleOwner()
+      var state: LocationState? = null
+      setContent {
+        state =
+          rememberLocationState(
+            provider = provider,
+            headingProvider = headingProvider,
+            lifecycleOwner = lifecycleOwner,
+          )
+      }
+
+      waitUntil { state?.status is LocationTrackingStatus.Unavailable }
+      assertEquals(LocationPermission.Unknown, state?.permission)
+      assertSame(failure, assertIs<LocationTrackingStatus.Unavailable>(state?.status).cause)
+      assertEquals(0, headingProvider.activeCollectors)
+      runOnIdle { state?.retry() }
+      waitUntil {
+        state?.lastLocation == locationProvider.location && headingProvider.activeCollectors == 1
+      }
+      waitForIdle()
+      assertEquals(2, attempts)
+      assertEquals(0, locationProvider.stopCount)
+      assertEquals(0, permissionRequests)
+
+      runOnIdle { permissionState.value = LocationPermission.NotGranted(canRequest = false) }
+      waitUntil { !locationProvider.active && headingProvider.activeCollectors == 0 }
+      assertEquals(LocationTrackingStatus.Stopped, state?.status)
+    }
+  }
+
+  @Test
+  fun unknownPermissionStopsWhenAuthorizationIsDeniedWithoutRequestingIt() = withMainDispatcher {
+    runComposeUiTest {
+      val permissionState = MutableStateFlow<LocationPermission>(LocationPermission.Unknown)
+      var attempts = 0
+      var permissionRequests = 0
+      var stopped = false
+      val provider =
+        object : LocationProvider {
+          override val permission = permissionState
+
+          override fun requestPermission() {
+            permissionRequests++
+          }
+
+          override fun updates(request: LocationRequest): Flow<LocationEvent> = flow {
+            attempts++
+            permission.value = LocationPermission.NotGranted(canRequest = true)
+            try {
+              awaitCancellation()
+            } finally {
+              stopped = true
+            }
+          }
+        }
+      val lifecycleOwner = ResumedLifecycleOwner()
+      var state: LocationState? = null
+      setContent {
+        state = rememberLocationState(provider = provider, lifecycleOwner = lifecycleOwner)
+      }
+      waitUntil { stopped && state?.permission is LocationPermission.NotGranted }
+      assertEquals(LocationTrackingStatus.Stopped, state?.status)
+      assertEquals(1, attempts)
+      assertEquals(0, permissionRequests)
     }
   }
 


### PR DESCRIPTION
## Description

Make location providers release their owned resources when disposed. Android providers remove activity observers and pending permission callbacks. iOS providers detach their authorization delegate and release the permission manager. The Compose defaults and Android demo close their providers. Desktop providers coordinate shutdown with active collections and native operations to prevent leaks, double disposal, and use after close. Browser providers now require an explicit coroutine scope.

Add `LocationPermission.Unknown` so a failed macOS authorization check no longer reports permission as granted. Location collection retries the check without prompting and exposes failures through the existing unavailable status and retry API. Heading collection still requires permission. Serialize macOS permission observations so stale reads cannot overwrite newer authorization changes.

## Validation

- Desktop, Android host, and iOS simulator suites; browser suites in Chrome.
- Four Android permission lifecycle tests on an API 36 emulator; iOS tests for delegate detachment, request rejection after closure, and retrying disposal on the main thread.
- Targeted macOS permission race tests and shared location-state tests.
- Android lint, documentation build and links, and repository static checks.
- Adversarial cleanup, quality, and correctness review; fixed findings and repeated review until no actionable findings remained.

Desktop backend lifecycle tests use fake platform clients. Native Windows/Linux services were not exercised locally.

## AI assistance

Implemented and reviewed with Codex (GPT-6), including implementation and adversarial review subagents.
