### PR TITLE
Simplify interaction responses and camera input hooks

### DIFF
--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/MapControlsDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/MapControlsDemo.kt
@@ -17,6 +17,7 @@ import org.maplibre.compose.demoapp.design.DropdownRow
 import org.maplibre.compose.interaction.KeyModifier
 import org.maplibre.compose.interaction.MapInteractions
 import org.maplibre.compose.interaction.ModifierMatch.Containing
+import org.maplibre.compose.interaction.ScrollResponse
 import org.maplibre.compose.map.MapState
 import org.maplibre.spatialk.geojson.Position
 
@@ -64,8 +65,8 @@ object MapControlsDemo : Demo {
         bindings {
           scroll {
             mappings {
-              on(modifiers = Containing(KeyModifier.Ctrl)) { zoom() }
-              otherwise { pan() }
+              on(modifiers = Containing(KeyModifier.Ctrl), response = ScrollResponse.Zoom)
+              otherwise(ScrollResponse.Pan)
             }
           }
         }

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Interaction.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Interaction.kt
@@ -7,6 +7,7 @@ import org.maplibre.compose.interaction.ClickResult
 import org.maplibre.compose.interaction.KeyModifier
 import org.maplibre.compose.interaction.MapInteractions
 import org.maplibre.compose.interaction.ModifierMatch.Containing
+import org.maplibre.compose.interaction.ScrollResponse
 import org.maplibre.compose.map.MaplibreMap
 import org.maplibre.spatialk.geojson.Position
 
@@ -31,8 +32,8 @@ fun Interaction() {
         bindings {
           scroll {
             mappings {
-              on(modifiers = Containing(KeyModifier.Ctrl)) { zoom() }
-              otherwise { pan() }
+              on(modifiers = Containing(KeyModifier.Ctrl), response = ScrollResponse.Zoom)
+              otherwise(ScrollResponse.Pan)
             }
           }
         }

--- a/docs/src/content/docs/interaction.mdx
+++ b/docs/src/content/docs/interaction.mdx
@@ -30,6 +30,8 @@ built-in input, including feature clicks.
 
 To stop [following the user's location](/maplibre-compose/location/) when they
 pan, use <Api of="PanCameraBuilder.onStart" display="camera.pan.onStart" />.
+This hook runs before the component responds to input and can run again within
+the same gesture. It does not report when camera movement ends.
 For moving the camera from app code, see [Control the camera](/maplibre-compose/camera/).
 
 ## Change scroll controls
@@ -42,6 +44,10 @@ while Ctrl-scroll zooms:
 A `mappings` block replaces the default responses for that input. Rows are
 tried from top to bottom; `otherwise` handles the remaining input. Available
 gestures depend on the input device and Compose host.
+
+A null pointer-type, button, or modifier filter matches any value. Key mappings
+default to exactly no modifiers; set `modifiers = null` to match a key with any
+modifiers.
 
 ## Handle map clicks
 

--- a/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/interaction/internal/ClickInputTest.kt
+++ b/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/interaction/internal/ClickInputTest.kt
@@ -27,8 +27,10 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import org.maplibre.compose.interaction.ClickEvent
 import org.maplibre.compose.interaction.ClickResult
+import org.maplibre.compose.interaction.DragResponse
 import org.maplibre.compose.interaction.MapInteractions
 import org.maplibre.compose.interaction.PointerButton
+import org.maplibre.compose.interaction.TapResponse
 import org.maplibre.compose.map.GestureTestFixture
 import org.maplibre.compose.map.RecordingGestureTarget
 import org.maplibre.compose.map.mapRuntimeForTest
@@ -148,7 +150,7 @@ class ClickInputTest {
             bindings {
               longPress {
                 enabled = true
-                mappings { otherwise { zoomIn() } }
+                mappings { otherwise(TapResponse.ZoomIn) }
               }
             }
           },
@@ -182,7 +184,7 @@ class ClickInputTest {
             drag {
               enabled = true
               pointerTypes = setOf(PointerType.Touch)
-              mappings { otherwise { pan() } }
+              mappings { otherwise(DragResponse.Pan) }
             }
           }
         }
@@ -462,7 +464,7 @@ class ClickInputTest {
           bindings {
             twoFingerTap {
               enabled = true
-              mappings { otherwise { zoomOut() } }
+              mappings { otherwise(TapResponse.ZoomOut) }
             }
           }
         },

--- a/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/interaction/internal/KeyAndRotaryInputTest.kt
+++ b/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/interaction/internal/KeyAndRotaryInputTest.kt
@@ -29,7 +29,9 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import org.junit.Assume.assumeTrue
 import org.maplibre.compose.camera.internal.CameraInputToken
+import org.maplibre.compose.interaction.DragResponse
 import org.maplibre.compose.interaction.KeyModifier
+import org.maplibre.compose.interaction.KeyResponse
 import org.maplibre.compose.interaction.MapInteractions
 import org.maplibre.compose.interaction.ModifierMatch
 import org.maplibre.compose.map.GestureTestFixture
@@ -86,11 +88,16 @@ class KeyAndRotaryInputTest {
           bindings {
             drag {
               enabled = true
-              mappings { on(modifiers = ModifierMatch.Containing(KeyModifier.Ctrl)) { pan() } }
+              mappings {
+                on(
+                  modifiers = ModifierMatch.Containing(KeyModifier.Ctrl),
+                  response = DragResponse.Pan,
+                )
+              }
             }
             keys {
               enabled = true
-              mappings { on(Key.DirectionRight) { panRight() } }
+              mappings { on(Key.DirectionRight, response = KeyResponse.PanRight) }
             }
           }
           camera { pan { momentum { enabled = false } } }
@@ -450,7 +457,7 @@ class KeyAndRotaryInputTest {
       waitUntil(timeoutMillis = TIMEOUT) { target.moveCalls.size == 1 }
       runOnIdle {
         options = MapInteractions {
-          bindings { keys { mappings { on(Key.DirectionRight) { zoomIn() } } } }
+          bindings { keys { mappings { on(Key.DirectionRight, response = KeyResponse.ZoomIn) } } }
         }
       }
       waitForIdle()

--- a/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/interaction/internal/ScrollGestureInputTest.kt
+++ b/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/interaction/internal/ScrollGestureInputTest.kt
@@ -26,6 +26,7 @@ import kotlin.time.Duration.Companion.milliseconds
 import org.maplibre.compose.interaction.KeyModifier
 import org.maplibre.compose.interaction.MapInteractions
 import org.maplibre.compose.interaction.ModifierMatch
+import org.maplibre.compose.interaction.ScrollResponse
 import org.maplibre.compose.map.GestureTestFixture
 
 @OptIn(ExperimentalAtomicApi::class, ExperimentalTestApi::class)
@@ -42,7 +43,7 @@ class ScrollGestureInputTest {
           bindings {
             scroll {
               enabled = true
-              mappings { otherwise { zoom() } }
+              mappings { otherwise(ScrollResponse.Zoom) }
             }
           }
         }
@@ -105,7 +106,7 @@ class ScrollGestureInputTest {
         MapInteractions {
           bindings {
             scroll {
-              mappings { otherwise { pan() } }
+              mappings { otherwise(ScrollResponse.Pan) }
             }
           }
         }
@@ -141,8 +142,11 @@ class ScrollGestureInputTest {
           bindings {
             scroll {
               mappings {
-                on(modifiers = ModifierMatch.Containing(KeyModifier.Ctrl)) { zoom() }
-                otherwise { pan() }
+                on(
+                  modifiers = ModifierMatch.Containing(KeyModifier.Ctrl),
+                  response = ScrollResponse.Zoom,
+                )
+                otherwise(ScrollResponse.Pan)
               }
             }
           }
@@ -177,7 +181,8 @@ class ScrollGestureInputTest {
   fun scroll_zoom_uses_vertical_motion_and_leaves_horizontal_only_input_unclaimed() {
     var parentSawConsumed = false
     fixture.runRecognitionTest(
-      options = MapInteractions { bindings { scroll { mappings { otherwise { zoom() } } } } },
+      options =
+        MapInteractions { bindings { scroll { mappings { otherwise(ScrollResponse.Zoom) } } } },
       parentModifier =
         Modifier.pointerInput(Unit) {
           awaitPointerEventScope {

--- a/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/interaction/internal/TransformInputTest.kt
+++ b/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/interaction/internal/TransformInputTest.kt
@@ -22,7 +22,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.camera.internal.CameraInputToken
-import org.maplibre.compose.interaction.CameraInputStart
+import org.maplibre.compose.interaction.DragResponse
 import org.maplibre.compose.interaction.MapInteractions
 import org.maplibre.compose.interaction.PointerButton
 import org.maplibre.compose.map.GestureTestFixture
@@ -403,7 +403,7 @@ class TransformInputTest {
             drag {
               enabled = true
 
-              mappings { on(button = PointerButton.Primary) { pan() } }
+              mappings { on(button = PointerButton.Primary, response = DragResponse.Pan) }
             }
             transform {
               pan {
@@ -533,13 +533,13 @@ class TransformInputTest {
 
   @Test
   fun pair_to_single_pan_restarts_the_semantic_component_under_the_retained_session() {
-    val starts = mutableListOf<CameraInputStart>()
+    var starts = 0
     fixture.runRecognitionTest(
       options =
         MapInteractions {
           camera {
             pan {
-              onStart { starts += it }
+              onStart { starts++ }
               momentum { enabled = false }
             }
           }
@@ -565,8 +565,7 @@ class TransformInputTest {
         up(1)
       }
       waitForIdle()
-      assertEquals(2, starts.size)
-      assertEquals(starts.first().sessionId, starts.last().sessionId)
+      assertEquals(2, starts)
       assertEquals(1, target.startedCount)
       assertEquals(1, target.endedCount)
     }

--- a/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MlnFfiMapCompositionTest.kt
+++ b/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MlnFfiMapCompositionTest.kt
@@ -53,6 +53,7 @@ import kotlinx.serialization.json.JsonObject
 import org.maplibre.compose.camera.CameraMoveReason
 import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.expressions.dsl.const
+import org.maplibre.compose.interaction.DragResponse
 import org.maplibre.compose.interaction.MapInteractions
 import org.maplibre.compose.interaction.PointerButton
 import org.maplibre.compose.layers.Anchor
@@ -128,7 +129,7 @@ class MlnFfiMapCompositionTest {
                 bindings {
                   drag {
                     enabled = true
-                    mappings { on(button = PointerButton.Primary) { pan() } }
+                    mappings { on(button = PointerButton.Primary, response = DragResponse.Pan) }
                   }
                 }
               }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/internal/CameraInputAuthority.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/internal/CameraInputAuthority.kt
@@ -6,8 +6,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
-import org.maplibre.compose.interaction.CameraInputOrigin
-import org.maplibre.compose.interaction.CameraInputStart
 import org.maplibre.compose.interaction.internal.CameraComponent
 import org.maplibre.compose.interaction.internal.CameraConfiguration
 import org.maplibre.compose.map.MapAdapter
@@ -38,7 +36,6 @@ internal inline fun runCameraCommand(
 
 /** The lifecycle lock serializes admission with takeover and completion fences. */
 internal class CameraInputAuthority(private val owner: MapState) {
-  private var nextId = 0L
   private var cameraGeneration = 0L
   private var inputGeneration = 0L
   private var active: CameraInputToken? = null
@@ -79,7 +76,7 @@ internal class CameraInputAuthority(private val owner: MapState) {
             target?.isGestureReady == true &&
             adapter === attachment.adapter &&
             (expectedInputGeneration == null || expectedInputGeneration == inputGeneration)
-        val token = Token(++nextId, attachment, target, ready)
+        val token = Token(attachment, target, ready)
         if (!ready) {
           return@serialized token
         }
@@ -154,7 +151,6 @@ internal class CameraInputAuthority(private val owner: MapState) {
   /** State and its synchronization stay together; backends only queue, execute, and finish. */
   inner class Token
   internal constructor(
-    val value: Long,
     val attachment: MapAttachment?,
     private val target: CameraInputTarget?,
     ready: Boolean,
@@ -164,14 +160,6 @@ internal class CameraInputAuthority(private val owner: MapState) {
     private var finishQueued = false
     private val completion = CompletableDeferred<Unit>().also { if (!ready) it.complete(Unit) }
     private val startedComponents = mutableSetOf<CameraComponent>()
-    private var inputOrigin = CameraInputOrigin.Drag
-
-    var origin: CameraInputOrigin
-      get() = owner.lifecycle.serialized { inputOrigin }
-      set(value) {
-        owner.lifecycle.serialized { inputOrigin = value }
-      }
-
     val acceptsCommands: Boolean
       get() = owner.lifecycle.serialized { acceptsLocked(enqueue = true) }
 
@@ -192,11 +180,9 @@ internal class CameraInputAuthority(private val owner: MapState) {
         owner.lifecycle.serialized {
           if (!acceptsLocked(enqueue = true) || !configuration.settings.enabled(component))
             return false
-          if (startedComponents.add(component))
-            configuration.onStart[component]?.let { it to CameraInputStart(value, inputOrigin) }
-          else null
+          if (startedComponents.add(component)) configuration.onStart[component] else null
         }
-      start?.let { (callback, event) -> callback(event) }
+      start?.invoke()
       return permitted(component)
     }
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/CameraConfiguration.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/CameraConfiguration.kt
@@ -1,26 +1,11 @@
 package org.maplibre.compose.interaction
 
-import androidx.compose.runtime.Immutable
 import org.maplibre.compose.interaction.internal.CameraComponent
 import org.maplibre.compose.interaction.internal.CameraConfiguration
 import org.maplibre.compose.interaction.internal.CameraSettings
 import org.maplibre.compose.interaction.internal.PanCameraConfiguration
 import org.maplibre.compose.interaction.internal.TiltCameraConfiguration
 import org.maplibre.compose.interaction.internal.VelocityCameraConfiguration
-
-/** The input source that began a permitted camera response. */
-public enum class CameraInputOrigin {
-  Drag,
-  Transform,
-  Scroll,
-  Tap,
-  TapDrag,
-  Key,
-  Rotary,
-}
-
-/** A component start within an input session. Several components can share [sessionId]. */
-@Immutable public data class CameraInputStart(val sessionId: Long, val origin: CameraInputOrigin)
 
 /** Permissions, release momentum, and semantic start callbacks for camera input. */
 @MapInteractionDsl
@@ -68,13 +53,13 @@ public class CameraBuilder internal constructor(from: CameraConfiguration) {
 public class PanCameraBuilder
 internal constructor(
   from: PanCameraConfiguration,
-  internal var start: ((CameraInputStart) -> Unit)?,
+  internal var start: (() -> Unit)?,
 ) {
   public var enabled: Boolean = from.enabled
   private val momentum = PanMomentumBuilder(from.momentum)
 
-  /** Runs before the first effective command each time this component starts. */
-  public fun onStart(block: ((CameraInputStart) -> Unit)?) {
+  /** Runs before this component begins responding to input, including restarts within a gesture. */
+  public fun onStart(block: (() -> Unit)?) {
     start = block
   }
 
@@ -90,13 +75,13 @@ internal constructor(
 public class VelocityCameraBuilder
 internal constructor(
   from: VelocityCameraConfiguration,
-  internal var start: ((CameraInputStart) -> Unit)?,
+  internal var start: (() -> Unit)?,
 ) {
   public var enabled: Boolean = from.enabled
   private val momentum = VelocityMomentumBuilder(from.momentum)
 
-  /** Runs before the first effective command each time this component starts. */
-  public fun onStart(block: ((CameraInputStart) -> Unit)?) {
+  /** Runs before this component begins responding to input, including restarts within a gesture. */
+  public fun onStart(block: (() -> Unit)?) {
     start = block
   }
 
@@ -113,13 +98,13 @@ internal constructor(
 public class TiltCameraBuilder
 internal constructor(
   from: TiltCameraConfiguration,
-  internal var start: ((CameraInputStart) -> Unit)?,
+  internal var start: (() -> Unit)?,
 ) {
   public var enabled: Boolean = from.enabled
   private val momentum = TiltMomentumBuilder(from.momentum)
 
-  /** Runs before the first effective command each time this component starts. */
-  public fun onStart(block: ((CameraInputStart) -> Unit)?) {
+  /** Runs before this component begins responding to input, including restarts within a gesture. */
+  public fun onStart(block: (() -> Unit)?) {
     start = block
   }
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/InputMatching.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/InputMatching.kt
@@ -19,11 +19,9 @@ public enum class KeyModifier {
   Meta,
 }
 
-/** Matches the complete modifier set, a subset, or any modifiers. */
+/** Matches the complete modifier set or a subset. A null filter matches any modifiers. */
 @Immutable
 public sealed class ModifierMatch private constructor() {
-  public data object Any : ModifierMatch()
-
   public class Exactly(vararg modifiers: KeyModifier) : ModifierMatch() {
     public val modifiers: Set<KeyModifier> = modifiers.toSet()
 
@@ -44,7 +42,6 @@ public sealed class ModifierMatch private constructor() {
 
   internal fun matches(actual: Set<KeyModifier>): Boolean =
     when (this) {
-      Any -> true
       is Exactly -> actual == modifiers
       is Containing -> actual.containsAll(modifiers)
     }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/InteractionBindings.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/InteractionBindings.kt
@@ -119,7 +119,7 @@ public class DragBindingBuilder internal constructor(from: DragBinding) {
 public class TransformPanBuilder internal constructor(from: TransformPanBinding) {
   public var enabled: Boolean = from.enabled
   public var pointerTypes: Set<PointerType>? = from.pointerTypes
-  public var modifiers: ModifierMatch = from.modifiers
+  public var modifiers: ModifierMatch? = from.modifiers
   /** Recognition distance for touch pairs. Host-recognized pans have already passed host slop. */
   public var startSlop: Dp = from.startSlop
 
@@ -138,7 +138,7 @@ public class TransformPanBuilder internal constructor(from: TransformPanBinding)
 public class TransformZoomBuilder internal constructor(from: TransformZoomBinding) {
   public var enabled: Boolean = from.enabled
   public var pointerTypes: Set<PointerType>? = from.pointerTypes
-  public var modifiers: ModifierMatch = from.modifiers
+  public var modifiers: ModifierMatch? = from.modifiers
   public var startSpanSlop: Dp = from.startSpanSlop
   public var anchor: GestureAnchor = from.anchor
   public var zoomScale: Double = from.zoomScale
@@ -161,7 +161,7 @@ public class TransformZoomBuilder internal constructor(from: TransformZoomBindin
 public class TransformRotateBuilder internal constructor(from: TransformRotateBinding) {
   public var enabled: Boolean = from.enabled
   public var pointerTypes: Set<PointerType>? = from.pointerTypes
-  public var modifiers: ModifierMatch = from.modifiers
+  public var modifiers: ModifierMatch? = from.modifiers
   public var startAngle: Double = from.startAngle
   public var anchor: GestureAnchor = from.anchor
   public var rotationScale: Double = from.rotationScale
@@ -186,7 +186,7 @@ public class TransformRotateBuilder internal constructor(from: TransformRotateBi
 public class TransformTiltBuilder internal constructor(from: TransformTiltBinding) {
   public var enabled: Boolean = from.enabled
   public var pointerTypes: Set<PointerType>? = from.pointerTypes
-  public var modifiers: ModifierMatch = from.modifiers
+  public var modifiers: ModifierMatch? = from.modifiers
   public var startSlop: Dp = from.startSlop
   public var pitchDegreesPerDp: Double = from.pitchDegreesPerDp
 
@@ -207,7 +207,7 @@ public class TransformTiltBuilder internal constructor(from: TransformTiltBindin
 public class TapDragBuilder internal constructor(from: TapDragBinding) {
   public var enabled: Boolean = from.enabled
   public var pointerTypes: Set<PointerType>? = from.pointerTypes
-  public var modifiers: ModifierMatch = from.modifiers
+  public var modifiers: ModifierMatch? = from.modifiers
   public var startSlop: Dp = from.startSlop
   public var anchor: GestureAnchor = from.anchor
   public var direction: QuickZoomDirection = from.direction

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/InteractionMappings.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/InteractionMappings.kt
@@ -3,165 +3,10 @@ package org.maplibre.compose.interaction
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.pointer.PointerType
 import org.maplibre.compose.interaction.internal.DragMapping
-import org.maplibre.compose.interaction.internal.DragResponse
 import org.maplibre.compose.interaction.internal.KeyMapping
-import org.maplibre.compose.interaction.internal.KeyResponse
 import org.maplibre.compose.interaction.internal.PointerPattern
 import org.maplibre.compose.interaction.internal.ScrollMapping
-import org.maplibre.compose.interaction.internal.ScrollResponse
 import org.maplibre.compose.interaction.internal.TapMapping
-import org.maplibre.compose.interaction.internal.TapResponse
-import org.maplibre.compose.interaction.internal.select
-
-/** One response is required in every mapping row. */
-@MapInteractionDsl
-public class DragResponseBuilder internal constructor() {
-  private var response: DragResponse? = null
-
-  private fun select(value: DragResponse) {
-    require(response == null) { "A mapping must declare exactly one response" }
-    response = value
-  }
-
-  public fun pan() {
-    select(DragResponse.Pan)
-  }
-
-  public fun rotateTilt() {
-    select(DragResponse.RotateTilt)
-  }
-
-  public fun fitBounds() {
-    select(DragResponse.FitBounds)
-  }
-
-  public fun none() {
-    select(DragResponse.None)
-  }
-
-  internal fun build(): DragResponse =
-    requireNotNull(response) { "A mapping must declare a response" }
-}
-
-@MapInteractionDsl
-public class ScrollResponseBuilder internal constructor() {
-  private var response: ScrollResponse? = null
-
-  private fun select(value: ScrollResponse) {
-    require(response == null) { "A mapping must declare exactly one response" }
-    response = value
-  }
-
-  public fun pan() {
-    select(ScrollResponse.Pan)
-  }
-
-  /** Zooms from vertical scrolling. Horizontal-only events remain unclaimed. */
-  public fun zoom() {
-    select(ScrollResponse.Zoom)
-  }
-
-  public fun none() {
-    select(ScrollResponse.None)
-  }
-
-  internal fun build(): ScrollResponse =
-    requireNotNull(response) { "A mapping must declare a response" }
-}
-
-@MapInteractionDsl
-public class TapResponseBuilder internal constructor() {
-  private var response: TapResponse? = null
-
-  private fun select(value: TapResponse) {
-    require(response == null) { "A mapping must declare exactly one response" }
-    response = value
-  }
-
-  public fun zoomIn() {
-    select(TapResponse.ZoomIn)
-  }
-
-  public fun zoomOut() {
-    select(TapResponse.ZoomOut)
-  }
-
-  public fun none() {
-    select(TapResponse.None)
-  }
-
-  internal fun build(): TapResponse =
-    requireNotNull(response) { "A mapping must declare a response" }
-}
-
-@MapInteractionDsl
-public class KeyResponseBuilder internal constructor() {
-  private var response: KeyResponse? = null
-
-  private fun select(value: KeyResponse) {
-    require(response == null) { "A mapping must declare exactly one response" }
-    response = value
-  }
-
-  public fun panLeft() {
-    select(KeyResponse.PanLeft)
-  }
-
-  public fun panRight() {
-    select(KeyResponse.PanRight)
-  }
-
-  public fun panUp() {
-    select(KeyResponse.PanUp)
-  }
-
-  public fun panDown() {
-    select(KeyResponse.PanDown)
-  }
-
-  public fun zoomIn() {
-    select(KeyResponse.ZoomIn)
-  }
-
-  public fun zoomOut() {
-    select(KeyResponse.ZoomOut)
-  }
-
-  public fun rotateLeft() {
-    select(KeyResponse.RotateLeft)
-  }
-
-  public fun rotateRight() {
-    select(KeyResponse.RotateRight)
-  }
-
-  public fun tiltUp() {
-    select(KeyResponse.TiltUp)
-  }
-
-  public fun tiltDown() {
-    select(KeyResponse.TiltDown)
-  }
-
-  public fun engage() {
-    select(KeyResponse.Engage)
-  }
-
-  public fun disengage() {
-    select(KeyResponse.Disengage)
-  }
-
-  public fun back() {
-    select(KeyResponse.Back)
-  }
-
-  public fun none() {
-    select(KeyResponse.None)
-  }
-
-  internal fun build(): KeyResponse =
-    requireNotNull(response) { "A mapping must declare a response" }
-}
 
 /** Ordered mappings; the first matching permitted response wins. */
 @MapInteractionDsl
@@ -172,21 +17,21 @@ public class DragMappingsBuilder internal constructor() {
   public fun on(
     pointerTypes: Set<PointerType>? = null,
     button: PointerButton? = null,
-    modifiers: ModifierMatch = ModifierMatch.Any,
-    block: DragResponseBuilder.() -> Unit,
+    modifiers: ModifierMatch? = null,
+    response: DragResponse,
   ) {
     require(!hasOtherwise) { "otherwise must be the final row" }
     rows +=
       DragMapping(
         PointerPattern(pointerTypes?.toSet(), button, modifiers),
-        DragResponseBuilder().apply(block).build(),
+        response,
       )
   }
 
-  public fun otherwise(block: DragResponseBuilder.() -> Unit) {
+  public fun otherwise(response: DragResponse) {
     require(!hasOtherwise) { "otherwise must be the final row" }
     hasOtherwise = true
-    rows += DragMapping(PointerPattern(), DragResponseBuilder().apply(block).build())
+    rows += DragMapping(PointerPattern(), response)
   }
 
   internal fun build(): List<DragMapping> = rows.toList()
@@ -200,21 +45,21 @@ public class ScrollMappingsBuilder internal constructor() {
 
   public fun on(
     pointerTypes: Set<PointerType>? = null,
-    modifiers: ModifierMatch = ModifierMatch.Any,
-    block: ScrollResponseBuilder.() -> Unit,
+    modifiers: ModifierMatch? = null,
+    response: ScrollResponse,
   ) {
     require(!hasOtherwise) { "otherwise must be the final row" }
     rows +=
       ScrollMapping(
         PointerPattern(pointerTypes?.toSet(), modifiers = modifiers),
-        ScrollResponseBuilder().apply(block).build(),
+        response,
       )
   }
 
-  public fun otherwise(block: ScrollResponseBuilder.() -> Unit) {
+  public fun otherwise(response: ScrollResponse) {
     require(!hasOtherwise) { "otherwise must be the final row" }
     hasOtherwise = true
-    rows += ScrollMapping(PointerPattern(), ScrollResponseBuilder().apply(block).build())
+    rows += ScrollMapping(PointerPattern(), response)
   }
 
   internal fun build(): List<ScrollMapping> = rows.toList()
@@ -231,21 +76,21 @@ public class TapMappingsBuilder internal constructor() {
 
   public fun on(
     pointerTypes: Set<PointerType>? = null,
-    modifiers: ModifierMatch = ModifierMatch.Any,
-    block: TapResponseBuilder.() -> Unit,
+    modifiers: ModifierMatch? = null,
+    response: TapResponse,
   ) {
     require(!hasOtherwise) { "otherwise must be the final row" }
     rows +=
       TapMapping(
         PointerPattern(pointerTypes = pointerTypes?.toSet(), modifiers = modifiers),
-        TapResponseBuilder().apply(block).build(),
+        response,
       )
   }
 
-  public fun otherwise(block: TapResponseBuilder.() -> Unit) {
+  public fun otherwise(response: TapResponse) {
     require(!hasOtherwise) { "otherwise must be the final row" }
     hasOtherwise = true
-    rows += TapMapping(PointerPattern(), TapResponseBuilder().apply(block).build())
+    rows += TapMapping(PointerPattern(), response)
   }
 
   internal fun build(): List<TapMapping> = rows.toList()
@@ -260,17 +105,17 @@ public class KeyMappingsBuilder internal constructor() {
   /** Modifiers match exactly by default, so unconfigured system shortcuts remain unclaimed. */
   public fun on(
     key: Key,
-    modifiers: ModifierMatch = ModifierMatch.Exactly(),
-    block: KeyResponseBuilder.() -> Unit,
+    modifiers: ModifierMatch? = ModifierMatch.Exactly(),
+    response: KeyResponse,
   ) {
     require(!hasOtherwise) { "otherwise must be the final row" }
-    rows += KeyMapping(key, modifiers, KeyResponseBuilder().apply(block).build())
+    rows += KeyMapping(key, modifiers, response)
   }
 
-  public fun otherwise(block: KeyResponseBuilder.() -> Unit) {
+  public fun otherwise(response: KeyResponse) {
     require(!hasOtherwise) { "otherwise must be the final row" }
     hasOtherwise = true
-    rows += KeyMapping(null, ModifierMatch.Any, KeyResponseBuilder().apply(block).build())
+    rows += KeyMapping(null, null, response)
   }
 
   internal fun build(): List<KeyMapping> = rows.toList()

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/InteractionResponses.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/InteractionResponses.kt
@@ -1,0 +1,45 @@
+package org.maplibre.compose.interaction
+
+/** Camera response to a drag. [None] leaves matching input unclaimed. */
+public enum class DragResponse {
+  Pan,
+  RotateTilt,
+  FitBounds,
+  None,
+}
+
+/** Camera response to scrolling. [None] leaves matching input unclaimed. */
+public enum class ScrollResponse {
+  Pan,
+  /** Zooms from vertical scrolling. Horizontal-only events remain unclaimed. */
+  Zoom,
+  None,
+}
+
+/** Camera response after an unhandled tap. */
+public enum class TapResponse {
+  ZoomIn,
+  ZoomOut,
+  None,
+}
+
+/** Camera or focus response to a key. */
+public enum class KeyResponse {
+  PanLeft,
+  PanRight,
+  PanUp,
+  PanDown,
+  ZoomIn,
+  ZoomOut,
+  RotateLeft,
+  RotateRight,
+  TiltUp,
+  TiltDown,
+  Engage,
+  Disengage,
+  Back,
+  None;
+
+  internal val isCamera: Boolean
+    get() = this !in setOf(Engage, Disengage, Back, None)
+}

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/GestureInputSession.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/GestureInputSession.kt
@@ -13,14 +13,12 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.maplibre.compose.camera.internal.CameraInputTarget
 import org.maplibre.compose.camera.internal.CameraInputToken
-import org.maplibre.compose.interaction.CameraInputOrigin
 
 /** A recognized input group and all its continuation work share this camera lifetime. */
 internal class GestureInputSession(
   private val parent: CoroutineScope,
   private val target: CameraInputTarget,
   val token: CameraInputToken = target.onGestureStarted(),
-  origin: CameraInputOrigin = CameraInputOrigin.Drag,
   private val onCancelled: () -> Unit = {},
 ) {
   private val work = Job(parent.coroutineContext[Job])
@@ -28,7 +26,6 @@ internal class GestureInputSession(
   private var ending = false
 
   init {
-    token.origin = origin
     token.registerJob(work)
     work.invokeOnCompletion {
       if (work.isCancelled) {
@@ -77,7 +74,7 @@ internal fun launchTapTransition(
   command: suspend CameraInputTarget.(CameraInputToken) -> Unit,
 ) {
   val token = target.onGestureStartedIfCurrent(generation) ?: return
-  val session = GestureInputSession(scope, target, token, origin = CameraInputOrigin.Tap)
+  val session = GestureInputSession(scope, target, token)
   session.scope.launch {
     try {
       command(target, token)

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/InteractionRouting.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/InteractionRouting.kt
@@ -2,8 +2,12 @@ package org.maplibre.compose.interaction.internal
 
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.pointer.PointerType
+import org.maplibre.compose.interaction.DragResponse
 import org.maplibre.compose.interaction.KeyModifier
+import org.maplibre.compose.interaction.KeyResponse
 import org.maplibre.compose.interaction.PointerButton
+import org.maplibre.compose.interaction.ScrollResponse
+import org.maplibre.compose.interaction.TapResponse
 
 internal fun PointerPattern.matches(
   sample: GesturePointerSample,
@@ -27,7 +31,7 @@ internal fun TapBinding.matches(sample: GesturePointerSample): Boolean =
 
 internal fun TapDragBinding.matches(sample: GesturePointerSample): Boolean =
   eligible(enabled, pointerTypes, sample) &&
-    modifiers.matches(sample.modifierKeys) &&
+    (modifiers?.matches(sample.modifierKeys) != false) &&
     PointerType.Mouse !in sample.pointerTypes &&
     PointerPattern(button = PointerButton.Primary).matches(sample)
 
@@ -113,7 +117,7 @@ internal fun KeyBinding.select(
     mappings
       .firstOrNull {
         (it.key == null || it.key == key) &&
-          it.modifiers.matches(modifiers) &&
+          (it.modifiers?.matches(modifiers) != false) &&
           camera.permits(it.response)
       }
       ?.response
@@ -136,16 +140,16 @@ internal fun KeyBinding.hasCameraBindings(camera: CameraSettings): Boolean {
 }
 
 internal fun TransformPanBinding.matches(sample: GesturePointerSample): Boolean =
-  eligible(enabled, pointerTypes, sample) && modifiers.matches(sample.modifierKeys)
+  eligible(enabled, pointerTypes, sample) && (modifiers?.matches(sample.modifierKeys) != false)
 
 internal fun TransformZoomBinding.matches(sample: GesturePointerSample): Boolean =
-  eligible(enabled, pointerTypes, sample) && modifiers.matches(sample.modifierKeys)
+  eligible(enabled, pointerTypes, sample) && (modifiers?.matches(sample.modifierKeys) != false)
 
 internal fun TransformRotateBinding.matches(sample: GesturePointerSample): Boolean =
-  eligible(enabled, pointerTypes, sample) && modifiers.matches(sample.modifierKeys)
+  eligible(enabled, pointerTypes, sample) && (modifiers?.matches(sample.modifierKeys) != false)
 
 internal fun TransformTiltBinding.matches(sample: GesturePointerSample): Boolean =
-  eligible(enabled, pointerTypes, sample) && modifiers.matches(sample.modifierKeys)
+  eligible(enabled, pointerTypes, sample) && (modifiers?.matches(sample.modifierKeys) != false)
 
 internal fun TransformBinding.hasDemand(
   sample: GesturePointerSample,

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/KeyInput.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/KeyInput.kt
@@ -26,8 +26,8 @@ import org.maplibre.compose.camera.internal.CameraInputToken
 import org.maplibre.compose.camera.internal.inputPanByAwaitingTransition
 import org.maplibre.compose.camera.internal.inputRotateAndPitchByAwaitingTransition
 import org.maplibre.compose.camera.internal.inputScaleByAwaitingTransition
-import org.maplibre.compose.interaction.CameraInputOrigin
 import org.maplibre.compose.interaction.KeyModifier
+import org.maplibre.compose.interaction.KeyResponse
 import org.maplibre.compose.interaction.MapInteractions
 
 /**
@@ -192,7 +192,7 @@ internal class KeyInput(
         ?: run {
           lateinit var created: GestureInputSession
           created =
-            GestureInputSession(scope, target, origin = CameraInputOrigin.Key) {
+            GestureInputSession(scope, target) {
               if (session === created) cancel()
             }
           created.also { session = it }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/PlatformTransformSession.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/PlatformTransformSession.kt
@@ -7,7 +7,6 @@ import kotlinx.coroutines.CoroutineScope
 import org.maplibre.compose.camera.internal.CameraInputTarget
 import org.maplibre.compose.camera.internal.inputPanBy
 import org.maplibre.compose.camera.internal.inputScaleBy
-import org.maplibre.compose.interaction.CameraInputOrigin
 import org.maplibre.compose.interaction.MapInteractions
 import org.maplibre.compose.interaction.internal.PlatformTransformRouting.Kind
 
@@ -124,7 +123,7 @@ internal class PlatformTransformSession(
       target.observeInput()
       lateinit var input: GestureInputSession
       input =
-        GestureInputSession(scope, target, origin = CameraInputOrigin.Transform) {
+        GestureInputSession(scope, target) {
           if (session === input) cancel()
         }
       session = input

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/PointerGesture.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/PointerGesture.kt
@@ -26,9 +26,10 @@ import org.maplibre.compose.camera.internal.inputPanBy
 import org.maplibre.compose.camera.internal.inputRotateAndPitchBy
 import org.maplibre.compose.camera.internal.inputScaleBy
 import org.maplibre.compose.camera.internal.inputScaleByAwaitingTransition
-import org.maplibre.compose.interaction.CameraInputOrigin
+import org.maplibre.compose.interaction.DragResponse
 import org.maplibre.compose.interaction.MapInteractions
 import org.maplibre.compose.interaction.QuickZoomDirection
+import org.maplibre.compose.interaction.TapResponse
 
 internal class PointerGesture(
   private val target: CameraInputTarget,
@@ -539,7 +540,7 @@ internal class PointerGesture(
         event,
         first,
         second,
-        begin = { beginGesture(CameraInputOrigin.Transform) },
+        begin = { beginGesture() },
         onRecognized = { component ->
           twoFingerTap = null
           deferredTwoFingerVelocity = deferredTwoFingerVelocity?.without(component)
@@ -842,21 +843,16 @@ internal class PointerGesture(
     previous?.cancel()
   }
 
-  private fun beginGesture(
-    origin: CameraInputOrigin =
-      if (selectedDrag == SelectedDrag.TapDrag) CameraInputOrigin.TapDrag
-      else CameraInputOrigin.Drag
-  ): CameraInputToken? {
+  private fun beginGesture(): CameraInputToken? {
     cancelLongClick()
     if (gestureInProgress) {
-      gestureToken?.origin = origin
       return gestureToken
     }
 
     val token = target.onGestureStarted()
     lateinit var session: GestureInputSession
     session =
-      GestureInputSession(scope, target, token, origin = origin) {
+      GestureInputSession(scope, target, token) {
         if (cameraSession === session) {
           val contactsRemain = lastSingle != null || pair != null
           cancel()

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/PointerMatching.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/PointerMatching.kt
@@ -9,7 +9,7 @@ import org.maplibre.compose.interaction.PointerButton
 internal data class PointerPattern(
   val pointerTypes: Set<PointerType>? = null,
   val button: PointerButton? = null,
-  val modifiers: ModifierMatch = ModifierMatch.Any,
+  val modifiers: ModifierMatch? = null,
 ) {
   fun matches(
     types: Set<PointerType>,
@@ -26,5 +26,5 @@ internal data class PointerPattern(
           types.all {
             it == PointerType.Touch || it == PointerType.Stylus || it == PointerType.Eraser
           })) &&
-      modifiers.matches(modifierKeys)
+      (modifiers?.matches(modifierKeys) != false)
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/PointerPairGesture.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/PointerPairGesture.kt
@@ -12,7 +12,6 @@ import org.maplibre.compose.camera.internal.CameraInputToken
 import org.maplibre.compose.camera.internal.inputPanBy
 import org.maplibre.compose.camera.internal.inputRotateAndPitchBy
 import org.maplibre.compose.camera.internal.inputScaleBy
-import org.maplibre.compose.interaction.CameraInputOrigin
 import org.maplibre.compose.interaction.GestureAnchor
 import org.maplibre.compose.interaction.MapInteractions
 
@@ -85,7 +84,6 @@ internal class PointerPairGesture(
     token = begin()
     if (token?.acceptsCommands != true) return false
     onRecognized(kind)
-    token?.origin = CameraInputOrigin.Transform
     token?.rearm(kind)
     return true
   }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/ResolvedBindings.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/ResolvedBindings.kt
@@ -7,14 +7,18 @@ import androidx.compose.ui.unit.dp
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import org.maplibre.compose.interaction.DragMappingsBuilder
+import org.maplibre.compose.interaction.DragResponse
 import org.maplibre.compose.interaction.GestureAnchor
 import org.maplibre.compose.interaction.KeyMappingsBuilder
 import org.maplibre.compose.interaction.KeyModifier
+import org.maplibre.compose.interaction.KeyResponse
 import org.maplibre.compose.interaction.ModifierMatch
 import org.maplibre.compose.interaction.PointerButton
 import org.maplibre.compose.interaction.QuickZoomDirection
 import org.maplibre.compose.interaction.ScrollMappingsBuilder
+import org.maplibre.compose.interaction.ScrollResponse
 import org.maplibre.compose.interaction.TapMappingsBuilder
+import org.maplibre.compose.interaction.TapResponse
 
 internal data class DragPanSettings(
   val startSlop: Dp = 4.dp,
@@ -46,14 +50,14 @@ internal data class DragBinding(
 internal data class TransformPanBinding(
   val enabled: Boolean = true,
   val pointerTypes: Set<PointerType>? = null,
-  val modifiers: ModifierMatch = ModifierMatch.Any,
+  val modifiers: ModifierMatch? = null,
   val startSlop: Dp = 4.dp,
 )
 
 internal data class TransformZoomBinding(
   val enabled: Boolean = true,
   val pointerTypes: Set<PointerType>? = null,
-  val modifiers: ModifierMatch = ModifierMatch.Any,
+  val modifiers: ModifierMatch? = null,
   val startSpanSlop: Dp = 7.dp,
   val anchor: GestureAnchor = GestureAnchor.Input,
   val zoomScale: Double = 1.0,
@@ -62,7 +66,7 @@ internal data class TransformZoomBinding(
 internal data class TransformRotateBinding(
   val enabled: Boolean = true,
   val pointerTypes: Set<PointerType>? = null,
-  val modifiers: ModifierMatch = ModifierMatch.Any,
+  val modifiers: ModifierMatch? = null,
   val startAngle: Double = 3.0,
   val anchor: GestureAnchor = GestureAnchor.Input,
   val rotationScale: Double = 1.0,
@@ -72,7 +76,7 @@ internal data class TransformRotateBinding(
 internal data class TransformTiltBinding(
   val enabled: Boolean = true,
   val pointerTypes: Set<PointerType>? = null,
-  val modifiers: ModifierMatch = ModifierMatch.Any,
+  val modifiers: ModifierMatch? = null,
   val startSlop: Dp = 16.dp,
   val pitchDegreesPerDp: Double = -0.1,
 )
@@ -81,7 +85,7 @@ internal data class TapDragBinding(
   val enabled: Boolean = true,
   val pointerTypes: Set<PointerType>? =
     setOf(PointerType.Touch, PointerType.Stylus, PointerType.Eraser),
-  val modifiers: ModifierMatch = ModifierMatch.Any,
+  val modifiers: ModifierMatch? = null,
   val startSlop: Dp = 7.dp,
   val anchor: GestureAnchor = GestureAnchor.CameraCenter,
   val direction: QuickZoomDirection = QuickZoomDirection.DownZoomsIn,
@@ -150,22 +154,24 @@ internal data class InteractionBindings(
             mappings =
               DragMappingsBuilder()
                 .apply {
-                  on(pointerTypes = mouse, button = PointerButton.Secondary) { rotateTilt() }
+                  on(
+                    pointerTypes = mouse,
+                    button = PointerButton.Secondary,
+                    response = DragResponse.RotateTilt,
+                  )
                   on(
                     pointerTypes = mouse,
                     button = PointerButton.Primary,
                     modifiers = ModifierMatch.Containing(KeyModifier.Ctrl),
-                  ) {
-                    rotateTilt()
-                  }
+                    response = DragResponse.RotateTilt,
+                  )
                   on(
                     pointerTypes = mouse,
                     button = PointerButton.Primary,
                     modifiers = ModifierMatch.Containing(KeyModifier.Shift),
-                  ) {
-                    fitBounds()
-                  }
-                  on(button = PointerButton.Primary) { pan() }
+                    response = DragResponse.FitBounds,
+                  )
+                  on(button = PointerButton.Primary, response = DragResponse.Pan)
                 }
                 .build()
           ),
@@ -174,7 +180,7 @@ internal data class InteractionBindings(
             mappings =
               ScrollMappingsBuilder()
                 .apply {
-                  otherwise { zoom() }
+                  otherwise(ScrollResponse.Zoom)
                 }
                 .build()
           ),
@@ -186,40 +192,57 @@ internal data class InteractionBindings(
                   on(
                     pointerTypes = mouse,
                     modifiers = ModifierMatch.Containing(KeyModifier.Shift),
-                  ) {
-                    zoomOut()
-                  }
-                  otherwise { zoomIn() }
+                    response = TapResponse.ZoomOut,
+                  )
+                  otherwise(TapResponse.ZoomIn)
                 }
                 .build()
           ),
         secondaryClick = TapBinding(pointerTypes = mouse),
         longPress = TapBinding(pointerTypes = touch),
         twoFingerTap =
-          TapBinding(mappings = TapMappingsBuilder().apply { otherwise { zoomOut() } }.build()),
+          TapBinding(
+            mappings = TapMappingsBuilder().apply { otherwise(TapResponse.ZoomOut) }.build()
+          ),
         keys =
           KeyBinding(
             mappings =
               KeyMappingsBuilder()
                 .apply {
-                  on(Key.DirectionLeft) { panLeft() }
-                  on(Key.DirectionRight) { panRight() }
-                  on(Key.DirectionUp) { panUp() }
-                  on(Key.DirectionDown) { panDown() }
-                  on(Key.DirectionLeft, ModifierMatch.Exactly(KeyModifier.Shift)) { rotateLeft() }
-                  on(Key.DirectionRight, ModifierMatch.Exactly(KeyModifier.Shift)) { rotateRight() }
-                  on(Key.DirectionUp, ModifierMatch.Exactly(KeyModifier.Shift)) { tiltUp() }
-                  on(Key.DirectionDown, ModifierMatch.Exactly(KeyModifier.Shift)) { tiltDown() }
+                  on(Key.DirectionLeft, response = KeyResponse.PanLeft)
+                  on(Key.DirectionRight, response = KeyResponse.PanRight)
+                  on(Key.DirectionUp, response = KeyResponse.PanUp)
+                  on(Key.DirectionDown, response = KeyResponse.PanDown)
+                  on(
+                    Key.DirectionLeft,
+                    ModifierMatch.Exactly(KeyModifier.Shift),
+                    response = KeyResponse.RotateLeft,
+                  )
+                  on(
+                    Key.DirectionRight,
+                    ModifierMatch.Exactly(KeyModifier.Shift),
+                    response = KeyResponse.RotateRight,
+                  )
+                  on(
+                    Key.DirectionUp,
+                    ModifierMatch.Exactly(KeyModifier.Shift),
+                    response = KeyResponse.TiltUp,
+                  )
+                  on(
+                    Key.DirectionDown,
+                    ModifierMatch.Exactly(KeyModifier.Shift),
+                    response = KeyResponse.TiltDown,
+                  )
                   for (key in listOf(Key.Plus, Key.Equals)) {
-                    on(key) { zoomIn() }
-                    on(key, ModifierMatch.Exactly(KeyModifier.Shift)) { zoomIn() }
+                    on(key, response = KeyResponse.ZoomIn)
+                    on(key, ModifierMatch.Exactly(KeyModifier.Shift), response = KeyResponse.ZoomIn)
                   }
-                  on(Key.Minus) { zoomOut() }
+                  on(Key.Minus, response = KeyResponse.ZoomOut)
                   for (key in listOf(Key.Enter, Key.NumPadEnter, Key.DirectionCenter)) {
-                    on(key) { engage() }
+                    on(key, response = KeyResponse.Engage)
                   }
-                  on(Key.Escape) { disengage() }
-                  on(Key.Back) { back() }
+                  on(Key.Escape, response = KeyResponse.Disengage)
+                  on(Key.Back, response = KeyResponse.Back)
                 }
                 .build()
           ),

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/ResolvedCameraConfiguration.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/ResolvedCameraConfiguration.kt
@@ -1,7 +1,5 @@
 package org.maplibre.compose.interaction.internal
 
-import org.maplibre.compose.interaction.CameraInputStart
-
 internal enum class CameraComponent {
   Pan,
   Zoom,
@@ -11,7 +9,7 @@ internal enum class CameraComponent {
 
 internal data class CameraConfiguration(
   val settings: CameraSettings = CameraSettings(),
-  val onStart: Map<CameraComponent, (CameraInputStart) -> Unit> = emptyMap(),
+  val onStart: Map<CameraComponent, () -> Unit> = emptyMap(),
 )
 
 internal data class CameraSettings(

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/ResolvedMappings.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/ResolvedMappings.kt
@@ -1,46 +1,11 @@
 package org.maplibre.compose.interaction.internal
 
 import androidx.compose.ui.input.key.Key
+import org.maplibre.compose.interaction.DragResponse
+import org.maplibre.compose.interaction.KeyResponse
 import org.maplibre.compose.interaction.ModifierMatch
-
-internal enum class DragResponse {
-  Pan,
-  RotateTilt,
-  FitBounds,
-  None,
-}
-
-internal enum class ScrollResponse {
-  Pan,
-  Zoom,
-  None,
-}
-
-internal enum class TapResponse {
-  ZoomIn,
-  ZoomOut,
-  None,
-}
-
-internal enum class KeyResponse {
-  PanLeft,
-  PanRight,
-  PanUp,
-  PanDown,
-  ZoomIn,
-  ZoomOut,
-  RotateLeft,
-  RotateRight,
-  TiltUp,
-  TiltDown,
-  Engage,
-  Disengage,
-  Back,
-  None;
-
-  val isCamera: Boolean
-    get() = this !in setOf(Engage, Disengage, Back, None)
-}
+import org.maplibre.compose.interaction.ScrollResponse
+import org.maplibre.compose.interaction.TapResponse
 
 internal data class DragMapping(val pattern: PointerPattern, val response: DragResponse)
 
@@ -53,6 +18,6 @@ internal data class TapMapping(val pattern: PointerPattern, val response: TapRes
 
 internal data class KeyMapping(
   val key: Key?,
-  val modifiers: ModifierMatch,
+  val modifiers: ModifierMatch?,
   val response: KeyResponse,
 )

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/RotaryGesture.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/RotaryGesture.kt
@@ -8,7 +8,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.maplibre.compose.camera.internal.CameraInputTarget
 import org.maplibre.compose.camera.internal.inputScaleBy
-import org.maplibre.compose.interaction.CameraInputOrigin
 
 /** Focused rotary input has its own burst; it does not resume a pointer's continuation. */
 internal class RotaryGesture(
@@ -42,7 +41,7 @@ internal class RotaryGesture(
 
           lateinit var created: GestureInputSession
           created =
-            GestureInputSession(scope, target, origin = CameraInputOrigin.Rotary) {
+            GestureInputSession(scope, target) {
               if (session === created) cancel()
             }
           created.also { session = it }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/ScrollGesture.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/ScrollGesture.kt
@@ -10,8 +10,8 @@ import kotlinx.coroutines.launch
 import org.maplibre.compose.camera.internal.CameraInputTarget
 import org.maplibre.compose.camera.internal.inputPanBy
 import org.maplibre.compose.camera.internal.inputScaleBy
-import org.maplibre.compose.interaction.CameraInputOrigin
 import org.maplibre.compose.interaction.MapInteractions
+import org.maplibre.compose.interaction.ScrollResponse
 
 /** Scroll shares the pointer arena so it sees consumption before claiming an event. */
 internal class ScrollGesture(
@@ -62,7 +62,7 @@ internal class ScrollGesture(
           takeOverContacts()
           lateinit var session: GestureInputSession
           session =
-            GestureInputSession(scope, target, origin = CameraInputOrigin.Scroll) {
+            GestureInputSession(scope, target) {
               if (burst?.session === session) cancel()
             }
           Burst(selected, session).also { burst = it }

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/camera/CameraInputTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/camera/CameraInputTest.kt
@@ -25,8 +25,6 @@ import org.maplibre.compose.camera.internal.inputRotateAndPitchBy
 import org.maplibre.compose.camera.internal.inputScaleBy
 import org.maplibre.compose.camera.internal.inputScaleByAwaitingTransition
 import org.maplibre.compose.interaction.CameraBuilder
-import org.maplibre.compose.interaction.CameraInputOrigin
-import org.maplibre.compose.interaction.CameraInputStart
 import org.maplibre.compose.interaction.ClickResult
 import org.maplibre.compose.interaction.MapInteractions
 import org.maplibre.compose.interaction.internal.CameraComponent
@@ -247,7 +245,7 @@ class CameraInputTest {
           }
           .build()
       )
-      val input = GestureInputSession(this, target, origin = CameraInputOrigin.Transform)
+      val input = GestureInputSession(this, target)
       target.inputPanBy(10.0, 20.0, gestureToken = input.token)
       target.inputScaleBy(2.0, DpOffset(10.dp, 20.dp), gestureToken = input.token)
       target.inputRotateAndPitchBy(
@@ -268,13 +266,13 @@ class CameraInputTest {
     }
 
   @Test
-  fun component_restarts_share_session_and_use_current_observer_without_cancelling_input() =
+  fun component_restarts_use_current_observer_without_cancelling_input() =
     cameraTest { state, target ->
-      val starts = mutableListOf<CameraInputStart>()
+      var starts = 0
       val initial =
-        CameraBuilder(CameraConfiguration()).apply { pan { onStart { starts += it } } }.build()
+        CameraBuilder(CameraConfiguration()).apply { pan { onStart { starts++ } } }.build()
       state.gestureAuthority.updateConfiguration(initial)
-      val input = GestureInputSession(this, target, origin = CameraInputOrigin.Transform)
+      val input = GestureInputSession(this, target)
       target.inputPanBy(1.0, 0.0, gestureToken = input.token)
       target.inputPanBy(2.0, 0.0, gestureToken = input.token)
       var replacement = 0
@@ -283,7 +281,7 @@ class CameraInputTest {
           .apply {
             pan {
               onStart {
-                starts += it
+                starts++
                 replacement++
               }
             }
@@ -294,13 +292,7 @@ class CameraInputTest {
       input.token.rearm(CameraComponent.Pan)
       target.inputPanBy(3.0, 0.0, gestureToken = input.token)
       assertEquals(1, replacement)
-      assertEquals(
-        listOf(
-          CameraInputStart(input.token.value, CameraInputOrigin.Transform),
-          CameraInputStart(input.token.value, CameraInputOrigin.Transform),
-        ),
-        starts,
-      )
+      assertEquals(2, starts)
       input.end()
       target.drain()
       runCurrent()

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/interaction/internal/InputMatchingTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/interaction/internal/InputMatchingTest.kt
@@ -16,7 +16,9 @@ class InputMatchingTest {
   @Test
   fun modifier_matching_distinguishes_any_exact_and_containing() {
     val ctrlShift = setOf(KeyModifier.Ctrl, KeyModifier.Shift)
-    assertTrue(ModifierMatch.Any.matches(ctrlShift))
+    assertTrue(
+      PointerPattern().matches(setOf(PointerType.Unknown), emptySet(), ctrlShift, contact = true)
+    )
     assertFalse(ModifierMatch.Exactly(KeyModifier.Ctrl).matches(ctrlShift))
     assertTrue(ModifierMatch.Containing(KeyModifier.Ctrl).matches(ctrlShift))
     assertFalse(ModifierMatch.Exactly().matches(ctrlShift))

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/interaction/internal/KeyInputTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/interaction/internal/KeyInputTest.kt
@@ -14,7 +14,6 @@ import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.maplibre.compose.camera.internal.CameraInputTarget
 import org.maplibre.compose.camera.internal.CameraInputToken
-import org.maplibre.compose.interaction.CameraInputStart
 import org.maplibre.compose.interaction.MapInteractions
 import org.maplibre.compose.map.GestureTestFixture
 
@@ -27,12 +26,12 @@ class MapKeyInputTest {
   @Test
   fun overlapping_keys_share_authority_and_components_rearm_only_after_their_last_release() =
     runTest {
-      val panStarts = mutableListOf<CameraInputStart>()
-      val zoomStarts = mutableListOf<CameraInputStart>()
+      var panStarts = 0
+      var zoomStarts = 0
       val options = MapInteractions {
         camera {
-          pan { onStart { panStarts += it } }
-          zoom { onStart { zoomStarts += it } }
+          pan { onStart { panStarts++ } }
+          zoom { onStart { zoomStarts++ } }
         }
       }
       map.target.updateConfiguration(options)
@@ -58,15 +57,14 @@ class MapKeyInputTest {
       down(Key.Plus)
       down(Key.DirectionLeft)
       assertEquals(1, map.target.startedCount)
-      assertEquals(1, panStarts.size)
-      assertEquals(panStarts.single().sessionId, zoomStarts.single().sessionId)
+      assertEquals(1, panStarts)
+      assertEquals(1, zoomStarts)
       up(Key.DirectionLeft)
       down(Key.DirectionRight)
-      assertEquals(1, panStarts.size)
+      assertEquals(1, panStarts)
       up(Key.DirectionRight)
       down(Key.DirectionRight)
-      assertEquals(2, panStarts.size)
-      assertEquals(panStarts.first().sessionId, panStarts.last().sessionId)
+      assertEquals(2, panStarts)
       up(Key.DirectionRight)
       assertEquals(0, map.target.endedCount)
       up(Key.Plus)

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/interaction/internal/MapInteractionsTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/interaction/internal/MapInteractionsTest.kt
@@ -11,10 +11,13 @@ import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import org.maplibre.compose.interaction.DragBindingBuilder
+import org.maplibre.compose.interaction.DragResponse
 import org.maplibre.compose.interaction.KeyModifier
+import org.maplibre.compose.interaction.KeyResponse
 import org.maplibre.compose.interaction.MapInteractions
 import org.maplibre.compose.interaction.ModifierMatch
 import org.maplibre.compose.interaction.PointerButton
+import org.maplibre.compose.interaction.ScrollResponse
 
 class MapInteractionsTest {
   private fun sample(
@@ -36,8 +39,8 @@ class MapInteractionsTest {
       bindings {
         scroll {
           mappings {
-            on { pan() }
-            otherwise { zoom() }
+            on(response = ScrollResponse.Pan)
+            otherwise(ScrollResponse.Zoom)
           }
         }
       }
@@ -50,8 +53,11 @@ class MapInteractionsTest {
       bindings {
         scroll {
           mappings {
-            on(modifiers = ModifierMatch.Containing(KeyModifier.Ctrl)) { none() }
-            otherwise { zoom() }
+            on(
+              modifiers = ModifierMatch.Containing(KeyModifier.Ctrl),
+              response = ScrollResponse.None,
+            )
+            otherwise(ScrollResponse.Zoom)
           }
         }
       }
@@ -66,7 +72,7 @@ class MapInteractionsTest {
           pan { enabled = !lockPan }
           zoom { enabled = lockPan }
         }
-        bindings { drag { mappings { otherwise { fitBounds() } } } }
+        bindings { drag { mappings { otherwise(DragResponse.FitBounds) } } }
       }
       assertNull(locked.bindings.drag.select(sample(), locked.camera.settings))
     }
@@ -148,9 +154,9 @@ class MapInteractionsTest {
       bindings {
         keys {
           mappings {
-            on(Key.Plus) { none() }
-            on(Key.Plus) { zoomIn() }
-            on(Key.Enter) { engage() }
+            on(Key.Plus, response = KeyResponse.None)
+            on(Key.Plus, response = KeyResponse.ZoomIn)
+            on(Key.Enter, response = KeyResponse.Engage)
           }
         }
       }
@@ -165,8 +171,8 @@ class MapInteractionsTest {
       bindings {
         keys {
           mappings {
-            on(Key.Plus) { zoomIn() }
-            on(Key.Enter) { engage() }
+            on(Key.Plus, response = KeyResponse.ZoomIn)
+            on(Key.Enter, response = KeyResponse.Engage)
           }
         }
       }
@@ -179,6 +185,42 @@ class MapInteractionsTest {
         MapInteractions.Standard.camera.settings,
       )
     )
+  }
+
+  @Test
+  fun null_modifiers_match_any_keys_and_restore_inherited_pointer_filters() {
+    val base = MapInteractions {
+      bindings {
+        transform { pan { modifiers = ModifierMatch.Exactly() } }
+        keys { mappings { on(Key.DirectionLeft, response = KeyResponse.PanLeft) } }
+      }
+    }
+    val modified = sample(type = PointerType.Touch, modifiers = setOf(KeyModifier.Alt))
+    assertFalse(base.bindings.transform.pan.matches(modified))
+    assertNull(
+      base.bindings.keys.select(Key.DirectionLeft, modified.modifierKeys, base.camera.settings)
+    )
+    val wildcard =
+      MapInteractions(from = base) {
+        bindings {
+          transform { pan { modifiers = null } }
+          keys {
+            mappings {
+              on(Key.DirectionLeft, modifiers = null, response = KeyResponse.PanLeft)
+            }
+          }
+        }
+      }
+    assertTrue(wildcard.bindings.transform.pan.matches(modified))
+    assertEquals(
+      KeyResponse.PanLeft,
+      wildcard.bindings.keys.select(
+        Key.DirectionLeft,
+        modified.modifierKeys,
+        wildcard.camera.settings,
+      ),
+    )
+    assertTrue(wildcard.hasCameraKeys)
   }
 
   @Test
@@ -198,29 +240,12 @@ class MapInteractionsTest {
     assertEquals(setOf(PointerType.Mouse), value.bindings.drag.pointerTypes)
     assertTrue(value.bindings.drag.enabled)
     assertFailsWith<IllegalArgumentException> {
-      MapInteractions { bindings { scroll { mappings { otherwise {} } } } }
-    }
-    assertFailsWith<IllegalArgumentException> {
       MapInteractions {
         bindings {
           scroll {
             mappings {
-              otherwise {
-                pan()
-                zoom()
-              }
-            }
-          }
-        }
-      }
-    }
-    assertFailsWith<IllegalArgumentException> {
-      MapInteractions {
-        bindings {
-          scroll {
-            mappings {
-              otherwise { pan() }
-              on { zoom() }
+              otherwise(ScrollResponse.Pan)
+              on(response = ScrollResponse.Zoom)
             }
           }
         }


### PR DESCRIPTION
## Description

Replace response sub-builders with public enums: `on(button = Primary, response = DragResponse.Pan)` and `otherwise(ScrollResponse.Zoom)`. A required argument replaces the runtime checks for exactly one response.

Use `null` for wildcard modifier filters, consistent with pointer types and buttons; key mappings still default to exactly no modifiers. Keep `onStart` as a component hook with no arguments and remove the unused session ID and input-origin metadata. Document that the hook can restart within a gesture and does not report movement completion. Update callers, examples, and regression tests.

## Validation

Passed `mise run check`, `mise run test:android`, `mise run test:desktop`, and `mise run test:js`. The library suites reported 305 Android host tests, 773 desktop tests (7 skipped), and 468 Chrome tests, with no failures. Android device and iOS tests were not run.

## AI assistance

Codex (GPT-6) implemented and validated the changes and drafted this description from the requested API simplifications. Human review is pending.
