### PR TITLE
fix: reconcile per-frame style revisions without blocking the UI thread

### DIFF
--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/benchmark/BenchmarkModels.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/benchmark/BenchmarkModels.kt
@@ -121,5 +121,6 @@ val allBenchmarkScenarios: List<BenchmarkScenario> =
     FlyAroundScenario,
     GeoJsonLoadScenario(synchronousUpdate = true),
     GeoJsonLoadScenario(synchronousUpdate = false),
+    LiveMarkerScenario,
     GestureTrailScenario,
   )

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/benchmark/LiveMarkerScenario.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/benchmark/LiveMarkerScenario.kt
@@ -1,0 +1,108 @@
+package org.maplibre.compose.demoapp.benchmark
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameMillis
+import androidx.compose.runtime.withFrameNanos
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import org.maplibre.compose.camera.CameraPosition
+import org.maplibre.compose.expressions.dsl.const
+import org.maplibre.compose.layers.CircleLayer
+import org.maplibre.compose.layers.LineLayer
+import org.maplibre.compose.map.MapState
+import org.maplibre.compose.sources.GeoJsonData
+import org.maplibre.compose.sources.rememberGeoJsonSource
+import org.maplibre.spatialk.geojson.Feature
+import org.maplibre.spatialk.geojson.LineString
+import org.maplibre.spatialk.geojson.Point
+import org.maplibre.spatialk.geojson.Position
+
+/**
+ * The live-tracking pattern: one small point source is replaced every frame while a static route
+ * line stays on the map. Exercises the per-frame cost of a GeoJSON data update, independent of
+ * payload size.
+ */
+internal object LiveMarkerScenario : BenchmarkScenario {
+  override val id = "live-marker"
+  override val title = "Live marker"
+  override val description =
+    "Moves one circle along a route every frame, like a live tracker. The route line never changes."
+  override val region = BenchmarkRegion
+  override val minZoom = 12
+  override val maxZoom = 16
+  override val camera = CameraPosition(target = BenchmarkCenter, zoom = 14.0)
+
+  private val route =
+    listOf(
+      Position(longitude = BenchmarkRegion.west, latitude = BenchmarkRegion.south),
+      Position(longitude = -74.012, latitude = 40.706),
+      Position(longitude = -74.006, latitude = 40.712),
+      Position(longitude = -74.000, latitude = 40.716),
+      Position(longitude = BenchmarkRegion.east, latitude = BenchmarkRegion.north),
+    )
+
+  private var marker by mutableStateOf(route.first())
+
+  @Composable
+  override fun MapContent(session: BenchmarkSession) {
+    LaunchedEffect(Unit) {
+      val startMillis = withFrameMillis { it }
+      while (true) {
+        withFrameMillis { frameMillis ->
+          val phase = ((frameMillis - startMillis) % LoopMillis).toDouble() / LoopMillis
+          marker = positionAt(phase)
+        }
+      }
+    }
+
+    val routeSource =
+      rememberGeoJsonSource(
+        GeoJsonData.Features(Feature(geometry = LineString(route), properties = null))
+      )
+    LineLayer(
+      id = "benchmark-live-route",
+      source = routeSource,
+      color = const(Color(0xFF546E7A)),
+      width = const(3.dp),
+      opacity = const(0.5f),
+    )
+
+    val markerSource =
+      rememberGeoJsonSource(
+        GeoJsonData.Features(Feature(geometry = Point(marker), properties = null))
+      )
+    CircleLayer(
+      id = "benchmark-live-marker",
+      source = markerSource,
+      radius = const(7.dp),
+      color = const(Color(0xFF00695C)),
+      strokeWidth = const(2.dp),
+      strokeColor = const(Color.White),
+    )
+  }
+
+  override suspend fun run(mapState: MapState, session: BenchmarkSession) {
+    session.ui.status = "Tracking the marker"
+    repeat(UpdateFrames) { withFrameNanos {} }
+  }
+
+  private fun positionAt(phase: Double): Position {
+    val segments = route.size - 1
+    val scaled = phase * segments
+    val index = scaled.toInt().coerceAtMost(segments - 1)
+    val fraction = scaled - index
+    val a = route[index]
+    val b = route[index + 1]
+    return Position(
+      longitude = a.longitude + (b.longitude - a.longitude) * fraction,
+      latitude = a.latitude + (b.latitude - a.latitude) * fraction,
+    )
+  }
+}
+
+private const val LoopMillis = 20_000L
+private const val UpdateFrames = 600

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleBinding.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleBinding.kt
@@ -105,6 +105,35 @@ internal interface StyleBinding {
 
   fun setLayerFilter(layerId: String, filter: JsonElement)
 
+  /**
+   * Applies a batch of layer property writes together.
+   *
+   * The default applies them one by one; an engine with per-call overhead can override this to
+   * apply them in one pass, possibly after this function returns. A write the engine rejects is
+   * logged and skipped: it does not fail the batch, the remaining writes, or the revision.
+   */
+  fun setLayerProperties(writes: List<LayerPropertyWrite>) {
+    writes.forEach { write ->
+      try {
+        if (write.kind == LayerPropertyKind.ROOT && write.name == "filter") {
+          setLayerFilter(write.layerId, write.value)
+        } else {
+          setLayerProperty(write.layerId, write.name, write.value, write.kind)
+        }
+      } catch (error: StyleMutationException) {
+        reportRejectedWrite(write, error)
+      }
+    }
+  }
+
+  /** Reports a write the engine rejected during [setLayerProperties]. */
+  fun reportRejectedWrite(write: LayerPropertyWrite, error: StyleMutationException) {
+    logger?.w(error) {
+      "Layer '${write.layerId}' of type '${write.layerType}' kept its previous '${write.name}': " +
+        "MapLibre rejected ${write.value}."
+    }
+  }
+
   /** @return null if the style has unloaded or the layer has no value for [name]. */
   fun layerProperty(layerId: String, name: String): JsonElement?
 
@@ -426,6 +455,18 @@ internal enum class LayerPropertyKind {
   /** Identifies a key on the layer object, such as `minzoom`, outside `layout` and `paint`. */
   ROOT,
 }
+
+/**
+ * One layer property change in a reconciled revision. [layerType] is carried only so a rejection
+ * can name it in a log after the write has left the reconciler's hands.
+ */
+internal class LayerPropertyWrite(
+  val layerId: String,
+  val layerType: String,
+  val name: String,
+  val value: JsonElement,
+  val kind: LayerPropertyKind,
+)
 
 /** Reports an engine error from a style mutation. */
 internal class StyleMutationException(message: String?, cause: Throwable?) :

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleInstallations.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleInstallations.kt
@@ -125,6 +125,11 @@ internal class LayerInstallation(
     reportUnsupported(definition)
   }
 
+  /**
+   * Applies the property writes that bring the installed layer from its current definition to
+   * [definition], as one batch. A rejected write is the engine keeping the previous value, so
+   * [current] advances regardless.
+   */
   fun update(definition: LayerDefinition, animatorDurationScale: Float = 1f) {
     style.requireCurrent()
     require(definition.id == id) { "A layer handle cannot change resource identity" }
@@ -132,23 +137,25 @@ internal class LayerInstallation(
     if (next == current) return
     val previousValue = current.value
     val nextValue = next.value
-    updateProperties(
-      previousValue["layout"] as? JsonObject,
-      nextValue["layout"] as? JsonObject,
-      LayerPropertyKind.LAYOUT,
-    )
-    updateProperties(
-      previousValue["paint"] as? JsonObject,
-      nextValue["paint"] as? JsonObject,
-      LayerPropertyKind.PAINT,
-    )
-    ROOT_PROPERTY_NAMES.forEach { name ->
-      val previous = previousValue[name]
-      val value = nextValue[name]
-      if (previous == value) return@forEach
-      if (name == "filter") style.setLayerFilter(id, value ?: JsonNull)
-      else style.setLayerProperty(id, name, value ?: JsonNull, LayerPropertyKind.ROOT)
+    val writes = buildList {
+      collectProperties(
+        previousValue["layout"] as? JsonObject,
+        nextValue["layout"] as? JsonObject,
+        LayerPropertyKind.LAYOUT,
+      )
+      collectProperties(
+        previousValue["paint"] as? JsonObject,
+        nextValue["paint"] as? JsonObject,
+        LayerPropertyKind.PAINT,
+      )
+      ROOT_PROPERTY_NAMES.forEach { name ->
+        val previous = previousValue[name]
+        val value = nextValue[name]
+        if (previous == value) return@forEach
+        add(LayerPropertyWrite(id, current.type, name, value ?: JsonNull, LayerPropertyKind.ROOT))
+      }
     }
+    style.setLayerProperties(writes)
     current = next
     reportUnsupported(definition)
   }
@@ -178,7 +185,7 @@ internal class LayerInstallation(
     check(added) { "Layer '$id' was not added because its style is no longer loaded" }
   }
 
-  private fun updateProperties(
+  private fun MutableList<LayerPropertyWrite>.collectProperties(
     previous: JsonObject?,
     next: JsonObject?,
     kind: LayerPropertyKind,
@@ -192,14 +199,7 @@ internal class LayerInstallation(
         val oldValue = previous?.get(name)
         val newValue = next?.get(name)
         if (oldValue == newValue) return@forEach
-        try {
-          style.setLayerProperty(id, name, newValue ?: clearingValue(kind, name), kind)
-        } catch (error: StyleMutationException) {
-          style.logger?.w(error) {
-            "Layer '$id' of type '${current.type}' kept its previous '$name': MapLibre rejected " +
-              "$newValue."
-          }
-        }
+        add(LayerPropertyWrite(id, current.type, name, newValue ?: clearingValue(kind, name), kind))
       }
   }
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleReconciler.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleReconciler.kt
@@ -10,10 +10,26 @@ internal class StyleReconciler {
   private val images = linkedMapOf<String, StyleImageDefinition>()
   private val replacedLayers = mutableMapOf<Anchor.Replace, LayerDefinition>()
 
+  /**
+   * The engine's layer order, bottom to top, as this reconciler's mutations leave it. Reading the
+   * engine's order is a cross-thread round trip on native engines, so it is tracked locally and
+   * re-read only when it may have drifted: after a binding change or a failed revision.
+   */
+  private var knownLayerIds: MutableList<String>? = null
+
   suspend fun apply(style: StyleBinding, revision: DesiredStyleRevision) {
     style.requireCurrent()
     if (binding !== style) reset(style)
+    try {
+      applyRevision(style, revision)
+    } catch (error: Throwable) {
+      // A mutation may have succeeded before the failure; the tracked order is no longer trusted.
+      knownLayerIds = null
+      throw error
+    }
+  }
 
+  private suspend fun applyRevision(style: StyleBinding, revision: DesiredStyleRevision) {
     val desiredSources = revision.sources.associateBy(SourceDefinition::id)
     val replacedSourceIds =
       sources.mapNotNullTo(mutableSetOf()) { (id, applied) ->
@@ -64,7 +80,7 @@ internal class StyleReconciler {
           val nextDesiredId = group.getOrNull(index + 1)?.definition?.id
           var applied = layers[id]
           if (applied == null) {
-            val before = beforeLayerId(style, anchor, previousId, id)
+            val before = beforeLayerId(layerIds(style), anchor, previousId, id)
             if (anchor is Anchor.Replace && anchor !in replacedLayers) {
               val replaced =
                 requireNotNull(style.getLayer(anchor.layerId)) {
@@ -85,15 +101,23 @@ internal class StyleReconciler {
                   ),
               )
             layers[id] = applied
+            layerIds(style).insertBelow(id, before)
             if (anchor is Anchor.Replace && group.first() === desired) {
               style.removeLayer(anchor.layerId)
+              layerIds(style).remove(anchor.layerId)
             }
           } else {
             applied.installation.update(desired.definition, revision.animatorDurationScale)
             applied.definition = desired.definition
-            if (shouldMoveLayer(style, anchor, previousId, id, nextDesiredId)) {
-              val before = beforeLayerId(style, anchor, previousId, id)
-              if (before != id) applied.installation.move(before)
+            if (shouldMoveLayer(layerIds(style), anchor, previousId, id, nextDesiredId)) {
+              val before = beforeLayerId(layerIds(style), anchor, previousId, id)
+              if (before != id) {
+                applied.installation.move(before)
+                layerIds(style).also {
+                  it.remove(id)
+                  it.insertBelow(id, before)
+                }
+              }
             }
           }
           previousId = id
@@ -107,6 +131,21 @@ internal class StyleReconciler {
     layers.clear()
     images.clear()
     replacedLayers.clear()
+    knownLayerIds = null
+  }
+
+  private fun layerIds(style: StyleBinding): MutableList<String> =
+    knownLayerIds ?: style.layerIds().toMutableList().also { knownLayerIds = it }
+
+  /** Places [id] directly below [beforeLayerId], or on top when that is empty. */
+  private fun MutableList<String>.insertBelow(id: String, beforeLayerId: String) {
+    if (beforeLayerId.isEmpty()) {
+      add(id)
+    } else {
+      val index = indexOf(beforeLayerId)
+      require(index >= 0) { "Layer ID '$beforeLayerId' not found in style" }
+      add(index, id)
+    }
   }
 
   private fun addSource(style: StyleBinding, definition: SourceDefinition) {
@@ -125,8 +164,10 @@ internal class StyleReconciler {
     if (isLastReplacement) {
       val original = requireNotNull(replacedLayers.remove(anchor))
       style.addLayer(original, beforeLayerId = applied.definition.id)
+      knownLayerIds?.insertBelow(anchor.layerId, applied.definition.id)
     }
     applied.installation.remove()
+    knownLayerIds?.remove(applied.definition.id)
     layers.remove(applied.definition.id)
   }
 
@@ -148,39 +189,38 @@ internal class StyleReconciler {
   }
 
   private fun shouldMoveLayer(
-    style: StyleBinding,
+    ids: List<String>,
     anchor: Anchor,
     previousId: String?,
     id: String,
     nextDesiredId: String?,
   ): Boolean {
-    val ids = style.layerIds()
     if (previousId != null) return ids.idAbove(previousId) != id
     if (nextDesiredId != null) return ids.positionBefore(id) != nextDesiredId
-    val before = beforeLayerId(style, anchor, previousId = null, desiredId = id)
+    val before = beforeLayerId(ids, anchor, previousId = null, desiredId = id)
     return before != id && ids.positionBefore(id) != before
   }
 
   private fun beforeLayerId(
-    style: StyleBinding,
+    ids: List<String>,
     anchor: Anchor,
     previousId: String?,
     desiredId: String? = null,
   ): String {
-    if (previousId != null) return style.layerIds().idAbove(previousId)
+    if (previousId != null) return ids.idAbove(previousId)
     if (anchor is Anchor.Replace && anchor in replacedLayers) {
-      val firstReplacement = style.layerIds().firstOrNull { layers[it]?.anchor == anchor }
+      val firstReplacement = ids.firstOrNull { layers[it]?.anchor == anchor }
       if (firstReplacement != null && firstReplacement != desiredId) return firstReplacement
-      if (desiredId != null && desiredId in style.layerIds()) {
-        return style.layerIds().positionBefore(desiredId)
+      if (desiredId != null && desiredId in ids) {
+        return ids.positionBefore(desiredId)
       }
     }
     return when (anchor) {
       is Anchor.Top -> ""
-      is Anchor.Bottom -> style.layerIds().firstOrNull().orEmpty()
-      is Anchor.Above -> style.layerIds().idAbove(anchor.layerId)
+      is Anchor.Bottom -> ids.firstOrNull().orEmpty()
+      is Anchor.Above -> ids.idAbove(anchor.layerId)
       is Anchor.Below -> anchor.layerId
-      is Anchor.Replace -> style.layerIds().idAbove(anchor.layerId)
+      is Anchor.Replace -> ids.idAbove(anchor.layerId)
     }
   }
 

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/style/RecordingStyleBinding.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/style/RecordingStyleBinding.kt
@@ -32,6 +32,7 @@ internal class RecordingStyleBinding(
   override val supportsCustomDemEncoding: Boolean = false,
   override val supportsRasterDemScheme: Boolean = true,
   private val refusedSourceRemovals: Set<String> = emptySet(),
+  private val refusedLayerProperties: Set<String> = emptySet(),
   override val supportsSky: Boolean = true,
   override val supportsProjection: Boolean = true,
   private val beforeAddImage: ((String) -> Unit)? = null,
@@ -50,6 +51,9 @@ internal class RecordingStyleBinding(
 
   /** Every layer property write after installation, as layer ID to property name, in order. */
   val layerPropertyWrites: MutableList<Pair<String, String>> = mutableListOf()
+
+  /** Every [setLayerProperties] batch, for batching assertions. */
+  val layerPropertyBatches: MutableList<List<LayerPropertyWrite>> = mutableListOf()
   private val images =
     images.associate { (id, bitmap) -> id to ImageSnapshot.capture(bitmap) }.toMutableMap()
   private val baseSources = sources.associateBy { it.id }.toMutableMap()
@@ -239,6 +243,9 @@ internal class RecordingStyleBinding(
     value: JsonElement,
     kind: LayerPropertyKind,
   ) {
+    if ("$layerId:$name" in refusedLayerProperties) {
+      throw StyleMutationException("Property '$name' on layer '$layerId' was refused", null)
+    }
     val layer = checkNotNull(layers[layerId]) { "Layer ID '$layerId' not found in style" }
     layerPropertyWrites += layerId to name
     val section =
@@ -253,6 +260,11 @@ internal class RecordingStyleBinding(
         val properties = (layer[section] as? JsonObject).orEmpty()
         JsonObject(layer + (section to JsonObject(properties + (name to value))))
       }
+  }
+
+  override fun setLayerProperties(writes: List<LayerPropertyWrite>) {
+    layerPropertyBatches += writes
+    super.setLayerProperties(writes)
   }
 
   override fun setLayerFilter(layerId: String, filter: JsonElement) {

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/style/StylePropertyBatchTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/style/StylePropertyBatchTest.kt
@@ -1,0 +1,94 @@
+package org.maplibre.compose.style
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import org.maplibre.compose.layers.Anchor
+
+class StylePropertyBatchTest {
+
+  @Test
+  fun a_layer_update_batches_its_property_writes() = runTest {
+    val style = RecordingStyleBinding()
+    val reconciler = StyleReconciler()
+
+    reconciler.apply(style, revision(background("a", "red"), background("b", "blue")))
+    reconciler.apply(style, revision(background("a", "green"), background("b", "yellow")))
+
+    // One batch per changed layer, nothing for unchanged definitions.
+    assertEquals(
+      listOf(
+        listOf("a" to "background-color"),
+        listOf("b" to "background-color"),
+      ),
+      style.layerPropertyBatches.map { batch -> batch.map { it.layerId to it.name } },
+    )
+    assertEquals(JsonPrimitive("green"), style.layerProperty("a", "background-color"))
+    assertEquals(JsonPrimitive("yellow"), style.layerProperty("b", "background-color"))
+
+    reconciler.apply(style, revision(background("a", "green"), background("b", "yellow")))
+    assertEquals(2, style.layerPropertyBatches.size, "an unchanged revision writes nothing")
+  }
+
+  @Test
+  fun a_transition_writes_before_the_value_it_times() = runTest {
+    val style = RecordingStyleBinding()
+    val reconciler = StyleReconciler()
+
+    reconciler.apply(style, revision(background("a", "red")))
+    reconciler.apply(
+      style,
+      revision(background("a", "green", transition = """{"duration":300.0,"delay":50.0}""")),
+    )
+
+    val writes = style.layerPropertyBatches.single().map { it.name }
+    assertEquals(
+      listOf("background-color-transition", "background-color"),
+      writes,
+      "a transition must write before the value it times",
+    )
+  }
+
+  @Test
+  fun a_rejected_write_keeps_its_value_without_failing_the_batch() = runTest {
+    val style = RecordingStyleBinding(refusedLayerProperties = setOf("a:background-color"))
+    val reconciler = StyleReconciler()
+
+    reconciler.apply(style, revision(background("a", "red"), background("b", "blue")))
+    reconciler.apply(style, revision(background("a", "green"), background("b", "yellow")))
+
+    assertEquals(JsonPrimitive("red"), style.layerProperty("a", "background-color"))
+    assertEquals(JsonPrimitive("yellow"), style.layerProperty("b", "background-color"))
+  }
+
+  private fun revision(vararg layers: LayerDefinition): DesiredStyleRevision =
+    DesiredStyleRevision(
+      sources = emptyList(),
+      layers = layers.map { DesiredStyleLayer(it, Anchor.Top, null, null) },
+      images = emptyList(),
+    )
+
+  private fun background(id: String, color: String, transition: String? = null): LayerDefinition =
+    LayerDefinition(
+      id = id,
+      type = "background",
+      sourceId = null,
+      value =
+        buildJsonObject {
+          put("id", JsonPrimitive(id))
+          put("type", JsonPrimitive("background"))
+          put(
+            "paint",
+            buildJsonObject {
+              put("background-color", JsonPrimitive(color))
+              if (transition != null) {
+                put("background-color-transition", Json.parseToJsonElement(transition))
+              }
+            },
+          )
+        },
+    )
+}

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -246,9 +246,8 @@ internal class MlnFfiMapSession(
   private var styleReadinessNotifiedFor: MlnFfiStyleBinding? = null
 
   /**
-   * Increments on every reconciliation. A posted revision completion that observes a newer
-   * generation was superseded: the newer revision posts its own completion, so the stale one only
-   * repaints. Read on the owner thread.
+   * Increments when a reconciliation or replay begins. A posted revision completion that observes a
+   * newer generation was superseded and only repaints. Read on the owner thread.
    */
   @Volatile private var reconcileGeneration = 0L
 
@@ -1108,6 +1107,8 @@ internal class MlnFfiMapSession(
   override suspend fun replayStyleRevision(revision: DesiredStyleRevision) {
     val binding = styleBinding ?: return
     if (!styleLoadTracker.beginReconciliation(binding.identity)) return
+    // A completion queued before the replay began must not confirm the replayed content.
+    ++reconcileGeneration
     try {
       styleReconciler.apply(binding, revision)
     } catch (error: CancellationException) {

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -245,6 +245,13 @@ internal class MlnFfiMapSession(
   /** The binding whose readiness callback has already succeeded; see [reconcileStyleRevision]. */
   private var styleReadinessNotifiedFor: MlnFfiStyleBinding? = null
 
+  /**
+   * Increments on every reconciliation. A posted revision completion that observes a newer
+   * generation was superseded: the newer revision posts its own completion, so the stale one only
+   * repaints. Read on the owner thread.
+   */
+  @Volatile private var reconcileGeneration = 0L
+
   internal val loadedStyleIdentity
     get() = styleBinding?.identity
 
@@ -1062,11 +1069,12 @@ internal class MlnFfiMapSession(
     val engine = lifecycleEngineIdentity ?: return
     val style = lifecycleStyleIdentity ?: return
     if (!styleLoadTracker.beginReconciliation(binding.identity)) return
+    val generation = ++reconcileGeneration
     try {
       styleReconciler.apply(binding, revision)
       val noteReconciled: (MapHandle) -> Unit = { map ->
         map.requestRepaint()
-        if (styleLoadTracker.reconciled(binding.identity)) {
+        if (generation == reconcileGeneration && styleLoadTracker.reconciled(binding.identity)) {
           lifecycleCallbacks.onStyleReady(engine, style, this)
         }
       }

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -242,6 +242,9 @@ internal class MlnFfiMapSession(
   @Volatile private var styleBinding: MlnFfiStyleBinding? = null
   private val styleReconciler = StyleReconciler()
 
+  /** The binding whose readiness callback has already succeeded; see [reconcileStyleRevision]. */
+  private var styleReadinessNotifiedFor: MlnFfiStyleBinding? = null
+
   internal val loadedStyleIdentity
     get() = styleBinding?.identity
 
@@ -278,6 +281,9 @@ internal class MlnFfiMapSession(
       sessionOpen = { lifecycle.acceptsWork },
       accessMap = { action ->
         if (!lifecycle.acceptsWork) false else runOnMap(action).let { true }
+      },
+      postMap = { action ->
+        if (!lifecycle.acceptsWork) false else loop?.post(action) ?: false
       },
       accessRenderSession = { action ->
         if (!lifecycle.acceptsWork || !renderSessionReady) {
@@ -1058,10 +1064,28 @@ internal class MlnFfiMapSession(
     if (!styleLoadTracker.beginReconciliation(binding.identity)) return
     try {
       styleReconciler.apply(binding, revision)
-      runOnMap {
-        it.requestRepaint()
+      val noteReconciled: (MapHandle) -> Unit = { map ->
+        map.requestRepaint()
         if (styleLoadTracker.reconciled(binding.identity)) {
           lifecycleCallbacks.onStyleReady(engine, style, this)
+        }
+      }
+      if (styleReadinessNotifiedFor === binding) {
+        // Steady state: per-frame revisions must not block the caller on the owner thread. The
+        // readiness callback already succeeded for this binding, so a later failure hides the
+        // presentation instead of propagating to the caller.
+        onMap { map ->
+          try {
+            noteReconciled(map)
+          } catch (error: Throwable) {
+            styleLoadTracker.failed(binding.identity)
+            throw error
+          }
+        }
+      } else {
+        // Until the style is ready, readiness failures must propagate to the caller.
+        if (runOnMap(noteReconciled) != null) {
+          styleReadinessNotifiedFor = binding
         }
       }
     } catch (error: CancellationException) {

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/NativeSnapshotterAdapter.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/NativeSnapshotterAdapter.kt
@@ -332,6 +332,7 @@ private class NativeSnapshotterAdapter(
       loggerProvider = { options.logger },
       sessionOpen = { open },
       accessMap = { action -> source.loop.call(action = action) != null },
+      postMap = { action -> source.loop.post(action = action) },
       accessRenderSession = { action ->
         source.loop.call(action = { _ -> source.resources.withSession(action) }) != null
       },

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/style/MlnFfiGeoJsonCoordinator.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/style/MlnFfiGeoJsonCoordinator.kt
@@ -19,7 +19,7 @@ internal class MlnFfiGeoJsonCoordinator<P : AutoCloseable>(
   private val prepare: (GeoJsonData) -> P,
   private val install: (P, isCurrent: () -> Boolean) -> Unit,
   private val reportFailure: (Throwable, isCurrent: () -> Boolean) -> Unit,
-  private val synchronousUpdate: Boolean = false,
+  val synchronousUpdate: Boolean = false,
   dispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) : AutoCloseable {
   private class Request {

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/style/MlnFfiStyleBinding.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/style/MlnFfiStyleBinding.kt
@@ -86,6 +86,7 @@ internal open class MlnFfiStyleBinding(
   private val loggerProvider: () -> MapLog? = { null },
   private val sessionOpen: () -> Boolean = { false },
   private val accessMap: ((MapHandle) -> Unit) -> Boolean = { false },
+  private val postMap: ((MapHandle) -> Unit) -> Boolean = { false },
   private val accessRenderSession: ((RenderSessionHandle) -> Unit) -> Boolean = { false },
   private val sourceChanged: (String) -> Unit = {},
   private val sourceDataFailed: (StyleIdentity, String, Throwable) -> Unit = { _, _, _ -> },
@@ -547,6 +548,20 @@ internal open class MlnFfiStyleBinding(
     data: GeoJsonData,
     fallbackOptions: GeoJsonOptions,
   ) {
+    // An established asynchronous installation accepts inline data from any thread; only its
+    // creation, URL updates, and synchronous updates need the owner thread. Per-frame updates
+    // must not block on a round trip.
+    if (data !is GeoJsonData.Uri && isLoaded) {
+      val coordinator = geoJsonLock.withLock { geoJsonCoordinators[sourceId] }
+      if (coordinator != null && !coordinator.synchronousUpdate) {
+        try {
+          coordinator.submit(data) { error("Expected inline data") }
+          return
+        } catch (closed: IllegalStateException) {
+          // The installation closed concurrently; retry on the owner thread below.
+        }
+      }
+    }
     mutateMap { map ->
       requireLoadedStyle()
       val coordinator =
@@ -812,15 +827,7 @@ internal open class MlnFfiStyleBinding(
   ) {
     mutateMap { map ->
       try {
-        when {
-          kind != LayerPropertyKind.ROOT -> map.setLayerProperty(layerId, name, value.toJsonBytes())
-          name == "source" -> map.setLayerSourceId(layerId, value.requireRootString(layerId, name))
-          name == "source-layer" ->
-            map.setLayerSourceLayer(layerId, value.requireRootString(layerId, name))
-          name == "minzoom" -> map.setLayerMinZoom(layerId, value.requireRootNumber(layerId, name))
-          name == "maxzoom" -> map.setLayerMaxZoom(layerId, value.requireRootNumber(layerId, name))
-          else -> map.setLayerProperty(layerId, name, value.toJsonBytes())
-        }
+        applyLayerWrite(map, layerId, name, value, kind)
       } catch (error: MaplibreException) {
         throw StyleMutationException(error.message, error)
       }
@@ -834,6 +841,46 @@ internal open class MlnFfiStyleBinding(
       } catch (error: MaplibreException) {
         throw StyleMutationException(error.message, error)
       }
+    }
+  }
+
+  /**
+   * The batch runs as one posted owner-thread task rather than one round trip per write. A rejected
+   * write is non-fatal — the engine keeps the previous value and the reconciler's bookkeeping
+   * already accounts for that — so the caller does not wait for the result.
+   */
+  override fun setLayerProperties(writes: List<LayerPropertyWrite>) {
+    if (writes.isEmpty()) return
+    postMap { map ->
+      if (!isLoaded) return@postMap
+      writes.forEach { write ->
+        try {
+          applyLayerWrite(map, write.layerId, write.name, write.value, write.kind)
+        } catch (error: MaplibreException) {
+          reportRejectedWrite(write, StyleMutationException(error.message, error))
+        }
+      }
+      requestRepaint(map)
+    }
+  }
+
+  private fun applyLayerWrite(
+    map: MapHandle,
+    layerId: String,
+    name: String,
+    value: JsonElement,
+    kind: LayerPropertyKind,
+  ) {
+    when {
+      kind == LayerPropertyKind.ROOT && name == "filter" ->
+        map.setLayerFilter(layerId, value.toJsonBytes())
+      kind != LayerPropertyKind.ROOT -> map.setLayerProperty(layerId, name, value.toJsonBytes())
+      name == "source" -> map.setLayerSourceId(layerId, value.requireRootString(layerId, name))
+      name == "source-layer" ->
+        map.setLayerSourceLayer(layerId, value.requireRootString(layerId, name))
+      name == "minzoom" -> map.setLayerMinZoom(layerId, value.requireRootNumber(layerId, name))
+      name == "maxzoom" -> map.setLayerMaxZoom(layerId, value.requireRootNumber(layerId, name))
+      else -> map.setLayerProperty(layerId, name, value.toJsonBytes())
     }
   }
 

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/MlnFfiStylePresentationTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/MlnFfiStylePresentationTest.kt
@@ -7,7 +7,10 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 import org.maplibre.compose.expressions.ast.ExpressionContext
 import org.maplibre.compose.expressions.dsl.const
 import org.maplibre.compose.layers.Anchor
@@ -91,6 +94,41 @@ class MlnFfiStylePresentationTest {
     }
   }
 
+  @Test
+  fun a_superseded_revision_completion_does_not_reveal_a_failed_revision() = runBlocking {
+    BridgeMapFixture.create().use { fixture ->
+      fixture.loadStyle(INITIAL_STYLE)
+      val session = fixture.session
+      session.reconcileStyleRevision(APPLICATION_REVISION)
+      assertTrue(session.canPresentFrames)
+
+      // Hold the owner thread so the next steady-state revision's completion stays queued.
+      val ownerBusy = CompletableDeferred<Unit>()
+      val releaseOwner = CompletableDeferred<Unit>()
+      assertTrue(
+        session.postOwnerTaskForTest {
+          ownerBusy.complete(Unit)
+          runBlocking { releaseOwner.await() }
+        }
+      )
+      withTimeout(5.seconds) { ownerBusy.await() }
+
+      // Steady state: this revision's completion is posted behind the held queue, not awaited.
+      session.reconcileStyleRevision(APPLICATION_REVISION)
+
+      // A newer reconciliation begins and fails before the queued completion runs.
+      assertFailsWith<IllegalArgumentException> { session.reconcileStyleRevision(BROKEN_REVISION) }
+      assertFalse(session.canPresentFrames)
+
+      releaseOwner.complete(Unit)
+      fixture.pump()
+      assertFalse(
+        session.canPresentFrames,
+        "the superseded completion must not reveal the failed revision",
+      )
+    }
+  }
+
   private companion object {
     val APPLICATION_COLOR = RgbaPixel(red = 0x33, green = 0x66, blue = 0x99, alpha = 0xff)
 
@@ -113,6 +151,24 @@ class MlnFfiStylePresentationTest {
               onLongClick = null,
             )
           ),
+        images = emptyList(),
+      )
+
+    /**
+     * Fails during reconciliation without touching the owner thread: the existing layer is
+     * unchanged, and the new layer anchors above a layer the base style does not have.
+     */
+    val BROKEN_REVISION =
+      DesiredStyleRevision(
+        sources = emptyList(),
+        layers =
+          APPLICATION_REVISION.layers +
+            DesiredStyleLayer(
+              definition = BackgroundLayer("broken").definition(),
+              anchor = Anchor.Above("missing"),
+              onClick = null,
+              onLongClick = null,
+            ),
         images = emptyList(),
       )
 

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/MlnFfiStylePresentationTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/MlnFfiStylePresentationTest.kt
@@ -95,39 +95,55 @@ class MlnFfiStylePresentationTest {
   }
 
   @Test
-  fun a_superseded_revision_completion_does_not_reveal_a_failed_revision() = runBlocking {
-    BridgeMapFixture.create().use { fixture ->
-      fixture.loadStyle(INITIAL_STYLE)
-      val session = fixture.session
-      session.reconcileStyleRevision(APPLICATION_REVISION)
-      assertTrue(session.canPresentFrames)
-
-      // Hold the owner thread so the next steady-state revision's completion stays queued.
-      val ownerBusy = CompletableDeferred<Unit>()
-      val releaseOwner = CompletableDeferred<Unit>()
-      assertTrue(
-        session.postOwnerTaskForTest {
-          ownerBusy.complete(Unit)
-          runBlocking { releaseOwner.await() }
-        }
-      )
-      withTimeout(5.seconds) { ownerBusy.await() }
-
-      // Steady state: this revision's completion is posted behind the held queue, not awaited.
-      session.reconcileStyleRevision(APPLICATION_REVISION)
-
-      // A newer reconciliation begins and fails before the queued completion runs.
+  fun a_superseded_revision_completion_does_not_reveal_a_failed_revision() =
+    assertSupersededCompletionStaysHidden { session ->
       assertFailsWith<IllegalArgumentException> { session.reconcileStyleRevision(BROKEN_REVISION) }
-      assertFalse(session.canPresentFrames)
-
-      releaseOwner.complete(Unit)
-      fixture.pump()
-      assertFalse(
-        session.canPresentFrames,
-        "the superseded completion must not reveal the failed revision",
-      )
     }
-  }
+
+  @Test
+  fun a_superseded_replay_completion_does_not_reveal_a_failed_replay() =
+    assertSupersededCompletionStaysHidden { session ->
+      assertFailsWith<IllegalArgumentException> { session.replayStyleRevision(BROKEN_REVISION) }
+    }
+
+  /**
+   * Queues a steady-state completion behind a held owner thread, then fails a newer reconciliation
+   * or replay through [fail]. The queued completion must not reveal the hidden presentation.
+   */
+  private fun assertSupersededCompletionStaysHidden(fail: suspend (MlnFfiMapSession) -> Unit) =
+    runBlocking {
+      BridgeMapFixture.create().use { fixture ->
+        fixture.loadStyle(INITIAL_STYLE)
+        val session = fixture.session
+        session.reconcileStyleRevision(APPLICATION_REVISION)
+        assertTrue(session.canPresentFrames)
+
+        // Hold the owner thread so the next steady-state revision's completion stays queued.
+        val ownerBusy = CompletableDeferred<Unit>()
+        val releaseOwner = CompletableDeferred<Unit>()
+        assertTrue(
+          session.postOwnerTaskForTest {
+            ownerBusy.complete(Unit)
+            runBlocking { releaseOwner.await() }
+          }
+        )
+        withTimeout(5.seconds) { ownerBusy.await() }
+
+        // Steady state: this revision's completion is posted behind the held queue, not awaited.
+        session.reconcileStyleRevision(APPLICATION_REVISION)
+
+        // A newer reconciliation begins and fails before the queued completion runs.
+        fail(session)
+        assertFalse(session.canPresentFrames)
+
+        releaseOwner.complete(Unit)
+        fixture.pump()
+        assertFalse(
+          session.canPresentFrames,
+          "the superseded completion must not reveal the failed revision",
+        )
+      }
+    }
 
   private companion object {
     val APPLICATION_COLOR = RgbaPixel(red = 0x33, green = 0x66, blue = 0x99, alpha = 0xff)


### PR DESCRIPTION
## Description

Fixes #1306. Reconciling a style revision did blocking round trips to the map's owner thread on the UI thread: a layer-order read per layer, a GeoJSON submission hop, and a repaint confirmation — every frame for demos with live-updating sources.

Now the reconciler tracks layer order locally, inline GeoJSON updates to an established source enqueue without a round trip, the repaint/readiness confirmation is posted once the style is ready, and a layer's property writes go out as one posted batch.

Adds a `live-marker` benchmark scenario covering the per-frame small-update pattern.

## Validation

- `live-marker` benchmark on an Android emulator: per-frame UI-thread reconcile cost went from ~2ms (plus up to ~9ms waiting on a busy owner thread) to ~0.2ms; dropped map frames 28–35% → 19–24%.
- New tests for batched property writes and superseded revision completions, each verified to fail without the change.
- `check`, `test:android`, `test:desktop`, `test:js` locally; full-platform CI green.

## AI assistance

Kimi Code CLI (investigation, instrumentation, implementation, benchmarks) with me directing the design and reviewing the diff.
