### PR TITLE
Share one style image between painters that draw identical pixels

### DIFF
--- a/lib/maplibre-compose/build.gradle.kts
+++ b/lib/maplibre-compose/build.gradle.kts
@@ -130,9 +130,9 @@ kotlin {
       implementation(libs.jetbrains.compose.ui.test)
     }
 
-    // Live-map and Compose UI tests shared by jsTest and every platform that consumes
-    // maplibreNativeMain. androidHostTest inherits commonTest and has no MapLibre runtime and no
-    // Compose UI test host.
+    // Live-map, Compose UI, and real-bitmap tests shared by jsTest and every platform that
+    // consumes maplibreNativeMain. androidHostTest inherits commonTest and has no MapLibre runtime,
+    // no Compose UI test host, and no android.graphics.Bitmap implementation.
     val liveMapTest =
       create("liveMapTest") {
         dependsOn(commonTest.get())

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/dsl/image.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/dsl/image.kt
@@ -77,6 +77,8 @@ public fun image(
  * The [Painter] will be drawn to an [ImageBitmap] and registered with the style when it's
  * referenced by a layer, and unregistered from the style if it's no longer referenced by any layer.
  * An ID referencing the bitmap will be generated automatically and inserted into the expression.
+ * Painters that draw identical pixels share one style image, so calling `painterResource` for the
+ * same resource in several layers registers the image once.
  *
  * The bitmap will be created with the provided [size], or the intrinsic size of the painter if not
  * provided, or 16x16 DP if the painter has no intrinsic size.

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/ImageManager.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/ImageManager.kt
@@ -15,31 +15,65 @@ import kotlin.math.ceil
 import org.maplibre.compose.util.ImageStretch
 import org.maplibre.compose.util.toImageBitmap
 
+/**
+ * Registers bitmaps and painters as style images and shares one style image between every reference
+ * that resolves to the same pixels.
+ *
+ * Bitmap and painter keys count references from compiled expressions. Each key resolves once to a
+ * [ContentKey], which counts the keys that resolved to it and owns the style image. Painters
+ * without value equality, such as vector painters from different call sites, therefore still share
+ * an image when they draw the same pixels.
+ */
 internal class ImageManager(private val node: StyleNode) {
-  private val bitmapIds = IncrementingId("bitmap")
-  private val bitmapCounter = ReferenceCounter<BitmapKey>()
-  private val bitmapDefinitions = linkedMapOf<BitmapKey, StyleImageDefinition>()
+  private val imageIds = IncrementingId("image")
+  private val contentCounter = ReferenceCounter<ContentKey>()
+  private val definitions = linkedMapOf<ContentKey, StyleImageDefinition>()
 
-  private val painterIds = IncrementingId("painter")
+  private val bitmapCounter = ReferenceCounter<BitmapKey>()
+  private val bitmapContent = mutableMapOf<BitmapKey, ContentKey>()
+
   private val painterCounter = ReferenceCounter<PainterKey>()
-  private val painterDefinitions = linkedMapOf<PainterKey, StyleImageDefinition>()
+  private val painterContent = mutableMapOf<PainterKey, ContentKey>()
 
   internal val desiredImages: List<StyleImageDefinition>
-    get() = bitmapDefinitions.values.toList() + painterDefinitions.values
+    get() = definitions.values.toList()
 
   internal fun acquireBitmap(key: BitmapKey): String {
     bitmapCounter.increment(key) {
-      val id = bitmapIds.next()
-      bitmapDefinitions[key] =
-        StyleImageDefinition(id, ImageSnapshot.capture(key.bitmap), key.isSdf, key.stretch)
-      node.scheduleApplyChanges()
+      bitmapContent[key] =
+        acquireContent(ContentKey(ImageSnapshot.capture(key.bitmap), key.isSdf, key.stretch))
     }
-    return bitmapDefinitions.getValue(key).id
+    return definitions.getValue(bitmapContent.getValue(key)).id
   }
 
   internal fun releaseBitmap(key: BitmapKey) {
-    bitmapCounter.decrement(key) {
-      bitmapDefinitions.remove(key)
+    bitmapCounter.decrement(key) { releaseContent(bitmapContent.remove(key)!!) }
+  }
+
+  internal fun acquirePainter(key: PainterKey): String {
+    painterCounter.increment(key) {
+      val bitmap = key.drawToBitmap().let { if (key.drawAsSdf) it.toSdf() else it }
+      painterContent[key] =
+        acquireContent(ContentKey(ImageSnapshot.capture(bitmap), key.drawAsSdf, key.stretch))
+    }
+    return definitions.getValue(painterContent.getValue(key)).id
+  }
+
+  internal fun releasePainter(key: PainterKey) {
+    painterCounter.decrement(key) { releaseContent(painterContent.remove(key)!!) }
+  }
+
+  private fun acquireContent(key: ContentKey): ContentKey {
+    contentCounter.increment(key) {
+      definitions[key] = StyleImageDefinition(imageIds.next(), key.image, key.sdf, key.stretch)
+      node.scheduleApplyChanges()
+    }
+    return key
+  }
+
+  private fun releaseContent(key: ContentKey) {
+    contentCounter.decrement(key) {
+      definitions.remove(key)
       node.scheduleApplyChanges()
     }
   }
@@ -67,25 +101,12 @@ internal class ImageManager(private val node: StyleNode) {
     return pixels.toImageBitmap(w, pixels.size / w)
   }
 
-  internal fun acquirePainter(key: PainterKey): String {
-    painterCounter.increment(key) {
-      val id = painterIds.next()
-      key.drawToBitmap().let { bitmap ->
-        val resolved = if (key.drawAsSdf) bitmap.toSdf() else bitmap
-        painterDefinitions[key] =
-          StyleImageDefinition(id, ImageSnapshot.capture(resolved), key.drawAsSdf, key.stretch)
-      }
-      node.scheduleApplyChanges()
-    }
-    return painterDefinitions.getValue(key).id
-  }
-
-  internal fun releasePainter(key: PainterKey) {
-    painterCounter.decrement(key) {
-      painterDefinitions.remove(key)
-      node.scheduleApplyChanges()
-    }
-  }
+  /** The resolved pixels and style image options that identify one style image. */
+  private data class ContentKey(
+    val image: ImageSnapshot,
+    val sdf: Boolean,
+    val stretch: ImageStretch?,
+  )
 
   internal data class BitmapKey(
     val bitmap: ImageBitmap,

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleDefinitions.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleDefinitions.kt
@@ -78,6 +78,8 @@ private constructor(
   val height: Int,
   private val pixels: IntArray,
 ) {
+  private val hash = 31 * (31 * width + height) + pixels.contentHashCode()
+
   fun toImageBitmap(): ImageBitmap = pixels.copyOf().toImageBitmap(width, height)
 
   override fun equals(other: Any?): Boolean =
@@ -86,7 +88,7 @@ private constructor(
       height == other.height &&
       pixels.contentEquals(other.pixels)
 
-  override fun hashCode(): Int = 31 * (31 * width + height) + pixels.contentHashCode()
+  override fun hashCode(): Int = hash
 
   companion object {
     fun capture(bitmap: ImageBitmap): ImageSnapshot {

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/style/ImageManagerTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/style/ImageManagerTest.kt
@@ -1,49 +1,11 @@
 package org.maplibre.compose.style
 
-import androidx.compose.ui.geometry.Size
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.DefaultAlpha
-import androidx.compose.ui.graphics.drawscope.DrawScope
-import androidx.compose.ui.graphics.painter.Painter
-import androidx.compose.ui.unit.Density
-import androidx.compose.ui.unit.LayoutDirection
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
 import org.maplibre.compose.map.FakeImageBitmap
 
 class ImageManagerTest {
-
-  @Test
-  fun distinct_painters_with_identical_pixels_share_one_image() {
-    val manager = ImageManager(StyleNode(RecordingStyleBinding()))
-    val first = painterKey(SolidPainter(Color.Red))
-    val second = painterKey(SolidPainter(Color.Red))
-
-    val firstId = manager.acquirePainter(first)
-    val secondId = manager.acquirePainter(second)
-
-    assertEquals(firstId, secondId)
-    assertEquals(listOf(firstId), manager.desiredImages.map { it.id })
-
-    manager.releasePainter(first)
-    assertEquals(listOf(firstId), manager.desiredImages.map { it.id })
-
-    manager.releasePainter(second)
-    assertTrue(manager.desiredImages.isEmpty())
-  }
-
-  @Test
-  fun painters_with_different_pixels_get_separate_images() {
-    val manager = ImageManager(StyleNode(RecordingStyleBinding()))
-
-    val redId = manager.acquirePainter(painterKey(SolidPainter(Color.Red)))
-    val blueId = manager.acquirePainter(painterKey(SolidPainter(Color.Blue)))
-
-    assertNotEquals(redId, blueId)
-    assertEquals(2, manager.desiredImages.size)
-  }
 
   @Test
   fun distinct_bitmaps_with_identical_pixels_share_one_image() {
@@ -58,25 +20,9 @@ class ImageManagerTest {
     assertEquals(1, manager.desiredImages.size)
 
     manager.releaseBitmap(first)
+    assertEquals(1, manager.desiredImages.size)
+
     manager.releaseBitmap(second)
     assertTrue(manager.desiredImages.isEmpty())
-  }
-
-  private fun painterKey(painter: Painter) =
-    ImageManager.PainterKey(
-      painter = painter,
-      density = Density(1f),
-      layoutDirection = LayoutDirection.Ltr,
-      size = null,
-      drawAsSdf = false,
-      stretch = null,
-      alpha = DefaultAlpha,
-      colorFilter = null,
-    )
-
-  private class SolidPainter(private val color: Color) : Painter() {
-    override val intrinsicSize: Size = Size(2f, 2f)
-
-    override fun DrawScope.onDraw() = drawRect(color)
   }
 }

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/style/ImageManagerTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/style/ImageManagerTest.kt
@@ -1,0 +1,82 @@
+package org.maplibre.compose.style
+
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.DefaultAlpha
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+import org.maplibre.compose.map.FakeImageBitmap
+
+class ImageManagerTest {
+
+  @Test
+  fun distinct_painters_with_identical_pixels_share_one_image() {
+    val manager = ImageManager(StyleNode(RecordingStyleBinding()))
+    val first = painterKey(SolidPainter(Color.Red))
+    val second = painterKey(SolidPainter(Color.Red))
+
+    val firstId = manager.acquirePainter(first)
+    val secondId = manager.acquirePainter(second)
+
+    assertEquals(firstId, secondId)
+    assertEquals(listOf(firstId), manager.desiredImages.map { it.id })
+
+    manager.releasePainter(first)
+    assertEquals(listOf(firstId), manager.desiredImages.map { it.id })
+
+    manager.releasePainter(second)
+    assertTrue(manager.desiredImages.isEmpty())
+  }
+
+  @Test
+  fun painters_with_different_pixels_get_separate_images() {
+    val manager = ImageManager(StyleNode(RecordingStyleBinding()))
+
+    val redId = manager.acquirePainter(painterKey(SolidPainter(Color.Red)))
+    val blueId = manager.acquirePainter(painterKey(SolidPainter(Color.Blue)))
+
+    assertNotEquals(redId, blueId)
+    assertEquals(2, manager.desiredImages.size)
+  }
+
+  @Test
+  fun distinct_bitmaps_with_identical_pixels_share_one_image() {
+    val manager = ImageManager(StyleNode(RecordingStyleBinding()))
+    val first = ImageManager.BitmapKey(FakeImageBitmap(2, 2), isSdf = false, stretch = null)
+    val second = ImageManager.BitmapKey(FakeImageBitmap(2, 2), isSdf = false, stretch = null)
+
+    val firstId = manager.acquireBitmap(first)
+    val secondId = manager.acquireBitmap(second)
+
+    assertEquals(firstId, secondId)
+    assertEquals(1, manager.desiredImages.size)
+
+    manager.releaseBitmap(first)
+    manager.releaseBitmap(second)
+    assertTrue(manager.desiredImages.isEmpty())
+  }
+
+  private fun painterKey(painter: Painter) =
+    ImageManager.PainterKey(
+      painter = painter,
+      density = Density(1f),
+      layoutDirection = LayoutDirection.Ltr,
+      size = null,
+      drawAsSdf = false,
+      stretch = null,
+      alpha = DefaultAlpha,
+      colorFilter = null,
+    )
+
+  private class SolidPainter(private val color: Color) : Painter() {
+    override val intrinsicSize: Size = Size(2f, 2f)
+
+    override fun DrawScope.onDraw() = drawRect(color)
+  }
+}

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/style/ImageManagerPainterTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/style/ImageManagerPainterTest.kt
@@ -1,0 +1,65 @@
+package org.maplibre.compose.style
+
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.DefaultAlpha
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+/** Draws painters to real bitmaps, which the Android host JVM cannot create. */
+class ImageManagerPainterTest {
+
+  @Test
+  fun distinct_painters_with_identical_pixels_share_one_image() {
+    val manager = ImageManager(StyleNode(RecordingStyleBinding()))
+    val first = painterKey(SolidPainter(Color.Red))
+    val second = painterKey(SolidPainter(Color.Red))
+
+    val firstId = manager.acquirePainter(first)
+    val secondId = manager.acquirePainter(second)
+
+    assertEquals(firstId, secondId)
+    assertEquals(listOf(firstId), manager.desiredImages.map { it.id })
+
+    manager.releasePainter(first)
+    assertEquals(listOf(firstId), manager.desiredImages.map { it.id })
+
+    manager.releasePainter(second)
+    assertTrue(manager.desiredImages.isEmpty())
+  }
+
+  @Test
+  fun painters_with_different_pixels_get_separate_images() {
+    val manager = ImageManager(StyleNode(RecordingStyleBinding()))
+
+    val redId = manager.acquirePainter(painterKey(SolidPainter(Color.Red)))
+    val blueId = manager.acquirePainter(painterKey(SolidPainter(Color.Blue)))
+
+    assertNotEquals(redId, blueId)
+    assertEquals(2, manager.desiredImages.size)
+  }
+
+  private fun painterKey(painter: Painter) =
+    ImageManager.PainterKey(
+      painter = painter,
+      density = Density(1f),
+      layoutDirection = LayoutDirection.Ltr,
+      size = null,
+      drawAsSdf = false,
+      stretch = null,
+      alpha = DefaultAlpha,
+      colorFilter = null,
+    )
+
+  private class SolidPainter(private val color: Color) : Painter() {
+    override val intrinsicSize: Size = Size(2f, 2f)
+
+    override fun DrawScope.onDraw() = drawRect(color)
+  }
+}


### PR DESCRIPTION
## Description

Style images were keyed by `Painter` instance. `VectorPainter` has no value equality, so every `painterResource` call site for the same XML icon added another copy of the image to the style (#696).

Style images are now keyed by their rendered pixels plus the SDF and stretch options. Bitmap and painter references count into that shared entry, so anything that draws the same pixels registers one image.

Fixes #696

## Validation

`mise run check`, `mise run test:android`, and `mise run test:desktop` pass. Painter tests live in `liveMapTest` because the Android host JVM cannot create bitmaps.

## AI assistance

Claude Code (Claude Fable 5.1) implemented and tested the change under user direction.
