### PR TITLE
demo: stack overlay controls under the compass

### DIFF
--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoMap.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoMap.kt
@@ -1,33 +1,45 @@
 package org.maplibre.compose.demoapp
 
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.ElevatedButton
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.onClick
 import androidx.compose.ui.semantics.semantics
@@ -48,11 +60,18 @@ import org.maplibre.compose.map.MapEvent
 import org.maplibre.compose.map.MapState
 import org.maplibre.compose.map.MaplibreMap
 import org.maplibre.compose.map.StyleLoadState
-import org.maplibre.compose.material3.Material3
+import org.maplibre.compose.material3.DisappearingCompassButton as MaterialDisappearingCompassButton
+import org.maplibre.compose.material3.DisappearingScaleBar as MaterialDisappearingScaleBar
+import org.maplibre.compose.material3.Material3AttributionOnly
 import org.maplibre.compose.material3.PointerPinButton
 import org.maplibre.compose.material3.ZoomButtons as MaterialZoomButtons
+import org.maplibre.compose.overlay.CompassButtonStyle
+import org.maplibre.compose.overlay.CompassDefaults
+import org.maplibre.compose.overlay.DisappearingCompassButton
+import org.maplibre.compose.overlay.DisappearingScaleBar
 import org.maplibre.compose.overlay.MapOverlay
 import org.maplibre.compose.overlay.ZoomButtons
+import org.maplibre.compose.overlay.ZoomButtonsDefaults
 import org.maplibre.compose.overlay.include
 import org.maplibre.spatialk.geojson.Position
 
@@ -79,48 +98,137 @@ internal suspend fun MapState.flyTo(destination: DemoDestination) {
   }
 }
 
+private val DemoControlSize = 48.dp
+
+/** Compass enter/exit: fade plus a height change so zoom and theme slide instead of popping. */
+private val DemoCompassEnter = fadeIn() + expandVertically()
+
+private val DemoCompassExit = fadeOut() + shrinkVertically()
+
 /**
- * The map controls the settings ask for. [controlsModifier] applies to the column of controls at
- * the trailing edge, so a shell can route D-pad focus through them.
+ * The map controls the settings ask for. Compass, zoom, and theme stack at the top-end, where the
+ * compass sits on [MapOverlay.Default]. The compass is first so hiding it slides the other buttons
+ * up; its slot expands and shrinks instead of popping. [controlsModifier] applies to the stack so a
+ * shell can route D-pad focus through it.
  */
 fun demoMapOverlay(settings: DemoSettings, controlsModifier: Modifier = Modifier): MapOverlay =
   MapOverlay {
     val overlayScope = this
-    include(if (settings.useMaterial3Controls) MapOverlay.Material3 else MapOverlay.Default)
+    val material3 = settings.useMaterial3Controls
+    val metersPerDp = mapState.viewport?.metersPerDpAtTarget ?: 0.0
+    val zoom = mapState.cameraPosition.zoom
+    if (material3) {
+      MaterialDisappearingScaleBar(
+        metersPerDp = metersPerDp,
+        zoom = zoom,
+        modifier = Modifier.align(Alignment.TopStart),
+      )
+    } else {
+      DisappearingScaleBar(
+        metersPerDp = metersPerDp,
+        zoom = zoom,
+        modifier = Modifier.align(Alignment.TopStart),
+      )
+    }
+    include(if (material3) MapOverlay.Material3AttributionOnly else MapOverlay.AttributionOnly)
     Column(
-      modifier = Modifier.align(Alignment.CenterEnd).then(controlsModifier),
-      verticalArrangement = Arrangement.spacedBy(8.dp),
-      horizontalAlignment = Alignment.CenterHorizontally,
+      modifier = Modifier.align(Alignment.TopEnd).then(controlsModifier),
+      horizontalAlignment = Alignment.End,
     ) {
-      if (settings.showZoomButtons) {
-        if (settings.useMaterial3Controls) overlayScope.MaterialZoomButtons()
-        else overlayScope.ZoomButtons()
-      }
-      val mode = settings.mapStyleMode
-      ElevatedButton(
-        onClick = { settings.mapStyleMode = mode.next },
-        modifier =
-          Modifier.size(48.dp).semantics {
-            contentDescription = "Map style: ${mode.displayName}"
-            onClick(label = "Switch to ${mode.next.displayName}", action = null)
-          },
-        shape = CircleShape,
-        contentPadding = PaddingValues(12.dp),
-      ) {
-        Icon(
-          imageVector =
-            vectorResource(
-              when (mode) {
-                MapStyleMode.System -> Res.drawable.brightness_auto_24px
-                MapStyleMode.Light -> Res.drawable.light_mode_24px
-                MapStyleMode.Dark -> Res.drawable.dark_mode_24px
-              }
-            ),
-          contentDescription = null,
+      val compassSpacing = Modifier.padding(bottom = MapOverlay.Spacing)
+      if (material3) {
+        overlayScope.MaterialDisappearingCompassButton(
+          contentModifier = compassSpacing,
+          enterTransition = DemoCompassEnter,
+          exitTransition = DemoCompassExit,
         )
+      } else {
+        overlayScope.DisappearingCompassButton(
+          contentModifier = compassSpacing,
+          enterTransition = DemoCompassEnter,
+          exitTransition = DemoCompassExit,
+        )
+      }
+      Column(
+        verticalArrangement = Arrangement.spacedBy(MapOverlay.Spacing),
+        horizontalAlignment = Alignment.End,
+      ) {
+        if (settings.showZoomButtons) {
+          if (material3) overlayScope.MaterialZoomButtons() else overlayScope.ZoomButtons()
+        }
+        DemoThemeToggleButton(settings)
       }
     }
   }
+
+@Composable
+private fun DemoThemeToggleButton(settings: DemoSettings) {
+  val mode = settings.mapStyleMode
+  val (style, contentColor) =
+    if (settings.useMaterial3Controls) {
+      val colors = ButtonDefaults.elevatedButtonColors()
+      CompassButtonStyle(
+        containerColor = colors.containerColor,
+        shadowElevation = 1.dp,
+        hoveredShadowElevation = 3.dp,
+      ) to colors.contentColor
+    } else {
+      CompassDefaults.style() to ZoomButtonsDefaults.ContentColor
+    }
+  DemoControlButton(
+    onClick = { settings.mapStyleMode = mode.next },
+    style = style,
+    contentDescription = "Map style: ${mode.displayName}",
+    onClickLabel = "Switch to ${mode.next.displayName}",
+  ) {
+    Icon(
+      imageVector =
+        vectorResource(
+          when (mode) {
+            MapStyleMode.System -> Res.drawable.brightness_auto_24px
+            MapStyleMode.Light -> Res.drawable.light_mode_24px
+            MapStyleMode.Dark -> Res.drawable.dark_mode_24px
+          }
+        ),
+      contentDescription = null,
+      tint = contentColor,
+    )
+  }
+}
+
+/** Same chrome as [org.maplibre.compose.overlay.CompassButton]. */
+@Composable
+private fun DemoControlButton(
+  onClick: () -> Unit,
+  style: CompassButtonStyle,
+  contentDescription: String,
+  onClickLabel: String,
+  content: @Composable () -> Unit,
+) {
+  val interactionSource = remember { MutableInteractionSource() }
+  val hovered by interactionSource.collectIsHoveredAsState()
+  val shadowElevation by
+    animateDpAsState(if (hovered) style.hoveredShadowElevation else style.shadowElevation)
+  Box(
+    Modifier.requiredSize(DemoControlSize)
+      .shadow(shadowElevation, style.shape, clip = false)
+      .background(style.containerColor, style.shape)
+      .clip(style.shape)
+      .semantics {
+        this.contentDescription = contentDescription
+        onClick(label = onClickLabel, action = null)
+      }
+      .clickable(
+        interactionSource = interactionSource,
+        indication = LocalIndication.current,
+        role = Role.Button,
+        onClick = onClick,
+      )
+      .padding(12.dp),
+    contentAlignment = Alignment.Center,
+    content = { content() },
+  )
+}
 
 /**
  * The shared map, the selected demo's overlay, the pointer pin, and the diagnostic overlays.

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/org/maplibre/compose/material3/CompassButton.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/org/maplibre/compose/material3/CompassButton.kt
@@ -79,7 +79,6 @@ public fun MapOverlayScope.CompassButton(
 @Composable
 public fun MapOverlayScope.DisappearingCompassButton(
   modifier: Modifier = Modifier,
-  contentModifier: Modifier = Modifier,
   onClick: () -> Unit = {},
   colors: ButtonColors = ButtonDefaults.elevatedButtonColors(),
   contentDescription: String = CompassDefaults.contentDescription(),
@@ -92,6 +91,7 @@ public fun MapOverlayScope.DisappearingCompassButton(
   exitTransition: ExitTransition = fadeOut(),
   getHomePosition: (CameraPosition) -> CameraPosition = { it.copy(bearing = 0.0, tilt = 0.0) },
   slop: Double = 0.5,
+  contentModifier: Modifier = Modifier,
 ) {
   BaseDisappearingCompassButton(
     modifier = modifier,

--- a/lib/maplibre-compose-material3/src/commonMain/kotlin/org/maplibre/compose/material3/CompassButton.kt
+++ b/lib/maplibre-compose-material3/src/commonMain/kotlin/org/maplibre/compose/material3/CompassButton.kt
@@ -70,6 +70,8 @@ public fun MapOverlayScope.CompassButton(
  * This is [org.maplibre.compose.overlay.DisappearingCompassButton] with the colors, shape, and
  * elevation of an [ElevatedButton].
  *
+ * @param contentModifier Applied to the button inside the visibility animation. Padding here
+ *   expands and shrinks with the button, unlike [modifier], which sits on the visibility wrapper.
  * @param visibilityDuration How long the button stays visible after the camera returns home.
  * @param slop How far the camera may turn from [getHomePosition] before the button appears, in
  *   degrees.
@@ -77,6 +79,7 @@ public fun MapOverlayScope.CompassButton(
 @Composable
 public fun MapOverlayScope.DisappearingCompassButton(
   modifier: Modifier = Modifier,
+  contentModifier: Modifier = Modifier,
   onClick: () -> Unit = {},
   colors: ButtonColors = ButtonDefaults.elevatedButtonColors(),
   contentDescription: String = CompassDefaults.contentDescription(),
@@ -92,6 +95,7 @@ public fun MapOverlayScope.DisappearingCompassButton(
 ) {
   BaseDisappearingCompassButton(
     modifier = modifier,
+    contentModifier = contentModifier,
     onClick = onClick,
     style = elevatedButtonStyle(colors, shape),
     contentDescription = contentDescription,

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/CompassButton.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/CompassButton.kt
@@ -124,6 +124,8 @@ public fun MapOverlayScope.CompassButton(
  * This component draws with Compose Foundation alone. The Material 3 module provides a themed
  * version of it.
  *
+ * @param contentModifier Applied to the button inside the visibility animation. Padding here
+ *   expands and shrinks with the button, unlike [modifier], which sits on the visibility wrapper.
  * @param visibilityDuration How long the button stays visible after the camera returns home.
  * @param slop How far the camera may turn from [getHomePosition] before the button appears, in
  *   degrees.
@@ -131,6 +133,7 @@ public fun MapOverlayScope.CompassButton(
 @Composable
 public fun MapOverlayScope.DisappearingCompassButton(
   modifier: Modifier = Modifier,
+  contentModifier: Modifier = Modifier,
   onClick: () -> Unit = {},
   style: CompassButtonStyle = CompassDefaults.style(),
   contentDescription: String = CompassDefaults.contentDescription(),
@@ -177,6 +180,7 @@ public fun MapOverlayScope.DisappearingCompassButton(
     exit = exitTransition,
   ) {
     overlayScope.CompassButton(
+      modifier = contentModifier,
       onClick = onClick,
       style = style,
       contentDescription = contentDescription,

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/CompassButton.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/CompassButton.kt
@@ -133,7 +133,6 @@ public fun MapOverlayScope.CompassButton(
 @Composable
 public fun MapOverlayScope.DisappearingCompassButton(
   modifier: Modifier = Modifier,
-  contentModifier: Modifier = Modifier,
   onClick: () -> Unit = {},
   style: CompassButtonStyle = CompassDefaults.style(),
   contentDescription: String = CompassDefaults.contentDescription(),
@@ -145,6 +144,7 @@ public fun MapOverlayScope.DisappearingCompassButton(
   exitTransition: ExitTransition = fadeOut(),
   getHomePosition: (CameraPosition) -> CameraPosition = { it.copy(bearing = 0.0, tilt = 0.0) },
   slop: Double = 0.5,
+  contentModifier: Modifier = Modifier,
 ) {
   val overlayScope = this
   val visible = remember { MutableTransitionState(false) }


### PR DESCRIPTION
## Description

The demo overlay stacked zoom and theme at the middle of the trailing edge, away from the compass in the top-end corner. That left the theme button using `ElevatedButton`, whose 58.dp min width did not match the 48.dp compass and zoom controls.

The overlay now stacks compass, zoom, and theme at the top-end. The theme button uses the same chrome as the compass (48.dp, hover elevation, Material 3 or foundation colors). The compass is first in the stack; its enter/exit animates height, and the gap below it lives inside that animation so zoom and theme slide instead of jumping when the compass hides.

Addresses the control-layout items on #1307. Location follow and the remaining mobile-layout notes stay for follow-up.

## Validation

- `:demo-app:common:compileKotlinJs` and `:demo-app:common:compileKotlinJvm` pass.
- `:lib:maplibre-compose:compileKotlinJvm` and `:lib:maplibre-compose-material3:compileKotlinJvm` pass after adding `contentModifier`.
- `dprint check` is clean on the touched files.
- Compass hide/show was checked in the running demo after the spacing jump; I did not re-check on a phone after the last spacing change.

## AI assistance

Cursor Grok 4.6 (Cursor agent).