### PR TITLE
Keep ordinary style updates out of the loading lifecycle

### DIFF
--- a/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MapLifecycleCallbackRaceTest.kt
+++ b/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MapLifecycleCallbackRaceTest.kt
@@ -12,7 +12,6 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.JsonObject
 import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.camera.internal.CameraCommandGuard
-import org.maplibre.compose.sources.Source
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.compose.style.RecordingStyleBinding
 import org.maplibre.compose.style.StyleBinding
@@ -322,7 +321,7 @@ private class OwnerThreadSourceReadStyleBinding : StyleBinding by RecordingStyle
   val sourceReadStarted = CountDownLatch(1)
   val ownerReadCompleted = CountDownLatch(1)
 
-  override fun getSources(): List<Source> {
+  override fun sourceIds(): List<String> {
     sourceReadStarted.countDown()
     assertTrue(
       ownerReadCompleted.await(5, TimeUnit.SECONDS),

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapAdapter.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapAdapter.kt
@@ -14,6 +14,7 @@ import org.maplibre.compose.expressions.value.BooleanValue
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.compose.style.DesiredStyleRevision
 import org.maplibre.compose.style.StyleBinding
+import org.maplibre.compose.style.StyleResourceChanges
 import org.maplibre.compose.util.VisibleBounds
 import org.maplibre.compose.util.VisibleRegion
 import org.maplibre.spatialk.geojson.BoundingBox
@@ -61,12 +62,13 @@ internal interface MapAdapter {
   fun setBaseStyle(style: BaseStyle)
 
   /**
-   * Applies one complete style-composition revision; [Callbacks.onStyleReady] reports readiness.
+   * Applies a style-composition revision. [Callbacks.onStyleReady] reports initial readiness;
+   * subsequent updates preserve readiness and return only the resources they changed.
    */
-  suspend fun reconcileStyleRevision(revision: DesiredStyleRevision)
+  suspend fun reconcileStyleRevision(revision: DesiredStyleRevision): StyleResourceChanges
 
   /** Restores a retained revision before the current composition is evaluated. */
-  suspend fun replayStyleRevision(revision: DesiredStyleRevision)
+  suspend fun replayStyleRevision(revision: DesiredStyleRevision): StyleResourceChanges
 
   fun getCameraPosition(): CameraPosition
 
@@ -129,7 +131,7 @@ internal interface MapAdapter {
     /** Offers the binding for a loaded style, or null when no binding is current. */
     fun onStyleChanged(map: MapAdapter, style: StyleBinding?)
 
-    /** Reports that the style composition applied and is ready to present. */
+    /** Reports that the base style and initial composition are ready to present. */
     fun onStyleReady(map: MapAdapter)
 
     /**
@@ -197,7 +199,7 @@ internal class DurableStyleCallbacks(private val owner: MapState) : MapAdapter.C
   }
 
   override fun onStyleSourcesChanged(map: MapAdapter, sourceId: String?) {
-    owner.refreshStyleSources(map)
+    owner.refreshStyleSources(map, sourceId)
   }
 
   override fun onEvent(map: MapAdapter, event: MapEvent) {

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.referentialEqualityPolicy
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.Saver
@@ -78,8 +79,8 @@ import org.maplibre.compose.style.StyleBinding
 import org.maplibre.compose.style.StyleHandleException
 import org.maplibre.compose.style.StyleHandleOperationGuard
 import org.maplibre.compose.style.StyleMutationException
+import org.maplibre.compose.style.StyleResourceChanges
 import org.maplibre.compose.style.TransitionOptions
-import org.maplibre.compose.style.canUpdateTo
 import org.maplibre.compose.style.scaledBy
 import org.maplibre.compose.style.systemAnimatorDurationScale
 import org.maplibre.compose.style.withScaledTransitions
@@ -159,10 +160,13 @@ public sealed interface StyleLoadState {
   /** Indicates that the current map surface is loading the desired style. */
   public data object Loading : StyleLoadState
 
-  /** Indicates that the current map surface loaded the desired style. */
+  /**
+   * The base style and initial composed content are ready. Ordinary content updates preserve this
+   * state; it does not indicate that tiles or animations have finished rendering.
+   */
   public data object Ready : StyleLoadState
 
-  /** Indicates that the current map surface failed to load the desired style. */
+  /** Loading the style or applying its composed content failed. A later revision may recover. */
   public data class Failed(public val reason: String?) : StyleLoadState
 }
 
@@ -186,20 +190,16 @@ internal interface MapStyleStateOwner {
   fun readyLoadedStyle(): StyleBinding?
 
   fun <T> runStyleHandleOperation(binding: StyleBinding, action: () -> T): T
-
-  fun styleHandleCheckpoint(binding: StyleBinding): Long
-
-  fun requireStyleHandleUnchanged(binding: StyleBinding, checkpoint: Long)
 }
 
 /** Desired and applied style state for one logical map or snapshotter. */
 public class MapStyleState internal constructor(initialBaseStyle: BaseStyle) {
   private var owner: MapStyleStateOwner? = null
   private val loadedStyle = AtomicReference<StyleBinding?>(null)
-  private val sourceIdentities = AtomicReference<Map<String, StyleResourceIdentity>>(emptyMap())
-  private val layerIdentities = AtomicReference<Map<String, StyleResourceIdentity>>(emptyMap())
-  private var sourcesState: Map<String, SourceHandle> by mutableStateOf(emptyMap())
-  private var layersState: Map<String, LayerHandle> by mutableStateOf(emptyMap())
+  private var sourcesState: Map<String, SourceHandle> by
+    mutableStateOf(emptyMap(), referentialEqualityPolicy())
+  private var layersState: Map<String, LayerHandle> by
+    mutableStateOf(emptyMap(), referentialEqualityPolicy())
   private var baseStyleState: BaseStyle by
     mutableStateOf(initialBaseStyle, structuralEqualityPolicy())
 
@@ -295,12 +295,12 @@ public class MapStyleState internal constructor(initialBaseStyle: BaseStyle) {
 
   private fun sourceHandle(current: StyleBinding, id: String): SourceHandle? = owner.let { owner ->
     val definition = owner?.desiredSourceDefinition(id)
-    val identity = sourceIdentity(id)
+    val identity = current.identity.sources.get(id)
     current.sourceHandle(
       id = id,
       definition = definition,
       currentDefinition = { owner?.desiredSourceDefinition(id) },
-      isCurrentResource = { sourceIdentities.load()[id] === identity },
+      isCurrentResource = { current.identity.sources.isCurrent(id, identity) },
       operations = operationGuard(current),
     )
   }
@@ -330,16 +330,12 @@ public class MapStyleState internal constructor(initialBaseStyle: BaseStyle) {
 
   internal fun updateLoadedStyle(style: StyleBinding?) {
     loadedStyle.store(style)
-    sourceIdentities.store(emptyMap())
-    layerIdentities.store(emptyMap())
     sourcesState = emptyMap()
     layersState = emptyMap()
   }
 
   internal fun invalidateLoadedStyle() {
     loadedStyle.exchange(null)?.invalidate()
-    sourceIdentities.store(emptyMap())
-    layerIdentities.store(emptyMap())
     sourcesState = emptyMap()
     layersState = emptyMap()
   }
@@ -361,9 +357,20 @@ public class MapStyleState internal constructor(initialBaseStyle: BaseStyle) {
   internal fun readResources(current: StyleBinding): LoadedStyleResources =
     LoadedStyleResources(readSources(current), readLayers(current))
 
-  internal fun readSources(current: StyleBinding): Map<String, SourceHandle> {
-    val ids = current.getSources().mapTo(linkedSetOf()) { it.id }
-    retainResourceIdentities(sourceIdentities, ids)
+  internal fun readSources(
+    current: StyleBinding,
+    changedId: String? = null,
+  ): Map<String, SourceHandle> {
+    if (changedId != null) {
+      val handle = sourceHandle(current, changedId)
+      val handles = sourcesState.toMutableMap()
+      if (handle == null) handles.remove(changedId) else handles[changedId] = handle
+      val ids = current.sourceIds()
+      current.identity.sources.retain(ids.toSet())
+      return ids.mapNotNull { id -> handles[id]?.let { id to it } }.toMap()
+    }
+    val ids = current.sourceIds().toSet()
+    current.identity.sources.retain(ids)
     return ids.mapNotNull { id -> sourceHandle(current, id)?.let { id to it } }.toMap()
   }
 
@@ -372,58 +379,26 @@ public class MapStyleState internal constructor(initialBaseStyle: BaseStyle) {
   }
 
   internal fun readLayers(current: StyleBinding): Map<String, LayerHandle> {
-    val ids = current.getLayers().mapTo(linkedSetOf()) { it.id }
-    retainResourceIdentities(layerIdentities, ids)
-    return ids
-      .mapNotNull { id ->
-        val identity = layerIdentity(id)
-        current
-          .layerHandle(
-            id,
-            isCurrentResource = { layerIdentities.load()[id] === identity },
-            operations = operationGuard(current),
-          )
-          ?.let { id to it }
-      }
-      .toMap()
+    val ids = current.layerIds().toSet()
+    current.identity.layers.retain(ids)
+    return ids.mapNotNull { id -> layerHandle(current, id)?.let { id to it } }.toMap()
   }
 
-  internal fun invalidateSourceIdentities(ids: Set<String>) {
-    removeResourceIdentities(sourceIdentities, ids)
+  internal fun layerHandle(current: StyleBinding, id: String): LayerHandle? {
+    val identity = current.identity.layers.get(id)
+    return current.layerHandle(
+      id,
+      isCurrentResource = { current.identity.layers.isCurrent(id, identity) },
+      operations = operationGuard(current),
+    )
   }
 
-  internal fun invalidateLayerIdentities(ids: Set<String>) {
-    removeResourceIdentities(layerIdentities, ids)
-  }
-
-  internal fun invalidateStructurallyReplacedResources(
-    previous: DesiredStyleRevision,
-    next: DesiredStyleRevision,
-  ) {
-    val nextSources = next.sources.associateBy(SourceDefinition::id)
-    val replacedSourceIds =
-      previous.sources
-        .filter { previousSource ->
-          nextSources[previousSource.id]?.let(previousSource::canUpdateTo) != true
-        }
-        .mapTo(mutableSetOf(), SourceDefinition::id)
-    invalidateSourceIdentities(replacedSourceIds)
-
-    val nextLayers = next.layers.associateBy { it.definition.id }
-    val replacedLayerIds =
-      previous.layers
-        .filter { previousLayer ->
-          val nextLayer = nextLayers[previousLayer.definition.id]
-          nextLayer == null ||
-            nextLayer.anchor != previousLayer.anchor ||
-            nextLayer.definition.type != previousLayer.definition.type ||
-            nextLayer.definition.sourceId != previousLayer.definition.sourceId ||
-            nextLayer.definition.value["source-layer"] !=
-              previousLayer.definition.value["source-layer"] ||
-            previousLayer.definition.sourceId in replacedSourceIds
-        }
-        .mapTo(mutableSetOf()) { it.definition.id }
-    invalidateLayerIdentities(replacedLayerIds)
+  internal fun updateLayers(handles: Map<String, LayerHandle?>, order: List<String>) {
+    val updated = layersState.toMutableMap()
+    handles.forEach { (id, handle) ->
+      if (handle == null) updated.remove(id) else updated[id] = handle
+    }
+    layersState = order.mapNotNull { id -> updated[id]?.let { id to it } }.toMap()
   }
 
   internal fun updateResources(resources: LoadedStyleResources) {
@@ -449,58 +424,7 @@ public class MapStyleState internal constructor(initialBaseStyle: BaseStyle) {
       override fun requireLayerWritable(id: String) {
         owner?.requireLayerWritable(id)
       }
-
-      override fun checkpoint(): Long = owner?.styleHandleCheckpoint(style) ?: 0L
-
-      override fun requireUnchanged(checkpoint: Long) {
-        owner?.requireStyleHandleUnchanged(style, checkpoint)
-      }
     }
-
-  private fun sourceIdentity(id: String): StyleResourceIdentity =
-    resourceIdentity(sourceIdentities, id)
-
-  private fun layerIdentity(id: String): StyleResourceIdentity =
-    resourceIdentity(layerIdentities, id)
-}
-
-private class StyleResourceIdentity
-
-private fun resourceIdentity(
-  identities: AtomicReference<Map<String, StyleResourceIdentity>>,
-  id: String,
-): StyleResourceIdentity {
-  while (true) {
-    val current = identities.load()
-    current[id]?.let {
-      return it
-    }
-    val identity = StyleResourceIdentity()
-    if (identities.compareAndSet(current, current + (id to identity))) return identity
-  }
-}
-
-private fun retainResourceIdentities(
-  identities: AtomicReference<Map<String, StyleResourceIdentity>>,
-  ids: Set<String>,
-) {
-  while (true) {
-    val current = identities.load()
-    val retained = current.filterKeys { it in ids }
-    if (retained.size == current.size || identities.compareAndSet(current, retained)) return
-  }
-}
-
-private fun removeResourceIdentities(
-  identities: AtomicReference<Map<String, StyleResourceIdentity>>,
-  ids: Set<String>,
-) {
-  if (ids.isEmpty()) return
-  while (true) {
-    val current = identities.load()
-    val remaining = current - ids
-    if (remaining.size == current.size || identities.compareAndSet(current, remaining)) return
-  }
 }
 
 internal data class LoadedStyleResources(
@@ -776,14 +700,6 @@ internal constructor(
             binding: StyleBinding,
             action: () -> T,
           ): T = this@MapState.runStyleHandleOperation(binding, action)
-
-          override fun styleHandleCheckpoint(binding: StyleBinding) =
-            this@MapState.styleHandleCheckpoint(binding)
-
-          override fun requireStyleHandleUnchanged(
-            binding: StyleBinding,
-            checkpoint: Long,
-          ) = this@MapState.requireStyleHandleUnchanged(binding, checkpoint)
         }
       )
     }
@@ -1058,6 +974,7 @@ internal constructor(
     while (true) {
       val read = lifecycle.serialized {
         if (!lifecycle.acceptsAdapter(adapter)) return false
+        if (style.loadState == StyleLoadState.Ready) return true
         val binding = style.currentLoadedStyle() ?: return false
         StyleResourceRead(binding, styleHandleEpoch, styleSourceChangeRevision)
       }
@@ -1079,28 +996,50 @@ internal constructor(
     }
   }
 
-  internal fun refreshStyleSources(adapter: MapAdapter): Boolean {
-    val read = lifecycle.serialized {
+  internal fun refreshStyleSources(adapter: MapAdapter, sourceId: String? = null): Boolean {
+    lifecycle.serialized {
       if (!lifecycle.acceptsAdapter(adapter)) return false
-      val sourceChangeRevision = ++styleSourceChangeRevision
-      if (style.loadState != StyleLoadState.Ready) return true
-      val binding = style.currentLoadedStyle() ?: return true
-      StyleResourceRead(binding, styleHandleEpoch, sourceChangeRevision)
+      styleSourceChangeRevision++
     }
-    val sources = runCatching { style.readSources(read.binding) }
-    if (sources.isFailure) {
-      val stillCurrent = lifecycle.serialized { isCurrentStyleResourceRead(adapter, read) }
-      if (!stillCurrent) return false
-      throw requireNotNull(sources.exceptionOrNull())
+    while (true) {
+      val read = lifecycle.serialized {
+        if (!lifecycle.acceptsAdapter(adapter)) return false
+        if (style.loadState != StyleLoadState.Ready) return true
+        val binding = style.currentLoadedStyle() ?: return true
+        StyleResourceRead(binding, styleHandleEpoch, styleSourceChangeRevision)
+      }
+      val sources = runCatching { style.readSources(read.binding, sourceId) }
+      if (sources.isFailure) {
+        val stillCurrent = lifecycle.serialized { isCurrentStyleResourceRead(adapter, read) }
+        if (!stillCurrent) return false
+        throw requireNotNull(sources.exceptionOrNull())
+      }
+      val committed = lifecycle.serialized {
+        if (!isCurrentStyleResourceRead(adapter, read)) return false
+        if (style.loadState != StyleLoadState.Ready) return false
+        if (styleSourceChangeRevision != read.sourceChangeRevision) return@serialized false
+        style.updateSources(sources.getOrThrow())
+        true
+      }
+      if (committed) return true
     }
-    return lifecycle.serialized {
-      if (!isCurrentStyleResourceRead(adapter, read)) return false
-      if (style.loadState != StyleLoadState.Ready) return false
-      // A later callback performs its own complete read, preserving source order without allowing
-      // this older result to overwrite it.
-      if (styleSourceChangeRevision != read.sourceChangeRevision) return true
-      style.updateSources(sources.getOrThrow())
-      true
+  }
+
+  internal fun updateStyleResources(adapter: MapAdapter, changes: StyleResourceChanges) {
+    if (changes.sources.isEmpty() && changes.layerOrder == null) return
+    val read = lifecycle.serialized {
+      if (!lifecycle.acceptsAdapter(adapter) || style.loadState != StyleLoadState.Ready) return
+      val binding = style.currentLoadedStyle() ?: return
+      if (binding.identity !== changes.identity) return
+      StyleResourceRead(binding, styleHandleEpoch, styleSourceChangeRevision)
+    }
+    changes.sources.forEach { refreshStyleSources(adapter, it) }
+    val layers = runCatching {
+      changes.layers.associateWith { style.layerHandle(read.binding, it) }
+    }
+    lifecycle.serialized {
+      if (!isCurrentStyleResourceRead(adapter, read)) return
+      changes.layerOrder?.let { style.updateLayers(layers.getOrThrow(), it) }
     }
   }
 
@@ -1142,10 +1081,11 @@ internal constructor(
           ?: backgroundStyleMutation
           ?: run {
             requireNoImperativeResourceConflicts(revision)
-            style.invalidateStructurallyReplacedResources(desiredStyleRevision, revision)
             styleHandleEpoch++
+            if (style.loadState is StyleLoadState.Failed) {
+              style.loadState = StyleLoadState.Loading
+            }
             desiredStyleRevision = revision
-            style.loadState = StyleLoadState.Loading
             return
           }
       }
@@ -1237,7 +1177,7 @@ internal constructor(
       lifecycle.serialized {
         requireStyleHandleLocked(binding)
         imperativeSources.remove(id)
-        style.invalidateSourceIdentities(setOf(id))
+        binding.identity.sources.remove(id)
       }
       refreshSourcesAfterCommand(binding)
       return true
@@ -1492,20 +1432,6 @@ internal constructor(
     val result = action()
     lifecycle.serialized { requireStyleHandleLocked(binding) }
     return result
-  }
-
-  internal fun styleHandleCheckpoint(binding: StyleBinding): Long = lifecycle.serialized {
-    requireStyleHandleLocked(binding)
-    styleHandleEpoch
-  }
-
-  internal fun requireStyleHandleUnchanged(binding: StyleBinding, checkpoint: Long) {
-    lifecycle.serialized {
-      requireStyleHandleLocked(binding)
-      check(styleHandleEpoch == checkpoint) {
-        "Style operation crossed a loaded-style resource change"
-      }
-    }
   }
 
   private fun requireStyleHandleLocked(binding: StyleBinding) {

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapSnapshotter.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapSnapshotter.kt
@@ -234,7 +234,6 @@ internal class MapSnapshotterImplementation(
   private val imperativeImages = mutableMapOf<String, ImperativeImageRecord>()
   private var activeStyleMutation: StyleMutationReservation? = null
   private var activeStyleClaim: StyleClaim? = null
-  private var styleHandleEpoch = 0L
   private var desiredRevision = DesiredStyleRevision.Empty
 
   override val style: MapStyleState =
@@ -279,18 +278,6 @@ internal class MapSnapshotterImplementation(
             binding: StyleBinding,
             action: () -> T,
           ): T = this@MapSnapshotterImplementation.runStyleHandleOperation(binding, action)
-
-          override fun styleHandleCheckpoint(binding: StyleBinding) =
-            this@MapSnapshotterImplementation.styleHandleCheckpoint(binding)
-
-          override fun requireStyleHandleUnchanged(
-            binding: StyleBinding,
-            checkpoint: Long,
-          ) =
-            this@MapSnapshotterImplementation.requireStyleHandleUnchanged(
-              binding,
-              checkpoint,
-            )
         }
       )
     }
@@ -315,7 +302,6 @@ internal class MapSnapshotterImplementation(
     val finishNow = lock.withLock {
       if (closed) return
       closed = true
-      styleHandleEpoch++
       val queued = queue.toList()
       queue.clear()
       queued.forEach { it.continuation.resumeWithException(snapshotterClosedCancellation()) }
@@ -457,7 +443,6 @@ internal class MapSnapshotterImplementation(
 
   private fun settleStyleAfterCancellation() {
     lock.withLock {
-      styleHandleEpoch++
       imperativeSources.clear()
       imperativeImages.clear()
       style.invalidateLoadedStyle()
@@ -500,7 +485,6 @@ internal class MapSnapshotterImplementation(
       requireOpenLocked()
       if (style.baseStyle == value) return
       requireNoActiveStyleMutation()
-      styleHandleEpoch++
       baseStyleRevision++
       imperativeSources.clear()
       imperativeImages.clear()
@@ -568,7 +552,7 @@ internal class MapSnapshotterImplementation(
       lock.withLock {
         requireStyleHandleLocked(binding)
         imperativeSources.remove(id)
-        style.invalidateSourceIdentities(setOf(id))
+        binding.identity.sources.remove(id)
       }
       refreshSourcesAfterCommand(binding)
       return true
@@ -696,23 +680,6 @@ internal class MapSnapshotterImplementation(
     return result
   }
 
-  internal fun styleHandleCheckpoint(binding: StyleBinding): Long = lock.withLock {
-    requireStyleHandleLocked(binding)
-    styleHandleEpoch
-  }
-
-  internal fun requireStyleHandleUnchanged(
-    binding: StyleBinding,
-    checkpoint: Long,
-  ) {
-    lock.withLock {
-      if (checkpoint != styleHandleEpoch) {
-        throw CancellationException("The loaded style changed during the operation")
-      }
-      requireStyleHandleLocked(binding)
-    }
-  }
-
   private suspend fun claimStyle(): StyleClaim {
     while (true) {
       val result = lock.withLock {
@@ -767,11 +734,7 @@ internal class MapSnapshotterImplementation(
     revision: DesiredStyleRevision,
   ): Boolean = lock.withLock {
     if (closed || capture.abandoned || claim.revision != baseStyleRevision) return@withLock false
-    styleHandleEpoch++
     val reusesLoadedStyle = style.currentLoadedStyle() === binding
-    if (reusesLoadedStyle) {
-      style.invalidateStructurallyReplacedResources(desiredRevision, revision)
-    }
     desiredRevision = revision
     if (!reusesLoadedStyle) {
       imperativeSources.clear()

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MaplibreMap.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MaplibreMap.kt
@@ -54,7 +54,7 @@ private class MapStateAttachment(
   suspend fun reconcileStyleRevision(map: MapAdapter, revision: DesiredStyleRevision) {
     state.beginStyleRevision(map, revision)
     try {
-      map.reconcileStyleRevision(revision)
+      state.updateStyleResources(map, map.reconcileStyleRevision(revision))
     } catch (error: CancellationException) {
       throw error
     } catch (error: Throwable) {
@@ -184,7 +184,7 @@ private fun MaplibreMapPresentation(
     val map = mapAttachment?.adapter ?: return@LaunchedEffect
     if (rememberedStyle == null) return@LaunchedEffect
     try {
-      map.replayStyleRevision(state.desiredStyleRevision)
+      state.updateStyleResources(map, map.replayStyleRevision(state.desiredStyleRevision))
     } catch (error: CancellationException) {
       throw error
     } catch (error: Throwable) {
@@ -223,7 +223,7 @@ private fun MaplibreMapPresentation(
         }
 
         override fun onStyleSourcesChanged(map: MapAdapter, sourceId: String?) {
-          state.refreshStyleSources(map)
+          state.refreshStyleSources(map, sourceId)
         }
 
         override fun onEvent(map: MapAdapter, event: MapEvent) {

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/sources/SourceHandle.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/sources/SourceHandle.kt
@@ -79,10 +79,8 @@ protected constructor(
   }
 
   protected suspend fun <T> suspendingOperation(action: suspend () -> T): T {
-    val checkpoint = operations.checkpoint()
     operation {}
     val result = action()
-    operations.requireUnchanged(checkpoint)
     operation {}
     return result
   }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleBinding.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleBinding.kt
@@ -69,9 +69,9 @@ internal interface StyleBinding {
 
   fun getSources(): List<Source>
 
-  fun getLayer(id: String): Layer?
+  fun sourceIds(): List<String> = getSources().map { it.id }
 
-  fun getLayers(): List<Layer>
+  fun getLayer(id: String): Layer?
 
   fun layerIds(): List<String>
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleHandleException.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleHandleException.kt
@@ -10,8 +10,4 @@ internal interface StyleHandleOperationGuard {
   fun requireSourceWritable(id: String)
 
   fun requireLayerWritable(id: String)
-
-  fun checkpoint(): Long
-
-  fun requireUnchanged(checkpoint: Long)
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleIdentity.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleIdentity.kt
@@ -1,8 +1,50 @@
+@file:OptIn(ExperimentalAtomicApi::class)
+
 package org.maplibre.compose.style
+
+import kotlin.concurrent.atomics.AtomicReference
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
 
 /** Opaque identity for one loaded base-style generation. */
 internal class StyleIdentity private constructor() {
+  val sources = ResourceIdentities()
+  val layers = ResourceIdentities()
+
   companion object {
     fun create(): StyleIdentity = StyleIdentity()
+  }
+}
+
+/** Resource identity follows the installed object, including replacement under the same ID. */
+internal class ResourceIdentities {
+  private val identities = AtomicReference<Map<String, Any>>(emptyMap())
+
+  fun get(id: String): Any {
+    while (true) {
+      val current = identities.load()
+      current[id]?.let {
+        return it
+      }
+      val identity = Any()
+      if (identities.compareAndSet(current, current + (id to identity))) return identity
+    }
+  }
+
+  fun isCurrent(id: String, identity: Any): Boolean = identities.load()[id] === identity
+
+  fun retain(ids: Set<String>) {
+    while (true) {
+      val current = identities.load()
+      val retained = current.filterKeys { it in ids }
+      if (retained.size == current.size || identities.compareAndSet(current, retained)) return
+    }
+  }
+
+  fun remove(id: String) {
+    while (true) {
+      val current = identities.load()
+      val remaining = current - id
+      if (remaining.size == current.size || identities.compareAndSet(current, remaining)) return
+    }
   }
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleInstallations.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleInstallations.kt
@@ -94,6 +94,7 @@ internal class SourceInstallation(
 
   fun remove() {
     style.requireCurrent()
+    style.identity.sources.remove(id)
     style.removeSource(id)
   }
 
@@ -162,6 +163,7 @@ internal class LayerInstallation(
 
   fun remove() {
     style.requireCurrent()
+    style.identity.layers.remove(id)
     style.removeLayer(id)
   }
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleLoadTracker.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleLoadTracker.kt
@@ -35,6 +35,9 @@ internal class StyleLoadTracker {
   val isReady: Boolean
     get() = lock.withLock { (load as? Load.Loaded)?.isReady == true }
 
+  val contentReady: Boolean
+    get() = lock.withLock { (load as? Load.Loaded)?.contentReady == true }
+
   fun request(): StyleRequestId = lock.withLock {
     currentRequest = StyleRequestId()
     load = Load.Loading
@@ -61,8 +64,8 @@ internal class StyleLoadTracker {
     true
   }
 
-  /** A retained replay also starts here; only the complete current revision can finish it. */
-  fun beginReconciliation(identity: StyleIdentity): Boolean = lock.withLock {
+  /** A new presentation waits for the current composition after replaying retained content. */
+  fun beginReplay(identity: StyleIdentity): Boolean = lock.withLock {
     val current = load as? Load.Loaded ?: return false
     if (current.identity !== identity) return false
     load = current.copy(contentReady = false)
@@ -100,9 +103,10 @@ internal class StyleLoadTracker {
   }
 
   fun failed(identity: StyleIdentity) = lock.withLock {
-    if (beginReconciliation(identity)) {
-      presentation = StylePresentation.Hidden
-    }
+    val current = load as? Load.Loaded ?: return@withLock
+    if (current.identity !== identity) return@withLock
+    load = current.copy(contentReady = false)
+    presentation = StylePresentation.Hidden
   }
 
   private fun retainPresentation() {

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleNode.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleNode.kt
@@ -5,16 +5,13 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.setValue
 
 internal class StyleNode(
-  var style: StyleBinding,
+  val style: StyleBinding,
   internal val replaceableSourceIds: Set<String> = emptySet(),
   replaceableLayerIds: Set<String> = emptySet(),
 ) : MapNode {
   val children = mutableListOf<MapNode>()
 
-  private val baseLayerIds =
-    style.getLayers().mapNotNullTo(mutableSetOf()) {
-      it.id.takeUnless(replaceableLayerIds::contains)
-    }
+  private val baseLayerIds = style.layerIds().toSet() - replaceableLayerIds
   internal val sourceManager = SourceManager(this)
   internal val imageManager = ImageManager(this)
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleReconciler.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleReconciler.kt
@@ -17,11 +17,11 @@ internal class StyleReconciler {
    */
   private var knownLayerIds: MutableList<String>? = null
 
-  suspend fun apply(style: StyleBinding, revision: DesiredStyleRevision) {
+  suspend fun apply(style: StyleBinding, revision: DesiredStyleRevision): StyleResourceChanges {
     style.requireCurrent()
     if (binding !== style) reset(style)
     try {
-      applyRevision(style, revision)
+      return applyRevision(style, revision)
     } catch (error: Throwable) {
       // A mutation may have succeeded before the failure; the tracked order is no longer trusted.
       knownLayerIds = null
@@ -29,7 +29,12 @@ internal class StyleReconciler {
     }
   }
 
-  private suspend fun applyRevision(style: StyleBinding, revision: DesiredStyleRevision) {
+  private suspend fun applyRevision(
+    style: StyleBinding,
+    revision: DesiredStyleRevision,
+  ): StyleResourceChanges {
+    val changes = StyleResourceChanges(style.identity)
+    var layerOrderChanged = false
     val desiredSources = revision.sources.associateBy(SourceDefinition::id)
     val replacedSourceIds =
       sources.mapNotNullTo(mutableSetOf()) { (id, applied) ->
@@ -47,26 +52,26 @@ internal class StyleReconciler {
           desired.definition.value["source-layer"] != applied.definition.value["source-layer"] ||
           desired.definition.sourceId in replacedSourceIds
       ) {
-        removeLayer(style, applied)
+        removeLayer(style, applied, changes)
       }
     }
 
     sources.values.toList().forEach { applied ->
       val desired = desiredSources[applied.definition.id]
       when {
-        desired == null -> removeSource(applied)
+        desired == null -> removeSource(applied, changes)
         applied.definition.canUpdateTo(desired) -> {
           applied.installation.update(desired)
           applied.definition = desired
         }
         else -> {
-          removeSource(applied)
-          addSource(style, desired)
+          removeSource(applied, changes)
+          addSource(style, desired, changes)
         }
       }
     }
     revision.sources.forEach { definition ->
-      if (definition.id !in sources) addSource(style, definition)
+      if (definition.id !in sources) addSource(style, definition, changes)
     }
 
     syncImages(style, revision.images)
@@ -100,9 +105,12 @@ internal class StyleReconciler {
                     revision.animatorDurationScale,
                   ),
               )
+            changes.layers.add(id)
             layers[id] = applied
             layerIds(style).insertBelow(id, before)
             if (anchor is Anchor.Replace && group.first() === desired) {
+              style.identity.layers.remove(anchor.layerId)
+              changes.layers.add(anchor.layerId)
               style.removeLayer(anchor.layerId)
               layerIds(style).remove(anchor.layerId)
             }
@@ -112,6 +120,7 @@ internal class StyleReconciler {
             if (shouldMoveLayer(layerIds(style), anchor, previousId, id, nextDesiredId)) {
               val before = beforeLayerId(layerIds(style), anchor, previousId, id)
               if (before != id) {
+                layerOrderChanged = true
                 applied.installation.move(before)
                 layerIds(style).also {
                   it.remove(id)
@@ -123,6 +132,9 @@ internal class StyleReconciler {
           previousId = id
         }
       }
+    if (changes.layers.isNotEmpty() || layerOrderChanged)
+      changes.layerOrder = layerIds(style).toList()
+    return changes
   }
 
   private fun reset(style: StyleBinding) {
@@ -148,21 +160,33 @@ internal class StyleReconciler {
     }
   }
 
-  private fun addSource(style: StyleBinding, definition: SourceDefinition) {
+  private fun addSource(
+    style: StyleBinding,
+    definition: SourceDefinition,
+    changes: StyleResourceChanges,
+  ) {
+    changes.sources.add(definition.id)
     sources[definition.id] = AppliedSource(definition, SourceInstallation(style, definition))
   }
 
-  private fun removeSource(applied: AppliedSource) {
+  private fun removeSource(applied: AppliedSource, changes: StyleResourceChanges) {
+    changes.sources.add(applied.definition.id)
     applied.installation.remove()
     sources.remove(applied.definition.id)
   }
 
-  private fun removeLayer(style: StyleBinding, applied: AppliedLayer) {
+  private fun removeLayer(
+    style: StyleBinding,
+    applied: AppliedLayer,
+    changes: StyleResourceChanges,
+  ) {
+    changes.layers.add(applied.definition.id)
     val anchor = applied.anchor
     val isLastReplacement =
       anchor is Anchor.Replace && layers.values.count { it.anchor == anchor } == 1
     if (isLastReplacement) {
       val original = requireNotNull(replacedLayers.remove(anchor))
+      changes.layers.add(original.id)
       style.addLayer(original, beforeLayerId = applied.definition.id)
       knownLayerIds?.insertBelow(anchor.layerId, applied.definition.id)
     }
@@ -258,3 +282,10 @@ internal fun SourceDefinition.canUpdateTo(next: SourceDefinition): Boolean =
       options == next.options
     else -> this == next
   }
+
+/** IDs touched by actual insertions, removals, or moves during an applied revision. */
+internal class StyleResourceChanges(val identity: StyleIdentity? = null) {
+  val sources = linkedSetOf<String>()
+  val layers = linkedSetOf<String>()
+  var layerOrder: List<String>? = null
+}

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
@@ -38,6 +38,8 @@ import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.camera.Viewport
 import org.maplibre.compose.camera.internal.CameraCommandGuard
 import org.maplibre.compose.expressions.ast.CompiledExpression
+import org.maplibre.compose.expressions.ast.ExpressionContext
+import org.maplibre.compose.expressions.dsl.const
 import org.maplibre.compose.expressions.value.BooleanValue
 import org.maplibre.compose.layers.Anchor
 import org.maplibre.compose.layers.BackgroundLayer
@@ -47,6 +49,7 @@ import org.maplibre.compose.sources.GeoJsonData
 import org.maplibre.compose.sources.GeoJsonOptions
 import org.maplibre.compose.sources.GeoJsonSource
 import org.maplibre.compose.sources.GeoJsonSourceHandle
+import org.maplibre.compose.sources.Source
 import org.maplibre.compose.sources.TileSetOptions
 import org.maplibre.compose.sources.VectorSource
 import org.maplibre.compose.style.BaseStyle
@@ -57,8 +60,11 @@ import org.maplibre.compose.style.Light
 import org.maplibre.compose.style.Projection
 import org.maplibre.compose.style.RecordingStyleBinding
 import org.maplibre.compose.style.Sky
+import org.maplibre.compose.style.StyleBinding
 import org.maplibre.compose.style.StyleHandleException
 import org.maplibre.compose.style.StyleImageDefinition
+import org.maplibre.compose.style.StyleReconciler
+import org.maplibre.compose.style.StyleResourceChanges
 import org.maplibre.compose.style.TransitionOptions
 import org.maplibre.compose.util.VisibleBounds
 import org.maplibre.compose.util.VisibleRegion
@@ -72,6 +78,252 @@ import org.maplibre.spatialk.geojson.dsl.buildFeatureCollection
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class MapPresentationTest {
+
+  @Test
+  fun property_and_data_revisions_preserve_readiness_handles_and_resource_lists() = runTest {
+    val fixture = presentationFixture()
+    try {
+      val source =
+        GeoJsonSource(
+          "puck",
+          GeoJsonData.JsonString("""{"type":"FeatureCollection","features":[]}"""),
+          GeoJsonOptions(),
+        )
+      val layer = BackgroundLayer("animated")
+      val original =
+        DesiredStyleRevision(
+          listOf(source.definition()),
+          listOf(DesiredStyleLayer(layer.definition(), Anchor.Top, null, null)),
+          emptyList(),
+        )
+      val backing =
+        RecordingStyleBinding(sources = listOf(attributedVectorSource("base", "Map attribution")))
+      var resourceReads = 0
+      val binding =
+        object : StyleBinding by backing {
+          override fun sourceIds(): List<String> {
+            resourceReads++
+            return backing.sourceIds()
+          }
+
+          override fun layerIds(): List<String> {
+            resourceReads++
+            return backing.layerIds()
+          }
+        }
+      val reconciler = StyleReconciler()
+      fixture.state.durableStyleCallbacks().onStyleChanged(fixture.adapter, binding)
+      fixture.state.beginStyleRevision(fixture.adapter, original)
+      reconciler.apply(binding, original)
+      fixture.state.markStyleReady(fixture.adapter)
+      val sourceHandle = checkNotNull(fixture.state.style.sources["puck"])
+      val layerHandle = checkNotNull(fixture.state.style.layers["animated"])
+      val initialReads = resourceReads
+
+      for (opacity in listOf(0.25, 0.5, 0.75)) {
+        source.setDesiredData(
+          GeoJsonData.JsonString(
+            """{"type":"Feature","geometry":{"type":"Point","coordinates":[0,0]},"properties":{"opacity":$opacity}}"""
+          )
+        )
+        val definition =
+          layer.definition().let {
+            it.copy(
+              value =
+                JsonObject(
+                  it.value +
+                    ("paint" to
+                      buildJsonObject {
+                        put("background-opacity", opacity)
+                      })
+                )
+            )
+          }
+        val revision =
+          DesiredStyleRevision(
+            listOf(source.definition()),
+            listOf(DesiredStyleLayer(definition, Anchor.Top, null, null)),
+            emptyList(),
+          )
+        fixture.state.beginStyleRevision(fixture.adapter, revision)
+        assertEquals(StyleLoadState.Ready, fixture.state.style.loadState)
+        assertEquals(listOf("Map attribution"), fixture.state.style.attributions())
+        fixture.state.updateStyleResources(fixture.adapter, reconciler.apply(binding, revision))
+        assertSame(sourceHandle, fixture.state.style.sources["puck"])
+        assertSame(layerHandle, fixture.state.style.layers["animated"])
+        assertEquals(JsonPrimitive(opacity), layerHandle.getProperty("background-opacity"))
+        assertEquals(initialReads, resourceReads, "a property update reread engine resources")
+      }
+
+      fixture.state.markStyleFailed(fixture.adapter, "revision failed")
+      fixture.state.beginStyleRevision(fixture.adapter, fixture.state.desiredStyleRevision)
+      assertEquals(StyleLoadState.Loading, fixture.state.style.loadState)
+      assertNull(fixture.state.style.layers["animated"])
+      fixture.state.markStyleReady(fixture.adapter)
+      assertEquals(StyleLoadState.Ready, fixture.state.style.loadState)
+      assertEquals(initialReads + 2, resourceReads, "recovery must refresh resource handles")
+    } finally {
+      fixture.close()
+    }
+  }
+
+  @Test
+  fun a_suspended_source_query_depends_on_its_source_identity_not_the_revision() = runTest {
+    for (replaceSource in listOf(false, true)) {
+      val fixture = presentationFixture()
+      try {
+        val started = CompletableDeferred<Unit>()
+        val result = CompletableDeferred<Double>()
+        val binding =
+          object : StyleBinding by RecordingStyleBinding() {
+            override suspend fun clusterExpansionZoom(
+              sourceId: String,
+              feature: Feature<*, JsonObject?>,
+            ): Double {
+              started.complete(Unit)
+              return result.await()
+            }
+          }
+        val source =
+          GeoJsonSource(
+            "points",
+            GeoJsonData.JsonString("""{"type":"FeatureCollection","features":[]}"""),
+            GeoJsonOptions(),
+          )
+        val layer = BackgroundLayer("background")
+        val original =
+          DesiredStyleRevision(
+            listOf(source.definition()),
+            listOf(DesiredStyleLayer(layer.definition(), Anchor.Top, null, null)),
+            emptyList(),
+          )
+        val reconciler = StyleReconciler()
+        fixture.state.updateLoadedStyle(fixture.adapter, binding)
+        fixture.state.beginStyleRevision(fixture.adapter, original)
+        reconciler.apply(binding, original)
+        fixture.state.markStyleReady(fixture.adapter)
+        val handle = assertIs<GeoJsonSourceHandle>(fixture.state.style.sources["points"])
+        val feature = Feature(Point(Position(0.0, 0.0)), buildJsonObject { put("cluster_id", 1) })
+        val query = async { runCatching { handle.getClusterExpansionZoom(feature) } }
+        started.await()
+        layer.setBackgroundOpacity(const(0.5f).compile(ExpressionContext.None))
+        val next =
+          DesiredStyleRevision(
+            if (replaceSource)
+              listOf(
+                GeoJsonSource(
+                    "points",
+                    GeoJsonData.JsonString("""{"type":"FeatureCollection","features":[]}"""),
+                    GeoJsonOptions(cluster = true),
+                  )
+                  .definition()
+              )
+            else original.sources,
+            listOf(DesiredStyleLayer(layer.definition(), Anchor.Top, null, null)),
+            emptyList(),
+          )
+        fixture.state.beginStyleRevision(fixture.adapter, next)
+        fixture.state.updateStyleResources(fixture.adapter, reconciler.apply(binding, next))
+        result.complete(4.0)
+        val outcome = query.await()
+        if (replaceSource) assertIs<IllegalStateException>(outcome.exceptionOrNull())
+        else assertEquals(4.0, outcome.getOrThrow())
+      } finally {
+        fixture.close()
+      }
+    }
+  }
+
+  @Test
+  fun a_named_source_event_refreshes_only_that_source() {
+    val fixture = presentationFixture()
+    try {
+      val backing =
+        RecordingStyleBinding(
+          sources =
+            listOf(
+              attributedVectorSource("first", "initial"),
+              attributedVectorSource("second", "unchanged"),
+            )
+        )
+      val reads = mutableListOf<String>()
+      val binding =
+        object : StyleBinding by backing {
+          override fun getSources(): List<Source> {
+            reads.add("all")
+            return backing.getSources()
+          }
+
+          override fun getSource(id: String): Source? {
+            reads.add(id)
+            return backing.getSource(id)
+          }
+        }
+      fixture.state.updateLoadedStyle(fixture.adapter, binding)
+      fixture.state.markStyleReady(fixture.adapter)
+      val second = fixture.state.style.sources["second"]
+      reads.clear()
+      backing.replaceSource(attributedVectorSource("first", "updated"))
+      fixture.state.durableStyleCallbacks().onStyleSourcesChanged(fixture.adapter, "first")
+      assertEquals(listOf("first"), reads)
+      assertSame(second, fixture.state.style.sources["second"])
+      assertEquals("updated", fixture.state.style.sources["first"]?.attributionHtml)
+      assertEquals(StyleLoadState.Ready, fixture.state.style.loadState)
+    } finally {
+      fixture.close()
+    }
+  }
+
+  @Test
+  fun resource_edits_update_the_catalog_without_restarting_loading() = runTest {
+    val fixture = presentationFixture()
+    try {
+      val backing = RecordingStyleBinding(layers = listOf(BackgroundLayer("base")))
+      val binding = backing
+      val reconciler = StyleReconciler()
+      fixture.state.updateLoadedStyle(fixture.adapter, binding)
+      fixture.state.markStyleReady(fixture.adapter)
+      val base = checkNotNull(fixture.state.style.layers["base"])
+      suspend fun apply(ids: List<String>, replaceBase: Boolean = false) {
+        val revision =
+          DesiredStyleRevision(
+            if (ids.isEmpty()) emptyList()
+            else listOf(attributedVectorSource("added", "attribution").definition()),
+            ids.map { id ->
+              DesiredStyleLayer(
+                BackgroundLayer(id).definition(),
+                if (replaceBase) Anchor.Replace("base") else Anchor.Top,
+                null,
+                null,
+              )
+            },
+            emptyList(),
+          )
+        fixture.state.beginStyleRevision(fixture.adapter, revision)
+        assertEquals(StyleLoadState.Ready, fixture.state.style.loadState)
+        fixture.state.updateStyleResources(fixture.adapter, reconciler.apply(binding, revision))
+        assertEquals(StyleLoadState.Ready, fixture.state.style.loadState)
+      }
+      apply(listOf("a", "b"))
+      val a = checkNotNull(fixture.state.style.layers["a"])
+      assertEquals(listOf("base", "a", "b"), fixture.state.style.layers.map { it.id })
+      assertEquals("attribution", fixture.state.style.sources["added"]?.attributionHtml)
+      apply(listOf("b", "a"))
+      assertEquals(listOf("base", "b", "a"), fixture.state.style.layers.map { it.id })
+      assertSame(a, fixture.state.style.layers["a"])
+      assertSame(base, fixture.state.style.layers["base"])
+      apply(listOf("replacement"), replaceBase = true)
+      assertEquals(listOf("replacement"), fixture.state.style.layers.map { it.id })
+      assertFailsWith<IllegalStateException> { base.getProperty("background-opacity") }
+      apply(emptyList())
+      assertEquals(listOf("base"), fixture.state.style.layers.map { it.id })
+      assertTrue(fixture.state.style.sources.none())
+      assertFailsWith<IllegalStateException> { base.getProperty("background-opacity") }
+      assertFailsWith<IllegalStateException> { a.getProperty("background-opacity") }
+    } finally {
+      fixture.close()
+    }
+  }
 
   @Test
   fun closing_map_state_closes_a_bound_session_before_it_is_published() = runTest {
@@ -533,7 +785,9 @@ class MapPresentationTest {
         layers = emptyList(),
         images = emptyList(),
       )
-    val loadedStyle = RecordingStyleBinding(sources = listOf(geoJson))
+    val loadedStyle = RecordingStyleBinding()
+    val reconciler = StyleReconciler()
+    reconciler.apply(loadedStyle, fixture.state.desiredStyleRevision)
     fixture.state.durableStyleCallbacks().onStyleChanged(fixture.adapter, loadedStyle)
     fixture.state.durableStyleCallbacks().onStyleReady(fixture.adapter)
     val handle = assertIs<GeoJsonSourceHandle>(fixture.state.style.sources["shared"])
@@ -547,13 +801,14 @@ class MapPresentationTest {
         images = emptyList(),
       ),
     )
+    fixture.state.updateStyleResources(
+      fixture.adapter,
+      reconciler.apply(loadedStyle, fixture.state.desiredStyleRevision),
+    )
     assertFailsWith<IllegalStateException> {
       handle.setFeatureState("7", buildJsonObject { put("stale", true) })
     }
     assertEquals(JsonObject(emptyMap()), loadedStyle.featureState("shared", null, "7"))
-
-    loadedStyle.replaceSource(vector)
-    fixture.state.markStyleReady(fixture.adapter)
 
     assertFailsWith<IllegalStateException> { handle.getFeatureState("7") }
     assertEquals(JsonObject(emptyMap()), loadedStyle.featureState("shared", null, "7"))
@@ -584,7 +839,9 @@ class MapPresentationTest {
     val original = attributedVectorSource("shared", "original")
     fixture.state.desiredStyleRevision =
       DesiredStyleRevision(listOf(original.definition()), emptyList(), emptyList())
-    val binding = RecordingStyleBinding(sources = listOf(original))
+    val binding = RecordingStyleBinding()
+    val reconciler = StyleReconciler()
+    reconciler.apply(binding, fixture.state.desiredStyleRevision)
     fixture.state.durableStyleCallbacks().onStyleChanged(fixture.adapter, binding)
     fixture.state.durableStyleCallbacks().onStyleReady(fixture.adapter)
     val stale = checkNotNull(fixture.state.style.sources["shared"])
@@ -594,8 +851,10 @@ class MapPresentationTest {
       fixture.adapter,
       DesiredStyleRevision(listOf(replacement.definition()), emptyList(), emptyList()),
     )
-    binding.replaceSource(replacement)
-    fixture.state.markStyleReady(fixture.adapter)
+    fixture.state.updateStyleResources(
+      fixture.adapter,
+      reconciler.apply(binding, fixture.state.desiredStyleRevision),
+    )
 
     assertFailsWith<IllegalStateException> { stale.attributionHtml }
     assertEquals("replacement", fixture.state.style.sources["shared"]?.attributionHtml)
@@ -692,7 +951,9 @@ class MapPresentationTest {
     val original = DesiredStyleLayer(layer.definition(), Anchor.Top, null, null)
     fixture.state.desiredStyleRevision =
       DesiredStyleRevision(emptyList(), listOf(original), emptyList())
-    val binding = RecordingStyleBinding(layers = listOf(layer))
+    val binding = RecordingStyleBinding()
+    val reconciler = StyleReconciler()
+    reconciler.apply(binding, fixture.state.desiredStyleRevision)
     fixture.state.durableStyleCallbacks().onStyleChanged(fixture.adapter, binding)
     fixture.state.durableStyleCallbacks().onStyleReady(fixture.adapter)
     val stale = checkNotNull(fixture.state.style.layers["background"])
@@ -701,7 +962,10 @@ class MapPresentationTest {
       fixture.adapter,
       DesiredStyleRevision(emptyList(), listOf(original.copy(anchor = Anchor.Bottom)), emptyList()),
     )
-    fixture.state.markStyleReady(fixture.adapter)
+    fixture.state.updateStyleResources(
+      fixture.adapter,
+      reconciler.apply(binding, fixture.state.desiredStyleRevision),
+    )
 
     assertFailsWith<IllegalStateException> { stale.getProperty("background-opacity") }
     assertTrue(fixture.state.style.layers["background"] != null)
@@ -1524,9 +1788,10 @@ internal open class PresentationTestAdapter(
       presentationWasVisibleWhileConfiguring || currentAttachment() != null
   }
 
-  override suspend fun reconcileStyleRevision(revision: DesiredStyleRevision) = Unit
+  override suspend fun reconcileStyleRevision(revision: DesiredStyleRevision) =
+    StyleResourceChanges()
 
-  override suspend fun replayStyleRevision(revision: DesiredStyleRevision) = Unit
+  override suspend fun replayStyleRevision(revision: DesiredStyleRevision) = StyleResourceChanges()
 
   override fun getCameraPosition(): CameraPosition = lastCameraPosition
 

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapSnapshotterTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapSnapshotterTest.kt
@@ -35,6 +35,7 @@ import org.maplibre.compose.style.BaseStyle
 import org.maplibre.compose.style.DesiredStyleRevision
 import org.maplibre.compose.style.RecordingStyleBinding
 import org.maplibre.compose.style.StyleHandleException
+import org.maplibre.compose.style.StyleReconciler
 
 class MapSnapshotterTest {
 
@@ -209,16 +210,15 @@ class MapSnapshotterTest {
     val original = attributedVectorSource("original")
     val replacement = attributedVectorSource("replacement")
     var desired = DesiredStyleRevision(listOf(original.definition()), emptyList(), emptyList())
-    val binding = RecordingStyleBinding(sources = listOf(original))
+    val binding = RecordingStyleBinding()
+    val reconciler = StyleReconciler()
     val runtime =
       mapRuntimeForTest(
         createSnapshotterAdapter = {
           FakeSnapshotterAdapter(
             prepare = { _, _ -> binding },
-            capture = { request, _ ->
-              if (desired.sources.single() == replacement.definition()) {
-                binding.replaceSource(replacement)
-              }
+            capture = { request, revision ->
+              reconciler.apply(binding, revision)
               FakeImageBitmap(request.width, request.height)
             },
           )

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/style/RecordingStyleBinding.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/style/RecordingStyleBinding.kt
@@ -110,10 +110,10 @@ internal class RecordingStyleBinding(
 
   override fun getSources(): List<Source> = sources.keys.mapNotNull(::getSource)
 
+  override fun sourceIds(): List<String> = sources.keys.toList()
+
   override fun getLayer(id: String): Layer? =
     baseLayers[id] ?: layers[id]?.let { UnknownLayer(id, it) }
-
-  override fun getLayers(): List<Layer> = orderedLayerIds.mapNotNull(::getLayer)
 
   override fun layerIds() = orderedLayerIds.toList()
 

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/style/StyleLoadTrackerTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/style/StyleLoadTrackerTest.kt
@@ -13,7 +13,7 @@ class StyleLoadTrackerTest {
       val tracker = StyleLoadTracker()
       val identity = StyleIdentity.create()
       assertTrue(tracker.loaded(tracker.requestId, identity, baseStyleReady = false))
-      assertTrue(tracker.beginReconciliation(identity))
+      assertTrue(tracker.beginReplay(identity))
       assertFalse(
         if (contentFirst) tracker.reconciled(identity) else tracker.baseStyleReady(identity)
       )
@@ -26,7 +26,10 @@ class StyleLoadTrackerTest {
       assertEquals(StylePresentation.Live, tracker.presentation)
       assertTrue(tracker.isReady)
       assertFalse(tracker.baseStyleReady(identity))
-      assertFalse(tracker.reconciled(identity), "readiness is reported only once per revision")
+      assertFalse(
+        tracker.reconciled(identity),
+        "readiness is reported only once per initialization",
+      )
     }
   }
 
@@ -41,16 +44,14 @@ class StyleLoadTrackerTest {
     assertEquals(StylePresentation.Retained, tracker.presentation)
     val second = StyleIdentity.create()
     assertTrue(tracker.loaded(replacement, second, baseStyleReady = false))
-    assertTrue(tracker.beginReconciliation(second))
+    assertTrue(tracker.beginReplay(second))
     assertEquals(StylePresentation.Retained, tracker.presentation)
     assertFalse(tracker.reconciled(second))
     assertEquals(StylePresentation.Live, tracker.presentation, "source loading may need frames")
     assertFalse(tracker.isReady)
     assertTrue(tracker.baseStyleReady(second))
 
-    assertTrue(tracker.beginReconciliation(second))
-    assertEquals(StylePresentation.Retained, tracker.presentation, "content updates are atomic too")
-    assertTrue(tracker.reconciled(second))
+    assertFalse(tracker.reconciled(second), "ordinary updates do not repeat readiness")
     assertEquals(StylePresentation.Live, tracker.presentation)
   }
 
@@ -88,11 +89,11 @@ class StyleLoadTrackerTest {
     val identity = StyleIdentity.create()
     assertTrue(tracker.loaded(tracker.requestId, identity))
     assertTrue(tracker.reconciled(identity))
-    assertTrue(tracker.beginReconciliation(identity))
+    assertTrue(tracker.beginReplay(identity))
     tracker.failed(identity)
     assertEquals(StylePresentation.Hidden, tracker.presentation)
     assertFalse(tracker.isReady)
-    assertTrue(tracker.beginReconciliation(identity))
+    assertTrue(tracker.beginReplay(identity))
     assertTrue(tracker.reconciled(identity))
     assertEquals(StylePresentation.Live, tracker.presentation)
   }
@@ -106,7 +107,7 @@ class StyleLoadTrackerTest {
     assertTrue(tracker.reconciled(identity))
     tracker.resetPresentation()
     assertEquals(StylePresentation.Hidden, tracker.presentation)
-    assertTrue(tracker.beginReconciliation(identity))
+    assertTrue(tracker.beginReplay(identity))
     assertEquals(
       StylePresentation.Hidden,
       tracker.presentation,
@@ -118,7 +119,7 @@ class StyleLoadTrackerTest {
     tracker.engineBecameUnavailable()
     assertNotSame(request, tracker.requestId)
     assertEquals(StylePresentation.Hidden, tracker.presentation)
-    assertFalse(tracker.beginReconciliation(identity))
+    assertFalse(tracker.beginReplay(identity))
     assertFalse(tracker.loaded(request, identity))
     assertFalse(tracker.reconciled(identity))
     assertFalse(tracker.failed(request))

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
@@ -66,6 +66,7 @@ import org.maplibre.compose.style.StyleLoadTracker
 import org.maplibre.compose.style.StylePresentation
 import org.maplibre.compose.style.StyleReconciler
 import org.maplibre.compose.style.StyleRequestId
+import org.maplibre.compose.style.StyleResourceChanges
 import org.maplibre.compose.util.AngleMath
 import org.maplibre.compose.util.VisibleBounds
 import org.maplibre.compose.util.VisibleRegion
@@ -626,37 +627,41 @@ internal class GlJsMapSession(
     if (hasReplayedPresentationState) onMap(::applyRequestedStyle)
   }
 
-  override suspend fun reconcileStyleRevision(revision: DesiredStyleRevision) {
-    val binding = styleBinding ?: return
-    val engine = lifecycleEngineIdentity ?: return
-    val style = lifecycleStyleIdentity ?: return
-    if (!styleLoadTracker.beginReconciliation(binding.identity)) return
+  override suspend fun reconcileStyleRevision(
+    revision: DesiredStyleRevision
+  ): StyleResourceChanges {
+    val binding = checkNotNull(styleBinding)
+    val engine = checkNotNull(lifecycleEngineIdentity)
+    val style = checkNotNull(lifecycleStyleIdentity)
     try {
-      styleReconciler.apply(binding, revision)
+      val changes = styleReconciler.apply(binding, revision)
       if (styleLoadTracker.reconciled(binding.identity)) {
         lifecycleCallbacks.onStyleReady(engine, style, this)
       }
+      surface?.requestFrame()
+      return changes
     } catch (error: CancellationException) {
       throw error
     } catch (error: Throwable) {
       styleLoadTracker.failed(binding.identity)
       throw error
     }
-    surface?.requestFrame()
   }
 
-  override suspend fun replayStyleRevision(revision: DesiredStyleRevision) {
-    val binding = styleBinding ?: return
-    if (!styleLoadTracker.beginReconciliation(binding.identity)) return
-    try {
-      styleReconciler.apply(binding, revision)
-    } catch (error: CancellationException) {
-      throw error
-    } catch (error: Throwable) {
-      styleLoadTracker.failed(binding.identity)
-      throw error
-    }
+  override suspend fun replayStyleRevision(revision: DesiredStyleRevision): StyleResourceChanges {
+    val binding = checkNotNull(styleBinding)
+    check(styleLoadTracker.beginReplay(binding.identity))
+    val changes =
+      try {
+        styleReconciler.apply(binding, revision)
+      } catch (error: CancellationException) {
+        throw error
+      } catch (error: Throwable) {
+        styleLoadTracker.failed(binding.identity)
+        throw error
+      }
     surface?.requestFrame()
+    return changes
   }
 
   private fun applyRequestedStyle(map: MaplibreMap) {

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/style/GlJsStyleBinding.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/style/GlJsStyleBinding.kt
@@ -183,12 +183,15 @@ internal class GlJsStyleBinding(
     return map.getStyle().sources.keys().map(::reconstructSource)
   }
 
+  override fun sourceIds(): List<String> {
+    requireLoaded()
+    return map.getStyle().sources.keys().toList()
+  }
+
   override fun getLayer(id: String): Layer? {
     requireLoaded()
     return map.getLayer(id)?.let { reconstructLayer(id) }
   }
-
-  override fun getLayers(): List<Layer> = layerIds().map(::reconstructLayer)
 
   override fun layerIds(): List<String> {
     requireLoaded()

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserStyleConformanceTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserStyleConformanceTest.kt
@@ -96,7 +96,7 @@ class BrowserStyleConformanceTest {
     }
     assertEquals(
       listOf("base-background", "switching-source-layer"),
-      style?.getLayers()?.map { it.id },
+      style?.layerIds(),
     )
 
     sourceLayer = "roads"
@@ -105,12 +105,12 @@ class BrowserStyleConformanceTest {
     }
     assertEquals(
       listOf("base-background", "switching-source-layer"),
-      style?.getLayers()?.map { it.id },
+      style?.layerIds(),
     )
 
     showLayer = false
     waitUntilMap("the replaced base layer to be restored") {
-      style?.getLayers()?.map { it.id } == listOf("base-background", "base-fill")
+      style?.layerIds() == listOf("base-background", "base-fill")
     }
     assertTrue(failures.isEmpty(), "the map reported load failures: $failures")
   }

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserStyleFailureTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserStyleFailureTest.kt
@@ -32,6 +32,8 @@ class BrowserStyleFailureTest {
             map.asDynamic().isStyleLoaded = { false }
             fixture.loadStyle(BaseStyle.Json(STYLE_B))
             map.asDynamic().isStyleLoaded = originalIsStyleLoaded
+          } else {
+            session.replayStyleRevision(DesiredStyleRevision.Empty)
           }
           session.callbacks =
             object : MapAdapter.Callbacks by callbacks {
@@ -54,6 +56,26 @@ class BrowserStyleFailureTest {
         session.reconcileStyleRevision(DesiredStyleRevision.Empty)
         assertTrue(session.canPresentFrames)
       }
+    }
+  }
+
+  @Test
+  fun ordinary_revisions_do_not_repeat_readiness(): MapTestResult = runMapTest {
+    createMapFixture().use { fixture ->
+      fixture.loadStyle(BaseStyle.Json(STYLE_A))
+      val session = fixture.session as GlJsMapSession
+      val callbacks = session.callbacks
+      var readyCount = 0
+      session.callbacks =
+        object : MapAdapter.Callbacks by callbacks {
+          override fun onStyleReady(map: MapAdapter) {
+            readyCount++
+            callbacks.onStyleReady(map)
+          }
+        }
+      repeat(3) { session.reconcileStyleRevision(DesiredStyleRevision.Empty) }
+      assertEquals(0, readyCount)
+      assertTrue(session.canPresentFrames)
     }
   }
 

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/testing/GlJsMapFixture.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/testing/GlJsMapFixture.kt
@@ -96,6 +96,7 @@ internal class GlJsMapFixture(private val extent: MapExtent) : MapFixture {
       }
     }
     glJsSession.reconcileStyleRevision(DesiredStyleRevision.Empty)
+    state.updateLoadedStyle(glJsSession, checkNotNull(recorder.style))
     state.markStyleReady(glJsSession)
   }
 

--- a/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/resource/DesktopPackagedStyleTest.kt
+++ b/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/resource/DesktopPackagedStyleTest.kt
@@ -48,8 +48,8 @@ class DesktopPackagedStyleTest {
       assertEquals(emptyList(), fixture.errors, "the map reported errors loading $url")
       val style = assertNotNull(fixture.style, "the style should have reached the callbacks")
       assertTrue(
-        style.getLayers().any { it.id == layerId },
-        "Expected the packaged style's own layer. Got ${style.getLayers().map { it.id }}",
+        layerId in style.layerIds(),
+        "Expected the packaged style's own layer. Got ${style.layerIds()}",
       )
     }
   }

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/layers/SymbolLayerCompositionTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/layers/SymbolLayerCompositionTest.kt
@@ -72,7 +72,7 @@ class SymbolLayerCompositionTest {
         composeStyle(
           style = binding,
           thenChange = {
-            assertEquals(ids.value, binding.getLayers().map { it.id })
+            assertEquals(ids.value, binding.layerIds())
             assertEquals(1, binding.imageIds.size)
             initialImageIds = binding.imageIds.toSet()
             ids.value = remaining
@@ -83,7 +83,7 @@ class SymbolLayerCompositionTest {
           }
         }
 
-        assertEquals(remaining, binding.getLayers().map { it.id })
+        assertEquals(remaining, binding.layerIds())
         assertEquals(if (remaining.isEmpty()) emptySet() else initialImageIds, binding.imageIds)
       }
     }

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/style/DeclaredStyleOwnershipTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/style/DeclaredStyleOwnershipTest.kt
@@ -123,8 +123,7 @@ class DeclaredStyleOwnershipTest {
         SnapshotStyleOwnership.Empty,
       )
     state.beginStyleRevision(session, revision)
-    session.reconcileStyleRevision(revision)
-    assertTrue(state.markStyleReady(session))
+    state.updateStyleResources(session, session.reconcileStyleRevision(revision))
   }
 
   private companion object {

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -64,6 +64,7 @@ import org.maplibre.compose.style.StyleLoadTracker
 import org.maplibre.compose.style.StylePresentation
 import org.maplibre.compose.style.StyleReconciler
 import org.maplibre.compose.style.StyleRequestId
+import org.maplibre.compose.style.StyleResourceChanges
 import org.maplibre.compose.util.VisibleBounds
 import org.maplibre.compose.util.VisibleRegion
 import org.maplibre.compose.util.metersPerDpAtLatitude
@@ -246,15 +247,6 @@ internal class MlnFfiMapSession(
 
   @Volatile private var styleBinding: MlnFfiStyleBinding? = null
   private val styleReconciler = StyleReconciler()
-
-  /** The binding whose readiness callback has already succeeded; see [reconcileStyleRevision]. */
-  private var styleReadinessNotifiedFor: MlnFfiStyleBinding? = null
-
-  /**
-   * Increments when a reconciliation or replay begins. A posted revision completion that observes a
-   * newer generation was superseded and only repaints. Read on the owner thread.
-   */
-  @Volatile private var reconcileGeneration = 0L
 
   internal val loadedStyleIdentity
     get() = styleBinding?.identity
@@ -1073,62 +1065,49 @@ internal class MlnFfiMapSession(
     onMap {}
   }
 
-  override suspend fun reconcileStyleRevision(revision: DesiredStyleRevision) {
-    val binding = styleBinding ?: return
-    val engine = lifecycleEngineIdentity ?: return
-    val style = lifecycleStyleIdentity ?: return
-    if (!styleLoadTracker.beginReconciliation(binding.identity)) return
-    val generation = ++reconcileGeneration
+  override suspend fun reconcileStyleRevision(
+    revision: DesiredStyleRevision
+  ): StyleResourceChanges {
+    val binding = checkNotNull(styleBinding)
+    val engine = checkNotNull(lifecycleEngineIdentity)
+    val style = checkNotNull(lifecycleStyleIdentity)
     try {
-      styleReconciler.apply(binding, revision)
-      val noteReconciled: (MapHandle) -> Unit = { map ->
-        map.requestRepaint()
-        if (generation == reconcileGeneration && styleLoadTracker.reconciled(binding.identity)) {
-          lifecycleCallbacks.onStyleReady(engine, style, this)
-        }
-      }
-      if (styleReadinessNotifiedFor === binding) {
-        // Steady state: per-frame revisions must not block the caller on the owner thread. The
-        // readiness callback already succeeded for this binding, so a later failure hides the
-        // presentation instead of propagating to the caller.
-        onMap { map ->
-          try {
-            noteReconciled(map)
-          } catch (error: Throwable) {
-            styleLoadTracker.failed(binding.identity)
-            throw error
+      val changes = styleReconciler.apply(binding, revision)
+      if (!styleLoadTracker.contentReady) {
+        runOnMap { map ->
+          map.requestRepaint()
+          if (styleLoadTracker.reconciled(binding.identity)) {
+            lifecycleCallbacks.onStyleReady(engine, style, this)
           }
         }
       } else {
-        // Until the style is ready, readiness failures must propagate to the caller.
-        if (runOnMap(noteReconciled) != null) {
-          styleReadinessNotifiedFor = binding
-        }
+        onMap { it.requestRepaint() }
       }
+      requestRender()
+      return changes
     } catch (error: CancellationException) {
       throw error
     } catch (error: Throwable) {
       styleLoadTracker.failed(binding.identity)
       throw error
     }
-    requestRender()
   }
 
-  override suspend fun replayStyleRevision(revision: DesiredStyleRevision) {
-    val binding = styleBinding ?: return
-    if (!styleLoadTracker.beginReconciliation(binding.identity)) return
-    // A completion queued before the replay began must not confirm the replayed content.
-    ++reconcileGeneration
-    try {
-      styleReconciler.apply(binding, revision)
-    } catch (error: CancellationException) {
-      throw error
-    } catch (error: Throwable) {
-      styleLoadTracker.failed(binding.identity)
-      throw error
-    }
+  override suspend fun replayStyleRevision(revision: DesiredStyleRevision): StyleResourceChanges {
+    val binding = checkNotNull(styleBinding)
+    check(styleLoadTracker.beginReplay(binding.identity))
+    val changes =
+      try {
+        styleReconciler.apply(binding, revision)
+      } catch (error: CancellationException) {
+        throw error
+      } catch (error: Throwable) {
+        styleLoadTracker.failed(binding.identity)
+        throw error
+      }
     onMap { it.requestRepaint() }
     requestRender()
+    return changes
   }
 
   /** Owner thread only. */

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/style/MlnFfiStyleBinding.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/style/MlnFfiStyleBinding.kt
@@ -172,14 +172,14 @@ internal open class MlnFfiStyleBinding(
   }
     .orEmpty()
 
+  override fun sourceIds(): List<String> = readMap { map ->
+    map.styleSourceIds().filter { isStyleSource(map, it) }
+  }
+    .orEmpty()
+
   override fun getLayer(id: String): Layer? = readMap { map ->
     if (!map.styleLayerExists(id)) null else reconstructLayer(map, id)
   }
-
-  override fun getLayers(): List<Layer> = readMap { map ->
-    map.styleLayerIds().map { reconstructLayer(map, it) }
-  }
-    .orEmpty()
 
   override fun layerIds(): List<String> = readMap { it.styleLayerIds() }.orEmpty()
 

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/MlnFfiMapIdleTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/MlnFfiMapIdleTest.kt
@@ -38,7 +38,7 @@ class MlnFfiMapIdleTest {
 
       requireNotNull(fixture.style).also { style ->
         style.getSources()
-        style.getLayers()
+        style.layerIds()
         style.getSource("missing")
         style.getLayer("missing")
       }

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/MlnFfiStylePresentationTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/MlnFfiStylePresentationTest.kt
@@ -7,10 +7,7 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
-import kotlin.time.Duration.Companion.seconds
-import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withTimeout
 import org.maplibre.compose.expressions.ast.ExpressionContext
 import org.maplibre.compose.expressions.dsl.const
 import org.maplibre.compose.layers.Anchor
@@ -23,6 +20,50 @@ import org.maplibre.compose.style.DesiredStyleRevision
 import org.maplibre.compose.testing.RgbaPixel
 
 class MlnFfiStylePresentationTest {
+
+  @Test
+  fun property_updates_render_without_repeating_style_readiness() = runBlocking {
+    BridgeMapFixture.create().use { fixture ->
+      fixture.loadStyle(INITIAL_STYLE)
+      val session = fixture.session
+      val callbacks = session.callbacks
+      var readyCount = 0
+      session.callbacks =
+        object : MapAdapter.Callbacks by callbacks {
+          override fun onStyleReady(map: MapAdapter) {
+            readyCount++
+            callbacks.onStyleReady(map)
+          }
+        }
+      session.reconcileStyleRevision(APPLICATION_REVISION)
+      assertEquals(1, readyCount)
+      val updated =
+        DesiredStyleRevision(
+          emptyList(),
+          listOf(
+            DesiredStyleLayer(
+              BackgroundLayer("application")
+                .apply {
+                  setBackgroundColor(const(Color.Green).compile(ExpressionContext.None))
+                }
+                .definition(),
+              Anchor.Top,
+              null,
+              null,
+            )
+          ),
+          emptyList(),
+        )
+      session.reconcileStyleRevision(updated)
+      val extent = BridgeMapFixture.DEFAULT_EXTENT
+      fixture.pumpUntil("the updated paint to render") {
+        fixture
+          .tryReadPixel(extent.physicalWidth / 2, extent.physicalHeight / 2)
+          ?.isNear(RgbaPixel(0, 255, 0, 255)) == true
+      }
+      assertEquals(1, readyCount, "a paint update repeated style initialization")
+    }
+  }
 
   @Test
   fun a_failed_readiness_callback_hides_the_presentation_until_reconciliation_recovers() =
@@ -94,57 +135,6 @@ class MlnFfiStylePresentationTest {
     }
   }
 
-  @Test
-  fun a_superseded_revision_completion_does_not_reveal_a_failed_revision() =
-    assertSupersededCompletionStaysHidden { session ->
-      assertFailsWith<IllegalArgumentException> { session.reconcileStyleRevision(BROKEN_REVISION) }
-    }
-
-  @Test
-  fun a_superseded_replay_completion_does_not_reveal_a_failed_replay() =
-    assertSupersededCompletionStaysHidden { session ->
-      assertFailsWith<IllegalArgumentException> { session.replayStyleRevision(BROKEN_REVISION) }
-    }
-
-  /**
-   * Queues a steady-state completion behind a held owner thread, then fails a newer reconciliation
-   * or replay through [fail]. The queued completion must not reveal the hidden presentation.
-   */
-  private fun assertSupersededCompletionStaysHidden(fail: suspend (MlnFfiMapSession) -> Unit) =
-    runBlocking {
-      BridgeMapFixture.create().use { fixture ->
-        fixture.loadStyle(INITIAL_STYLE)
-        val session = fixture.session
-        session.reconcileStyleRevision(APPLICATION_REVISION)
-        assertTrue(session.canPresentFrames)
-
-        // Hold the owner thread so the next steady-state revision's completion stays queued.
-        val ownerBusy = CompletableDeferred<Unit>()
-        val releaseOwner = CompletableDeferred<Unit>()
-        assertTrue(
-          session.postOwnerTaskForTest {
-            ownerBusy.complete(Unit)
-            runBlocking { releaseOwner.await() }
-          }
-        )
-        withTimeout(5.seconds) { ownerBusy.await() }
-
-        // Steady state: this revision's completion is posted behind the held queue, not awaited.
-        session.reconcileStyleRevision(APPLICATION_REVISION)
-
-        // A newer reconciliation begins and fails before the queued completion runs.
-        fail(session)
-        assertFalse(session.canPresentFrames)
-
-        releaseOwner.complete(Unit)
-        fixture.pump()
-        assertFalse(
-          session.canPresentFrames,
-          "the superseded completion must not reveal the failed revision",
-        )
-      }
-    }
-
   private companion object {
     val APPLICATION_COLOR = RgbaPixel(red = 0x33, green = 0x66, blue = 0x99, alpha = 0xff)
 
@@ -167,24 +157,6 @@ class MlnFfiStylePresentationTest {
               onLongClick = null,
             )
           ),
-        images = emptyList(),
-      )
-
-    /**
-     * Fails during reconciliation without touching the owner thread: the existing layer is
-     * unchanged, and the new layer anchors above a layer the base style does not have.
-     */
-    val BROKEN_REVISION =
-      DesiredStyleRevision(
-        sources = emptyList(),
-        layers =
-          APPLICATION_REVISION.layers +
-            DesiredStyleLayer(
-              definition = BackgroundLayer("broken").definition(),
-              anchor = Anchor.Above("missing"),
-              onClick = null,
-              onLongClick = null,
-            ),
         images = emptyList(),
       )
 

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/testing/MlnFfiMapFixture.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/testing/MlnFfiMapFixture.kt
@@ -51,12 +51,8 @@ internal class MlnFfiMapFixture(val bridge: BridgeMapFixture, private val extent
   override suspend fun loadStyle(style: BaseStyle, timeout: Duration) {
     state.style.loadState = org.maplibre.compose.map.StyleLoadState.Loading
     state.updateLoadedStyle(bridge.session, null)
-    val styleReadyCountBefore = events.count { it == MapFixture.STYLE_READY }
     bridge.loadStyle(style, timeout, extent)
     bridge.session.reconcileStyleRevision(DesiredStyleRevision.Empty)
-    bridge.pumpUntil("style $style to finish reconciliation", timeout, extent) {
-      events.count { it == MapFixture.STYLE_READY } > styleReadyCountBefore
-    }
     state.updateLoadedStyle(bridge.session, checkNotNull(bridge.style))
     check(state.markStyleReady(bridge.session))
   }


### PR DESCRIPTION
## Description

Keep ordinary style updates out of the loading lifecycle. This fixes severe stutter and attribution flicker when the location puck updates layer properties during camera movement.

Update resource collections from actual additions and removals, and validate suspended queries against their source identity. Remove per-revision readiness completion tracking, snapshot query checkpoints, and bulk layer reconstruction.

## Validation

- Android host, macOS desktop, and Chrome browser test suites.
- Samsung SM-F966U1: panning and flying to location confirmed smooth.
- Changed-file static checks and `git diff --check`.

## AI assistance

OpenAI Codex (GPT-6) assisted with investigation, implementation, tests, and review.
