### PR TITLE
fix: stop double-applying safe insets in the demo panel

### DIFF
--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoApp.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoApp.kt
@@ -204,7 +204,6 @@ private fun DemoShell(state: DemoAppState, contentPadding: PaddingValues) {
           Modifier.align(Alignment.CenterStart)
             .fillMaxHeight()
             .padding(safeInsets.asPaddingValues())
-            // Consumed so Material components in the panel don't inset themselves again.
             .consumeWindowInsets(safeInsets.asPaddingValues())
             .padding(ShellSpacing)
             .graphicsLayer { translationX = panelTranslation }

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoApp.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoApp.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
@@ -203,6 +204,8 @@ private fun DemoShell(state: DemoAppState, contentPadding: PaddingValues) {
           Modifier.align(Alignment.CenterStart)
             .fillMaxHeight()
             .padding(safeInsets.asPaddingValues())
+            // Consumed so Material components in the panel don't inset themselves again.
+            .consumeWindowInsets(safeInsets.asPaddingValues())
             .padding(ShellSpacing)
             .graphicsLayer { translationX = panelTranslation }
             .semantics { if (!panelOpen) hideFromAccessibility() }

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoPanel.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoPanel.kt
@@ -10,7 +10,6 @@ import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -198,8 +197,6 @@ private fun DemosScreen(
           Icon(vectorResource(Res.drawable.settings_24px), contentDescription = "Settings")
         }
       },
-      // The shell's safe-inset padding already offsets the panel, so the app bar adds none.
-      windowInsets = WindowInsets(0),
       colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Transparent),
     )
     Column(Modifier.verticalScroll(rememberScrollState()).padding(bottom = 16.dp)) {
@@ -291,7 +288,6 @@ internal fun SettingsSubScreen(title: String, onBack: () -> Unit, content: @Comp
           Icon(vectorResource(Res.drawable.arrow_back_24px), contentDescription = "Back")
         }
       },
-      windowInsets = WindowInsets(0),
       colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Transparent),
     )
     Column(Modifier.verticalScroll(rememberScrollState()).padding(bottom = 16.dp)) { content() }

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoPanel.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoPanel.kt
@@ -10,6 +10,7 @@ import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -197,6 +198,8 @@ private fun DemosScreen(
           Icon(vectorResource(Res.drawable.settings_24px), contentDescription = "Settings")
         }
       },
+      // The shell's safe-inset padding already offsets the panel, so the app bar adds none.
+      windowInsets = WindowInsets(0),
       colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Transparent),
     )
     Column(Modifier.verticalScroll(rememberScrollState()).padding(bottom = 16.dp)) {
@@ -288,6 +291,7 @@ internal fun SettingsSubScreen(title: String, onBack: () -> Unit, content: @Comp
           Icon(vectorResource(Res.drawable.arrow_back_24px), contentDescription = "Back")
         }
       },
+      windowInsets = WindowInsets(0),
       colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Transparent),
     )
     Column(Modifier.verticalScroll(rememberScrollState()).padding(bottom = 16.dp)) { content() }


### PR DESCRIPTION
## Description

The demo shell already pads the panel by the safe drawing insets, but the Material 3 `TopAppBar`s inside the panel also applied their default `safeDrawing` window insets, so notched devices showed a status-bar-height "forehead" above the panel title (and double leading insets in landscape). The shell now consumes the insets where it pads, so Material components inside the panel see zero remaining insets.

## Validation

`mise run check` and `:demo-app:android:compileDebugKotlin` pass. On an API 36 emulator with a status bar, app-bar node bounds match the single-inset geometry exactly (title top = status bar + spacing + content padding + centered title, no extra inset), and the panel still clears the status bar.

## AI assistance

opencode agent (GLM-5.3) investigated, drafted the fix, and validated it on emulator.