### PR TITLE
build: scope web dependency setup to its consumers

### DIFF
--- a/docs/mise.toml
+++ b/docs/mise.toml
@@ -9,8 +9,13 @@ cp -a build/dokka/html/. docs/public/api/
 node docs/scripts/generate-api-index.mjs
 '''
 
+[deps.pnpm]
+auto = true
+dir = ".."
+
 [deps.versions]
 auto = true
+depends = ["pnpm"]
 description = "Write the versions the pages quote into src/generated."
 sources = [
   "../gradle/libs.versions.toml",

--- a/mise.toml
+++ b/mise.toml
@@ -88,13 +88,16 @@ CHROME_BIN = { value = '''{{ exec(command="node -e \"console.log(require(process
 postinstall = ["hk install --mise --quiet"]
 
 [deps.pnpm]
-auto = true
+auto = false
 
 [deps.chromium]
-auto = true
+auto = false
 sources = ["mise.lock"]
 outputs = [".cache/playwright/chromium-*"]
 run = "playwright install chromium --no-shell"
+
+[tasks."deps:chromium"]
+run = "mise deps install chromium"
 
 [tasks.check]
 description = "Run every formatter and linter in report-only mode."
@@ -193,6 +196,7 @@ udid="$(.mise/bin/boot-ios-simulator)"
 '''
 
 [tasks."test:js"]
+depends = ["deps:chromium"]
 description = "Run the Kotlin/JS browser test suite."
 run = "./gradlew jsBrowserTest"
 
@@ -242,7 +246,7 @@ cp docs/cloudflare-pages/_redirects build/cloudflare-pages/_redirects
 
 [tasks."test:pages"]
 description = "Load the embedded browser demo from the packaged Cloudflare Pages site."
-depends = ["build:pages"]
+depends = ["build:pages", "deps:chromium"]
 run = '''
 pages_test_dir="$(mktemp -d)"
 pages_preview_pid=""


### PR DESCRIPTION
## Description

Install pnpm packages automatically only for docs commands, and make Chromium installation an explicit prerequisite of JS and packaged-page tests. Non-web commands currently download 546 packages and a browser before doing unrelated work. Docs version generation now explicitly follows package installation.

Three isolated local runs with empty package/browser outputs reduced no-op setup from an 11.2s median to 0.7s. The complete test matrix and browser test suites remain in place.

## Validation

- `mise run check` passed, including docs initialization, formatting, type/lint checks, action validation, and shell/Python checks.
- `mise run test:js` passed with real Chrome after the explicit browser install.
- Docs setup also passed with CI's pinned mise 2026.8.3.
- The packaged-page suite and other operating systems await CI validation.

## AI assistance

Implemented and validated with OpenAI GPT-6 in the Codex harness, following a user-requested CI setup investigation.
