### PR TITLE
ci: add draft and ready PR matrix tiers with full opt-in

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ env:
 jobs:
   plan:
     timeout-minutes: 5
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     outputs:
       tier: ${{ steps.plan.outputs.tier }}
       desktop: ${{ steps.plan.outputs.desktop }}
@@ -40,11 +40,9 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: ./.github/actions/setup-ci-deps
-        with:
-          gradle: "false"
       - id: plan
-        run: mise run ci:plan
+        # Planning needs only the runner Python standard library.
+        run: python3 .mise/tasks/ci/plan
 
   hygiene:
     needs: plan

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,14 @@ on:
   push:
     branches: [main]
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+      - converted_to_draft
+      - labeled
+      - unlabeled
   workflow_dispatch:
     inputs:
       secrets:
@@ -21,7 +29,25 @@ env:
   CI_SECRETS: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'workflow_dispatch' && github.event.inputs.secrets != 'false') }}
 
 jobs:
+  plan:
+    timeout-minutes: 5
+    runs-on: ubuntu-24.04
+    outputs:
+      tier: ${{ steps.plan.outputs.tier }}
+      desktop: ${{ steps.plan.outputs.desktop }}
+      expected: ${{ steps.plan.outputs.expected }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-ci-deps
+        with:
+          gradle: "false"
+      - id: plan
+        run: mise run ci:plan
+
   hygiene:
+    needs: plan
     timeout-minutes: 25
     runs-on: ubuntu-24.04
     permissions:
@@ -67,6 +93,7 @@ jobs:
         if: steps.apply-fix.outputs.committed != 'true'
 
   android:
+    needs: plan
     strategy:
       fail-fast: false
       matrix:
@@ -159,6 +186,8 @@ jobs:
             demo-app/wearos/build/outputs/apk/release/wearos-release.apk
 
   ios:
+    needs: plan
+    if: needs.plan.outputs.tier != 'draft'
     timeout-minutes: 45
     runs-on: macos-26
     steps:
@@ -194,6 +223,7 @@ jobs:
             **/build/test-results
 
   ios-device:
+    needs: plan
     timeout-minutes: 45
     runs-on: macos-26
     steps:
@@ -206,6 +236,7 @@ jobs:
       - run: mise run build:ios:device
 
   js:
+    needs: plan
     timeout-minutes: 20
     runs-on: ubuntu-24.04
     steps:
@@ -239,40 +270,10 @@ jobs:
             **/build/test-results
 
   desktop:
+    needs: plan
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - runner: macos-26
-            save_toolchains: "false"
-            artifact_type: dmg
-            artifact_glob: "*"
-            artifact_name: demo-app-desktop-macos-arm64
-            test_variant: desktop-macos-arm64
-          - runner: ubuntu-24.04
-            save_toolchains: "false"
-            artifact_type: appimage
-            artifact_glob: "*.tar"
-            artifact_name: demo-app-desktop-linux-x64
-            test_variant: desktop-linux-x64
-          - runner: ubuntu-24.04-arm
-            save_toolchains: "true"
-            artifact_type: appimage
-            artifact_glob: "*.tar"
-            artifact_name: demo-app-desktop-linux-arm64
-            test_variant: desktop-linux-arm64
-          - runner: windows-2022
-            save_toolchains: "true"
-            artifact_type: msi
-            artifact_glob: "*"
-            artifact_name: demo-app-desktop-windows-x64
-            test_variant: desktop-windows-x64
-          - runner: windows-11-arm
-            save_toolchains: "true"
-            artifact_type: msi
-            artifact_glob: "*"
-            artifact_name: demo-app-desktop-windows-arm64
-            test_variant: desktop-windows-arm64
+      matrix: ${{ fromJSON(needs.plan.outputs.desktop) }}
     timeout-minutes: 45
     runs-on: ${{ matrix.runner }}
     steps:
@@ -316,6 +317,7 @@ jobs:
             "demo-app/desktop/build/compose/binaries/main/${{ matrix.artifact_type }}/${{ matrix.artifact_glob }}"
 
   docs:
+    needs: plan
     timeout-minutes: 30
     runs-on: ubuntu-24.04
     environment:
@@ -382,6 +384,7 @@ jobs:
   all-good:
     if: ${{ always() }}
     needs:
+      - plan
       - hygiene
       - android
       - ios
@@ -392,14 +395,17 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-24.04
     steps:
-      - name: Check that every needed job succeeded
+      - name: Check that every selected job succeeded
         env:
-          RESULTS: ${{ join(needs.*.result, ', ') }}
-          ANY_BAD: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+          EXPECTED: ${{ needs.plan.outputs.expected }}
+          RESULTS: ${{ toJSON(needs) }}
         run: |
           echo "needed job results: ${RESULTS}"
-          if [ "${ANY_BAD}" = true ]; then
-            echo "a needed job did not succeed"
-            exit 1
-          fi
-          echo 'All checks passed!'
+          jq --exit-status --null-input \
+            --argjson expected "$EXPECTED" \
+            --argjson results "$RESULTS" '
+              ($expected | length > 0)
+              and (($expected | keys) == ($results | keys))
+              and all($expected | keys[]; $results[.].result == $expected[.])
+            '
+          echo 'All selected checks passed!'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -403,6 +403,7 @@ jobs:
             --argjson expected "$EXPECTED" \
             --argjson results "$RESULTS" '
               ($expected | length > 0)
+              and all($results[]; .result == "success" or .result == "skipped")
               and (($expected | keys) == ($results | keys))
               and all($expected | keys[]; $results[.].result == $expected[.])
             '

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ permissions:
   contents: read
 
 env:
-  CI_SECRETS: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'workflow_dispatch' && github.event.inputs.secrets != 'false') }}
+  CI_SECRETS: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'workflow_dispatch' && github.event.inputs.secrets != 'false') }}
 
 jobs:
   plan:
@@ -52,7 +52,7 @@ jobs:
       contents: write
       actions: write
     env:
-      DEPENDABOT_PR: ${{ github.event_name == 'pull_request' && github.actor == 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository }}
+      DEPENDABOT_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: env.DEPENDABOT_PR != 'true'
@@ -325,7 +325,7 @@ jobs:
         ${{
           github.event_name == 'push'
           || (github.event_name == 'pull_request'
-          && github.actor != 'dependabot[bot]'
+          && github.event.pull_request.user.login != 'dependabot[bot]'
           && github.event.pull_request.head.repo.full_name == github.repository)
           || (github.event_name == 'workflow_dispatch'
           && github.event.inputs.secrets != 'false')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,10 +42,9 @@ jobs:
           persist-credentials: false
       - id: plan
         # Planning needs only the runner Python standard library.
-        run: python3 .mise/tasks/ci/plan
+        run: bash .mise/tasks/ci/plan
 
   hygiene:
-    needs: plan
     timeout-minutes: 25
     runs-on: ubuntu-24.04
     permissions:
@@ -91,7 +90,6 @@ jobs:
         if: steps.apply-fix.outputs.committed != 'true'
 
   android:
-    needs: plan
     strategy:
       fail-fast: false
       matrix:
@@ -221,7 +219,6 @@ jobs:
             **/build/test-results
 
   ios-device:
-    needs: plan
     timeout-minutes: 45
     runs-on: macos-26
     steps:
@@ -234,7 +231,6 @@ jobs:
       - run: mise run build:ios:device
 
   js:
-    needs: plan
     timeout-minutes: 20
     runs-on: ubuntu-24.04
     steps:
@@ -315,7 +311,6 @@ jobs:
             "demo-app/desktop/build/compose/binaries/main/${{ matrix.artifact_type }}/${{ matrix.artifact_glob }}"
 
   docs:
-    needs: plan
     timeout-minutes: 30
     runs-on: ubuntu-24.04
     environment:

--- a/.mise/tasks/ci/plan
+++ b/.mise/tasks/ci/plan
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+# [MISE] description="Select CI coverage from the GitHub event."
+# [MISE] shell="python"
+
+import json
+import os
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT))
+
+from ci.pr_matrix import plan
+
+selection = plan(
+    os.environ["GITHUB_EVENT_NAME"],
+    json.loads(pathlib.Path(os.environ["GITHUB_EVENT_PATH"]).read_text()),
+)
+with pathlib.Path(os.environ["GITHUB_OUTPUT"]).open("a") as output:
+    for key, value in selection.items():
+        encoded = value if isinstance(value, str) else json.dumps(value, separators=(",", ":"))
+        print(f"{key}={encoded}", file=output)
+with pathlib.Path(os.environ["GITHUB_STEP_SUMMARY"]).open("a") as summary:
+    print(f"CI tier: **{selection['tier']}**", file=summary)
+    print("\nDesktop runners: " + ", ".join(row["runner"] for row in selection["desktop"]["include"]), file=summary)
+    print("\nAdd `ci:full` to a pull request to run every platform, including on drafts.", file=summary)

--- a/.mise/tasks/ci/plan
+++ b/.mise/tasks/ci/plan
@@ -1,26 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/env bash
 # [MISE] description="Select CI coverage from the GitHub event."
-# [MISE] shell="python"
-
-import json
-import os
-import pathlib
-import sys
-
-ROOT = pathlib.Path(__file__).resolve().parents[3]
-sys.path.insert(0, str(ROOT))
-
-from ci.pr_matrix import plan
-
-selection = plan(
-    os.environ["GITHUB_EVENT_NAME"],
-    json.loads(pathlib.Path(os.environ["GITHUB_EVENT_PATH"]).read_text()),
-)
-with pathlib.Path(os.environ["GITHUB_OUTPUT"]).open("a") as output:
-    for key, value in selection.items():
-        encoded = value if isinstance(value, str) else json.dumps(value, separators=(",", ":"))
-        print(f"{key}={encoded}", file=output)
-with pathlib.Path(os.environ["GITHUB_STEP_SUMMARY"]).open("a") as summary:
-    print(f"CI tier: **{selection['tier']}**", file=summary)
-    print("\nDesktop runners: " + ", ".join(row["runner"] for row in selection["desktop"]["include"]), file=summary)
-    print("\nAdd `ci:full` to a pull request to run every platform, including on drafts.", file=summary)
+set -euo pipefail
+cd "${MISE_PROJECT_ROOT:-$(cd "$(dirname "$0")/../../.." && pwd)}"
+exec python3 -m ci.pr_matrix

--- a/.mise/tasks/ci/test-scripts
+++ b/.mise/tasks/ci/test-scripts
@@ -2,4 +2,4 @@
 # [MISE] description="Run the unit tests for the ci/ scripts."
 set -euo pipefail
 cd "${MISE_PROJECT_ROOT:-$(cd "$(dirname "$0")/../../.." && pwd)}"
-exec python3 -m unittest ci.style_spec_parity_test ci.action_pins_test
+exec python3 -m unittest ci.style_spec_parity_test ci.action_pins_test ci.pr_matrix_test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,3 +76,12 @@ change, with detail proportional to its complexity.
 
 Use draft status for unfinished work, unresolved decisions, or pending human
 review of generated code.
+
+Draft PRs run Android, JS, Linux x64 desktop, docs, hygiene, and iOS device
+compilation; ready PRs also run iOS simulator, macOS desktop, and Windows x64
+tests. Main and manual runs always include every platform.
+
+For CI, FFI, toolchain, native loading, packaging, or architecture-sensitive
+changes, request every platform (including Linux/Windows ARM64) with
+`gh pr edit <number> --add-label 'ci:full'`. The label also works on drafts and
+persists across pushes; removing it restores the default tier.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,7 @@ review of generated code.
 
 Draft PRs run Android, JS, Linux x64 desktop, docs, hygiene, and iOS device
 compilation; ready PRs also run iOS simulator, macOS desktop, and Windows x64
-tests. Main and manual runs always include every platform.
+tests. Dependabot PRs, main, and manual runs always include every platform.
 
 For CI, FFI, toolchain, native loading, packaging, or architecture-sensitive
 changes, request every platform (including Linux/Windows ARM64) with

--- a/ci/desktop_matrix.json
+++ b/ci/desktop_matrix.json
@@ -1,0 +1,42 @@
+[
+  {
+    "runner": "macos-26",
+    "save_toolchains": "false",
+    "artifact_type": "dmg",
+    "artifact_glob": "*",
+    "artifact_name": "demo-app-desktop-macos-arm64",
+    "test_variant": "desktop-macos-arm64"
+  },
+  {
+    "runner": "ubuntu-24.04",
+    "save_toolchains": "false",
+    "artifact_type": "appimage",
+    "artifact_glob": "*.tar",
+    "artifact_name": "demo-app-desktop-linux-x64",
+    "test_variant": "desktop-linux-x64"
+  },
+  {
+    "runner": "ubuntu-24.04-arm",
+    "save_toolchains": "true",
+    "artifact_type": "appimage",
+    "artifact_glob": "*.tar",
+    "artifact_name": "demo-app-desktop-linux-arm64",
+    "test_variant": "desktop-linux-arm64"
+  },
+  {
+    "runner": "windows-2022",
+    "save_toolchains": "true",
+    "artifact_type": "msi",
+    "artifact_glob": "*",
+    "artifact_name": "demo-app-desktop-windows-x64",
+    "test_variant": "desktop-windows-x64"
+  },
+  {
+    "runner": "windows-11-arm",
+    "save_toolchains": "true",
+    "artifact_type": "msi",
+    "artifact_glob": "*",
+    "artifact_name": "demo-app-desktop-windows-arm64",
+    "test_variant": "desktop-windows-arm64"
+  }
+]

--- a/ci/pr_matrix.py
+++ b/ci/pr_matrix.py
@@ -1,4 +1,4 @@
-"""Select PR coverage while keeping main and manual CI runs complete."""
+"""Select PR coverage while keeping dependency, main, and manual runs complete."""
 
 from __future__ import annotations
 
@@ -15,7 +15,9 @@ def plan(event_name: str, event: dict) -> dict:
         # Missing PR metadata is an error, not permission to run fewer tests.
         pr = event["pull_request"]
         labels = {label["name"] for label in pr["labels"]}
-        if FULL_LABEL not in labels:
+        # The PR author stays the same when a maintainer labels or reruns it.
+        dependabot = pr["user"]["login"] == "dependabot[bot]"
+        if not dependabot and FULL_LABEL not in labels:
             tier = "draft" if pr["draft"] else "ready"
 
     runners = {

--- a/ci/pr_matrix.py
+++ b/ci/pr_matrix.py
@@ -1,0 +1,36 @@
+"""Select PR coverage while keeping main and manual CI runs complete."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+
+FULL_LABEL = "ci:full"
+MATRIX = pathlib.Path(__file__).with_name("desktop_matrix.json")
+
+
+def plan(event_name: str, event: dict) -> dict:
+    tier = "full"
+    if event_name == "pull_request":
+        # Missing PR metadata is an error, not permission to run fewer tests.
+        pr = event["pull_request"]
+        labels = {label["name"] for label in pr["labels"]}
+        if FULL_LABEL not in labels:
+            tier = "draft" if pr["draft"] else "ready"
+
+    runners = {
+        "draft": {"ubuntu-24.04"},
+        "ready": {"ubuntu-24.04", "macos-26", "windows-2022"},
+    }
+    desktop = [
+        row
+        for row in json.loads(MATRIX.read_text())
+        if tier == "full" or row["runner"] in runners[tier]
+    ]
+    expected = dict.fromkeys(
+        ["plan", "hygiene", "android", "ios", "ios-device", "js", "desktop", "docs"],
+        "success",
+    )
+    if tier == "draft":
+        expected["ios"] = "skipped"
+    return {"tier": tier, "desktop": {"include": desktop}, "expected": expected}

--- a/ci/pr_matrix.py
+++ b/ci/pr_matrix.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import pathlib
 
 FULL_LABEL = "ci:full"
@@ -36,3 +37,33 @@ def plan(event_name: str, event: dict) -> dict:
     if tier == "draft":
         expected["ios"] = "skipped"
     return {"tier": tier, "desktop": {"include": desktop}, "expected": expected}
+
+
+def main() -> None:
+    selection = plan(
+        os.environ["GITHUB_EVENT_NAME"],
+        json.loads(pathlib.Path(os.environ["GITHUB_EVENT_PATH"]).read_text()),
+    )
+    with pathlib.Path(os.environ["GITHUB_OUTPUT"]).open("a") as output:
+        for key, value in selection.items():
+            encoded = (
+                value
+                if isinstance(value, str)
+                else json.dumps(value, separators=(",", ":"))
+            )
+            print(f"{key}={encoded}", file=output)
+    with pathlib.Path(os.environ["GITHUB_STEP_SUMMARY"]).open("a") as summary:
+        print(f"CI tier: **{selection['tier']}**", file=summary)
+        print(
+            "\nDesktop runners: "
+            + ", ".join(row["runner"] for row in selection["desktop"]["include"]),
+            file=summary,
+        )
+        print(
+            "\nAdd `ci:full` to a pull request to run every platform, including on drafts.",
+            file=summary,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/pr_matrix_test.py
+++ b/ci/pr_matrix_test.py
@@ -21,9 +21,19 @@ ALL_RUNNERS = {
 }
 
 
-def pr_event(draft: bool = False, labels: tuple[str, ...] = (), **extra) -> dict:
+def pr_event(
+    draft: bool = False,
+    labels: tuple[str, ...] = (),
+    *,
+    author: str = "contributor",
+    **extra,
+) -> dict:
     return {
-        "pull_request": {"draft": draft, "labels": [{"name": name} for name in labels]},
+        "pull_request": {
+            "draft": draft,
+            "labels": [{"name": name} for name in labels],
+            "user": {"login": author},
+        },
         **extra,
     }
 
@@ -77,6 +87,33 @@ class PlanTest(unittest.TestCase):
             )
             self.assertEqual(selection["tier"], tier)
 
+    def test_dependabot_prs_always_run_full_even_after_maintainer_events(self) -> None:
+        for draft in [True, False]:
+            for action, sender in [
+                ("opened", "dependabot[bot]"),
+                ("synchronize", "maintainer"),
+                ("unlabeled", "maintainer"),
+            ]:
+                with self.subTest(draft=draft, action=action, sender=sender):
+                    selection = plan(
+                        "pull_request",
+                        pr_event(
+                            draft,
+                            author="dependabot[bot]",
+                            action=action,
+                            sender={"login": sender},
+                        ),
+                    )
+                    self.assertEqual(selection["tier"], "full")
+                    self.assert_runners(selection, ALL_RUNNERS)
+                    self.assertEqual(set(selection["expected"].values()), {"success"})
+
+    def test_dependabot_sender_does_not_expand_another_authors_pr(self) -> None:
+        selection = plan(
+            "pull_request", pr_event(draft=True, sender={"login": "dependabot[bot]"})
+        )
+        self.assertEqual(selection["tier"], "draft")
+
     def test_push_and_dispatch_always_run_full(self) -> None:
         for event in ["push", "workflow_dispatch"]:
             selection = plan(event, pr_event(draft=True))
@@ -84,7 +121,12 @@ class PlanTest(unittest.TestCase):
             self.assert_runners(selection, ALL_RUNNERS)
 
     def test_missing_pr_metadata_fails_closed(self) -> None:
-        for event in [{}, {"pull_request": {}}, {"pull_request": {"labels": []}}]:
+        for event in [
+            {},
+            {"pull_request": {}},
+            {"pull_request": {"labels": []}},
+            {"pull_request": {"labels": [], "draft": False}},
+        ]:
             with self.assertRaises(KeyError):
                 plan("pull_request", event)
 

--- a/ci/pr_matrix_test.py
+++ b/ci/pr_matrix_test.py
@@ -195,6 +195,13 @@ class RequiredCheckTest(unittest.TestCase):
                             self.check(expected, {**results, job: {"result": outcome}})
                         )
 
+    def test_planner_cannot_allow_failure_or_cancellation(self) -> None:
+        for outcome in ["failure", "cancelled"]:
+            expected = {**plan("push", {})["expected"], "ios": outcome}
+            results = {job: {"result": value} for job, value in expected.items()}
+            with self.subTest(outcome=outcome):
+                self.assertFalse(self.check(expected, results))
+
     def test_missing_plan_or_missing_or_unexpected_job_fails(self) -> None:
         expected = plan("push", {})["expected"]
         results = {job: {"result": "success"} for job in expected}

--- a/ci/pr_matrix_test.py
+++ b/ci/pr_matrix_test.py
@@ -1,0 +1,172 @@
+"""Exercise CI tier changes and the actual required-check shell command."""
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import subprocess
+import textwrap
+import unittest
+
+from ci.pr_matrix import plan
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+ALL_RUNNERS = {
+    "ubuntu-24.04",
+    "ubuntu-24.04-arm",
+    "macos-26",
+    "windows-2022",
+    "windows-11-arm",
+}
+
+
+def pr_event(draft: bool = False, labels: tuple[str, ...] = (), **extra) -> dict:
+    return {
+        "pull_request": {"draft": draft, "labels": [{"name": name} for name in labels]},
+        **extra,
+    }
+
+
+class PlanTest(unittest.TestCase):
+    def assert_runners(self, selection: dict, expected: set[str]) -> None:
+        rows = selection["desktop"]["include"]
+        self.assertEqual({row["runner"] for row in rows}, expected)
+        self.assertEqual(len(rows), len(expected))
+        for row in rows:
+            self.assertTrue(row["artifact_name"].startswith("demo-app-desktop-"))
+            self.assertIn(row["artifact_type"], {"dmg", "msi", "appimage"})
+
+    def test_draft_keeps_compile_and_linux_runtime_coverage(self) -> None:
+        selection = plan("pull_request", pr_event(draft=True))
+        self.assertEqual(selection["tier"], "draft")
+        self.assert_runners(selection, {"ubuntu-24.04"})
+        self.assertEqual(selection["expected"]["ios"], "skipped")
+        for job in ["android", "ios-device", "js", "desktop", "docs", "hygiene"]:
+            self.assertEqual(selection["expected"][job], "success")
+
+    def test_ready_keeps_each_desktop_graphics_bridge(self) -> None:
+        selection = plan("pull_request", pr_event(action="ready_for_review"))
+        self.assertEqual(selection["tier"], "ready")
+        self.assert_runners(selection, {"ubuntu-24.04", "macos-26", "windows-2022"})
+        self.assertEqual(set(selection["expected"].values()), {"success"})
+
+    def test_opt_in_persists_across_events_and_overrides_draft(self) -> None:
+        for draft in [True, False]:
+            for action in [
+                "labeled",
+                "synchronize",
+                "ready_for_review",
+                "converted_to_draft",
+            ]:
+                with self.subTest(draft=draft, action=action):
+                    selection = plan(
+                        "pull_request", pr_event(draft, ("ci:full",), action=action)
+                    )
+                    self.assertEqual(selection["tier"], "full")
+                    self.assert_runners(selection, ALL_RUNNERS)
+                    self.assertEqual(set(selection["expected"].values()), {"success"})
+
+    def test_removed_or_unrelated_label_uses_current_pr_state(self) -> None:
+        for draft, tier in [(True, "draft"), (False, "ready")]:
+            selection = plan(
+                "pull_request",
+                pr_event(
+                    draft, ("infra",), action="unlabeled", label={"name": "ci:full"}
+                ),
+            )
+            self.assertEqual(selection["tier"], tier)
+
+    def test_push_and_dispatch_always_run_full(self) -> None:
+        for event in ["push", "workflow_dispatch"]:
+            selection = plan(event, pr_event(draft=True))
+            self.assertEqual(selection["tier"], "full")
+            self.assert_runners(selection, ALL_RUNNERS)
+
+    def test_missing_pr_metadata_fails_closed(self) -> None:
+        for event in [{}, {"pull_request": {}}, {"pull_request": {"labels": []}}]:
+            with self.assertRaises(KeyError):
+                plan("pull_request", event)
+
+
+class WorkflowEventsTest(unittest.TestCase):
+    def test_readiness_and_label_changes_recompute_the_tier(self) -> None:
+        workflow = (ROOT / ".github/workflows/ci.yml").read_text()
+        pr = workflow.split("  pull_request:\n", 1)[1].split("  workflow_dispatch:", 1)[
+            0
+        ]
+        events = {
+            line.strip().removeprefix("- ")
+            for line in pr.splitlines()
+            if line.strip().startswith("- ")
+        }
+        self.assertEqual(
+            events,
+            {
+                "opened",
+                "synchronize",
+                "reopened",
+                "ready_for_review",
+                "converted_to_draft",
+                "labeled",
+                "unlabeled",
+            },
+        )
+
+
+class RequiredCheckTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        workflow = (ROOT / ".github/workflows/ci.yml").read_text()
+        step = workflow.split(
+            "      - name: Check that every selected job succeeded\n", 1
+        )[1]
+        cls.script = textwrap.dedent(step.split("        run: |\n", 1)[1])
+
+    def check(self, expected: dict, results: dict) -> bool:
+        result = subprocess.run(
+            ["bash", "-e", "-c", self.script],
+            env={
+                **os.environ,
+                "EXPECTED": json.dumps(expected),
+                "RESULTS": json.dumps(results),
+            },
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        return result.returncode == 0
+
+    def test_every_tier_accepts_only_its_expected_results(self) -> None:
+        for event in [pr_event(True), pr_event(), pr_event(True, ("ci:full",))]:
+            expected = plan("pull_request", event)["expected"]
+            results = {job: {"result": result} for job, result in expected.items()}
+            self.assertTrue(self.check(expected, results))
+            for job, wanted in expected.items():
+                for outcome in ["success", "skipped", "failure", "cancelled"]:
+                    if outcome == wanted:
+                        continue
+                    with self.subTest(
+                        job=job, outcome=outcome, draft=event["pull_request"]["draft"]
+                    ):
+                        self.assertFalse(
+                            self.check(expected, {**results, job: {"result": outcome}})
+                        )
+
+    def test_missing_plan_or_missing_or_unexpected_job_fails(self) -> None:
+        expected = plan("push", {})["expected"]
+        results = {job: {"result": "success"} for job in expected}
+        self.assertFalse(self.check({}, results))
+        self.assertFalse(self.check({}, {}))
+        self.assertFalse(
+            self.check(
+                expected, {job: value for job, value in results.items() if job != "ios"}
+            )
+        )
+        self.assertFalse(
+            self.check(expected, {**results, "unplanned": {"result": "success"}})
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ci/pr_matrix_test.py
+++ b/ci/pr_matrix_test.py
@@ -6,6 +6,7 @@ import json
 import os
 import pathlib
 import subprocess
+import tempfile
 import textwrap
 import unittest
 
@@ -129,6 +130,38 @@ class PlanTest(unittest.TestCase):
         ]:
             with self.assertRaises(KeyError):
                 plan("pull_request", event)
+
+
+class PlanCommandTest(unittest.TestCase):
+    def test_task_runs_outside_checkout_without_mise_environment(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory)
+            event = root / "event.json"
+            output = root / "output"
+            summary = root / "summary"
+            event.write_text(json.dumps(pr_event(draft=True)))
+            subprocess.run(
+                ["bash", str(ROOT / ".mise/tasks/ci/plan")],
+                cwd=root,
+                env={
+                    "PATH": os.environ["PATH"],
+                    "GITHUB_EVENT_NAME": "pull_request",
+                    "GITHUB_EVENT_PATH": str(event),
+                    "GITHUB_OUTPUT": str(output),
+                    "GITHUB_STEP_SUMMARY": str(summary),
+                },
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            values = dict(
+                line.split("=", 1) for line in output.read_text().splitlines()
+            )
+            self.assertEqual(values["tier"], "draft")
+            desktop = json.loads(values["desktop"])["include"]
+            self.assertEqual([row["runner"] for row in desktop], ["ubuntu-24.04"])
+            self.assertEqual(json.loads(values["expected"])["ios"], "skipped")
+            self.assertIn("CI tier: **draft**", summary.read_text())
 
 
 class WorkflowEventsTest(unittest.TestCase):


### PR DESCRIPTION
## Description

Reduce repeated CI work by using a smaller matrix for draft PRs and covering each desktop OS once PRs are ready for review. Dependabot-authored PRs, main, and manual runs always use the full matrix.

The persistent `ci:full` label requests every platform on any PR, including drafts and desktop ARM64 variants. The required check rejects failures and unexpected skips while allowing jobs omitted by the selected tier.

## Validation

Tests cover tier selection, readiness and label events, Dependabot authorship, and required-check results. Script tests and static checks passed.

## AI assistance

GPT-6 via Codex.
