### PR TITLE
Add configurable bearing snapping after rotation

### DIFF
--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Interaction.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Interaction.kt
@@ -3,6 +3,7 @@
 package org.maplibre.compose.docsnippets
 
 import androidx.compose.runtime.Composable
+import org.maplibre.compose.interaction.BearingTargets
 import org.maplibre.compose.interaction.ClickResult
 import org.maplibre.compose.interaction.KeyModifier
 import org.maplibre.compose.interaction.MapInteractions
@@ -24,6 +25,22 @@ fun Interaction() {
       }
   )
   // #endregion camera-movement
+
+  // #region bearing-snapping
+  MaplibreMap(
+    interactions =
+      MapInteractions {
+        camera {
+          rotate {
+            snapping {
+              targets = BearingTargets.evenlySpaced(count = 4)
+              tolerance = 7.0
+            }
+          }
+        }
+      }
+  )
+  // #endregion bearing-snapping
 
   // #region scroll-mappings
   MaplibreMap(

--- a/docs/src/content/docs/interaction.mdx
+++ b/docs/src/content/docs/interaction.mdx
@@ -73,15 +73,8 @@ layer handles, such as clearing an app's selection.
 
 ## Snap rotation to bearings
 
-Enable `camera { rotate { snapping { … } } }` to settle near a bearing after
-rotation input and its momentum finish. Snapping is disabled by default. An
-empty `snapping()` block enables north snapping within 7°. Use
-`BearingTargets.at(32.0)` for a custom bearing, multiple arguments for selected
-bearings, or `evenlySpaced(count = 4, offset = 0.0)` for cardinal directions.
+Use `camera.rotate.snapping` to snap to nearby bearings after rotation ends.
+Choose specific bearings or evenly spaced targets, such as the four cardinal
+directions:
 
 <Code code={region(interaction, "bearing-snapping")} lang="kotlin" />
-
-The nearest target within `tolerance` wins. Other bearings stay free. Settlement
-uses `animationDuration` and preserves the camera center, zoom, and tilt. New
-input or programmatic camera control cancels it. Programmatic movement does not
-snap. To disable inherited snapping, use `snapping { enabled = false }`.

--- a/docs/src/content/docs/interaction.mdx
+++ b/docs/src/content/docs/interaction.mdx
@@ -70,3 +70,18 @@ to make small features easier to select:
 Layers receive clicks from front to back until a handler returns
 `ClickResult.Consume`. Use `callbacks.click.onUnhandled` for clicks that no
 layer handles, such as clearing an app's selection.
+
+## Snap rotation to bearings
+
+Enable `camera { rotate { snapping { … } } }` to settle near a bearing after
+rotation input and its momentum finish. Snapping is disabled by default. An
+empty `snapping()` block enables north snapping within 7°. Use
+`BearingTargets.at(32.0)` for a custom bearing, multiple arguments for selected
+bearings, or `evenlySpaced(count = 4, offset = 0.0)` for cardinal directions.
+
+<Code code={region(interaction, "bearing-snapping")} lang="kotlin" />
+
+The nearest target within `tolerance` wins. Other bearings stay free. Settlement
+uses `animationDuration` and preserves the camera center, zoom, and tilt. New
+input or programmatic camera control cancels it. Programmatic movement does not
+snap. To disable inherited snapping, use `snapping { enabled = false }`.

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/internal/CameraInputAuthority.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/internal/CameraInputAuthority.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import org.maplibre.compose.interaction.BearingSnapping
 import org.maplibre.compose.interaction.internal.CameraComponent
 import org.maplibre.compose.interaction.internal.CameraConfiguration
 import org.maplibre.compose.map.MapAdapter
@@ -160,6 +161,16 @@ internal class CameraInputAuthority(private val owner: MapState) {
     private var finishQueued = false
     private val completion = CompletableDeferred<Unit>().also { if (!ready) it.complete(Unit) }
     private val startedComponents = mutableSetOf<CameraComponent>()
+    private var rotated = false
+
+    val bearingSnapping: BearingSnapping?
+      get() =
+        owner.lifecycle.serialized {
+          configuration.settings.rotate.snapping.takeIf {
+            acceptsLocked(enqueue = true) && rotated && it.enabled
+          }
+        }
+
     val acceptsCommands: Boolean
       get() = owner.lifecycle.serialized { acceptsLocked(enqueue = true) }
 
@@ -180,6 +191,7 @@ internal class CameraInputAuthority(private val owner: MapState) {
         owner.lifecycle.serialized {
           if (!acceptsLocked(enqueue = true) || !configuration.settings.enabled(component))
             return false
+          if (component == CameraComponent.Rotate) rotated = true
           if (startedComponents.add(component)) configuration.onStart[component] else null
         }
       start?.invoke()

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/internal/CameraInputTarget.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/internal/CameraInputTarget.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.DpRect
 import kotlin.time.Duration
 import org.maplibre.compose.camera.CameraPosition
+import org.maplibre.compose.interaction.BearingSnapping
 import org.maplibre.spatialk.geojson.Position
 
 /** Camera operations used by built-in map controls. Screen distances are dp. */
@@ -22,6 +23,13 @@ internal interface CameraInputTarget {
 
   suspend fun fitBoundsAwaitingTransition(
     fit: BoxZoomFit,
+    duration: Duration,
+    gestureToken: CameraInputToken,
+  )
+
+  /** Selects a target on the engine thread after queued movement, under the same camera token. */
+  suspend fun snapBearingAwaitingTransition(
+    snapping: BearingSnapping,
     duration: Duration,
     gestureToken: CameraInputToken,
   )

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/BearingSnapping.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/BearingSnapping.kt
@@ -2,7 +2,11 @@ package org.maplibre.compose.interaction
 
 import kotlin.math.abs
 
-/** Settles near a target after rotation input and its momentum finish normally. */
+/**
+ * Settles near a target after rotation input and its momentum finish normally.
+ *
+ * Snapping is disabled until configured. The initial targets and tolerance snap to north within 7°.
+ */
 @MapInteractionDsl
 public class BearingSnappingBuilder internal constructor(from: BearingSnapping) {
   /** Whether to settle. Entering a snapping block enables it unless explicitly disabled. */

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/BearingSnapping.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/BearingSnapping.kt
@@ -1,0 +1,34 @@
+package org.maplibre.compose.interaction
+
+import kotlin.math.abs
+
+/** Settles near a target after rotation input and its momentum finish normally. */
+@MapInteractionDsl
+public class BearingSnappingBuilder internal constructor(from: BearingSnapping) {
+  /** Whether to settle. Entering a snapping block enables it unless explicitly disabled. */
+  public var enabled: Boolean = true
+
+  public var targets: BearingTargets = from.targets
+
+  /**
+   * Maximum circular distance in degrees, inclusive, from the nearest target. Must be in [0, 180].
+   * Equidistant targets choose the lowest normalized bearing. Bearings outside this range stay
+   * free.
+   */
+  public var tolerance: Double = from.tolerance
+
+  internal fun build(): BearingSnapping {
+    require(tolerance.isFinite() && tolerance in 0.0..180.0) { "tolerance must be in [0, 180]" }
+    return BearingSnapping(enabled, targets, tolerance)
+  }
+}
+
+internal data class BearingSnapping(
+  val enabled: Boolean = false,
+  val targets: BearingTargets = BearingTargets.at(0.0),
+  val tolerance: Double = 7.0,
+) {
+  fun delta(bearing: Double): Double? =
+    if (!enabled || !bearing.isFinite()) null
+    else targets.nearestDelta(bearing).takeIf { it != 0.0 && abs(it) <= tolerance }
+}

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/BearingTargets.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/BearingTargets.kt
@@ -1,0 +1,37 @@
+package org.maplibre.compose.interaction
+
+import androidx.compose.runtime.Immutable
+import kotlin.math.abs
+
+/** An immutable set of bearings in degrees clockwise from north. */
+@Immutable
+public class BearingTargets private constructor(internal val bearings: List<Double>) {
+  override fun equals(other: Any?): Boolean = other is BearingTargets && bearings == other.bearings
+
+  override fun hashCode(): Int = bearings.hashCode()
+
+  internal fun nearestDelta(bearing: Double): Double =
+    bearings.map { bearingDelta(bearing, it) }.minBy { abs(it) }
+
+  public companion object {
+    /** Finite bearings, normalized to [0, 360). Duplicate bearings are combined. */
+    public fun at(vararg bearings: Double): BearingTargets {
+      require(bearings.isNotEmpty()) { "At least one bearing is required" }
+      require(bearings.all { it.isFinite() }) { "Bearings must be finite" }
+      return BearingTargets(bearings.map(::normalizeBearing).distinct().sorted())
+    }
+
+    /** [count] equally spaced bearings, starting at [offset] degrees clockwise from north. */
+    public fun evenlySpaced(count: Int, offset: Double = 0.0): BearingTargets {
+      require(count > 0) { "count must be positive" }
+      require(offset.isFinite()) { "offset must be finite" }
+      val start = normalizeBearing(offset)
+      return BearingTargets(List(count) { normalizeBearing(start + it * (360.0 / count)) }.sorted())
+    }
+  }
+}
+
+internal fun normalizeBearing(bearing: Double): Double = ((bearing % 360.0) + 360.0) % 360.0
+
+internal fun bearingDelta(from: Double, to: Double): Double =
+  normalizeBearing(normalizeBearing(to) - normalizeBearing(from) + 180.0) - 180.0

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/CameraConfiguration.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/CameraConfiguration.kt
@@ -4,6 +4,7 @@ import org.maplibre.compose.interaction.internal.CameraComponent
 import org.maplibre.compose.interaction.internal.CameraConfiguration
 import org.maplibre.compose.interaction.internal.CameraSettings
 import org.maplibre.compose.interaction.internal.PanCameraConfiguration
+import org.maplibre.compose.interaction.internal.RotateCameraConfiguration
 import org.maplibre.compose.interaction.internal.TiltCameraConfiguration
 import org.maplibre.compose.interaction.internal.VelocityCameraConfiguration
 
@@ -13,7 +14,7 @@ public class CameraBuilder internal constructor(from: CameraConfiguration) {
   private val pan = PanCameraBuilder(from.settings.pan, from.onStart[CameraComponent.Pan])
   private val zoom = VelocityCameraBuilder(from.settings.zoom, from.onStart[CameraComponent.Zoom])
   private val rotate =
-    VelocityCameraBuilder(from.settings.rotate, from.onStart[CameraComponent.Rotate])
+    RotateCameraBuilder(from.settings.rotate, from.onStart[CameraComponent.Rotate])
   private val tilt = TiltCameraBuilder(from.settings.tilt, from.onStart[CameraComponent.Tilt])
 
   public fun pan(block: PanCameraBuilder.() -> Unit) {
@@ -28,7 +29,7 @@ public class CameraBuilder internal constructor(from: CameraConfiguration) {
    * Configures bearing input. Release momentum applies to recognized two-pointer rotation;
    * single-pointer rotate/tilt drags and keys add no rotation momentum.
    */
-  public fun rotate(block: VelocityCameraBuilder.() -> Unit) {
+  public fun rotate(block: RotateCameraBuilder.() -> Unit) {
     rotate.apply(block)
   }
 
@@ -113,4 +114,37 @@ internal constructor(
   }
 
   internal fun build(): TiltCameraConfiguration = TiltCameraConfiguration(enabled, momentum.build())
+}
+
+/** Bearing permission, release momentum, and optional settlement after user input. */
+@MapInteractionDsl
+public class RotateCameraBuilder
+internal constructor(
+  from: RotateCameraConfiguration,
+  internal var start: (() -> Unit)?,
+) {
+  public var enabled: Boolean = from.enabled
+  private val momentum = VelocityMomentumBuilder(from.momentum)
+  private var snapping = from.snapping
+
+  public fun onStart(block: (() -> Unit)?) {
+    start = block
+  }
+
+  public fun momentum(block: VelocityMomentumBuilder.() -> Unit) {
+    momentum.apply(block)
+  }
+
+  /**
+   * Enables settlement after rotation input and momentum end. Uses the interaction animation
+   * duration and preserves center, zoom, and tilt. Programmatic camera movement is unaffected. New
+   * input or camera control cancels settlement. Set `enabled = false` to disable inherited
+   * snapping.
+   */
+  public fun snapping(block: BearingSnappingBuilder.() -> Unit = {}) {
+    snapping = BearingSnappingBuilder(snapping).apply(block).build()
+  }
+
+  internal fun build(): RotateCameraConfiguration =
+    RotateCameraConfiguration(enabled, momentum.build(), snapping)
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/GestureInputSession.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/GestureInputSession.kt
@@ -1,6 +1,8 @@
 package org.maplibre.compose.interaction.internal
 
 import kotlin.coroutines.ContinuationInterceptor
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
@@ -19,6 +21,7 @@ internal class GestureInputSession(
   private val parent: CoroutineScope,
   private val target: CameraInputTarget,
   val token: CameraInputToken = target.onGestureStarted(),
+  private val animationDuration: Duration = 300.milliseconds,
   private val onCancelled: () -> Unit = {},
 ) {
   private val work = Job(parent.coroutineContext[Job])
@@ -50,8 +53,16 @@ internal class GestureInputSession(
       try {
         work.children.toList().joinAll()
         if (work.isCancelled) return@launch
+        withContext(scope.coroutineContext) {
+          token.bearingSnapping?.let {
+            target.snapBearingAwaitingTransition(it, animationDuration, token)
+          }
+        }
         target.onGestureEnded(token)
         withContext(NonCancellable) { token.awaitCompletion() }
+      } catch (error: Throwable) {
+        cancel()
+        throw error
       } finally {
         work.complete()
       }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/KeyInput.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/KeyInput.kt
@@ -192,7 +192,11 @@ internal class KeyInput(
         ?: run {
           lateinit var created: GestureInputSession
           created =
-            GestureInputSession(scope, target) {
+            GestureInputSession(
+              scope,
+              target,
+              animationDuration = settings.scaledAnimationDuration(),
+            ) {
               if (session === created) cancel()
             }
           created.also { session = it }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/PointerGesture.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/PointerGesture.kt
@@ -852,7 +852,12 @@ internal class PointerGesture(
     val token = target.onGestureStarted()
     lateinit var session: GestureInputSession
     session =
-      GestureInputSession(scope, target, token) {
+      GestureInputSession(
+        scope,
+        target,
+        token,
+        animationDuration = options.scaledAnimationDuration(),
+      ) {
         if (cameraSession === session) {
           val contactsRemain = lastSingle != null || pair != null
           cancel()

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/ResolvedCameraConfiguration.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/ResolvedCameraConfiguration.kt
@@ -1,5 +1,7 @@
 package org.maplibre.compose.interaction.internal
 
+import org.maplibre.compose.interaction.BearingSnapping
+
 internal enum class CameraComponent {
   Pan,
   Zoom,
@@ -15,7 +17,7 @@ internal data class CameraConfiguration(
 internal data class CameraSettings(
   val pan: PanCameraConfiguration = PanCameraConfiguration(),
   val zoom: VelocityCameraConfiguration = VelocityCameraConfiguration(),
-  val rotate: VelocityCameraConfiguration = VelocityCameraConfiguration(),
+  val rotate: RotateCameraConfiguration = RotateCameraConfiguration(),
   val tilt: TiltCameraConfiguration = TiltCameraConfiguration(),
 ) {
   fun enabled(component: CameraComponent): Boolean =
@@ -40,4 +42,10 @@ internal data class VelocityCameraConfiguration(
 internal data class TiltCameraConfiguration(
   val enabled: Boolean = true,
   val momentum: TiltMomentum = TiltMomentum(),
+)
+
+internal data class RotateCameraConfiguration(
+  val enabled: Boolean = true,
+  val momentum: VelocityMomentum = VelocityMomentum(),
+  val snapping: BearingSnapping = BearingSnapping(),
 )

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/interaction/internal/BearingSnappingTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/interaction/internal/BearingSnappingTest.kt
@@ -1,0 +1,76 @@
+package org.maplibre.compose.interaction.internal
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import org.maplibre.compose.interaction.BearingSnapping
+import org.maplibre.compose.interaction.BearingTargets
+import org.maplibre.compose.interaction.MapInteractions
+
+class BearingSnappingTest {
+  @Test
+  fun custom_targets_use_circular_distance_and_leave_other_bearings_free() {
+    val snap = BearingSnapping(true, BearingTargets.at(32.0, 358.0), 7.0)
+    assertEquals(-5.0, snap.delta(3.0))
+    assertEquals(7.0, snap.delta(25.0))
+    assertNull(snap.delta(24.9))
+    assertNull(snap.delta(32.0))
+    assertEquals(-5.0, snap.delta(723.0))
+  }
+
+  @Test
+  fun evenly_spaced_targets_support_offsets_and_deterministic_ties() {
+    val snap = BearingSnapping(true, BearingTargets.evenlySpaced(4, 32.0), 45.0)
+    assertEquals(2.0, snap.delta(120.0))
+    assertEquals(-2.0, snap.delta(214.0))
+    assertEquals(-45.0, snap.delta(77.0))
+    assertEquals(2.0, snap.delta(300.0))
+  }
+
+  @Test
+  fun targets_copy_and_normalize_caller_input() {
+    val input = doubleArrayOf(-2.0, 358.0, 32.0)
+    val targets = BearingTargets.at(*input)
+    input[0] = 100.0
+    assertEquals(BearingTargets.at(32.0, 358.0), targets)
+    assertEquals(BearingTargets.at(0.0, 90.0, 180.0, 270.0), BearingTargets.evenlySpaced(4))
+    assertEquals(BearingTargets.at(12.0), BearingTargets.evenlySpaced(1, 372.0))
+  }
+
+  @Test
+  fun snapping_is_opt_in_and_can_disable_inherited_settings() {
+    assertNull(MapInteractions.Standard.camera.settings.rotate.snapping.delta(3.0))
+    val configured = MapInteractions {
+      camera { rotate { snapping { targets = BearingTargets.at(32.0) } } }
+    }
+    assertEquals(2.0, configured.camera.settings.rotate.snapping.delta(30.0))
+    val disabled =
+      MapInteractions(configured) { camera { rotate { snapping { enabled = false } } } }
+    assertNull(disabled.camera.settings.rotate.snapping.delta(30.0))
+    assertEquals(
+      2.0,
+      MapInteractions(disabled) { camera { rotate { snapping() } } }
+        .camera
+        .settings
+        .rotate
+        .snapping
+        .delta(30.0),
+    )
+  }
+
+  @Test
+  fun invalid_targets_and_tolerances_are_rejected() {
+    assertFailsWith<IllegalArgumentException> { BearingTargets.at() }
+    assertFailsWith<IllegalArgumentException> { BearingTargets.at(Double.NaN) }
+    assertFailsWith<IllegalArgumentException> { BearingTargets.evenlySpaced(0) }
+    assertFailsWith<IllegalArgumentException> {
+      BearingTargets.evenlySpaced(4, Double.POSITIVE_INFINITY)
+    }
+    for (value in listOf(-1.0, 181.0, Double.NaN)) {
+      assertFailsWith<IllegalArgumentException> {
+        MapInteractions { camera { rotate { snapping { tolerance = value } } } }
+      }
+    }
+  }
+}

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/GestureTestFixture.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/GestureTestFixture.kt
@@ -6,6 +6,7 @@ import kotlin.time.Duration
 import org.maplibre.compose.camera.internal.BoxZoomFit
 import org.maplibre.compose.camera.internal.CameraInputTarget
 import org.maplibre.compose.camera.internal.CameraInputToken
+import org.maplibre.compose.interaction.BearingSnapping
 import org.maplibre.compose.interaction.ClickResult
 import org.maplibre.compose.interaction.MapInteractions
 import org.maplibre.compose.interaction.internal.ClickPath
@@ -148,6 +149,17 @@ internal class RecordingGestureTarget(
     gestureToken: CameraInputToken,
     anchor: DpOffset?,
   ) = rotateAndPitchBy(bearingDelta, pitchDelta, duration, anchor, gestureToken)
+
+  override suspend fun snapBearingAwaitingTransition(
+    snapping: BearingSnapping,
+    duration: Duration,
+    gestureToken: CameraInputToken,
+  ) =
+    command(gestureToken) {
+      snapping.delta(getCameraPosition().bearing)?.let {
+        rotateCalls += RotateCall(it, 0.0, null)
+      }
+    }
 
   var clickFamilies = setOf(TapFamily.Tap, TapFamily.LongPress, TapFamily.SecondaryClick)
   val deliveredTapFamilies = mutableListOf<TapFamily>()

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
@@ -55,6 +55,7 @@ import org.maplibre.compose.gljs.queryPoint
 import org.maplibre.compose.gljs.styleJson
 import org.maplibre.compose.gljs.styleUrl
 import org.maplibre.compose.gljs.subscribe
+import org.maplibre.compose.interaction.BearingSnapping
 import org.maplibre.compose.logging.MapLog
 import org.maplibre.compose.logging.MapLogLevel
 import org.maplibre.compose.logging.MapLogSource
@@ -1255,6 +1256,24 @@ internal class GlJsMapSession(
   ) {
     onGestureMap(gestureToken) { map ->
       map.easeTo(rotateOptions(map, bearingDelta, pitchDelta, anchor, duration))
+    }
+  }
+
+  override suspend fun snapBearingAwaitingTransition(
+    snapping: BearingSnapping,
+    duration: Duration,
+    gestureToken: CameraInputToken,
+  ) {
+    awaitCameraRelease(gestureToken = gestureToken) { map ->
+      val current = map.getBearing()
+      snapping.delta(current)?.let { delta ->
+        map.easeTo(
+          unsafeJso<EaseToOptions> {
+            bearing = current + delta
+            this.duration = duration.inWholeMilliseconds.toDouble()
+          }
+        )
+      }
     }
   }
 

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/camera/CameraInputIntegrationTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/camera/CameraInputIntegrationTest.kt
@@ -18,8 +18,10 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
 import org.maplibre.compose.camera.internal.inputPanBy
 import org.maplibre.compose.camera.internal.inputPanByAwaitingTransition
+import org.maplibre.compose.camera.internal.inputRotateAndPitchBy
 import org.maplibre.compose.camera.internal.inputRotateAndPitchByAwaitingTransition
 import org.maplibre.compose.camera.internal.inputScaleByAwaitingTransition
+import org.maplibre.compose.interaction.BearingTargets
 import org.maplibre.compose.interaction.CameraBuilder
 import org.maplibre.compose.interaction.internal.CameraConfiguration
 import org.maplibre.compose.interaction.internal.GestureInputSession
@@ -30,6 +32,89 @@ import org.maplibre.compose.testing.runMapTest
 import org.maplibre.spatialk.geojson.Position
 
 class CameraInputIntegrationTest {
+  @Test
+  fun rotation_settles_after_queued_movement_and_momentum_preserving_other_components():
+    MapTestResult = runMapTest {
+    coroutineScope {
+      createMapFixture().use { fixture ->
+        fixture.loadStyle(BaseStyle.Empty)
+        fixture.awaitMapReady()
+        fixture.session.setCameraPadding(PaddingValues(start = 65.dp, top = 25.dp, end = 10.dp))
+        fixture.state.gestureAuthority.updateConfiguration(
+          CameraBuilder(CameraConfiguration())
+            .apply {
+              rotate { snapping { targets = BearingTargets.evenlySpaced(4, 32.0) } }
+            }
+            .build()
+        )
+        for (momentum in listOf(false, true)) {
+          val before =
+            CameraPosition(target = Position(3.0, 45.0), zoom = 5.0, bearing = 20.0, tilt = 30.0)
+          fixture.state.setCameraPosition(before)
+          fixture.settle()
+          fixture.awaitWhileRendering("rotation settlement") {
+            val input = GestureInputSession(this, fixture.gestures)
+            fixture.gestures.inputRotateAndPitchBy(8.0, 0.0, gestureToken = input.token)
+            if (momentum)
+              input.scope.launch {
+                fixture.gestures.inputRotateAndPitchByAwaitingTransition(
+                  3.0,
+                  0.0,
+                  0.1.seconds,
+                  input.token,
+                )
+              }
+            input.end()
+            input.scope.coroutineContext[Job]!!.join()
+          }
+          val after = fixture.state.cameraPosition
+          assertEquals(32.0, after.bearing, 1e-6)
+          assertEquals(before.target.longitude, after.target.longitude, 1e-6)
+          assertEquals(before.target.latitude, after.target.latitude, 1e-6)
+          assertEquals(before.zoom, after.zoom, 1e-6)
+          assertEquals(before.tilt, after.tilt, 1e-6)
+          assertFalse(fixture.state.isCameraMoving)
+        }
+      }
+    }
+  }
+
+  @Test
+  fun snapping_does_not_follow_pan_or_override_programmatic_takeover(): MapTestResult = runMapTest {
+    coroutineScope {
+      createMapFixture().use { fixture ->
+        fixture.loadStyle(BaseStyle.Empty)
+        fixture.awaitMapReady()
+        fixture.state.gestureAuthority.updateConfiguration(
+          CameraBuilder(CameraConfiguration())
+            .apply {
+              rotate { snapping() }
+            }
+            .build()
+        )
+        fixture.state.setCameraPosition(CameraPosition(zoom = 5.0, bearing = 3.0))
+        fixture.settle()
+        fixture.awaitWhileRendering("pan without rotation") {
+          val input = GestureInputSession(this, fixture.gestures)
+          fixture.gestures.inputPanBy(10.0, 0.0, input.token)
+          input.end()
+          input.scope.coroutineContext[Job]!!.join()
+        }
+        assertEquals(3.0, fixture.state.cameraPosition.bearing, 1e-6)
+        val input = GestureInputSession(this, fixture.gestures, animationDuration = 30.seconds)
+        fixture.gestures.inputRotateAndPitchBy(1.0, 0.0, gestureToken = input.token)
+        input.end()
+        fixture.pumpUntil("settling to start") { fixture.state.isCameraMoving }
+        fixture.state.setCameraPosition(CameraPosition(zoom = 5.0, bearing = 42.0))
+        fixture.awaitWhileRendering("takeover to cancel settlement") {
+          input.scope.coroutineContext[Job]!!.join()
+        }
+        fixture.settle()
+        assertEquals(42.0, fixture.state.cameraPosition.bearing, 1e-6)
+      }
+    }
+  }
+
   @Test
   fun recognized_input_stops_programmatic_motion_before_its_first_delta(): MapTestResult =
     runMapTest {

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -32,6 +32,7 @@ import org.maplibre.compose.camera.internal.boxZoomFit
 import org.maplibre.compose.camera.internal.runCameraCommand
 import org.maplibre.compose.expressions.ast.CompiledExpression
 import org.maplibre.compose.expressions.value.BooleanValue
+import org.maplibre.compose.interaction.BearingSnapping
 import org.maplibre.compose.logging.MapLog
 import org.maplibre.compose.mlnffi.EglContextHandles
 import org.maplibre.compose.mlnffi.MapRenderBackend
@@ -1369,6 +1370,7 @@ internal class MlnFfiMapSession(
     duration: Duration,
     gestureToken: CameraInputToken? = null,
     guard: CameraCommandGuard? = null,
+    shouldStart: (MapHandle) -> Boolean = { true },
     start: (MapHandle, AnimationOptions) -> Unit,
   ): Unit = suspendCancellableCoroutine { continuation ->
     val enqueue = {
@@ -1382,7 +1384,8 @@ internal class MlnFfiMapSession(
                   guard,
                   activate = { gestureToken?.let { activateGesture(map, it) } },
                 ) {
-                  startTransitionOnMap(map, duration, start, continuation)
+                  if (shouldStart(map)) startTransitionOnMap(map, duration, start, continuation)
+                  else if (continuation.isActive) continuation.resume(Unit)
                 }
             if (!started && continuation.isActive) continuation.resume(Unit)
           },
@@ -1872,6 +1875,28 @@ internal class MlnFfiMapSession(
         }
       if (duration == Duration.ZERO) map.jumpTo(target)
       else map.easeTo(target, duration.toAnimationOptions())
+    }
+  }
+
+  override suspend fun snapBearingAwaitingTransition(
+    snapping: BearingSnapping,
+    duration: Duration,
+    gestureToken: CameraInputToken,
+  ) {
+    if (!acceptsGestures) return
+    var bearing = 0.0
+    startTransitionAwaitingRelease(
+      duration,
+      gestureToken = gestureToken,
+      shouldStart = { map ->
+        val current = map.camera.bearing ?: 0.0
+        snapping.delta(current)?.let {
+          bearing = current + it
+          true
+        } ?: false
+      },
+    ) { map, animation ->
+      map.easeTo(CameraOptions().also { it.bearing = bearing }, animation)
     }
   }
 


### PR DESCRIPTION
## Description

Add opt-in `camera { rotate { snapping { … } } }` to settle near selected bearings after rotation input and momentum finish. `BearingTargets` supports custom bearings and evenly spaced bearings with an offset. Settlement preserves center, zoom, and tilt and shares the input session's cancellation and camera ownership.

First part of #1317; independent haptic notches are in #1320.

## Validation

- `mise run check`
- `mise run test:android`
- `mise run test:desktop`
- `mise run test:js`
- `mise run test:ios`

Geometry tests cover custom targets, wraparound, tolerance, offsets, ties, and inherited configuration. Live-map tests cover queued movement, momentum, padded-center preservation, and camera takeover. Android device execution is pending CI.

## AI assistance

Implemented with GPT-6 through Codex from a user-reviewed API design.
