### PR TITLE
Add configurable bearing haptics on iOS Android and macOS

### DIFF
--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Interaction.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Interaction.kt
@@ -5,6 +5,7 @@ package org.maplibre.compose.docsnippets
 import androidx.compose.runtime.Composable
 import org.maplibre.compose.interaction.BearingTargets
 import org.maplibre.compose.interaction.ClickResult
+import org.maplibre.compose.interaction.HapticEmphasis
 import org.maplibre.compose.interaction.KeyModifier
 import org.maplibre.compose.interaction.MapInteractions
 import org.maplibre.compose.interaction.ModifierMatch.Containing
@@ -41,6 +42,23 @@ fun Interaction() {
       }
   )
   // #endregion bearing-snapping
+
+  // #region bearing-haptics
+  MaplibreMap(
+    interactions =
+      MapInteractions {
+        camera {
+          rotate {
+            haptics {
+              notch(BearingTargets.evenlySpaced(24), HapticEmphasis.Subtle)
+              notch(BearingTargets.evenlySpaced(4), HapticEmphasis.Standard)
+              notch(BearingTargets.at(0.0), HapticEmphasis.Emphasized)
+            }
+          }
+        }
+      }
+  )
+  // #endregion bearing-haptics
 
   // #region scroll-mappings
   MaplibreMap(

--- a/docs/src/content/docs/interaction.mdx
+++ b/docs/src/content/docs/interaction.mdx
@@ -78,3 +78,11 @@ Choose specific bearings or evenly spaced targets, such as the four cardinal
 directions:
 
 <Code code={region(interaction, "bearing-snapping")} lang="kotlin" />
+
+## Feel bearing notches
+
+Use `camera.rotate.haptics` to add feedback at chosen bearings while rotating.
+Haptics work independently of snapping and support Android, iOS, and macOS.
+Combine notches with different emphasis levels:
+
+<Code code={region(interaction, "bearing-haptics")} lang="kotlin" />

--- a/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/interaction/internal/BearingHapticFeedback.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/interaction/internal/BearingHapticFeedback.kt
@@ -1,0 +1,28 @@
+package org.maplibre.compose.interaction.internal
+
+import android.os.Build
+import android.view.HapticFeedbackConstants
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalView
+import org.maplibre.compose.interaction.HapticEmphasis
+
+@Composable
+internal actual fun rememberBearingHapticFeedback(): (HapticEmphasis) -> Unit {
+  val view = LocalView.current
+  return remember(view) {
+    { emphasis ->
+      val constant =
+        when (emphasis) {
+          HapticEmphasis.Subtle ->
+            if (Build.VERSION.SDK_INT >= 34) HapticFeedbackConstants.SEGMENT_FREQUENT_TICK
+            else HapticFeedbackConstants.CLOCK_TICK
+          HapticEmphasis.Standard ->
+            if (Build.VERSION.SDK_INT >= 34) HapticFeedbackConstants.SEGMENT_TICK
+            else HapticFeedbackConstants.CLOCK_TICK
+          HapticEmphasis.Emphasized -> HapticFeedbackConstants.CONTEXT_CLICK
+        }
+      view.performHapticFeedback(constant)
+    }
+  }
+}

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/internal/CameraInputAuthority.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/internal/CameraInputAuthority.kt
@@ -1,5 +1,6 @@
 package org.maplibre.compose.camera.internal
 
+import kotlin.time.TimeSource
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Job
@@ -7,6 +8,8 @@ import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import org.maplibre.compose.interaction.BearingSnapping
+import org.maplibre.compose.interaction.HapticEmphasis
+import org.maplibre.compose.interaction.internal.BearingHapticDetector
 import org.maplibre.compose.interaction.internal.CameraComponent
 import org.maplibre.compose.interaction.internal.CameraConfiguration
 import org.maplibre.compose.map.MapAdapter
@@ -162,6 +165,29 @@ internal class CameraInputAuthority(private val owner: MapState) {
     private val completion = CompletableDeferred<Unit>().also { if (!ready) it.complete(Unit) }
     private val startedComponents = mutableSetOf<CameraComponent>()
     private var rotated = false
+    private var hapticDetector: BearingHapticDetector? = null
+    private var onHaptic: ((HapticEmphasis) -> Unit)? = null
+    private val hapticClock = TimeSource.Monotonic.markNow()
+
+    fun setHapticFeedback(callback: (HapticEmphasis) -> Unit) {
+      owner.lifecycle.serialized { onHaptic = callback }
+    }
+
+    /** Called after a direct rotation executes; callbacks leave the lifecycle lock. */
+    fun reportRotation(from: Double, to: Double) {
+      val event =
+        owner.lifecycle.serialized {
+          if (!acceptsLocked(enqueue = false)) return@serialized null
+          val callback = onHaptic ?: return@serialized null
+          val detector =
+            hapticDetector
+              ?: BearingHapticDetector(configuration.settings.rotate.haptics).also {
+                hapticDetector = it
+              }
+          detector.update(from, to, hapticClock.elapsedNow())?.let { callback to it }
+        }
+      event?.let { (callback, emphasis) -> callback(emphasis) }
+    }
 
     val bearingSnapping: BearingSnapping?
       get() =
@@ -201,6 +227,7 @@ internal class CameraInputAuthority(private val owner: MapState) {
     fun rearm(component: CameraComponent) =
       owner.lifecycle.serialized {
         startedComponents.remove(component)
+        if (component == CameraComponent.Rotate) hapticDetector = null
       }
 
     fun registerJob(value: Job) {

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/internal/CameraInputResponse.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/internal/CameraInputResponse.kt
@@ -30,6 +30,7 @@ internal fun CameraInputTarget.inputRotateAndPitchBy(
   pitchDelta: Double,
   anchor: DpOffset? = null,
   gestureToken: CameraInputToken?,
+  feedback: Boolean = true,
 ) {
   val token = gestureToken ?: return
   val bearing =
@@ -41,6 +42,7 @@ internal fun CameraInputTarget.inputRotateAndPitchBy(
       pitch,
       anchor = anchor.takeIf { token.permitted(CameraComponent.Pan) },
       gestureToken = token,
+      feedback = feedback,
     )
 }
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/internal/CameraInputTarget.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/internal/CameraInputTarget.kt
@@ -70,6 +70,7 @@ internal interface CameraInputTarget {
     duration: Duration = Duration.ZERO,
     anchor: DpOffset? = null,
     gestureToken: CameraInputToken? = null,
+    feedback: Boolean = false,
   )
 
   /** Suspends until the map hands the camera back at the end of the transition. */

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/BearingHaptics.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/BearingHaptics.kt
@@ -1,0 +1,31 @@
+package org.maplibre.compose.interaction
+
+/**
+ * Relative emphasis. Platforms may use the same feedback for several levels, or remain silent.
+ * macOS uses the trackpad alignment pattern for every level.
+ */
+public enum class HapticEmphasis {
+  Subtle,
+  Standard,
+  Emphasized,
+}
+
+/** Haptic notches during pointer rotation, independent of bearing snapping. */
+@MapInteractionDsl
+public class BearingHapticsBuilder internal constructor() {
+  private val notches = mutableListOf<BearingHapticNotch>()
+
+  /**
+   * Adds feedback near or across [targets]. Overlapping notches produce one event with the greatest
+   * emphasis. Feedback requires moving away before re-entry and is rate limited during fast
+   * rotation. Starting at a notch is silent; crossings between input samples still produce
+   * feedback.
+   */
+  public fun notch(targets: BearingTargets, emphasis: HapticEmphasis = HapticEmphasis.Standard) {
+    notches += BearingHapticNotch(targets, emphasis)
+  }
+
+  internal fun build(): List<BearingHapticNotch> = notches.toList()
+}
+
+internal data class BearingHapticNotch(val targets: BearingTargets, val emphasis: HapticEmphasis)

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/BearingSnapping.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/BearingSnapping.kt
@@ -5,7 +5,7 @@ import kotlin.math.abs
 /**
  * Settles near a target after rotation input and its momentum finish normally.
  *
- * Snapping is disabled until configured. The initial targets and tolerance snap to north within 7°.
+ * Snapping defaults to north within 7°. Set [enabled] to false to disable it.
  */
 @MapInteractionDsl
 public class BearingSnappingBuilder internal constructor(from: BearingSnapping) {
@@ -28,7 +28,7 @@ public class BearingSnappingBuilder internal constructor(from: BearingSnapping) 
 }
 
 internal data class BearingSnapping(
-  val enabled: Boolean = false,
+  val enabled: Boolean = true,
   val targets: BearingTargets = BearingTargets.at(0.0),
   val tolerance: Double = 7.0,
 ) {

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/CameraConfiguration.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/CameraConfiguration.kt
@@ -147,10 +147,10 @@ internal constructor(
   }
 
   /**
-   * Replaces haptic notches; an empty block disables them. Feedback is opt-in and runs during
-   * pointer rotation, not momentum, settlement, keys, or programmatic camera changes. iOS, Android,
-   * and macOS use platform feedback subject to hardware and system settings. Other platforms are
-   * silent.
+   * Replaces the default standard-emphasis north notch; an empty block disables feedback. Runs
+   * during pointer rotation, not momentum, settlement, keys, or programmatic camera changes. iOS,
+   * Android, and macOS use platform feedback subject to hardware and system settings. Other
+   * platforms are silent.
    */
   public fun haptics(block: BearingHapticsBuilder.() -> Unit) {
     haptics = BearingHapticsBuilder().apply(block).build()

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/CameraConfiguration.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/CameraConfiguration.kt
@@ -126,6 +126,7 @@ internal constructor(
   public var enabled: Boolean = from.enabled
   private val momentum = VelocityMomentumBuilder(from.momentum)
   private var snapping = from.snapping
+  private var haptics = from.haptics
 
   public fun onStart(block: (() -> Unit)?) {
     start = block
@@ -145,6 +146,16 @@ internal constructor(
     snapping = BearingSnappingBuilder(snapping).apply(block).build()
   }
 
+  /**
+   * Replaces haptic notches; an empty block disables them. Feedback is opt-in and runs during
+   * pointer rotation, not momentum, settlement, keys, or programmatic camera changes. iOS, Android,
+   * and macOS use platform feedback subject to hardware and system settings. Other platforms are
+   * silent.
+   */
+  public fun haptics(block: BearingHapticsBuilder.() -> Unit) {
+    haptics = BearingHapticsBuilder().apply(block).build()
+  }
+
   internal fun build(): RotateCameraConfiguration =
-    RotateCameraConfiguration(enabled, momentum.build(), snapping)
+    RotateCameraConfiguration(enabled, momentum.build(), snapping, haptics)
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/BearingHapticDetector.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/BearingHapticDetector.kt
@@ -1,0 +1,50 @@
+package org.maplibre.compose.interaction.internal
+
+import kotlin.math.abs
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import org.maplibre.compose.interaction.BearingHapticNotch
+import org.maplibre.compose.interaction.HapticEmphasis
+import org.maplibre.compose.interaction.bearingDelta
+
+/** Engine-applied samples only; one detector belongs to one rotation input session. */
+internal class BearingHapticDetector(notches: List<BearingHapticNotch>) {
+  private class Notch(val bearing: Double, val emphasis: HapticEmphasis, var armed: Boolean = false)
+
+  private val notches = notches.flatMap { group ->
+    group.targets.bearings.map { Notch(it, group.emphasis) }
+  }
+  private var initialized = false
+  private var lastTick: Duration? = null
+
+  fun update(from: Double, to: Double, now: Duration): HapticEmphasis? {
+    if (!from.isFinite() || !to.isFinite()) return null
+    val travel = bearingDelta(from, to)
+    if (travel == 0.0) return null
+    var strongest: HapticEmphasis? = null
+    for (notch in notches) {
+      val distance = bearingDelta(from, notch.bearing)
+      if (!initialized) notch.armed = abs(distance) > CAPTURE_DEGREES
+      val reached =
+        distance >= min(0.0, travel) - CAPTURE_DEGREES &&
+          distance <= max(0.0, travel) + CAPTURE_DEGREES
+      if (notch.armed && reached) {
+        if (strongest == null || notch.emphasis > strongest) strongest = notch.emphasis
+        notch.armed = false
+      }
+      if (abs(bearingDelta(to, notch.bearing)) > REARM_DEGREES) notch.armed = true
+    }
+    initialized = true
+    // Consume crossings even when suppressed, so they cannot replay as delayed ticks.
+    if (strongest == null || lastTick?.let { now - it < 50.milliseconds } == true) return null
+    lastTick = now
+    return strongest
+  }
+
+  private companion object {
+    const val CAPTURE_DEGREES = 1.0
+    const val REARM_DEGREES = 2.0
+  }
+}

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/BearingHapticFeedback.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/BearingHapticFeedback.kt
@@ -1,0 +1,7 @@
+package org.maplibre.compose.interaction.internal
+
+import androidx.compose.runtime.Composable
+import org.maplibre.compose.interaction.HapticEmphasis
+
+/** Called on the Compose input dispatcher. Unsupported platforms deliberately do nothing. */
+@Composable internal expect fun rememberBearingHapticFeedback(): (HapticEmphasis) -> Unit

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/GestureInputSession.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/GestureInputSession.kt
@@ -9,12 +9,14 @@ import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.maplibre.compose.camera.internal.CameraInputTarget
 import org.maplibre.compose.camera.internal.CameraInputToken
+import org.maplibre.compose.interaction.HapticEmphasis
 
 /** A recognized input group and all its continuation work share this camera lifetime. */
 internal class GestureInputSession(
@@ -22,15 +24,26 @@ internal class GestureInputSession(
   private val target: CameraInputTarget,
   val token: CameraInputToken = target.onGestureStarted(),
   private val animationDuration: Duration = 300.milliseconds,
+  onHaptic: ((HapticEmphasis) -> Unit)? = null,
   private val onCancelled: () -> Unit = {},
 ) {
   private val work = Job(parent.coroutineContext[Job])
   val scope = CoroutineScope(parent.coroutineContext + work)
   private var ending = false
+  private val feedback = onHaptic?.let { Channel<HapticEmphasis>(Channel.CONFLATED) }
 
   init {
     token.registerJob(work)
+    if (feedback != null && onHaptic != null) {
+      token.setHapticFeedback { feedback.trySend(it) }
+      scope.launch {
+        for (emphasis in feedback) {
+          if (token.acceptsCommands) onHaptic(emphasis)
+        }
+      }
+    }
     work.invokeOnCompletion {
+      feedback?.cancel()
       if (work.isCancelled) {
         target.cancelGesture(token)
         // Authority can be revoked from an engine callback. Explicit dispatch prevents a Main
@@ -49,6 +62,7 @@ internal class GestureInputSession(
   fun end() {
     if (ending || work.isCancelled) return
     ending = true
+    feedback?.close()
     parent.launch(start = CoroutineStart.UNDISPATCHED) {
       try {
         work.children.toList().joinAll()
@@ -72,6 +86,7 @@ internal class GestureInputSession(
   /** Revocation precedes coroutine cleanup, so queued camera commands cannot execute meanwhile. */
   fun cancel() {
     if (work.isCompleted) return
+    feedback?.cancel()
     target.cancelGesture(token)
     work.cancel()
   }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/InputModifier.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/InputModifier.kt
@@ -36,6 +36,7 @@ import org.maplibre.compose.generated.Res
 import org.maplibre.compose.generated.map
 import org.maplibre.compose.generated.map_engaged
 import org.maplibre.compose.generated.map_not_engaged
+import org.maplibre.compose.interaction.HapticEmphasis
 import org.maplibre.compose.interaction.MapInteractions
 
 /**
@@ -131,6 +132,7 @@ internal fun Modifier.mapInput(
       boxZoom,
       platformRouting,
       rememberScrollConverter(),
+      rememberBearingHapticFeedback(),
     )
 }
 
@@ -163,8 +165,9 @@ private fun Modifier.pointerGestures(
   boxZoom: BoxZoomPreview,
   platformRouting: PlatformTransformRouting,
   scrollConverter: ScrollConverter,
+  onHaptic: (HapticEmphasis) -> Unit,
 ): Modifier =
-  pointerInput(target, options.settings, density, scrollConverter) {
+  pointerInput(target, options.settings, density, scrollConverter, onHaptic) {
     val scope = CoroutineScope(currentCoroutineContext())
     val scroll =
       ScrollGesture(
@@ -198,6 +201,7 @@ private fun Modifier.pointerGestures(
         doubleClickTimeoutMillis = viewConfiguration.doubleTapTimeoutMillis,
         longClickTimeoutMillis = viewConfiguration.longPressTimeoutMillis,
         scope = scope,
+        onHaptic = onHaptic.takeIf { options.camera.settings.rotate.haptics.isNotEmpty() },
         onAcceptedPress = {
           scroll.cancel()
           platform.cancel()

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/PointerGesture.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/PointerGesture.kt
@@ -27,6 +27,7 @@ import org.maplibre.compose.camera.internal.inputRotateAndPitchBy
 import org.maplibre.compose.camera.internal.inputScaleBy
 import org.maplibre.compose.camera.internal.inputScaleByAwaitingTransition
 import org.maplibre.compose.interaction.DragResponse
+import org.maplibre.compose.interaction.HapticEmphasis
 import org.maplibre.compose.interaction.MapInteractions
 import org.maplibre.compose.interaction.QuickZoomDirection
 import org.maplibre.compose.interaction.TapResponse
@@ -51,6 +52,7 @@ internal class PointerGesture(
   private val longClickTimeoutMillis: Long,
   private val scope: CoroutineScope,
   private val onAcceptedPress: () -> Unit,
+  private val onHaptic: ((HapticEmphasis) -> Unit)? = null,
 ) {
   private val gestureToken: CameraInputToken?
     get() = cameraSession?.token
@@ -823,6 +825,7 @@ internal class PointerGesture(
         target.inputRotateAndPitchBy(
           velocity.bearingDelta * fraction,
           0.0,
+          feedback = false,
           anchor = anchor,
           gestureToken = token,
         )
@@ -857,6 +860,7 @@ internal class PointerGesture(
         target,
         token,
         animationDuration = options.scaledAnimationDuration(),
+        onHaptic = onHaptic,
       ) {
         if (cameraSession === session) {
           val contactsRemain = lastSingle != null || pair != null

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/ResolvedCameraConfiguration.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/ResolvedCameraConfiguration.kt
@@ -2,6 +2,8 @@ package org.maplibre.compose.interaction.internal
 
 import org.maplibre.compose.interaction.BearingHapticNotch
 import org.maplibre.compose.interaction.BearingSnapping
+import org.maplibre.compose.interaction.BearingTargets
+import org.maplibre.compose.interaction.HapticEmphasis
 
 internal enum class CameraComponent {
   Pan,
@@ -49,5 +51,6 @@ internal data class RotateCameraConfiguration(
   val enabled: Boolean = true,
   val momentum: VelocityMomentum = VelocityMomentum(),
   val snapping: BearingSnapping = BearingSnapping(),
-  val haptics: List<BearingHapticNotch> = emptyList(),
+  val haptics: List<BearingHapticNotch> =
+    listOf(BearingHapticNotch(BearingTargets.at(0.0), HapticEmphasis.Standard)),
 )

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/ResolvedCameraConfiguration.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/ResolvedCameraConfiguration.kt
@@ -1,5 +1,6 @@
 package org.maplibre.compose.interaction.internal
 
+import org.maplibre.compose.interaction.BearingHapticNotch
 import org.maplibre.compose.interaction.BearingSnapping
 
 internal enum class CameraComponent {
@@ -48,4 +49,5 @@ internal data class RotateCameraConfiguration(
   val enabled: Boolean = true,
   val momentum: VelocityMomentum = VelocityMomentum(),
   val snapping: BearingSnapping = BearingSnapping(),
+  val haptics: List<BearingHapticNotch> = emptyList(),
 )

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/camera/CameraInputTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/camera/CameraInputTest.kt
@@ -24,8 +24,10 @@ import org.maplibre.compose.camera.internal.inputPanBy
 import org.maplibre.compose.camera.internal.inputRotateAndPitchBy
 import org.maplibre.compose.camera.internal.inputScaleBy
 import org.maplibre.compose.camera.internal.inputScaleByAwaitingTransition
+import org.maplibre.compose.interaction.BearingTargets
 import org.maplibre.compose.interaction.CameraBuilder
 import org.maplibre.compose.interaction.ClickResult
+import org.maplibre.compose.interaction.HapticEmphasis
 import org.maplibre.compose.interaction.MapInteractions
 import org.maplibre.compose.interaction.internal.CameraComponent
 import org.maplibre.compose.interaction.internal.CameraConfiguration
@@ -44,6 +46,33 @@ import org.maplibre.spatialk.geojson.Position
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class CameraInputTest {
+  @Test
+  fun haptics_survive_new_samples_but_pending_feedback_is_cancelled_on_takeover() =
+    cameraTest { _, target ->
+      val options = MapInteractions {
+        camera { rotate { haptics { notch(BearingTargets.at(0.0)) } } }
+      }
+      target.updateConfiguration(options)
+      val ticks = mutableListOf<HapticEmphasis>()
+      val input = GestureInputSession(this, target, onHaptic = { ticks += it })
+      runCurrent()
+      target.observeInput()
+      input.token.reportRotation(355.0, 5.0)
+      runCurrent()
+      assertEquals(listOf(HapticEmphasis.Standard), ticks)
+      input.cancel()
+      target.drain()
+      runCurrent()
+
+      ticks.clear()
+      val cancelled = GestureInputSession(this, target, onHaptic = { ticks += it })
+      cancelled.token.reportRotation(355.0, 5.0)
+      target.interruptCamera()
+      runCurrent()
+      target.drain()
+      assertTrue(ticks.isEmpty())
+    }
+
   @Test
   fun newer_input_preserves_queued_click_delivery_but_rejects_its_camera_fallthrough() =
     cameraTest { _, target ->

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/interaction/internal/BearingHapticDetectorTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/interaction/internal/BearingHapticDetectorTest.kt
@@ -1,0 +1,76 @@
+package org.maplibre.compose.interaction.internal
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.time.Duration.Companion.milliseconds
+import org.maplibre.compose.interaction.BearingHapticNotch
+import org.maplibre.compose.interaction.BearingTargets
+import org.maplibre.compose.interaction.HapticEmphasis
+import org.maplibre.compose.interaction.MapInteractions
+
+class BearingHapticDetectorTest {
+  private fun north() =
+    BearingHapticDetector(
+      listOf(BearingHapticNotch(BearingTargets.at(0.0), HapticEmphasis.Standard))
+    )
+
+  @Test
+  fun starting_at_a_notch_is_silent_and_jitter_requires_leaving_before_reentry() {
+    val detector = north()
+    assertNull(detector.update(0.0, 0.5, 0.milliseconds))
+    assertNull(detector.update(0.5, -0.5, 100.milliseconds))
+    assertNull(detector.update(-0.5, -3.0, 200.milliseconds))
+    assertEquals(HapticEmphasis.Standard, detector.update(-3.0, -0.5, 300.milliseconds))
+    assertNull(detector.update(-0.5, 0.5, 400.milliseconds))
+    assertNull(detector.update(0.5, -0.5, 500.milliseconds))
+  }
+
+  @Test
+  fun detects_crossings_between_samples_in_both_directions_across_north() {
+    val detector = north()
+    assertEquals(HapticEmphasis.Standard, detector.update(355.0, 5.0, 0.milliseconds))
+    assertEquals(HapticEmphasis.Standard, detector.update(5.0, 355.0, 100.milliseconds))
+  }
+
+  @Test
+  fun custom_offsets_and_layered_notches_emit_only_the_strongest_tick() {
+    val detector =
+      BearingHapticDetector(
+        listOf(
+          BearingHapticNotch(BearingTargets.evenlySpaced(24, 32.0), HapticEmphasis.Subtle),
+          BearingHapticNotch(BearingTargets.evenlySpaced(4, 32.0), HapticEmphasis.Standard),
+          BearingHapticNotch(BearingTargets.at(32.0), HapticEmphasis.Emphasized),
+        )
+      )
+    assertEquals(HapticEmphasis.Emphasized, detector.update(28.0, 34.0, 0.milliseconds))
+    assertEquals(HapticEmphasis.Subtle, detector.update(34.0, 49.0, 100.milliseconds))
+    assertEquals(HapticEmphasis.Standard, detector.update(49.0, 124.0, 200.milliseconds))
+  }
+
+  @Test
+  fun fast_rotation_coalesces_crossings_without_replaying_suppressed_ticks() {
+    val detector = north()
+    assertEquals(HapticEmphasis.Standard, detector.update(-5.0, 5.0, 0.milliseconds))
+    assertNull(detector.update(5.0, 0.5, 10.milliseconds))
+    assertNull(detector.update(0.5, -0.5, 100.milliseconds))
+    assertNull(detector.update(-0.5, -5.0, 200.milliseconds))
+    assertEquals(HapticEmphasis.Standard, detector.update(-5.0, 5.0, 300.milliseconds))
+  }
+
+  @Test
+  fun haptic_blocks_replace_inherited_notches_without_enabling_snapping() {
+    val north = MapInteractions { camera { rotate { haptics { notch(BearingTargets.at(0.0)) } } } }
+    assertEquals(false, north.camera.settings.rotate.snapping.enabled)
+    val other =
+      MapInteractions(north) { camera { rotate { haptics { notch(BearingTargets.at(32.0)) } } } }
+    assertEquals(
+      listOf(BearingHapticNotch(BearingTargets.at(32.0), HapticEmphasis.Standard)),
+      other.camera.settings.rotate.haptics,
+    )
+    assertEquals(
+      emptyList(),
+      MapInteractions(north) { camera { rotate { haptics {} } } }.camera.settings.rotate.haptics,
+    )
+  }
+}

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/interaction/internal/BearingHapticDetectorTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/interaction/internal/BearingHapticDetectorTest.kt
@@ -60,7 +60,17 @@ class BearingHapticDetectorTest {
 
   @Test
   fun haptic_blocks_replace_inherited_notches_without_enabling_snapping() {
-    val north = MapInteractions { camera { rotate { haptics { notch(BearingTargets.at(0.0)) } } } }
+    val defaults = MapInteractions.Standard.camera.settings.rotate.haptics
+    val detector = BearingHapticDetector(defaults)
+    assertEquals(HapticEmphasis.Standard, detector.update(355.0, 5.0, 0.milliseconds))
+    val north = MapInteractions {
+      camera {
+        rotate {
+          snapping { enabled = false }
+          haptics { notch(BearingTargets.at(0.0)) }
+        }
+      }
+    }
     assertEquals(false, north.camera.settings.rotate.snapping.enabled)
     val other =
       MapInteractions(north) { camera { rotate { haptics { notch(BearingTargets.at(32.0)) } } } }

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/interaction/internal/BearingSnappingTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/interaction/internal/BearingSnappingTest.kt
@@ -39,8 +39,12 @@ class BearingSnappingTest {
   }
 
   @Test
-  fun snapping_is_opt_in_and_can_disable_inherited_settings() {
-    assertNull(MapInteractions.Standard.camera.settings.rotate.snapping.delta(3.0))
+  fun snapping_defaults_to_north_and_can_disable_inherited_settings() {
+    val defaults = MapInteractions.Standard.camera.settings.rotate.snapping
+    assertEquals(-3.0, defaults.delta(3.0))
+    assertEquals(7.0, defaults.delta(353.0))
+    assertNull(defaults.delta(352.9))
+    assertNull(defaults.delta(90.0))
     val configured = MapInteractions {
       camera { rotate { snapping { targets = BearingTargets.at(32.0) } } }
     }

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/GestureTestFixture.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/GestureTestFixture.kt
@@ -120,6 +120,7 @@ internal class RecordingGestureTarget(
     duration: Duration,
     anchor: DpOffset?,
     gestureToken: CameraInputToken?,
+    feedback: Boolean,
   ) = command(gestureToken) { rotateCalls += RotateCall(bearingDelta, pitchDelta, anchor) }
 
   override suspend fun fitBoundsAwaitingTransition(

--- a/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/interaction/internal/BearingHapticFeedback.kt
+++ b/lib/maplibre-compose/src/iosMain/kotlin/org/maplibre/compose/interaction/internal/BearingHapticFeedback.kt
@@ -1,0 +1,23 @@
+package org.maplibre.compose.interaction.internal
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import org.maplibre.compose.interaction.HapticEmphasis
+import platform.UIKit.UIImpactFeedbackGenerator
+import platform.UIKit.UIImpactFeedbackStyle
+
+@Composable
+internal actual fun rememberBearingHapticFeedback(): (HapticEmphasis) -> Unit = remember {
+  val generators =
+    HapticEmphasis.entries.associateWith { emphasis ->
+      UIImpactFeedbackGenerator(
+        style =
+          when (emphasis) {
+            HapticEmphasis.Subtle -> UIImpactFeedbackStyle.UIImpactFeedbackStyleLight
+            HapticEmphasis.Standard -> UIImpactFeedbackStyle.UIImpactFeedbackStyleMedium
+            HapticEmphasis.Emphasized -> UIImpactFeedbackStyle.UIImpactFeedbackStyleHeavy
+          }
+      )
+    }
+  return@remember { emphasis: HapticEmphasis -> generators.getValue(emphasis).impactOccurred() }
+}

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/interaction/internal/BearingHapticFeedback.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/interaction/internal/BearingHapticFeedback.kt
@@ -1,0 +1,9 @@
+package org.maplibre.compose.interaction.internal
+
+import androidx.compose.runtime.Composable
+import org.maplibre.compose.interaction.HapticEmphasis
+
+private val silentFeedback: (HapticEmphasis) -> Unit = {}
+
+@Composable
+internal actual fun rememberBearingHapticFeedback(): (HapticEmphasis) -> Unit = silentFeedback

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
@@ -1253,9 +1253,13 @@ internal class GlJsMapSession(
     duration: Duration,
     anchor: DpOffset?,
     gestureToken: CameraInputToken?,
+    feedback: Boolean,
   ) {
     onGestureMap(gestureToken) { map ->
+      val before = map.getBearing()
       map.easeTo(rotateOptions(map, bearingDelta, pitchDelta, anchor, duration))
+      if (feedback && bearingDelta != 0.0 && duration == Duration.ZERO)
+        gestureToken?.reportRotation(before, map.getBearing())
     }
   }
 

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/bridge/ObjectiveC.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/desktop/bridge/ObjectiveC.kt
@@ -70,6 +70,11 @@ internal object ObjectiveC {
     JNI.invokePPPV(receiver, selector, argument, implementation(receiver, selector))
   }
 
+  fun sendVoid(receiver: Long, selectorName: String, first: Long, second: Long) {
+    val selector = selector(selectorName)
+    JNI.invokePPPPV(receiver, selector, first, second, implementation(receiver, selector))
+  }
+
   fun nsString(value: String): Long =
     MemoryStack.stackPush().use { stack ->
       sendPointer(
@@ -102,6 +107,7 @@ internal object ObjectiveC {
   private fun loadFrameworkForClass(className: String) {
     when {
       className.startsWith("MTL") -> loadFramework("Metal")
+      className == "NSHapticFeedbackManager" -> loadFramework("AppKit")
       else -> loadFramework("Foundation")
     }
   }

--- a/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/interaction/internal/BearingHapticFeedback.kt
+++ b/lib/maplibre-compose/src/jvmMain/kotlin/org/maplibre/compose/interaction/internal/BearingHapticFeedback.kt
@@ -1,0 +1,23 @@
+package org.maplibre.compose.interaction.internal
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import org.maplibre.compose.desktop.bridge.ObjectiveC
+import org.maplibre.compose.interaction.HapticEmphasis
+
+@Composable
+internal actual fun rememberBearingHapticFeedback(): (HapticEmphasis) -> Unit = remember {
+  if (System.getProperty("os.name").orEmpty().startsWith("Mac", ignoreCase = true)) {
+    { _: HapticEmphasis -> performMacosBearingHaptic() }
+  } else {
+    { _: HapticEmphasis -> }
+  }
+}
+
+internal fun performMacosBearingHaptic() {
+  ObjectiveC.runInAutoreleasePool {
+    // AppKit chooses the current device and honors preferences. All emphasis levels use alignment.
+    val performer = ObjectiveC.sendClassPointer("NSHapticFeedbackManager", "defaultPerformer")
+    ObjectiveC.sendVoid(performer, "performFeedbackPattern:performanceTime:", 1L, 1L)
+  }
+}

--- a/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/interaction/internal/BearingHapticFeedbackTest.kt
+++ b/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/interaction/internal/BearingHapticFeedbackTest.kt
@@ -1,0 +1,13 @@
+package org.maplibre.compose.interaction.internal
+
+import java.awt.EventQueue
+import kotlin.test.Test
+import org.junit.Assume.assumeTrue
+
+class BearingHapticFeedbackTest {
+  @Test
+  fun macos_alignment_feedback_calls_the_platform_performer() {
+    assumeTrue(System.getProperty("os.name").orEmpty().startsWith("Mac", ignoreCase = true))
+    EventQueue.invokeAndWait { performMacosBearingHaptic() }
+  }
+}

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/camera/CameraInputIntegrationTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/camera/CameraInputIntegrationTest.kt
@@ -23,6 +23,7 @@ import org.maplibre.compose.camera.internal.inputRotateAndPitchByAwaitingTransit
 import org.maplibre.compose.camera.internal.inputScaleByAwaitingTransition
 import org.maplibre.compose.interaction.BearingTargets
 import org.maplibre.compose.interaction.CameraBuilder
+import org.maplibre.compose.interaction.HapticEmphasis
 import org.maplibre.compose.interaction.internal.CameraConfiguration
 import org.maplibre.compose.interaction.internal.GestureInputSession
 import org.maplibre.compose.style.BaseStyle
@@ -32,6 +33,46 @@ import org.maplibre.compose.testing.runMapTest
 import org.maplibre.spatialk.geojson.Position
 
 class CameraInputIntegrationTest {
+  @Test
+  fun haptic_feedback_tracks_applied_rotation_but_not_momentum_or_settlement(): MapTestResult =
+    runMapTest {
+      coroutineScope {
+        createMapFixture().use { fixture ->
+          fixture.loadStyle(BaseStyle.Empty)
+          fixture.awaitMapReady()
+          fixture.state.gestureAuthority.updateConfiguration(
+            CameraBuilder(CameraConfiguration())
+              .apply {
+                rotate {
+                  snapping()
+                  haptics { notch(BearingTargets.at(0.0)) }
+                }
+              }
+              .build()
+          )
+          fixture.state.setCameraPosition(CameraPosition(zoom = 5.0, bearing = 355.0))
+          fixture.settle()
+          val ticks = mutableListOf<HapticEmphasis>()
+          val input = GestureInputSession(this, fixture.gestures, onHaptic = { ticks += it })
+          fixture.gestures.inputRotateAndPitchBy(10.0, 0.0, gestureToken = input.token)
+          fixture.pumpUntil("a haptic crossing after applied rotation") { ticks.isNotEmpty() }
+          assertEquals(listOf(HapticEmphasis.Standard), ticks)
+          fixture.gestures.inputRotateAndPitchBy(
+            -10.0,
+            0.0,
+            gestureToken = input.token,
+            feedback = false,
+          )
+          input.end()
+          fixture.awaitWhileRendering("silent momentum and settlement") {
+            input.scope.coroutineContext[Job]!!.join()
+          }
+          assertEquals(listOf(HapticEmphasis.Standard), ticks)
+          assertEquals(0.0, fixture.state.cameraPosition.bearing, 1e-6)
+        }
+      }
+    }
+
   @Test
   fun rotation_settles_after_queued_movement_and_momentum_preserving_other_components():
     MapTestResult = runMapTest {

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -1862,6 +1862,7 @@ internal class MlnFfiMapSession(
     duration: Duration,
     anchor: DpOffset?,
     gestureToken: CameraInputToken?,
+    feedback: Boolean,
   ) {
     // The read and the write must happen together on the owner thread.
     onMap(gestureToken) { map ->
@@ -1875,6 +1876,9 @@ internal class MlnFfiMapSession(
         }
       if (duration == Duration.ZERO) map.jumpTo(target)
       else map.easeTo(target, duration.toAnimationOptions())
+      if (feedback && bearingDelta != 0.0 && duration == Duration.ZERO) {
+        gestureToken?.reportRotation(camera.bearing ?: 0.0, map.camera.bearing ?: 0.0)
+      }
     }
   }
 


### PR DESCRIPTION
## Description

Stacked on #1319. Add independent `camera { rotate { haptics { … } } }` configuration for custom or evenly spaced bearing notches. Groups can use different emphasis levels; overlapping crossings produce one tick, with hysteresis, rate limiting, and conflation to prevent repeated or queued vibrations.

Feedback follows engine-applied pointer rotation and stays silent during momentum, snapping, keyboard controls, and programmatic camera movement. iOS uses impact feedback, Android uses platform haptic constants, and macOS uses alignment feedback for all emphasis levels. Other platforms remain silent.

North snapping within 7° and a standard-emphasis north haptic notch are enabled by default; both can be configured or disabled independently.

Completes the implementation for #1317 together with #1319.

## Validation

- `mise run check`
- `mise run test:android`
- `mise run test:desktop`
- `mise run test:ios`
- `mise run test:js` with `GRADLE_OPTS='-Dorg.gradle.project.kotlin.daemon.jvmargs=-Xmx4g'`; the default 2 GiB compiler heap ran out of memory before browser tests started.

Tests cover crossings between samples, wraparound, custom offsets, overlapping groups, jitter, rate limiting, configuration inheritance, cancellation, and live-map suppression during momentum and snapping. The macOS smoke test calls the real AppKit performer. The default configuration was also tested manually on desktop and a physical Android phone.

## AI assistance

Implemented with GPT-6 through Codex from a user-reviewed API design.

