### PR TITLE
build: make Compose compiler reports opt-in

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -172,6 +172,19 @@ The boot task opens the emulator window by default. Pass `--headless` to run it
 without a window. The AVD lives under `build/android-emulator`, so removing the
 build tree removes the device.
 
+## Inspect Compose compiler reports
+
+The demo's Compose compiler reports are disabled by default so normal builds can
+reuse cached compilation across checkout paths. To regenerate reports for the
+iOS simulator compilation on macOS, run:
+
+```bash
+mise exec -- ./gradlew :demo-app:common:compileKotlinIosSimulatorArm64 --rerun -PcomposeCompilerReports=true
+```
+
+Reports are written to `demo-app/common/build/compose/reports`. Use `--rerun`
+because restoring cached compilation does not recreate the diagnostic files.
+
 ## Building documentation
 
 `mise run build:docs` builds the Starlight site and the Dokka API reference into

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -172,19 +172,6 @@ The boot task opens the emulator window by default. Pass `--headless` to run it
 without a window. The AVD lives under `build/android-emulator`, so removing the
 build tree removes the device.
 
-## Inspect Compose compiler reports
-
-The demo's Compose compiler reports are disabled by default so normal builds can
-reuse cached compilation across checkout paths. To regenerate reports for the
-iOS simulator compilation on macOS, run:
-
-```bash
-mise exec -- ./gradlew :demo-app:common:compileKotlinIosSimulatorArm64 --rerun -PcomposeCompilerReports=true
-```
-
-Reports are written to `demo-app/common/build/compose/reports`. Use `--rerun`
-because restoring cached compilation does not recreate the diagnostic files.
-
 ## Building documentation
 
 `mise run build:docs` builds the Starlight site and the Dokka API reference into

--- a/demo-app/common/build.gradle.kts
+++ b/demo-app/common/build.gradle.kts
@@ -123,6 +123,8 @@ kotlin {
 
 compose.resources { packageOfResClass = "org.maplibre.compose.demoapp.generated" }
 
-composeCompiler { reportsDestination = layout.buildDirectory.dir("compose/reports") }
+if (providers.gradleProperty("composeCompilerReports").orNull == "true") {
+  composeCompiler { reportsDestination = layout.buildDirectory.dir("compose/reports") }
+}
 
 stageIosSimulatorTestResources()


### PR DESCRIPTION
## Description

Make demo Compose compiler reports opt-in with `-PcomposeCompilerReports=true`. The always-enabled absolute report destination becomes part of the Kotlin task inputs, preventing cache reuse after moving to a different checkout path.

Stacked on #1297, which makes the final iOS test binaries cacheable. This PR contains only the report opt-in. In three local relocated-checkout comparisons, the demo link invocation fell from an 8.9s median to 1.4s. Stable-path CI builds do not incur this relocation penalty.

## Validation

- In a fresh source archive, demo main compilation, test compilation, and test linking all restored `FROM-CACHE`.
- All six demo iOS tests executed and passed with reports disabled by default.
- Explicit report generation passed with `:demo-app:common:compileKotlinIosSimulatorArm64 --rerun -PcomposeCompilerReports=true`. Use `--rerun` when regenerating reports because restoring cached compilation does not recreate these diagnostic files.
- Formatting passed.

## AI assistance

Implemented and validated with OpenAI GPT-6 in the Codex harness, following a user-requested build cache investigation.
