### PR TITLE
build: restore caching for iOS test links

### DIFF
--- a/buildSrc/src/main/kotlin/iosTestResources.kt
+++ b/buildSrc/src/main/kotlin/iosTestResources.kt
@@ -20,7 +20,8 @@ fun Project.stageIosSimulatorTestResources() {
       tasks.register<Sync>("stageIosSimulatorArm64Test") {
         dependsOn(link, resources)
         from(link.flatMap { it.destinationDirectory })
-        from(resourceDirectory) { into("compose-resources") }
+        // Copy retains deleted files in its output; stage only its current source tree.
+        from(resources.map { it.source }) { into("compose-resources") }
         into(layout.buildDirectory.dir("test-bundles/iosSimulatorArm64"))
       }
     tasks.named<KotlinNativeSimulatorTest>("iosSimulatorArm64Test") {

--- a/buildSrc/src/main/kotlin/iosTestResources.kt
+++ b/buildSrc/src/main/kotlin/iosTestResources.kt
@@ -7,8 +7,14 @@ import org.jetbrains.kotlin.gradle.targets.native.tasks.KotlinNativeSimulatorTes
 import org.jetbrains.kotlin.gradle.tasks.KotlinNativeLink
 
 fun Project.stageIosSimulatorTestResources() {
-  // Compose registers its copy task after evaluation. Give it a directory that the linker
-  // does not own, then assemble both outputs for the existing simulator test runner.
+  // Work around an output overlap observed with Compose 1.12.0 and Kotlin 2.4.10:
+  // copyTestComposeResourcesForIosSimulatorArm64 writes compose-resources beneath
+  // linkDebugTestIosSimulatorArm64's destinationDirectory. Gradle 9.5.0 --info reports
+  // "Task output caching requires exclusive access to output paths", so the library and
+  // demo test links run again even when compilation is FROM-CACHE. Move the copy output
+  // out of the linker directory, then assemble the binary and resources for the test runner.
+  // Remove this workaround once upstream gives the copy and link tasks disjoint outputs.
+  // Compose registers its copy task after evaluation.
   afterEvaluate {
     val resourceDirectory = layout.buildDirectory.dir("compose/iosSimulatorArm64TestResources")
     val resources =

--- a/buildSrc/src/main/kotlin/iosTestResources.kt
+++ b/buildSrc/src/main/kotlin/iosTestResources.kt
@@ -1,0 +1,37 @@
+import org.gradle.api.Project
+import org.gradle.api.tasks.Copy
+import org.gradle.api.tasks.Sync
+import org.gradle.kotlin.dsl.named
+import org.gradle.kotlin.dsl.register
+import org.jetbrains.kotlin.gradle.targets.native.tasks.KotlinNativeSimulatorTest
+import org.jetbrains.kotlin.gradle.tasks.KotlinNativeLink
+
+fun Project.stageIosSimulatorTestResources() {
+  // Compose registers its copy task after evaluation. Give it a directory that the linker
+  // does not own, then assemble both outputs for the existing simulator test runner.
+  afterEvaluate {
+    val resourceDirectory = layout.buildDirectory.dir("compose/iosSimulatorArm64TestResources")
+    val resources =
+      tasks.named<Copy>("copyTestComposeResourcesForIosSimulatorArm64") {
+        into(resourceDirectory)
+      }
+    val link = tasks.named<KotlinNativeLink>("linkDebugTestIosSimulatorArm64")
+    val bundle =
+      tasks.register<Sync>("stageIosSimulatorArm64Test") {
+        dependsOn(link, resources)
+        from(link.flatMap { it.destinationDirectory })
+        from(resourceDirectory) { into("compose-resources") }
+        into(layout.buildDirectory.dir("test-bundles/iosSimulatorArm64"))
+      }
+    tasks.named<KotlinNativeSimulatorTest>("iosSimulatorArm64Test") {
+      dependsOn(bundle)
+      executableProperty.set(
+        files(
+          bundle.zip(link.flatMap { it.outputFile }) { staged, binary ->
+            staged.destinationDir.resolve(binary.name)
+          }
+        )
+      )
+    }
+  }
+}

--- a/buildSrc/src/main/kotlin/iosTestResources.kt
+++ b/buildSrc/src/main/kotlin/iosTestResources.kt
@@ -25,7 +25,10 @@ fun Project.stageIosSimulatorTestResources() {
     val bundle =
       tasks.register<Sync>("stageIosSimulatorArm64Test") {
         dependsOn(link, resources)
-        from(link.flatMap { it.destinationDirectory })
+        from(link.flatMap { it.destinationDirectory }) {
+          // Older builds may have left resources in the linker directory.
+          exclude("compose-resources/**")
+        }
         // Copy retains deleted files in its output; stage only its current source tree.
         from(resources.map { it.source }) { into("compose-resources") }
         into(layout.buildDirectory.dir("test-bundles/iosSimulatorArm64"))

--- a/demo-app/common/build.gradle.kts
+++ b/demo-app/common/build.gradle.kts
@@ -124,3 +124,5 @@ kotlin {
 compose.resources { packageOfResClass = "org.maplibre.compose.demoapp.generated" }
 
 composeCompiler { reportsDestination = layout.buildDirectory.dir("compose/reports") }
+
+stageIosSimulatorTestResources()

--- a/lib/maplibre-compose/build.gradle.kts
+++ b/lib/maplibre-compose/build.gradle.kts
@@ -219,3 +219,5 @@ class ShutdownTestClasspathArguments(@get:Classpath val classpath: FileCollectio
 tasks.named<Test>("jvmTest") {
   jvmArgumentProviders.add(ShutdownTestClasspathArguments(classpath))
 }
+
+stageIosSimulatorTestResources()


### PR DESCRIPTION
## Description

Compose copies iOS test resources inside the directory owned by Kotlin's link task, causing Gradle to disable output caching for the library and demo test binaries. Give resource copying a separate destination, then assemble the executable, dSYM, and resources for the existing simulator test runner.

With warm Native dependencies, an isolated local benchmark reduced the unchanged link invocation from a 10.2s median to 1.9s over three samples. This measures binary cache reuse on an 18-CPU Mac, not expected CI timing.

## Validation

- `mise run test:ios` passed all 585 tests on the refreshed main base: 564 library, 15 location, and six demo tests; zero failures or skips.
- Deleted all three nonempty test binary directories and confirmed every link restored `FROM-CACHE`.
- Changed a real string resource and confirmed the staged bundle changed; restored the source and confirmed the original bundle contents returned.
- Formatting passed. Non-macOS configuration awaits CI.

## AI assistance

Implemented and validated with OpenAI GPT-6 in the Codex harness, following a user-requested iOS linking investigation.
