### PR TITLE
Serialize render-session teardown on the renderer thread

### DIFF
--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -201,10 +201,16 @@ internal class MlnFfiMapSession(
   /** Guarded by [stateLock]; once true, the map has dimensions suitable for fitting bounds. */
   private var hasAttachedViewport = false
 
-  /** Renderer-thread state. */
+  /**
+   * Renderer-thread state, like [renderSessionReady] and [attachedTarget]: read and written only on
+   * the host's renderer thread, which [render] runs on and
+   * [MlnFfiMapHostSession.withRendererAccess] reaches from any other thread. A close requested from
+   * another thread therefore closes whatever is attached when the request reaches that thread,
+   * never a handle read earlier, and a frame queued behind it sees the cleared state.
+   */
   private var renderSession: RenderSessionHandle? = null
 
-  /** Renderer-thread state; the FFI creates its renderer during the first successful render. */
+  /** The FFI creates its renderer during the first successful render. */
   private var renderSessionReady = false
 
   @Volatile private var hostSession: MlnFfiMapHostSession? = null
@@ -297,13 +303,13 @@ internal class MlnFfiMapSession(
         if (!lifecycle.acceptsWork) false else loop?.post(action) ?: false
       },
       accessRenderSession = { action ->
-        if (!lifecycle.acceptsWork || !renderSessionReady) {
+        if (!lifecycle.acceptsWork) {
           false
         } else {
           withRendererAccess {
             val session = renderSession
-            if (session == null) {
-              logger?.d { "Ignoring a render session call: no session is attached yet" }
+            if (session == null || !renderSessionReady) {
+              logger?.d { "Ignoring a render session call: no session is ready yet" }
               false
             } else {
               action(session)
@@ -378,7 +384,7 @@ internal class MlnFfiMapSession(
       return MlnFfiFrameResult.SKIPPED
     renderedCameraPadding = appliedCameraPadding
 
-    if (!ensureAttached(map, frame)) return MlnFfiFrameResult.SKIPPED
+    if (!ensureAttached(loop, map, frame)) return MlnFfiFrameResult.SKIPPED
     // Consumed before rendering, so an update published during the render below is not discarded.
     if (!renderRequested.exchange(false)) return MlnFfiFrameResult.SKIPPED
     // The cap measures start-to-start; measuring from the end of the last render rejects every
@@ -568,6 +574,7 @@ internal class MlnFfiMapSession(
     styleBinding = null
     appliedStyleRequest = null
     styleLoadTracker.engineBecameUnavailable()
+    // After loop is cleared, so a frame queued behind this close re-reads it and does not attach.
     closeRenderSession()
     try {
       stopping?.close()
@@ -591,23 +598,23 @@ internal class MlnFfiMapSession(
     releaseRenderSession()?.let { throw it }
   }
 
-  /** Clears bookkeeping before attempting the owner-thread close and returns its failure. */
+  /**
+   * Closes whatever is attached once this reaches the host's renderer thread, and returns the
+   * failure. A session attaches only through a host, and [onSurfaceLost] closes it before the host
+   * is dropped, so there is nothing to close without one.
+   */
   private fun releaseRenderSession(): Throwable? {
-    val handle = renderSession
+    val host = hostSession ?: return null
+    return runCatching { host.withRendererAccess { closeAttachedSession() } }.exceptionOrNull()
+  }
+
+  /** Renderer thread only. Clears the bookkeeping first, so a failed close is not retried. */
+  private fun closeAttachedSession() {
+    val handle = renderSession ?: return
     renderSession = null
     renderSessionReady = false
     attachedTarget = null
-    if (handle == null) return null
-
-    val host = hostSession
-    if (host == null) {
-      // Only the thread that attached the handle may close it, and that is reached through the
-      // host.
-      return IllegalStateException(
-        "Cannot close the MapLibre render session because its host surface is already gone"
-      )
-    }
-    return runCatching { host.withRendererAccess { handle.close() } }.exceptionOrNull()
+    handle.close()
   }
 
   // endregion
@@ -622,9 +629,19 @@ internal class MlnFfiMapSession(
     requestedCamera?.let { map.jumpTo(it.toCameraOptions(cameraPadding)) }
   }
 
-  private fun ensureAttached(map: MapHandle, frame: MlnFfiMapFrame): Boolean {
+  /**
+   * Renderer thread only. Teardown clears [loop] or closes the lifecycle before it queues its close
+   * on this thread, so a frame that read them earlier re-reads them here: attaching behind that
+   * close would leave a session nothing closes, and native then refuses to destroy the map.
+   */
+  private fun ensureAttached(
+    loop: MlnFfiMapRuntimeLoop,
+    map: MapHandle,
+    frame: MlnFfiMapFrame,
+  ): Boolean {
     val extent = frame.extent
     if (extent.isEmpty) return false
+    if (this.loop !== loop || !lifecycle.acceptsWork) return false
 
     val key = TargetKey(frame.target.generation, extent)
     val attached = attachedTarget
@@ -645,7 +662,8 @@ internal class MlnFfiMapSession(
     }
 
     // Attaching before closing throws, because a map permits only one live session.
-    closeRenderSession()
+    runCatching { closeAttachedSession() }
+      .onFailure { logger?.e(it) { "Failed to close the MapLibre render session" } }
 
     // There is no map.resize: attaching sets the map's size from the descriptor's logical extent.
     renderSession =

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -202,11 +202,9 @@ internal class MlnFfiMapSession(
   private var hasAttachedViewport = false
 
   /**
-   * Renderer-thread state, like [renderSessionReady] and [attachedTarget]: read and written only on
+   * Renderer-thread state, with [renderSessionReady] and [attachedTarget]: read and written only on
    * the host's renderer thread, which [render] runs on and
-   * [MlnFfiMapHostSession.withRendererAccess] reaches from any other thread. A close requested from
-   * another thread therefore closes whatever is attached when the request reaches that thread,
-   * never a handle read earlier, and a frame queued behind it sees the cleared state.
+   * [MlnFfiMapHostSession.withRendererAccess] reaches from any other thread.
    */
   private var renderSession: RenderSessionHandle? = null
 
@@ -574,7 +572,7 @@ internal class MlnFfiMapSession(
     styleBinding = null
     appliedStyleRequest = null
     styleLoadTracker.engineBecameUnavailable()
-    // After loop is cleared, so a frame queued behind this close re-reads it and does not attach.
+    // After loop is cleared: a frame queued behind this close re-reads it in ensureAttached.
     closeRenderSession()
     try {
       stopping?.close()
@@ -600,8 +598,8 @@ internal class MlnFfiMapSession(
 
   /**
    * Closes whatever is attached once this reaches the host's renderer thread, and returns the
-   * failure. A session attaches only through a host, and [onSurfaceLost] closes it before the host
-   * is dropped, so there is nothing to close without one.
+   * failure. Nothing is attached without a host: [onSurfaceLost] closes the session before it drops
+   * one.
    */
   private fun releaseRenderSession(): Throwable? {
     val host = hostSession ?: return null
@@ -630,9 +628,8 @@ internal class MlnFfiMapSession(
   }
 
   /**
-   * Renderer thread only. Teardown clears [loop] or closes the lifecycle before it queues its close
-   * on this thread, so a frame that read them earlier re-reads them here: attaching behind that
-   * close would leave a session nothing closes, and native then refuses to destroy the map.
+   * Renderer thread only. Re-reads [loop] and the lifecycle: teardown clears or closes them before
+   * it queues its close on this thread, and a session attached behind that close is never closed.
    */
   private fun ensureAttached(
     loop: MlnFfiMapRuntimeLoop,

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/MlnFfiRenderSessionTeardownTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/MlnFfiRenderSessionTeardownTest.kt
@@ -17,11 +17,10 @@ import org.maplibre.compose.style.BaseStyle
 import org.maplibre.compose.testing.RecordingList
 
 /**
- * Detaching and closing a map while its host is still driving frames. The lifecycle runs on its own
- * thread and closes the render session through the host's renderer thread, which may have a frame
- * queued ahead of that close. Such a frame must neither attach a second session, which native
- * refuses, nor attach one behind the close, which nothing would close: native then refuses to
- * destroy the map, and the runtime and its owner thread's live-runtime slot leak with it.
+ * Detaching and closing a map while its host is still driving frames. The lifecycle closes the
+ * render session through the host's renderer thread, which may have a frame queued ahead of that
+ * close; the frame must neither attach a second session nor attach one behind the close, or native
+ * refuses to destroy the map and the runtime leaks.
  */
 class MlnFfiRenderSessionTeardownTest {
 
@@ -49,7 +48,6 @@ class MlnFfiRenderSessionTeardownTest {
       it.whileRenderingOnRendererThread {
         awaitFirstFrame(it)
         runBlocking { it.session.detachPresentation() }
-        // The surface outlives the presentation, so frames keep flowing until the map closes.
         it.state.close()
         runBlocking { it.state.awaitClosed() }
       }
@@ -62,10 +60,10 @@ class MlnFfiRenderSessionTeardownTest {
   }
 
   private fun awaitFirstFrame(fixture: BridgeMapFixture) {
-    val deadline = TimeSource.Monotonic.markNow() + FIRST_FRAME_TIMEOUT
+    val deadline = TimeSource.Monotonic.markNow() + 30.seconds
     while (!fixture.hasRendered) {
       check(deadline.hasNotPassedNow()) { "The renderer thread never drew. Errors: $errors" }
-      parkForTest(POLL_INTERVAL_MILLIS)
+      parkForTest(8L)
     }
   }
 
@@ -79,8 +77,5 @@ class MlnFfiRenderSessionTeardownTest {
         ]}
         """
       )
-
-    val FIRST_FRAME_TIMEOUT = 30.seconds
-    const val POLL_INTERVAL_MILLIS = 8L
   }
 }

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/MlnFfiRenderSessionTeardownTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/MlnFfiRenderSessionTeardownTest.kt
@@ -1,0 +1,86 @@
+package org.maplibre.compose.map
+
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeSource
+import kotlinx.coroutines.runBlocking
+import org.maplibre.compose.logging.MapLogLevel
+import org.maplibre.compose.logging.MapLogRecord
+import org.maplibre.compose.logging.MapLogger
+import org.maplibre.compose.logging.MapLogging
+import org.maplibre.compose.mlnffi.BridgeMapFixture
+import org.maplibre.compose.mlnffi.parkForTest
+import org.maplibre.compose.style.BaseStyle
+import org.maplibre.compose.testing.RecordingList
+
+/**
+ * Detaching and closing a map while its host is still driving frames. The lifecycle runs on its own
+ * thread and closes the render session through the host's renderer thread, which may have a frame
+ * queued ahead of that close. Such a frame must neither attach a second session, which native
+ * refuses, nor attach one behind the close, which nothing would close: native then refuses to
+ * destroy the map, and the runtime and its owner thread's live-runtime slot leak with it.
+ */
+class MlnFfiRenderSessionTeardownTest {
+
+  private val previousLogger = MapLogging.logger
+  private val errors = RecordingList<MapLogRecord>()
+
+  @BeforeTest
+  fun captureErrors() {
+    MapLogging.logger = MapLogger { record ->
+      if (record.level >= MapLogLevel.Error) errors += record
+      previousLogger?.log(record)
+    }
+  }
+
+  @AfterTest
+  fun restoreLogger() {
+    MapLogging.logger = previousLogger
+  }
+
+  @Test
+  fun detaching_and_closing_behind_queued_frames_destroys_the_map_and_runtime() {
+    val fixture = BridgeMapFixture.create()
+    fixture.use {
+      it.loadStyleBeforeRendering(STYLE)
+      it.whileRenderingOnRendererThread {
+        awaitFirstFrame(it)
+        runBlocking { it.session.detachPresentation() }
+        // The surface outlives the presentation, so frames keep flowing until the map closes.
+        it.state.close()
+        runBlocking { it.state.awaitClosed() }
+      }
+    }
+    assertEquals(
+      emptyList(),
+      errors.map { "${it.message}: ${it.throwable}" },
+      "teardown behind queued frames should close the render session, map, and runtime",
+    )
+  }
+
+  private fun awaitFirstFrame(fixture: BridgeMapFixture) {
+    val deadline = TimeSource.Monotonic.markNow() + FIRST_FRAME_TIMEOUT
+    while (!fixture.hasRendered) {
+      check(deadline.hasNotPassedNow()) { "The renderer thread never drew. Errors: $errors" }
+      parkForTest(POLL_INTERVAL_MILLIS)
+    }
+  }
+
+  private companion object {
+    /** Inline and layer-only, so the test needs no network. */
+    val STYLE =
+      BaseStyle.Json(
+        """
+        {"version":8,"sources":{},"layers":[
+          {"id":"bg","type":"background","paint":{"background-color":"#eee"}}
+        ]}
+        """
+      )
+
+    val FIRST_FRAME_TIMEOUT = 30.seconds
+    const val POLL_INTERVAL_MILLIS = 8L
+  }
+}

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/mlnffi/BridgeMapFixture.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/mlnffi/BridgeMapFixture.kt
@@ -102,8 +102,7 @@ private constructor(
       }
 
       override fun enqueueRenderer(action: () -> Unit): Boolean {
-        val thread = rendererThread
-        if (thread == null) driver.withRendererAccess(action) else thread.post(action)
+        withRendererAccess(action)
         return true
       }
     }
@@ -246,13 +245,9 @@ private constructor(
 
   /**
    * Runs [block] on this thread while a dedicated renderer thread drives frames, and returns its
-   * result.
-   *
-   * Renderer access requested from any other thread is serialized onto that thread the way a
-   * platform host serializes it onto its own, in the order that exposes bookkeeping the session
-   * keeps off that thread: the access runs after a frame that started after the request, as it does
-   * behind a frame the host had already posted. A frame that fails, or a frame that this call ends
-   * while an access is still queued, fails the call.
+   * result. Renderer access from any other thread runs on that thread behind a frame that started
+   * after the request, as it does on a host that had already posted a frame. A frame that fails
+   * fails this call.
    */
   fun <T> whileRenderingOnRendererThread(block: () -> T): T {
     val thread = RendererThread(driver) { frame() }
@@ -260,12 +255,9 @@ private constructor(
     thread.start()
     val result = runCatching(block)
     rendererThread = null
-    val renderFailure = thread.stop()
-    result.exceptionOrNull()?.let { failure ->
-      renderFailure?.let(failure::addSuppressed)
-      throw failure
+    thread.stop()?.let { renderFailure ->
+      result.exceptionOrNull()?.addSuppressed(renderFailure) ?: throw renderFailure
     }
-    renderFailure?.let { throw it }
     return result.getOrThrow()
   }
 
@@ -332,11 +324,7 @@ private constructor(
     FfiTestPlatform.deleteCacheFile(cacheFile)
   }
 
-  /**
-   * Drives frames until stopped, running queued renderer access between them. An access requested
-   * from another thread waits for a frame that started after the request; one requested on this
-   * thread runs at once.
-   */
+  /** Drives frames until stopped, running queued renderer access between them. */
   private class RendererThread(
     private val driver: FfiTestRenderDriver,
     private val frame: () -> Unit,
@@ -365,14 +353,6 @@ private constructor(
       enqueue { result = runCatching { driver.withRendererAccess(action) } }.awaitUntilOpen()
       return checkNotNull(result) { "The test renderer thread stopped before running an access" }
         .getOrThrow()
-    }
-
-    fun post(action: () -> Unit) {
-      if (thread.isCurrent()) {
-        driver.withRendererAccess(action)
-        return
-      }
-      enqueue { runCatching { driver.withRendererAccess(action) } }
     }
 
     /** Stops the thread and returns what failed on it, if anything. */
@@ -413,12 +393,12 @@ private constructor(
     }
 
     private fun runQueuedAccess() {
-      val ready = lock.withLock {
-        val eligible = queue.filter { it.framesStartedWhenQueued < framesStarted }
-        queue.removeAll(eligible)
-        eligible
-      }
-      ready.forEach { access ->
+      while (true) {
+        val access =
+          lock.withLock {
+            val next = queue.firstOrNull() ?: return@withLock null
+            if (next.framesStartedWhenQueued < framesStarted) queue.removeFirst() else null
+          } ?: return
         try {
           access.run()
         } finally {

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/mlnffi/BridgeMapFixture.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/mlnffi/BridgeMapFixture.kt
@@ -3,6 +3,7 @@
 package org.maplibre.compose.mlnffi
 
 import androidx.compose.ui.unit.LayoutDirection
+import kotlin.concurrent.Volatile
 import kotlin.concurrent.atomics.AtomicBoolean
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.time.Duration
@@ -84,6 +85,9 @@ private constructor(
     recorder.state = state
   }
 
+  /** The thread [whileRenderingOnRendererThread] drives frames from, while one is running. */
+  @Volatile private var rendererThread: RendererThread? = null
+
   private val hostSession =
     object : MlnFfiMapHostSession {
       override val backends: RenderBackendPair = driver.backends
@@ -92,10 +96,14 @@ private constructor(
         frameRequested = true
       }
 
-      override fun <T> withRendererAccess(action: () -> T): T = driver.withRendererAccess(action)
+      override fun <T> withRendererAccess(action: () -> T): T {
+        val thread = rendererThread ?: return driver.withRendererAccess(action)
+        return thread.run(action)
+      }
 
       override fun enqueueRenderer(action: () -> Unit): Boolean {
-        driver.withRendererAccess(action)
+        val thread = rendererThread
+        if (thread == null) driver.withRendererAccess(action) else thread.post(action)
         return true
       }
     }
@@ -132,6 +140,7 @@ private constructor(
    * Whether MapLibre has rendered at least once, which is how a test knows the map exists and is
    * attached. The runtime and map are created on their own thread, so the first frame is not it.
    */
+  @Volatile
   var hasRendered: Boolean = false
     internal set
 
@@ -235,6 +244,31 @@ private constructor(
     }
   }
 
+  /**
+   * Runs [block] on this thread while a dedicated renderer thread drives frames, and returns its
+   * result.
+   *
+   * Renderer access requested from any other thread is serialized onto that thread the way a
+   * platform host serializes it onto its own, in the order that exposes bookkeeping the session
+   * keeps off that thread: the access runs after a frame that started after the request, as it does
+   * behind a frame the host had already posted. A frame that fails, or a frame that this call ends
+   * while an access is still queued, fails the call.
+   */
+  fun <T> whileRenderingOnRendererThread(block: () -> T): T {
+    val thread = RendererThread(driver) { frame() }
+    rendererThread = thread
+    thread.start()
+    val result = runCatching(block)
+    rendererThread = null
+    val renderFailure = thread.stop()
+    result.exceptionOrNull()?.let { failure ->
+      renderFailure?.let(failure::addSuppressed)
+      throw failure
+    }
+    renderFailure?.let { throw it }
+    return result.getOrThrow()
+  }
+
   /** Runs [block] on another thread while this one renders frames, and returns its result. */
   fun <T> awaitWhileRendering(
     description: String,
@@ -296,6 +330,106 @@ private constructor(
     }
     runCatching { driver.close() }
     FfiTestPlatform.deleteCacheFile(cacheFile)
+  }
+
+  /**
+   * Drives frames until stopped, running queued renderer access between them. An access requested
+   * from another thread waits for a frame that started after the request; one requested on this
+   * thread runs at once.
+   */
+  private class RendererThread(
+    private val driver: FfiTestRenderDriver,
+    private val frame: () -> Unit,
+  ) {
+    private class Access(
+      val framesStartedWhenQueued: Long,
+      val run: () -> Unit,
+      val done: MlnFfiGate,
+    )
+
+    private val lock = MlnFfiLock()
+    private val queue = ArrayDeque<Access>()
+    private var framesStarted = 0L
+    private var stopped = false
+    @Volatile private var stopRequested = false
+    @Volatile private var failure: Throwable? = null
+    private val thread = MlnFfiOwnerThread("maplibre-compose-test-renderer", ::loop)
+
+    fun start() {
+      thread.start()
+    }
+
+    fun <T> run(action: () -> T): T {
+      if (thread.isCurrent()) return driver.withRendererAccess(action)
+      var result: Result<T>? = null
+      enqueue { result = runCatching { driver.withRendererAccess(action) } }.awaitUntilOpen()
+      return checkNotNull(result) { "The test renderer thread stopped before running an access" }
+        .getOrThrow()
+    }
+
+    fun post(action: () -> Unit) {
+      if (thread.isCurrent()) {
+        driver.withRendererAccess(action)
+        return
+      }
+      enqueue { runCatching { driver.withRendererAccess(action) } }
+    }
+
+    /** Stops the thread and returns what failed on it, if anything. */
+    fun stop(): Throwable? {
+      stopRequested = true
+      check(thread.join(STOP_TIMEOUT_MILLIS)) { "The test renderer thread did not stop" }
+      return failure
+    }
+
+    /** Queues [run] and returns the gate that opens once it has run or been abandoned. */
+    private fun enqueue(run: () -> Unit): MlnFfiGate {
+      val done = MlnFfiGate()
+      val accepted = lock.withLock {
+        if (!stopped) queue += Access(framesStarted, run, done)
+        !stopped
+      }
+      if (!accepted) done.open()
+      return done
+    }
+
+    private fun loop() {
+      try {
+        while (!stopRequested) {
+          runQueuedAccess()
+          lock.withLock { framesStarted++ }
+          frame()
+          parkForTest(1L)
+        }
+      } catch (error: Throwable) {
+        failure = error
+      } finally {
+        val abandoned = lock.withLock {
+          stopped = true
+          queue.toList().also { queue.clear() }
+        }
+        abandoned.forEach { it.done.open() }
+      }
+    }
+
+    private fun runQueuedAccess() {
+      val ready = lock.withLock {
+        val eligible = queue.filter { it.framesStartedWhenQueued < framesStarted }
+        queue.removeAll(eligible)
+        eligible
+      }
+      ready.forEach { access ->
+        try {
+          access.run()
+        } finally {
+          access.done.open()
+        }
+      }
+    }
+
+    private companion object {
+      const val STOP_TIMEOUT_MILLIS = 30_000L
+    }
   }
 
   companion object {


### PR DESCRIPTION
## Description

`MlnFfiMapSession` cleared its render-session bookkeeping on the lifecycle thread before closing the handle on the renderer thread, so a frame queued ahead of that close could attach a session nothing closed. Native then refused to destroy the map, and the leaked runtime failed unrelated tests. The bookkeeping now lives only on the renderer thread: a close from another thread closes whatever is attached when it lands there, and `ensureAttached` re-reads the loop and lifecycle so a frame behind the close does not attach. Fixes #1328.

## Validation

`MlnFfiRenderSessionTeardownTest` drives frames from a renderer thread that runs a queued frame ahead of each foreign access; it reproduces the issue unfixed and passes fixed. Desktop, Android host, and Android device suites pass. iOS not run.

## AI assistance

Claude Fable 5.1 in Claude Code drafted the change, the test, and this description.
