### PR TITLE
Simplify style ownership and expose typed source handles

### DIFF
--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoAppState.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoAppState.kt
@@ -2,6 +2,7 @@ package org.maplibre.compose.demoapp
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
@@ -155,12 +156,13 @@ fun rememberDemoAppState(): DemoAppState {
   val mapState =
     rememberMapState(
       runtime = mapRuntime,
-      baseStyle = appliedStyle.base,
+      initialBaseStyle = appliedStyle.base,
       initialCameraPosition = StartPosition,
     ) {
       mapConfiguration.selectedDemo?.let { demo -> key(demo) { demo.MapContent() } }
       DemoLocationMapContent(location, locationState)
     }
+  SideEffect { mapState.style.baseStyle = appliedStyle.base }
   val frameRateState = remember { FrameRateState() }
   return remember {
     DemoAppState(mapRuntime, mapState, settings, location, frameRateState, mapConfiguration)

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/benchmark/BenchmarkMap.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/benchmark/BenchmarkMap.kt
@@ -10,6 +10,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.withFrameNanos
@@ -66,11 +67,12 @@ internal fun BenchmarkMap(state: DemoAppState, viewportInsets: MapViewportInsets
   val mapState =
     rememberMapState(
       runtime = state.mapRuntime,
-      baseStyle = scenario.style.base,
+      initialBaseStyle = scenario.style.base,
       initialCameraPosition = scenario.camera,
     ) {
       scenario.MapContent(session)
     }
+  SideEffect { mapState.style.baseStyle = scenario.style.base }
   val mapLoaded = remember(scenario.id) { CompletableDeferred<Unit>() }
   LaunchedEffect(mapState.style.loadState, mapLoaded) {
     when (val load = mapState.style.loadState) {

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/MagnifyingLensDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/MagnifyingLensDemo.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableDoubleStateOf
 import androidx.compose.runtime.mutableFloatStateOf
@@ -96,7 +97,9 @@ object MagnifyingLensDemo : Demo {
   @Composable
   override fun MapOverlayScope.Overlay(state: DemoAppState) {
     val appliedStyle = state.appliedStyle
-    val lensState = rememberMapState(runtime = state.mapRuntime, baseStyle = appliedStyle.base)
+    val lensState =
+      rememberMapState(runtime = state.mapRuntime, initialBaseStyle = appliedStyle.base)
+    SideEffect { lensState.style.baseStyle = appliedStyle.base }
     val density = LocalDensity.current
     val layoutDirection = LocalLayoutDirection.current
     val lensSizePx = with(density) { lensSize.dp.toPx() }

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/MapSnapshotterDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/MapSnapshotterDemo.kt
@@ -101,7 +101,7 @@ object MapSnapshotterDemo : Demo {
     val snapshotter =
       remember(state.mapRuntime, appliedBaseStyle) {
         state.mapRuntime.createSnapshotter(
-          baseStyle = appliedBaseStyle,
+          initialBaseStyle = appliedBaseStyle,
           content = { SnapshotMarker() },
         )
       }

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Composition.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Composition.kt
@@ -15,7 +15,7 @@ fun Composition() {
   val state =
     rememberMapState(
       runtime = runtime,
-      baseStyle = BaseStyle.Uri("https://tiles.openfreemap.org/styles/liberty"),
+      initialBaseStyle = BaseStyle.Uri("https://tiles.openfreemap.org/styles/liberty"),
     ) {
       // Sources and layers declared here are added to the base style.
     }

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Layers.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Layers.kt
@@ -33,7 +33,9 @@ import org.maplibre.spatialk.geojson.toJson
 fun Layers() {
   // #region simple
   val baseState =
-    rememberMapState(baseStyle = BaseStyle.Uri("https://tiles.openfreemap.org/styles/liberty")) {
+    rememberMapState(
+      initialBaseStyle = BaseStyle.Uri("https://tiles.openfreemap.org/styles/liberty")
+    ) {
       getBaseSource(id = "openmaptiles")?.let { tiles ->
         CircleLayer(id = "example", source = tiles, sourceLayer = "poi")
       }

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Snapshotter.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Snapshotter.kt
@@ -23,7 +23,7 @@ suspend fun captureCurrentMap(
 ): ImageBitmap {
   val snapshotter =
     runtime.createSnapshotter(
-      baseStyle = mapState.style.baseStyle,
+      initialBaseStyle = mapState.style.baseStyle,
       content = content,
     )
   return try {

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Styling.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Styling.kt
@@ -4,6 +4,7 @@ package org.maplibre.compose.docsnippets
 
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
 import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.maplibre.compose.demoapp.generated.Res
 import org.maplibre.compose.map.MaplibreMap
@@ -15,21 +16,22 @@ import org.maplibre.compose.style.BaseStyle
 fun Styling() {
   // #region simple
   val simple =
-    rememberMapState(baseStyle = BaseStyle.Uri("https://tiles.openfreemap.org/styles/liberty"))
+    rememberMapState(
+      initialBaseStyle = BaseStyle.Uri("https://tiles.openfreemap.org/styles/liberty")
+    )
   MaplibreMap(state = simple)
   // #endregion simple
 
   // #region dynamic
   val variant = if (isSystemInDarkTheme()) "dark" else "light"
-  val dynamic =
-    rememberMapState(
-      baseStyle = BaseStyle.Uri("https://api.protomaps.com/styles/v4/$variant/en.json?key=MY_KEY")
-    )
+  val baseStyle = BaseStyle.Uri("https://api.protomaps.com/styles/v4/$variant/en.json?key=MY_KEY")
+  val dynamic = rememberMapState(initialBaseStyle = baseStyle)
+  SideEffect { dynamic.style.baseStyle = baseStyle }
   MaplibreMap(state = dynamic)
   // #endregion dynamic
 
   // #region local
-  val local = rememberMapState(baseStyle = BaseStyle.Uri(Res.getUri("files/style.json")))
+  val local = rememberMapState(initialBaseStyle = BaseStyle.Uri(Res.getUri("files/style.json")))
   MaplibreMap(state = local)
   // #endregion local
 }

--- a/docs/src/content/docs/composition.mdx
+++ b/docs/src/content/docs/composition.mdx
@@ -16,7 +16,7 @@ viewport, projection, and feature-query operations while the map is attached.
 
 ## The style is base plus content
 
-A MapLibre style is a document with sources and layers. The `baseStyle`
+A MapLibre style is a document with sources and layers. The `initialBaseStyle`
 parameter loads that document without modification. The trailing
 <Api of="rememberMapState" /> block declares your sources, layers, and their
 positions in the layer stack.
@@ -25,7 +25,18 @@ positions in the layer stack.
 
 The library manages the sources and layers in the style block. It
 does not modify the rest of the base style. To change a base style layer,
-replace it with <Api of="Anchor.Replace" /> and declare its replacement yourself.
+use its handle in `mapState.style.layers`, or replace it with
+<Api of="Anchor.Replace" /> and declare its replacement yourself.
+
+`initialBaseStyle` seeds the map once. Changing that input does not reload the
+remembered map; assign `mapState.style.baseStyle` to switch styles.
+
+Composition owns the definitions and lifetimes of declared sources, layers, and
+images. Handles reject definition writes and removal commands for those resources.
+Use `mapState.style.sources[source]` to obtain a declared source's typed handle for
+feature state, cluster queries, and invalidation. These runtime operations do not
+change its declared definition. Handles belong to one loaded style generation;
+look them up again after a style reload or resource replacement.
 
 ## Recomposition updates the style
 
@@ -40,7 +51,7 @@ current state, and let the runtime reconcile it.
 
 ## Style switches re-apply your content
 
-When the `baseStyle` input changes, the map loads the new style and evaluates
+When you assign `mapState.style.baseStyle`, the map loads the new style and evaluates
 the style block against it. Each evaluation declares your
 sources and layers against the new style. They persist across the switch
 without extra code. An `Anchor` that names a base layer applies only when that

--- a/docs/src/content/docs/styling.mdx
+++ b/docs/src/content/docs/styling.mdx
@@ -27,8 +27,8 @@ Create a <Api of="MapState" /> with the style URI as its initial
 
 ## Switch styles at runtime
 
-Select a style with regular Compose logic. The map animates the transition
-between styles. For example, select a style from the system theme:
+Assign `mapState.style.baseStyle` to switch styles. To follow Compose state such
+as the system theme, assign it in a `SideEffect`:
 
 <Code code={region(styling, "dynamic")} lang="kotlin" title="App.kt" />
 

--- a/lib/maplibre-compose/src/androidDeviceTest/kotlin/org/maplibre/compose/camera/AndroidMapStateRecreationTest.kt
+++ b/lib/maplibre-compose/src/androidDeviceTest/kotlin/org/maplibre/compose/camera/AndroidMapStateRecreationTest.kt
@@ -122,7 +122,7 @@ class MapStateRecreationActivity : ComponentActivity() {
     setContent {
       val firstRuntime: MapRuntime = DefaultMapRuntime.instance
       val secondRuntime: MapRuntime = DefaultMapRuntime.instance
-      val state = rememberMapState(firstRuntime, baseStyle = BaseStyle.Empty)
+      val state = rememberMapState(firstRuntime, initialBaseStyle = BaseStyle.Empty)
       SideEffect {
         mapState = state
         defaultRuntimeIsShared = firstRuntime === secondRuntime

--- a/lib/maplibre-compose/src/androidDeviceTest/kotlin/org/maplibre/compose/map/AndroidExplicitRuntimeTest.kt
+++ b/lib/maplibre-compose/src/androidDeviceTest/kotlin/org/maplibre/compose/map/AndroidExplicitRuntimeTest.kt
@@ -20,7 +20,7 @@ class AndroidExplicitRuntimeTest {
       createMapRuntime(
         MapRuntimeOptions(cacheFile = Path(cacheDirectory.resolve("cache.db").absolutePath))
       )
-    val state = runtime.createMapState(baseStyle = BaseStyle.Empty)
+    val state = runtime.createMapState(initialBaseStyle = BaseStyle.Empty)
 
     try {
       assertSame(context.applicationContext, AndroidMlnFfiPlatform.applicationContext)

--- a/lib/maplibre-compose/src/androidDeviceTest/kotlin/org/maplibre/compose/mlnffi/AndroidSurfaceReplacementTest.kt
+++ b/lib/maplibre-compose/src/androidDeviceTest/kotlin/org/maplibre/compose/mlnffi/AndroidSurfaceReplacementTest.kt
@@ -248,7 +248,7 @@ private fun TestMap(
   onPresentation: () -> Unit,
   onFrame: () -> Unit,
 ) {
-  val state = rememberMapState(baseStyle = SOLID_STYLE)
+  val state = rememberMapState(initialBaseStyle = SOLID_STYLE)
   LaunchedEffect(state) {
     onState(state)
     snapshotFlow { state.currentMapAttachment }.first { it != null }

--- a/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/layers/LayerClickOrderTest.kt
+++ b/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/layers/LayerClickOrderTest.kt
@@ -136,7 +136,7 @@ class LayerClickOrderTest {
       mapState =
         rememberMapState(
           initialCameraPosition = CameraPosition(target = Position(0.0, 0.0), zoom = START_ZOOM),
-          baseStyle = BaseStyle.Empty,
+          initialBaseStyle = BaseStyle.Empty,
         ) {
           val source = rememberGeoJsonSource(data = GeoJsonData.JsonString(WORLD_POLYGON))
 

--- a/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MlnFfiMapCompositionTest.kt
+++ b/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MlnFfiMapCompositionTest.kt
@@ -96,7 +96,8 @@ class MlnFfiMapCompositionTest {
     runFfiComposeUiTest {
       val runtime = createMapRuntime(runtimeOptions)
       val start = CameraPosition(target = Position(0.0, 0.0), zoom = 12.0, tilt = 60.0)
-      val state = runtime.createMapState(baseStyle = BaseStyle.Empty, initialCameraPosition = start)
+      val state =
+        runtime.createMapState(initialBaseStyle = BaseStyle.Empty, initialCameraPosition = start)
       var configuration by mutableStateOf(MapInteractions.None)
       var density = 1f
       try {
@@ -176,7 +177,7 @@ class MlnFfiMapCompositionTest {
   @Test
   fun map_state_renders_a_base_style_and_publishes_one_presentation() = runFfiComposeUiTest {
     val runtime = createMapRuntime(runtimeOptions)
-    val state = runtime.createMapState(baseStyle = BaseStyle.Empty)
+    val state = runtime.createMapState(initialBaseStyle = BaseStyle.Empty)
 
     setFfiTestMapContent(runtimeOptions) { MaplibreMap(state = state) }
     waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) {
@@ -198,7 +199,7 @@ class MlnFfiMapCompositionTest {
   @Test
   fun focus_modifiers_on_the_map_modifier_reach_the_input_node() = runFfiComposeUiTest {
     val runtime = createMapRuntime(runtimeOptions)
-    val state = runtime.createMapState(baseStyle = BaseStyle.Empty)
+    val state = runtime.createMapState(initialBaseStyle = BaseStyle.Empty)
     val focusRequester = FocusRequester()
     val hasFocus = AtomicBoolean(false)
 
@@ -231,7 +232,7 @@ class MlnFfiMapCompositionTest {
     val state =
       runtime.createMapState(
         initialCameraPosition = CameraPosition(zoom = 1.0),
-        baseStyle = BaseStyle.Empty,
+        initialBaseStyle = BaseStyle.Empty,
       )
     var constraints by mutableStateOf(CameraConstraints())
 
@@ -273,8 +274,8 @@ class MlnFfiMapCompositionTest {
         onDispose {}
       }
     }
-    val first = runtime.createMapState(baseStyle = BaseStyle.Empty, content = content)
-    val second = runtime.createMapState(baseStyle = BaseStyle.Empty, content = content)
+    val first = runtime.createMapState(initialBaseStyle = BaseStyle.Empty, content = content)
+    val second = runtime.createMapState(initialBaseStyle = BaseStyle.Empty, content = content)
 
     setFfiTestMapContent(runtimeOptions, presentationCount = 2) {
       if (showFirst) {
@@ -332,7 +333,7 @@ class MlnFfiMapCompositionTest {
           onDispose {}
         }
       }
-      val state = runtime.createMapState(baseStyle = BaseStyle.Empty, content = content)
+      val state = runtime.createMapState(initialBaseStyle = BaseStyle.Empty, content = content)
 
       setFfiTestMapContent(runtimeOptions) { MaplibreMap(state = state) }
       waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) {
@@ -359,7 +360,7 @@ class MlnFfiMapCompositionTest {
       var presented by mutableStateOf(true)
       var latest by mutableStateOf(false)
       val state =
-        runtime.createMapState(baseStyle = BaseStyle.Empty) {
+        runtime.createMapState(initialBaseStyle = BaseStyle.Empty) {
           BackgroundLayer(
             id = if (latest) "latest-background" else "initial-background",
             color = const(if (latest) Color.Blue else Color.Red),
@@ -405,7 +406,7 @@ class MlnFfiMapCompositionTest {
       val runtime = createMapRuntime(runtimeOptions)
       var invalidAnchor by mutableStateOf(true)
       val state =
-        runtime.createMapState(baseStyle = BaseStyle.Empty) {
+        runtime.createMapState(initialBaseStyle = BaseStyle.Empty) {
           if (invalidAnchor) {
             Anchor.Below("missing-base-layer") {
               BackgroundLayer(id = "application-background", color = const(Color.Red))
@@ -441,7 +442,8 @@ class MlnFfiMapCompositionTest {
   fun a_map_state_retains_its_native_map_between_presentations() = runFfiComposeUiTest {
     val runtime = createMapRuntime(runtimeOptions)
     val camera = CameraPosition(target = Position(longitude = 11.0, latitude = 47.0), zoom = 6.0)
-    val state = runtime.createMapState(initialCameraPosition = camera, baseStyle = BaseStyle.Empty)
+    val state =
+      runtime.createMapState(initialCameraPosition = camera, initialBaseStyle = BaseStyle.Empty)
     var presented by mutableStateOf(true)
 
     setFfiTestMapContent(runtimeOptions, presentationCount = 2) {
@@ -489,7 +491,7 @@ class MlnFfiMapCompositionTest {
       val state =
         runtime.createMapState(
           initialCameraPosition = camera,
-          baseStyle = REPLACEMENT_STYLE,
+          initialBaseStyle = REPLACEMENT_STYLE,
         )
       var presented by mutableStateOf(true)
       var scaleFactor by mutableStateOf(1f)
@@ -547,7 +549,7 @@ class MlnFfiMapCompositionTest {
       BaseStyle.Json("""{"version":8,"sources":{},"layers":[{"id":"bg-a","type":"background"}]}""")
     val second =
       BaseStyle.Json("""{"version":8,"sources":{},"layers":[{"id":"bg-b","type":"background"}]}""")
-    val state = runtime.createMapState(baseStyle = first)
+    val state = runtime.createMapState(initialBaseStyle = first)
 
     setFfiTestMapContent(runtimeOptions) { MaplibreMap(state = state) }
     waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) {
@@ -579,7 +581,7 @@ class MlnFfiMapCompositionTest {
   @Test
   fun a_failed_replacement_style_hides_the_native_map() = runFfiComposeUiTest {
     val runtime = createMapRuntime(runtimeOptions)
-    val state = runtime.createMapState(baseStyle = BaseStyle.Empty)
+    val state = runtime.createMapState(initialBaseStyle = BaseStyle.Empty)
 
     setFfiTestMapContent(runtimeOptions) { MaplibreMap(state = state) }
     waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) {
@@ -830,7 +832,7 @@ private fun TestMap(
   val state =
     rememberMapState(
       initialCameraPosition = initialCameraPosition,
-      baseStyle = baseStyle,
+      initialBaseStyle = baseStyle,
     ) {
       content()
     }

--- a/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MlnFfiStyleSwitchTest.kt
+++ b/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MlnFfiStyleSwitchTest.kt
@@ -58,7 +58,7 @@ class MlnFfiStyleSwitchTest {
     var style by mutableStateOf(STYLES[0])
     var extraLayer by mutableStateOf(false)
     val state =
-      runtime.createMapState(baseStyle = STYLES[0].base) {
+      runtime.createMapState(initialBaseStyle = STYLES[0].base) {
         val points = rememberGeoJsonSource(data = GeoJsonData.Features(pointAt(longitude = 0.0)))
         // Two layers on one source at different anchors, so the re-add order matters.
         CircleLayer(id = "user-circles", source = points, color = const(Color.Red))
@@ -113,7 +113,7 @@ class MlnFfiStyleSwitchTest {
     var sourceLayer by mutableStateOf("places")
     var showReplacement by mutableStateOf(true)
     val state =
-      runtime.createMapState(baseStyle = REPLACEMENT_STYLES[0]) {
+      runtime.createMapState(initialBaseStyle = REPLACEMENT_STYLES[0]) {
         val points = rememberGeoJsonSource(data = GeoJsonData.Features(pointAt(longitude = 0.0)))
         if (showReplacement) {
           Anchor.Replace("base-slot") {
@@ -186,7 +186,7 @@ class MlnFfiStyleSwitchTest {
       )
     var showLatestLayer by mutableStateOf(false)
     val state =
-      runtime.createMapState(baseStyle = INITIAL_STYLE) {
+      runtime.createMapState(initialBaseStyle = INITIAL_STYLE) {
         if (showLatestLayer) {
           Anchor.Below("base-c") {
             BackgroundLayer(id = "user-latest", color = const(Color.Blue))

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/Anchor.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/Anchor.kt
@@ -17,9 +17,9 @@ internal val LocalAnchor: ProvidableCompositionLocal<Anchor> = compositionLocalO
  * in the base style JSON rather than exclusively on top of these.
  *
  * **Note:** This mechanism can only be used to anchor layers at `layerId`s from the *base map
- * style* referred to in the `baseStyle` parameter of the
- * [MapLibreMap][org.maplibre.compose.map.MaplibreMap] composable. Anchoring layers defined in the
- * composition to other layers defined in the composition is not possible.
+ * style* loaded by [MapStyleState.baseStyle][org.maplibre.compose.map.MapStyleState.baseStyle].
+ * Anchoring layers defined in the composition to other layers defined in the composition is not
+ * possible.
  *
  * See [Anchor.Companion] for [Composable] functions to use in the layers composition.
  */

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/LayerHandle.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/LayerHandle.kt
@@ -15,7 +15,12 @@ import org.maplibre.compose.style.scaledBy
 import org.maplibre.compose.style.toTransitionJson
 import org.maplibre.compose.style.toTransitionOptions
 
-/** Provides imperative property access to a layer for one loaded base-style generation. */
+/**
+ * Provides property access to a layer for one loaded base-style generation.
+ *
+ * Style content owns all properties of declared layers. Their properties can be read, but setter
+ * calls and [clearFilter] throw [StyleHandleException]. Base-style layers also permit writes.
+ */
 public class LayerHandle
 internal constructor(
   public val id: String,
@@ -104,6 +109,7 @@ internal constructor(
   }
 
   private inline fun mutate(property: String, action: () -> Unit) {
+    operations.requireLayerWritable(id)
     try {
       action()
     } catch (error: StyleMutationException) {

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -114,27 +113,27 @@ public interface MapRuntime {
   public val offlineManager: OfflineManager
 
   /**
-   * Creates a logical map with [baseStyle] and the sources, layers, and images that [content]
-   * declares. The caller must close the result.
+   * Creates a logical map with [initialBaseStyle] and the sources, layers, and images that
+   * [content] declares. The caller must close the result.
    *
    * [content] reads the returned state through [LocalMapState] and its viewport through
    * [LocalViewport].
    */
   public fun createMapState(
-    baseStyle: BaseStyle,
+    initialBaseStyle: BaseStyle,
     initialCameraPosition: CameraPosition = CameraPosition(),
     content: @Composable @MaplibreComposable () -> Unit = {},
   ): MapState
 
   /**
-   * Creates an independent non-UI map with [baseStyle] and the sources, layers, and images that
-   * [content] declares, for image capture. The caller must close the result.
+   * Creates an independent non-UI map with [initialBaseStyle] and the sources, layers, and images
+   * that [content] declares, for image capture. The caller must close the result.
    *
    * [content] reads the viewport of each capture request through [LocalViewport]. It has no
    * [MapState], so [LocalMapState] is null.
    */
   public fun createSnapshotter(
-    baseStyle: BaseStyle,
+    initialBaseStyle: BaseStyle,
     content: @Composable @MaplibreComposable () -> Unit = {},
   ): MapSnapshotter
 
@@ -172,6 +171,10 @@ internal interface MapStyleStateOwner {
 
   fun desiredSourceDefinition(id: String): org.maplibre.compose.style.SourceDefinition?
 
+  fun requireSourceWritable(id: String)
+
+  fun requireLayerWritable(id: String)
+
   fun addStyleSource(source: Source): SourceHandle
 
   fun removeStyleSource(id: String): Boolean
@@ -200,6 +203,9 @@ public class MapStyleState internal constructor(initialBaseStyle: BaseStyle) {
   private var baseStyleState: BaseStyle by
     mutableStateOf(initialBaseStyle, structuralEqualityPolicy())
 
+  /**
+   * The current base style. Assigning a new value loads it and replaces generation-bound resources.
+   */
   public var baseStyle: BaseStyle
     get() = baseStyleState
     set(value) {
@@ -435,6 +441,14 @@ public class MapStyleState internal constructor(initialBaseStyle: BaseStyle) {
     object : StyleHandleOperationGuard {
       override fun <T> run(action: () -> T): T =
         owner?.runStyleHandleOperation(style, action) ?: action()
+
+      override fun requireSourceWritable(id: String) {
+        owner?.requireSourceWritable(id)
+      }
+
+      override fun requireLayerWritable(id: String) {
+        owner?.requireLayerWritable(id)
+      }
 
       override fun checkpoint(): Long = owner?.styleHandleCheckpoint(style) ?: 0L
 
@@ -732,6 +746,16 @@ internal constructor(
 
           override fun desiredSourceDefinition(id: String) =
             this@MapState.desiredSourceDefinition(id)
+
+          override fun requireSourceWritable(id: String) = lifecycle.serialized {
+            requireNoDesiredSource(id)
+          }
+
+          override fun requireLayerWritable(id: String) = lifecycle.serialized {
+            if (desiredStyleRevision.layers.any { it.definition.id == id }) {
+              throw StyleHandleException("Layer ID '$id' is declared by the style content")
+            }
+          }
 
           override fun addStyleSource(source: Source) = this@MapState.addStyleSource(source)
 
@@ -1764,8 +1788,10 @@ internal class MapPresentationOwnerToken
 /**
  * Remembers a logical map and closes it when this call leaves composition.
  *
- * [baseStyle] and [content] define the desired style. Changes to these inputs update the remembered
- * map. Restoration creates a new map with the saved camera position and the current style inputs.
+ * [initialBaseStyle] and [initialCameraPosition] seed the map. Changes to these inputs do not
+ * update it; use [MapStyleState.baseStyle] and [MapState.setCameraPosition]. Changes to [content]
+ * update the declared resources. Restoration creates a new map with the saved camera position and
+ * the current [initialBaseStyle].
  *
  * [content] declares the map's sources, layers, and images. It reads the returned state through
  * [LocalMapState] and its viewport through [LocalViewport].
@@ -1773,30 +1799,27 @@ internal class MapPresentationOwnerToken
 @Composable
 public fun rememberMapState(
   runtime: MapRuntime = DefaultMapRuntime.instance,
-  baseStyle: BaseStyle = BaseStyle.Demo,
+  initialBaseStyle: BaseStyle = BaseStyle.Demo,
   initialCameraPosition: CameraPosition = CameraPosition(),
   content: @Composable @MaplibreComposable () -> Unit = {},
 ): MapState {
   val currentContent by rememberUpdatedState(content)
   val stableContent = remember<@Composable @MaplibreComposable () -> Unit> { { currentContent() } }
   val state =
-    rememberSaveable(runtime, saver = mapStateSaver(runtime, baseStyle, stableContent)) {
+    rememberSaveable(runtime, saver = mapStateSaver(runtime, initialBaseStyle, stableContent)) {
       runtime.createMapState(
-        baseStyle = baseStyle,
+        initialBaseStyle = initialBaseStyle,
         initialCameraPosition = initialCameraPosition,
         content = stableContent,
       )
     }
-  SideEffect {
-    if (state.style.baseStyle != baseStyle) state.style.baseStyle = baseStyle
-  }
   DisposableEffect(state) { onDispose { state.close() } }
   return state
 }
 
 private fun mapStateSaver(
   runtime: MapRuntime,
-  baseStyle: BaseStyle,
+  initialBaseStyle: BaseStyle,
   content: @Composable @MaplibreComposable () -> Unit,
 ): Saver<MapState, List<Double>> =
   Saver(
@@ -1808,7 +1831,7 @@ private fun mapStateSaver(
     restore = { values ->
       require(values.size == 5) { "A saved camera position must contain five values" }
       runtime.createMapState(
-        baseStyle = baseStyle,
+        initialBaseStyle = initialBaseStyle,
         initialCameraPosition =
           CameraPosition(
             bearing = values[0],
@@ -1845,20 +1868,20 @@ internal class RuntimeImplementation(
   private var closedState: Boolean by mutableStateOf(false)
 
   final override fun createMapState(
-    baseStyle: BaseStyle,
+    initialBaseStyle: BaseStyle,
     initialCameraPosition: CameraPosition,
     content: @Composable @MaplibreComposable () -> Unit,
   ): MapState = lock.withLock {
     requireOpenLocked()
-    MapState(this, initialCameraPosition, baseStyle, content).also(children::add)
+    MapState(this, initialCameraPosition, initialBaseStyle, content).also(children::add)
   }
 
   final override fun createSnapshotter(
-    baseStyle: BaseStyle,
+    initialBaseStyle: BaseStyle,
     content: @Composable @MaplibreComposable () -> Unit,
   ): MapSnapshotter = lock.withLock {
     requireOpenLocked()
-    MapSnapshotterImplementation(this, baseStyle, content).also(snapshotters::add)
+    MapSnapshotterImplementation(this, initialBaseStyle, content).also(snapshotters::add)
   }
 
   private fun requireOpen() {

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapSnapshotter.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapSnapshotter.kt
@@ -247,6 +247,16 @@ internal class MapSnapshotterImplementation(
           override fun desiredSourceDefinition(id: String) =
             this@MapSnapshotterImplementation.desiredSourceDefinition(id)
 
+          override fun requireSourceWritable(id: String) = lock.withLock {
+            requireNoDesiredSource(id)
+          }
+
+          override fun requireLayerWritable(id: String) = lock.withLock {
+            if (desiredRevision.layers.any { it.definition.id == id }) {
+              throw StyleHandleException("Layer ID '$id' is declared by the style content")
+            }
+          }
+
           override fun addStyleSource(source: Source) =
             this@MapSnapshotterImplementation.addStyleSource(source)
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapStyleResources.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapStyleResources.kt
@@ -4,8 +4,24 @@ import androidx.compose.runtime.Stable
 import androidx.compose.ui.graphics.ImageBitmap
 import kotlinx.serialization.json.JsonElement
 import org.maplibre.compose.layers.LayerHandle
+import org.maplibre.compose.sources.CustomGeometrySource
+import org.maplibre.compose.sources.CustomGeometrySourceHandle
+import org.maplibre.compose.sources.CustomVectorSource
+import org.maplibre.compose.sources.CustomVectorSourceHandle
+import org.maplibre.compose.sources.GeoJsonSource
+import org.maplibre.compose.sources.GeoJsonSourceHandle
+import org.maplibre.compose.sources.ImageSource
+import org.maplibre.compose.sources.ImageSourceHandle
+import org.maplibre.compose.sources.RasterDemSource
+import org.maplibre.compose.sources.RasterDemSourceHandle
+import org.maplibre.compose.sources.RasterSource
+import org.maplibre.compose.sources.RasterSourceHandle
 import org.maplibre.compose.sources.Source
 import org.maplibre.compose.sources.SourceHandle
+import org.maplibre.compose.sources.UnknownSource
+import org.maplibre.compose.sources.UnknownSourceHandle
+import org.maplibre.compose.sources.VectorSource
+import org.maplibre.compose.sources.VectorSourceHandle
 import org.maplibre.compose.style.Light
 import org.maplibre.compose.style.Projection
 import org.maplibre.compose.style.Sky
@@ -18,6 +34,45 @@ public class StyleSources internal constructor(private val style: MapStyleState)
   Iterable<SourceHandle> {
   /** Returns the current generation's handle for [id], or null when unavailable or absent. */
   public operator fun get(id: String): SourceHandle? = style.sourceHandle(id)
+
+  /**
+   * Returns the current handle with [source]'s ID, or null while absent or no style is ready. A
+   * remembered source is installed only while a declared layer references it. Look up a new handle
+   * after a base-style reload or source replacement.
+   */
+  public operator fun get(source: Source): SourceHandle? = get(source.id)
+
+  /** Returns the current handle with [source]'s ID and type, or null while unavailable. */
+  public operator fun get(source: GeoJsonSource): GeoJsonSourceHandle? =
+    get(source.id) as? GeoJsonSourceHandle
+
+  /** Returns the current handle with [source]'s ID and type, or null while unavailable. */
+  public operator fun get(source: ImageSource): ImageSourceHandle? =
+    get(source.id) as? ImageSourceHandle
+
+  /** Returns the current handle with [source]'s ID and type, or null while unavailable. */
+  public operator fun get(source: VectorSource): VectorSourceHandle? =
+    get(source.id) as? VectorSourceHandle
+
+  /** Returns the current handle with [source]'s ID and type, or null while unavailable. */
+  public operator fun get(source: RasterSource): RasterSourceHandle? =
+    get(source.id) as? RasterSourceHandle
+
+  /** Returns the current handle with [source]'s ID and type, or null while unavailable. */
+  public operator fun get(source: RasterDemSource): RasterDemSourceHandle? =
+    get(source.id) as? RasterDemSourceHandle
+
+  /** Returns the current handle with [source]'s ID and type, or null while unavailable. */
+  public operator fun get(source: CustomGeometrySource): CustomGeometrySourceHandle? =
+    get(source.id) as? CustomGeometrySourceHandle
+
+  /** Returns the current handle with [source]'s ID and type, or null while unavailable. */
+  public operator fun get(source: CustomVectorSource): CustomVectorSourceHandle? =
+    get(source.id) as? CustomVectorSourceHandle
+
+  /** Returns the current handle with [source]'s ID and type, or null while unavailable. */
+  public operator fun get(source: UnknownSource): UnknownSourceHandle? =
+    get(source.id) as? UnknownSourceHandle
 
   /** Adds [source] to the current loaded-style generation and returns its handle. */
   public fun add(source: Source): SourceHandle = style.requireOwner().addStyleSource(source)

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/sources/Source.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/sources/Source.kt
@@ -29,8 +29,7 @@ public sealed class Source(internal val id: String) {
 }
 
 /**
- * Get the source with the given [id] from the base style specified via the `baseStyle` parameter in
- * [MaplibreMap][org.maplibre.compose.map.MaplibreMap].
+ * Get the source with the given [id] from the base style of the current loaded style.
  *
  * @throws IllegalStateException if the source does not exist
  */

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/sources/SourceHandle.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/sources/SourceHandle.kt
@@ -18,7 +18,14 @@ import org.maplibre.spatialk.geojson.Feature
 import org.maplibre.spatialk.geojson.FeatureCollection
 import org.maplibre.spatialk.geojson.Geometry
 
-/** Provides imperative access to a source for one loaded base-style generation. */
+/**
+ * Provides access to a source for one loaded base-style generation.
+ *
+ * Style content owns the definitions of declared sources: attempts to replace their data, image,
+ * URI, or bounds throw [StyleHandleException]. Feature state, queries, and invalidation remain
+ * available. Base-style sources and sources added through
+ * [org.maplibre.compose.map.StyleSources.add] also permit definition writes.
+ */
 public sealed class SourceHandle
 protected constructor(
   public val id: String,
@@ -66,6 +73,11 @@ protected constructor(
     action()
   }
 
+  protected fun definitionOperation(action: () -> Unit): Unit = operation {
+    operations.requireSourceWritable(id)
+    action()
+  }
+
   protected suspend fun <T> suspendingOperation(action: suspend () -> T): T {
     val checkpoint = operations.checkpoint()
     operation {}
@@ -109,10 +121,11 @@ internal constructor(
    * data. The source's currently applied options determine this behavior, including after source
    * replacement. The browser ignores this option.
    *
-   * @throws StyleHandleException if submission or synchronous preparation or installation fails.
+   * @throws StyleHandleException if style content declares this source, or submission or
+   *   synchronous preparation or installation fails.
    */
   public fun setData(data: GeoJsonData) {
-    operation {
+    definitionOperation {
       mutate("set data") { style.submitGeoJsonData(id, data, options) }
     }
   }
@@ -263,9 +276,13 @@ internal constructor(
   currentKind: () -> String?,
   operations: StyleHandleOperationGuard,
 ) : SourceHandle(id, style, "image", currentKind, operations) {
-  /** Updates the geographic corners of the image. */
+  /**
+   * Updates the geographic corners of the image.
+   *
+   * @throws StyleHandleException if style content declares this source.
+   */
   public fun setBounds(bounds: PositionQuad) {
-    operation {
+    definitionOperation {
       style.setImageSourceCoordinates(
         id,
         listOf(bounds.topLeft, bounds.topRight, bounds.bottomRight, bounds.bottomLeft),
@@ -273,14 +290,22 @@ internal constructor(
     }
   }
 
-  /** Replaces the source image with [image]. */
+  /**
+   * Replaces the source image with [image].
+   *
+   * @throws StyleHandleException if style content declares this source.
+   */
   public fun setImage(image: ImageBitmap) {
-    operation { style.setImageSourceImage(id, image) }
+    definitionOperation { style.setImageSourceImage(id, image) }
   }
 
-  /** Replaces the source image URI with [uri]. */
+  /**
+   * Replaces the source image URI with [uri].
+   *
+   * @throws StyleHandleException if style content declares this source.
+   */
   public fun setUri(uri: String) {
-    operation { style.setImageSourceUrl(id, uri) }
+    definitionOperation { style.setImageSourceUrl(id, uri) }
   }
 }
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleHandleException.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleHandleException.kt
@@ -7,6 +7,10 @@ public class StyleHandleException(message: String, cause: Throwable? = null) :
 internal interface StyleHandleOperationGuard {
   fun <T> run(action: () -> T): T
 
+  fun requireSourceWritable(id: String)
+
+  fun requireLayerWritable(id: String)
+
   fun checkpoint(): Long
 
   fun requireUnchanged(checkpoint: Long)

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
@@ -1102,7 +1102,7 @@ class MapPresentationTest {
     val initialCamera = CameraPosition(target = Position(12.0, 34.0), zoom = 8.0)
     val state =
       runtime.createMapState(
-        baseStyle = BaseStyle.Demo,
+        initialBaseStyle = BaseStyle.Demo,
         initialCameraPosition = initialCamera,
       )
     val token = state.reservePresentation()

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserMapLifecycleTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserMapLifecycleTest.kt
@@ -74,7 +74,7 @@ class BrowserMapLifecycleTest {
       val state =
         runtime.createMapState(
           initialCameraPosition = initialCamera,
-          baseStyle = STYLE_A,
+          initialBaseStyle = STYLE_A,
         )
       val presented = mutableStateOf(true)
 

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserMapStyleStateTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserMapStyleStateTest.kt
@@ -132,7 +132,7 @@ class BrowserMapStyleStateTest {
       val presented = mutableStateOf(true)
       val useLatestRevision = mutableStateOf(false)
       val state =
-        runtime.createMapState(baseStyle = STYLE_A) {
+        runtime.createMapState(initialBaseStyle = STYLE_A) {
           val suffix = if (useLatestRevision.value) "latest" else "initial"
           RasterLayer(
             id = "$suffix-overlay",
@@ -208,7 +208,7 @@ class BrowserMapStyleStateTest {
   fun a_web_presentation_waits_for_a_viewport_and_survives_style_failure(): Promise<*> =
     runBrowserMapTest {
       val runtime = createMapRuntime(MapRuntimeOptions())
-      val state = runtime.createMapState(baseStyle = STYLE_A)
+      val state = runtime.createMapState(initialBaseStyle = STYLE_A)
       val size = mutableStateOf(0.dp)
 
       setBrowserMapContent { MaplibreMap(state = state, modifier = Modifier.size(size.value)) }
@@ -245,7 +245,7 @@ class BrowserMapStyleStateTest {
     Promise<*> = runBrowserMapTest {
     val runtime = createMapRuntime(MapRuntimeOptions())
     val state =
-      runtime.createMapState(baseStyle = STYLE_A) {
+      runtime.createMapState(initialBaseStyle = STYLE_A) {
         BackgroundLayer(id = "application", color = const(Color.Red))
       }
 
@@ -318,7 +318,7 @@ class BrowserMapStyleStateTest {
       var styleState: MapStyleState? = null
       var mapState: MapState? = null
       setBrowserMapContent {
-        val current = rememberMapState(baseStyle = tileJsonStyle)
+        val current = rememberMapState(initialBaseStyle = tileJsonStyle)
         mapState = current
         styleState = current.style
         MaplibreMap(state = current, modifier = Modifier)
@@ -352,7 +352,7 @@ class BrowserMapStyleStateTest {
         var mapState: MapState? = null
         setBrowserMapContent {
           val logicalMap =
-            rememberMapState(baseStyle = BaseStyle.Empty) {
+            rememberMapState(initialBaseStyle = BaseStyle.Empty) {
               if (showLateSource.value) {
                 RasterLayer(id = "late-layer", source = source, visible = true)
               }
@@ -393,7 +393,7 @@ class BrowserMapStyleStateTest {
     var mapState: MapState? = null
     setBrowserMapContent {
       val logicalMap =
-        rememberMapState(baseStyle = current.value) {
+        rememberMapState(initialBaseStyle = current.value) {
           identity = LocalStyleNode.current.style.identity
         }
       mapState = logicalMap
@@ -410,7 +410,7 @@ class BrowserMapStyleStateTest {
     )
 
     val observed = mutableListOf<List<String>>()
-    current.value = styleWith("second", "second-source")
+    runOnIdle { checkNotNull(mapState).style.baseStyle = styleWith("second", "second-source") }
     waitUntilMap("the second style's sources to be reported") {
       styleState?.sources?.map { it.attributionHtml }?.let { observed += it }
       mapState?.style?.loadState == StyleLoadState.Ready &&

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserStyleConformanceTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserStyleConformanceTest.kt
@@ -129,7 +129,7 @@ class BrowserStyleConformanceTest {
     onMapLoadFailed: (String?) -> Unit = {},
     content: @Composable @MaplibreComposable () -> Unit = {},
   ) {
-    val state = rememberMapState(baseStyle = baseStyle, content = content)
+    val state = rememberMapState(initialBaseStyle = baseStyle, content = content)
     val loadState = state.style.loadState
     LaunchedEffect(loadState) {
       if (loadState is StyleLoadState.Failed) onMapLoadFailed(loadState.reason)

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserCameraTransitionLifecycleTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserCameraTransitionLifecycleTest.kt
@@ -95,7 +95,8 @@ class BrowserCameraTransitionLifecycleTest {
   fun a_destroyed_web_map_cannot_move_the_logical_map_or_a_cached_presentation(): Promise<*> =
     runBrowserMapTest {
       val runtime = createMapRuntime(MapRuntimeOptions())
-      val state = runtime.createMapState(initialCameraPosition = CURRENT_CAMERA, baseStyle = STYLE)
+      val state =
+        runtime.createMapState(initialCameraPosition = CURRENT_CAMERA, initialBaseStyle = STYLE)
       val presented = mutableStateOf(true)
 
       setBrowserMapContent { if (presented.value) MaplibreMap(state = state) }

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserMapSnapshotterTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserMapSnapshotterTest.kt
@@ -92,7 +92,7 @@ class BrowserMapSnapshotterTest {
         POINT_STYLE()
       }
       val runtime = createMapRuntime(MapRuntimeOptions())
-      val state = runtime.createMapState(baseStyle = BASE_STYLE, content = content)
+      val state = runtime.createMapState(initialBaseStyle = BASE_STYLE, content = content)
       val snapshotter = runtime.createSnapshotter(BASE_STYLE, content)
       try {
         setBrowserMapContent(size = SIZE) { MaplibreMap(state = state) }

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserMapStateTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserMapStateTest.kt
@@ -30,7 +30,7 @@ class BrowserMapStateTest {
       firstRuntime = DefaultMapRuntime.instance
       secondRuntime = DefaultMapRuntime.instance
       if (includeState.value) {
-        val remembered = rememberMapState(firstRuntime, baseStyle = BaseStyle.Empty)
+        val remembered = rememberMapState(firstRuntime, initialBaseStyle = BaseStyle.Empty)
         SideEffect { state = remembered }
       }
     }
@@ -50,7 +50,7 @@ class BrowserMapStateTest {
   fun map_state_renders_a_base_style_and_publishes_one_presentation(): Promise<*> =
     runBrowserMapTest {
       val runtime = createMapRuntime(MapRuntimeOptions())
-      val state = runtime.createMapState(baseStyle = BaseStyle.Empty)
+      val state = runtime.createMapState(initialBaseStyle = BaseStyle.Empty)
       val includeRival = mutableStateOf(false)
 
       setBrowserMapContent {

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/testing/GlJsMapFixture.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/testing/GlJsMapFixture.kt
@@ -35,7 +35,7 @@ internal class GlJsMapFixture(private val extent: MapExtent) : MapFixture {
   override val state =
     runtime.createMapState(
       initialCameraPosition = CameraPosition(zoom = 0.0),
-      baseStyle = BaseStyle.Empty,
+      initialBaseStyle = BaseStyle.Empty,
     )
   private val glJsSession = GlJsMapSession(state.lifecycle, recorder, MapLog, LayoutDirection.Ltr)
   private val token = state.reservePresentation()

--- a/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/map/DesktopPresentationHostLifetimeTest.kt
+++ b/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/map/DesktopPresentationHostLifetimeTest.kt
@@ -38,7 +38,7 @@ class DesktopPresentationHostLifetimeTest {
   fun replacing_a_compatible_presentation_host_keeps_the_runtime_logical_map_and_engine() =
     runFfiComposeUiTest {
       val runtime = createNativeMapRuntime(runtimeOptions)
-      val state = runtime.createMapState(baseStyle = BaseStyle.Empty)
+      val state = runtime.createMapState(initialBaseStyle = BaseStyle.Empty)
       var host by
         mutableStateOf(
           ContextlessPresentationHost("first", equalityKey = "same"),
@@ -73,7 +73,7 @@ class DesktopPresentationHostLifetimeTest {
   @Test
   fun inspection_mode_does_not_require_a_presentation_host() = runFfiComposeUiTest {
     val runtime = createNativeMapRuntime(runtimeOptions)
-    val state = runtime.createMapState(baseStyle = BaseStyle.Empty)
+    val state = runtime.createMapState(initialBaseStyle = BaseStyle.Empty)
 
     setContent {
       CompositionLocalProvider(LocalInspectionMode provides true) { MaplibreMap(state = state) }

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/RememberMapStyleTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/RememberMapStyleTest.kt
@@ -1,0 +1,37 @@
+package org.maplibre.compose.map
+
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.v2.runComposeUiTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+import org.maplibre.compose.style.BaseStyle
+
+@OptIn(ExperimentalTestApi::class)
+class RememberMapStyleTest {
+  @Test
+  fun recomposition_does_not_overwrite_a_base_style_command() = runComposeUiTest {
+    val runtime = mapRuntimeForTest()
+    val seed = mutableStateOf<BaseStyle>(BaseStyle.Empty)
+    lateinit var state: MapState
+    setContent {
+      val remembered = rememberMapState(runtime, initialBaseStyle = seed.value)
+      SideEffect { state = remembered }
+    }
+    waitForIdle()
+    val original = state
+    val replacement = BaseStyle.Json("""{"version":8,"sources":{},"layers":[]}""")
+    runOnIdle {
+      state.style.baseStyle = replacement
+      seed.value = BaseStyle.Demo
+    }
+    runOnIdle {
+      assertSame(original, state)
+      assertEquals(replacement, state.style.baseStyle)
+    }
+    runtime.close()
+    runtime.awaitClosed()
+  }
+}

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/overlay/MapOverlayTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/overlay/MapOverlayTest.kt
@@ -25,7 +25,7 @@ import org.maplibre.spatialk.geojson.Position
 class MapOverlayTest {
   @Test
   fun overlay_composes_before_the_map_attaches() = runComposeUiTest {
-    val mapState = mapRuntimeForTest().createMapState(baseStyle = BaseStyle.Empty)
+    val mapState = mapRuntimeForTest().createMapState(initialBaseStyle = BaseStyle.Empty)
     setContent {
       MapOverlayHost(
         overlay = {
@@ -46,7 +46,7 @@ class MapOverlayTest {
 
   @Test
   fun removing_a_placed_towards_child_resets_its_state() = runComposeUiTest {
-    val mapState = mapRuntimeForTest().createMapState(baseStyle = BaseStyle.Empty)
+    val mapState = mapRuntimeForTest().createMapState(initialBaseStyle = BaseStyle.Empty)
     val state = PlacedTowardsState()
     var show by mutableStateOf(true)
     setContent {

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/overlay/ZoomButtonsTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/overlay/ZoomButtonsTest.kt
@@ -23,7 +23,7 @@ import org.maplibre.compose.style.BaseStyle
 class ZoomButtonsTest {
   @Test
   fun zoom_buttons_compose_before_the_map_attaches_and_report_clicks() = runComposeUiTest {
-    val mapState = mapRuntimeForTest().createMapState(baseStyle = BaseStyle.Empty)
+    val mapState = mapRuntimeForTest().createMapState(initialBaseStyle = BaseStyle.Empty)
     var zoomInClicks = 0
     var zoomOutClicks = 0
     setContent {
@@ -53,7 +53,7 @@ class ZoomButtonsTest {
 
   @Test
   fun full_overlay_draws_zoom_buttons() = runComposeUiTest {
-    val mapState = mapRuntimeForTest().createMapState(baseStyle = BaseStyle.Empty)
+    val mapState = mapRuntimeForTest().createMapState(initialBaseStyle = BaseStyle.Empty)
     setContent {
       MapOverlayHost(
         overlay = { include(MapOverlay.Full) },

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/style/DeclaredStyleOwnershipTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/style/DeclaredStyleOwnershipTest.kt
@@ -1,0 +1,141 @@
+package org.maplibre.compose.style
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.DpRect
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.maplibre.compose.layers.CircleLayer
+import org.maplibre.compose.layers.RasterLayer
+import org.maplibre.compose.map.DefaultStyleCompositionEvaluator
+import org.maplibre.compose.map.SnapshotStyleOwnership
+import org.maplibre.compose.sources.GeoJsonData
+import org.maplibre.compose.sources.GeoJsonOptions
+import org.maplibre.compose.sources.GeoJsonSource
+import org.maplibre.compose.sources.ImageSource
+import org.maplibre.compose.sources.rememberGeoJsonSource
+import org.maplibre.compose.sources.rememberImageSource
+import org.maplibre.compose.testing.MapFixture
+import org.maplibre.compose.testing.MapTestResult
+import org.maplibre.compose.testing.createMapFixture
+import org.maplibre.compose.testing.runMapTest
+import org.maplibre.compose.util.MaplibreComposable
+import org.maplibre.compose.util.PositionQuad
+import org.maplibre.spatialk.geojson.Geometry
+import org.maplibre.spatialk.geojson.Point
+import org.maplibre.spatialk.geojson.Position
+import org.maplibre.spatialk.geojson.dsl.addFeature
+import org.maplibre.spatialk.geojson.dsl.buildFeatureCollection
+
+class DeclaredStyleOwnershipTest {
+  @Test
+  fun declared_sources_allow_feature_state_and_clusters_but_reject_definition_writes():
+    MapTestResult = runMapTest {
+    createMapFixture().use { fixture ->
+      fixture.loadStyle(BaseStyle.Empty)
+      lateinit var source: GeoJsonSource
+      fixture.declare {
+        source = rememberGeoJsonSource(DATA, GeoJsonOptions(cluster = true))
+        CircleLayer("points", source, visible = true)
+      }
+      val handle = assertNotNull(fixture.state.style.sources[source])
+      val selected = buildJsonObject { put("selected", true) }
+      handle.setFeatureState("0", selected)
+      assertEquals(selected, handle.getFeatureState("0"))
+      handle.removeFeatureState("0", "selected")
+      assertEquals(JsonObject(emptyMap()), handle.getFeatureState("0"))
+      handle.setFeatureState("0", selected)
+      handle.resetFeatureStates()
+      assertEquals(JsonObject(emptyMap()), handle.getFeatureState("0"))
+      assertFailsWith<StyleHandleException> { handle.setData(EMPTY_DATA) }
+      assertFailsWith<StyleHandleException> { fixture.state.style.sources.remove(handle.id) }
+
+      val layer = assertNotNull(fixture.state.style.layers["points"])
+      assertEquals(JsonPrimitive("circle"), layer.getProperty("type"))
+      assertFailsWith<StyleHandleException> {
+        layer.setPaintProperty("circle-radius", JsonPrimitive(20))
+      }
+      assertFailsWith<StyleHandleException> {
+        layer.setLayoutProperty("visibility", JsonPrimitive("none"))
+      }
+      assertFailsWith<StyleHandleException> { layer.setRootProperty("minzoom", JsonPrimitive(2)) }
+      assertFailsWith<StyleHandleException> { layer.clearFilter() }
+      assertFailsWith<StyleHandleException> { layer.setPaintTransition("circle-radius", null) }
+
+      val area = DpRect(0.dp, 0.dp, 512.dp, 512.dp)
+      fixture.pumpUntil("the declared source's cluster") {
+        fixture.state.queryRenderedFeatures(area).any(handle::isCluster)
+      }
+      val cluster = fixture.state.queryRenderedFeatures(area).first(handle::isCluster)
+      assertTrue(handle.getClusterExpansionZoom(cluster) > 0.0)
+      assertTrue(handle.getClusterChildren(cluster).features.isNotEmpty())
+      assertEquals(3, handle.getClusterLeaves(cluster, 10, 0).features.size)
+
+      fixture.loadStyle(BaseStyle.Empty)
+      assertFailsWith<IllegalStateException> { handle.getFeatureState("0") }
+    }
+  }
+
+  @Test
+  fun declared_image_sources_reject_each_definition_write(): MapTestResult = runMapTest {
+    createMapFixture().use { fixture ->
+      fixture.loadStyle(BaseStyle.Empty)
+      val bounds =
+        PositionQuad(
+          Position(-1.0, 1.0),
+          Position(1.0, 1.0),
+          Position(1.0, -1.0),
+          Position(-1.0, -1.0),
+        )
+      val bitmap = ImageBitmap(1, 1)
+      lateinit var source: ImageSource
+      fixture.declare {
+        source = rememberImageSource(bounds, bitmap)
+        RasterLayer("image", source, visible = true)
+      }
+      val handle = assertNotNull(fixture.state.style.sources[source])
+      assertFailsWith<StyleHandleException> { handle.setBounds(bounds) }
+      assertFailsWith<StyleHandleException> { handle.setImage(bitmap) }
+      assertFailsWith<StyleHandleException> { handle.setUri("https://example.invalid/image.png") }
+    }
+  }
+
+  /** Evaluate real composables, then publish and reconcile through the map's production paths. */
+  private suspend fun MapFixture.declare(content: @Composable @MaplibreComposable () -> Unit) {
+    awaitMapReady()
+    val revision =
+      DefaultStyleCompositionEvaluator.evaluate(
+        content,
+        checkNotNull(style),
+        checkNotNull(session.getViewport()),
+        Density(1f),
+        LayoutDirection.Ltr,
+        SnapshotStyleOwnership.Empty,
+      )
+    state.beginStyleRevision(session, revision)
+    session.reconcileStyleRevision(revision)
+    assertTrue(state.markStyleReady(session))
+  }
+
+  private companion object {
+    val EMPTY_DATA = GeoJsonData.JsonString("""{"type":"FeatureCollection","features":[]}""")
+    val DATA =
+      GeoJsonData.Features(
+        buildFeatureCollection<Geometry, JsonObject?> {
+          repeat(3) { index ->
+            addFeature(geometry = Point(Position(index * 0.001, 0.0))) { setId(index.toLong()) }
+          }
+        }
+      )
+  }
+}

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/style/LoadedStyleResourceMutationTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/style/LoadedStyleResourceMutationTest.kt
@@ -25,7 +25,8 @@ class LoadedStyleResourceMutationTest {
           options = GeoJsonOptions(),
         )
 
-      assertIs<GeoJsonSourceHandle>(fixture.state.style.sources.add(source))
+      val handle = assertIs<GeoJsonSourceHandle>(fixture.state.style.sources.add(source))
+      handle.setData(GeoJsonData.JsonString("""{"type":"FeatureCollection","features":[]}"""))
       assertIs<GeoJsonSourceHandle>(fixture.state.style.sources["imperative"])
       fixture.state.style.images.add("imperative", ImageBitmap(1, 1))
       fixture.settle()

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/PlatformMapAccessTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/PlatformMapAccessTest.kt
@@ -203,7 +203,7 @@ class PlatformMapAccessTest {
         closeResources = {},
         logger = null,
       )
-    val state = runtime.createMapState(baseStyle = BaseStyle.Empty)
+    val state = runtime.createMapState(initialBaseStyle = BaseStyle.Empty)
     try {
       block(state, runtime)
     } finally {


### PR DESCRIPTION
## Description

Give each style definition one writer. Rename creation parameters to `initialBaseStyle` and remove the `rememberMapState` synchronization: subsequent style changes use `mapState.style.baseStyle`. Update demos and examples to assign it explicitly when following Compose state.

Reject handle writes to declaratively owned layer properties and source data, images, URIs, and bounds, for both maps and snapshotters. Add typed `style.sources[source]` lookup so declared sources can use feature state, cluster queries, and invalidation. Base-style resources and imperative source additions remain writable.

## Validation

- Before rebasing: desktop, browser, and Android host suites passed, along with static checks and style-spec parity.
- After rebasing onto current main: focused desktop ownership, base-style recomposition, source mutation, and layer handle tests passed; static checks passed.
- New live-map tests exercise declared GeoJSON and image sources, feature state, cluster queries, rejected definition writes, and stale handles after reload.
- iOS and Android device tests were not run locally.

## AI assistance

Claude Fable 5.1 supplied the initial API audit. Codex (GPT-6) assisted with implementation, tests, documentation, and this PR description.
