### PR TITLE
fix: decouple MapLibre logo layout from attribution button

### DIFF
--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/org/maplibre/compose/material3/MapOverlay.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/org/maplibre/compose/material3/MapOverlay.kt
@@ -1,8 +1,5 @@
 package org.maplibre.compose.material3
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import org.maplibre.compose.overlay.MapOverlay
@@ -10,15 +7,8 @@ import org.maplibre.compose.overlay.MaplibreLogo
 import org.maplibre.compose.overlay.include
 
 private val Material3AttributionOnlyOverlay = MapOverlay {
-  val overlayScope = this
-  Row(
-    Modifier.align(Alignment.BottomStart).fillMaxWidth(),
-    horizontalArrangement = Arrangement.SpaceBetween,
-    verticalAlignment = Alignment.CenterVertically,
-  ) {
-    MaplibreLogo()
-    overlayScope.ExpandingAttributionButton()
-  }
+  MaplibreLogo(Modifier.align(Alignment.BottomStart))
+  ExpandingAttributionButton(Modifier.align(Alignment.BottomEnd))
 }
 
 private val Material3DefaultOverlay = MapOverlay {

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/MapOverlay.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/MapOverlay.kt
@@ -1,10 +1,7 @@
 package org.maplibre.compose.overlay
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.LayoutScopeMarker
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.Stable
@@ -145,15 +142,8 @@ public class MapOverlay(
      * the app shows the attribution somewhere else.
      */
     public val AttributionOnly: MapOverlay = MapOverlay {
-      val overlayScope = this
-      Row(
-        Modifier.align(Alignment.BottomStart).fillMaxWidth(),
-        horizontalArrangement = Arrangement.SpaceBetween,
-        verticalAlignment = Alignment.CenterVertically,
-      ) {
-        MaplibreLogo()
-        overlayScope.ExpandingAttributionButton()
-      }
+      MaplibreLogo(Modifier.align(Alignment.BottomStart))
+      ExpandingAttributionButton(Modifier.align(Alignment.BottomEnd))
     }
 
     /**


### PR DESCRIPTION
## Description

Previously, `MapOverlay.AttributionOnly` and `Material3AttributionOnlyOverlay` placed `MaplibreLogo` and `ExpandingAttributionButton` together in a full-width `Row` with `verticalAlignment = Alignment.CenterVertically`.

Because the logo was vertically centered in this row, its vertical position depended on the row's height, which in turn was driven by `ExpandingAttributionButton` (40.dp / 48.dp vs. the logo's 23.dp). During style switches, style attributions momentarily clear while the new style is loading, causing the button to return early and unmount. This shrank the row's height to 23.dp and caused the logo to drop to the bottom edge for a moment before jumping back up when the style finished loading.

The overlay now aligns `MaplibreLogo` to `BottomStart` and `ExpandingAttributionButton` to `BottomEnd` independently without wrapping them in a row. The logo's position is now completely stable across style loads and regardless of attribution presence.

## Validation

- `mise run check` passed clean.
- Desktop JVM tests (`:lib:maplibre-compose:jvmTest`, `:lib:maplibre-compose-material3:jvmTest`) passed.
- Verified style switching in the demo app with both Foundation and Material 3 controls.

## AI assistance

Antigravity agent investigated the layout dependency and drafted the fix.