### PR TITLE
ci: isolate iOS Native cache writers

### DIFF
--- a/.github/actions/setup-ci-deps/action.yml
+++ b/.github/actions/setup-ci-deps/action.yml
@@ -6,6 +6,9 @@ inputs:
     description: Set up Gradle and its user-home cache; jobs that run no Gradle build leave this off
     required: false
     default: "true"
+  native-cache-scope:
+    description: Native target family whose compiled dependencies this job preserves
+    default: distribution
   save-toolchains:
     description: >-
       Save the toolchain cache when this job misses it. One job per runner label
@@ -99,16 +102,16 @@ runs:
       shell: pwsh
       run: '"GRADLE_ACTIONS_SKIP_BUILD_RESULT_CAPTURE=true" >> $env:GITHUB_ENV'
 
-    # Roughly a gigabyte, and outside the Gradle user home. Its version tracks
-    # Kotlin's, which is what the key hashes.
+    # Keep simulator and device compiler caches separate so a faster unrelated
+    # job cannot save their immutable cache key before linking finishes.
     - name: Cache the Kotlin/Native toolchain
       if: ${{ inputs.gradle == 'true' }}
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ~/.konan
-        key: konan-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('gradle/libs.versions.toml') }}
+        key: konan-v2-${{ runner.os }}-${{ runner.arch }}-${{ inputs.native-cache-scope }}-${{ hashFiles('gradle/libs.versions.toml') }}
         restore-keys: |
-          konan-v1-${{ runner.os }}-${{ runner.arch }}-
+          konan-v2-${{ runner.os }}-${{ runner.arch }}-${{ inputs.native-cache-scope }}-
 
     - name: Point Gradle at a same-volume temp directory
       if: ${{ inputs.gradle == 'true' && runner.os == 'Windows' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,7 @@ jobs:
       - uses: ./.github/actions/setup-ci-deps
         with:
           save-toolchains: "true"
+          native-cache-scope: ios-simulator
       - id: ios-tests
         run: mise run test:ios
       - name: Upload iOS test results to Trunk
@@ -207,6 +208,7 @@ jobs:
       - uses: ./.github/actions/setup-ci-deps
         with:
           save-toolchains: "false"
+          native-cache-scope: ios-device
       - run: mise run build:ios:device
 
   js:


### PR DESCRIPTION
## Description

Give simulator and device jobs separate Kotlin/Native cache keys and restore prefixes. Previously, a faster desktop job could save the shared immutable key before either iOS job finished, preventing their compiled dependency caches from being saved.

The default scope remains available to other Gradle jobs. This keeps whole `~/.konan` archives, so the target scopes duplicate the downloaded base distribution; splitting download and compiled-cache paths is a separate optimization. The job matrix and test commands are unchanged.

## Validation

- Actionlint, action-pin validation, and formatting passed.
- Isolated local measurements with the distribution already installed: warming Native compiled dependencies reduced a required simulator link invocation from a 74.8s median to 10.2s over three samples on an 18-CPU Mac. This is not a prediction of CI savings.
- GitHub cache restore/save behavior awaits CI validation.

## AI assistance

Implemented and validated with OpenAI GPT-6 in the Codex harness, following a user-requested CI cache investigation.
