### PR TITLE
Remove Anchor.Replace

### DIFF
--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Composition.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Composition.kt
@@ -3,6 +3,8 @@
 package org.maplibre.compose.docsnippets
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import kotlinx.serialization.json.JsonPrimitive
 import org.maplibre.compose.map.DefaultMapRuntime
 import org.maplibre.compose.map.MaplibreMap
 import org.maplibre.compose.map.rememberMapState
@@ -21,4 +23,11 @@ fun Composition() {
     }
   MaplibreMap(state = state)
   // #endregion base-plus-content
+
+  // #region base-layer-handle
+  val buildings = state.style.layers["building"]
+  LaunchedEffect(buildings) {
+    buildings?.setPaintProperty("fill-color", JsonPrimitive("#2196f3"))
+  }
+  // #endregion base-layer-handle
 }

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Composition.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Composition.kt
@@ -3,8 +3,6 @@
 package org.maplibre.compose.docsnippets
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import kotlinx.serialization.json.JsonPrimitive
 import org.maplibre.compose.map.DefaultMapRuntime
 import org.maplibre.compose.map.MaplibreMap
 import org.maplibre.compose.map.rememberMapState
@@ -23,11 +21,4 @@ fun Composition() {
     }
   MaplibreMap(state = state)
   // #endregion base-plus-content
-
-  // #region base-layer-handle
-  val buildings = state.style.layers["building"]
-  LaunchedEffect(buildings) {
-    buildings?.setPaintProperty("fill-color", JsonPrimitive("#2196f3"))
-  }
-  // #endregion base-layer-handle
 }

--- a/docs/scripts/generate-api-index.mjs
+++ b/docs/scripts/generate-api-index.mjs
@@ -118,7 +118,7 @@ for (const module of entries(apiDir)) {
 }
 
 // A companion factory function can share its name with the class it builds
-// (e.g. `Anchor.Replace`). Within one module and package, keep the type page.
+// (e.g. `Anchor.Above`). Within one module and package, keep the type page.
 for (const [name, hits] of Object.entries(symbols)) {
   const deduped = new Map();
   for (const hit of hits) {

--- a/docs/src/content/docs/composition.mdx
+++ b/docs/src/content/docs/composition.mdx
@@ -24,11 +24,8 @@ positions in the layer stack.
 <Code code={region(composition, "base-plus-content")} lang="kotlin" title="App.kt" />
 
 The library manages the sources and layers in the style block. It
-does not modify the rest of the base style. To change a base style layer,
-look up its <Api of="LayerHandle" /> in `mapState.style.layers` and write the
-property through the handle, in an effect keyed on the handle:
-
-<Code code={region(composition, "base-layer-handle")} lang="kotlin" title="App.kt" />
+does not modify the rest of the base style. To change a base style layer, use
+its <Api of="LayerHandle" /> from `mapState.style.layers`.
 
 `initialBaseStyle` seeds the map once. Changing that input does not reload the
 remembered map; assign `mapState.style.baseStyle` to switch styles.

--- a/docs/src/content/docs/composition.mdx
+++ b/docs/src/content/docs/composition.mdx
@@ -25,8 +25,12 @@ positions in the layer stack.
 
 The library manages the sources and layers in the style block. It
 does not modify the rest of the base style. To change a base style layer,
-use its handle in `mapState.style.layers`, or replace it with
-<Api of="Anchor.Replace" /> and declare its replacement yourself.
+look up its <Api of="LayerHandle" /> in `mapState.style.layers` and write the
+property through the handle. The lookup returns null until the style is ready,
+and each loaded style generation has its own handles, so key the effect on the
+handle to reapply the change after a style switch:
+
+<Code code={region(composition, "base-layer-handle")} lang="kotlin" title="App.kt" />
 
 `initialBaseStyle` seeds the map once. Changing that input does not reload the
 remembered map; assign `mapState.style.baseStyle` to switch styles.

--- a/docs/src/content/docs/composition.mdx
+++ b/docs/src/content/docs/composition.mdx
@@ -26,9 +26,7 @@ positions in the layer stack.
 The library manages the sources and layers in the style block. It
 does not modify the rest of the base style. To change a base style layer,
 look up its <Api of="LayerHandle" /> in `mapState.style.layers` and write the
-property through the handle. The lookup returns null until the style is ready,
-and each loaded style generation has its own handles, so key the effect on the
-handle to reapply the change after a style switch:
+property through the handle, in an effect keyed on the handle:
 
 <Code code={region(composition, "base-layer-handle")} lang="kotlin" title="App.kt" />
 

--- a/docs/src/content/docs/layers.mdx
+++ b/docs/src/content/docs/layers.mdx
@@ -57,8 +57,8 @@ after the property. The default, null, uses the global transition that
 ## Anchor a layer in the stack
 
 By default, your layers draw above the base style layers. <Api of="Anchor" />
-inserts a layer at another position: at the `Bottom`, at the `Top`, `Above` or
-`Below` a named base layer, or as a `Replace`ment for a base layer:
+inserts a layer at another position: at the `Bottom`, at the `Top`, or `Above`
+or `Below` a named base layer:
 
 <Code code={rememberedMapStyle(region(layers, "anchors"))} lang="kotlin" title="App.kt" />
 

--- a/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MlnFfiStyleSwitchTest.kt
+++ b/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MlnFfiStyleSwitchTest.kt
@@ -111,19 +111,16 @@ class MlnFfiStyleSwitchTest {
     val runtime = createMapRuntime(runtimeOptions)
     var style by mutableStateOf(SLOT_STYLES[0])
     var sourceLayer by mutableStateOf("places")
-    var showLayer by mutableStateOf(true)
     val state =
       runtime.createMapState(initialBaseStyle = SLOT_STYLES[0]) {
         val points = rememberGeoJsonSource(data = GeoJsonData.Features(pointAt(longitude = 0.0)))
-        if (showLayer) {
-          Anchor.Below("base-slot") {
-            FillLayer(
-              id = "user-anchored",
-              source = points,
-              sourceLayer = sourceLayer,
-              color = const(Color.Blue),
-            )
-          }
+        Anchor.Below("base-slot") {
+          FillLayer(
+            id = "user-anchored",
+            source = points,
+            sourceLayer = sourceLayer,
+            color = const(Color.Blue),
+          )
         }
       }
 
@@ -150,10 +147,6 @@ class MlnFfiStyleSwitchTest {
     }
     waitUntil(timeoutMillis = SETTLE_TIMEOUT_MILLIS) {
       slotLayers() == listOf("bg-b", "user-anchored", "base-slot")
-    }
-    runOnUiThread { showLayer = false }
-    waitUntil(timeoutMillis = SETTLE_TIMEOUT_MILLIS) {
-      slotLayers() == listOf("bg-b", "base-slot")
     }
     runtime.close()
     runtime.awaitClosed()

--- a/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MlnFfiStyleSwitchTest.kt
+++ b/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MlnFfiStyleSwitchTest.kt
@@ -107,18 +107,18 @@ class MlnFfiStyleSwitchTest {
   }
 
   @Test
-  fun recreating_a_replacement_layer_while_switching_the_base_style() = runFfiComposeUiTest {
+  fun recreating_an_anchored_layer_while_switching_the_base_style() = runFfiComposeUiTest {
     val runtime = createMapRuntime(runtimeOptions)
-    var style by mutableStateOf(REPLACEMENT_STYLES[0])
+    var style by mutableStateOf(SLOT_STYLES[0])
     var sourceLayer by mutableStateOf("places")
-    var showReplacement by mutableStateOf(true)
+    var showLayer by mutableStateOf(true)
     val state =
-      runtime.createMapState(initialBaseStyle = REPLACEMENT_STYLES[0]) {
+      runtime.createMapState(initialBaseStyle = SLOT_STYLES[0]) {
         val points = rememberGeoJsonSource(data = GeoJsonData.Features(pointAt(longitude = 0.0)))
-        if (showReplacement) {
-          Anchor.Replace("base-slot") {
+        if (showLayer) {
+          Anchor.Below("base-slot") {
             FillLayer(
-              id = "user-replacement",
+              id = "user-anchored",
               source = points,
               sourceLayer = sourceLayer,
               color = const(Color.Blue),
@@ -135,14 +135,13 @@ class MlnFfiStyleSwitchTest {
       state.currentMapAttachment != null && state.style.loadState == StyleLoadState.Ready
     }
     val session = requireNotNull(state.currentMapAttachment).adapter as MlnFfiMapSession
-    fun replacementLayers(): List<String> =
-      session.currentStyleLayerIds().filter { it in REPLACEMENT_LAYER_IDS }
+    fun slotLayers(): List<String> = session.currentStyleLayerIds().filter { it in SLOT_LAYER_IDS }
     waitUntil(timeoutMillis = SETTLE_TIMEOUT_MILLIS) {
-      replacementLayers() == listOf("bg-a", "user-replacement")
+      slotLayers() == listOf("bg-a", "user-anchored", "base-slot")
     }
 
     runOnUiThread {
-      style = REPLACEMENT_STYLES[1]
+      style = SLOT_STYLES[1]
       sourceLayer = "roads"
       state.style.baseStyle = style
     }
@@ -150,11 +149,11 @@ class MlnFfiStyleSwitchTest {
       state.style.loadState == StyleLoadState.Ready
     }
     waitUntil(timeoutMillis = SETTLE_TIMEOUT_MILLIS) {
-      replacementLayers() == listOf("bg-b", "user-replacement")
+      slotLayers() == listOf("bg-b", "user-anchored", "base-slot")
     }
-    runOnUiThread { showReplacement = false }
+    runOnUiThread { showLayer = false }
     waitUntil(timeoutMillis = SETTLE_TIMEOUT_MILLIS) {
-      replacementLayers() == listOf("bg-b", "base-slot")
+      slotLayers() == listOf("bg-b", "base-slot")
     }
     runtime.close()
     runtime.awaitClosed()
@@ -286,9 +285,9 @@ class MlnFfiStyleSwitchTest {
         "user-circles",
       )
 
-    val REPLACEMENT_LAYER_IDS = setOf("bg-a", "bg-b", "base-slot", "user-replacement")
+    val SLOT_LAYER_IDS = setOf("bg-a", "bg-b", "base-slot", "user-anchored")
 
-    val REPLACEMENT_STYLES =
+    val SLOT_STYLES =
       listOf(
         BaseStyle.Json(
           """

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/Anchor.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/Anchor.kt
@@ -49,12 +49,6 @@ public sealed interface Anchor {
    */
   public data class Below(val layerId: String) : Anchor
 
-  /**
-   * Layer(s) replace the layer (i.e. are shown instead of it) with the given [layerId] from the
-   * base map style. See [Anchor.Companion.Replace] to use this in the layers composition.
-   */
-  public data class Replace(val layerId: String) : Anchor
-
   public companion object {
     /** The layers specified in [block] are put at the top, i.e. in front of all other layers. */
     @Composable
@@ -83,15 +77,6 @@ public sealed interface Anchor {
     @MaplibreComposable
     public fun Below(layerId: String, block: @Composable () -> Unit): Unit =
       At(Below(layerId), block)
-
-    /**
-     * The layers specified in [block] replace the layer (i.e. are shown instead of it) with the
-     * given [layerId] from the base map style.
-     */
-    @Composable
-    @MaplibreComposable
-    public fun Replace(layerId: String, block: @Composable () -> Unit): Unit =
-      At(Replace(layerId), block)
 
     /** The layers specified in [block] are put at the given [Anchor]. */
     @Composable

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleReconciler.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleReconciler.kt
@@ -8,7 +8,6 @@ internal class StyleReconciler {
   private val sources = linkedMapOf<String, AppliedSource>()
   private val layers = linkedMapOf<String, AppliedLayer>()
   private val images = linkedMapOf<String, StyleImageDefinition>()
-  private val replacedLayers = mutableMapOf<Anchor.Replace, LayerDefinition>()
 
   /**
    * The engine's layer order, bottom to top, as this reconciler's mutations leave it. Reading the
@@ -85,14 +84,7 @@ internal class StyleReconciler {
           val nextDesiredId = group.getOrNull(index + 1)?.definition?.id
           var applied = layers[id]
           if (applied == null) {
-            val before = beforeLayerId(layerIds(style), anchor, previousId, id)
-            if (anchor is Anchor.Replace && anchor !in replacedLayers) {
-              val replaced =
-                requireNotNull(style.getLayer(anchor.layerId)) {
-                  "Layer ID '${anchor.layerId}' not found in base style"
-                }
-              replacedLayers[anchor] = replaced.definition()
-            }
+            val before = beforeLayerId(layerIds(style), anchor, previousId)
             applied =
               AppliedLayer(
                 definition = desired.definition,
@@ -108,17 +100,11 @@ internal class StyleReconciler {
             changes.layers.add(id)
             layers[id] = applied
             layerIds(style).insertBelow(id, before)
-            if (anchor is Anchor.Replace && group.first() === desired) {
-              style.identity.layers.remove(anchor.layerId)
-              changes.layers.add(anchor.layerId)
-              style.removeLayer(anchor.layerId)
-              layerIds(style).remove(anchor.layerId)
-            }
           } else {
             applied.installation.update(desired.definition, revision.animatorDurationScale)
             applied.definition = desired.definition
             if (shouldMoveLayer(layerIds(style), anchor, previousId, id, nextDesiredId)) {
-              val before = beforeLayerId(layerIds(style), anchor, previousId, id)
+              val before = beforeLayerId(layerIds(style), anchor, previousId)
               if (before != id) {
                 layerOrderChanged = true
                 applied.installation.move(before)
@@ -142,7 +128,6 @@ internal class StyleReconciler {
     sources.clear()
     layers.clear()
     images.clear()
-    replacedLayers.clear()
     knownLayerIds = null
   }
 
@@ -181,15 +166,6 @@ internal class StyleReconciler {
     changes: StyleResourceChanges,
   ) {
     changes.layers.add(applied.definition.id)
-    val anchor = applied.anchor
-    val isLastReplacement =
-      anchor is Anchor.Replace && layers.values.count { it.anchor == anchor } == 1
-    if (isLastReplacement) {
-      val original = requireNotNull(replacedLayers.remove(anchor))
-      changes.layers.add(original.id)
-      style.addLayer(original, beforeLayerId = applied.definition.id)
-      knownLayerIds?.insertBelow(anchor.layerId, applied.definition.id)
-    }
     applied.installation.remove()
     knownLayerIds?.remove(applied.definition.id)
     layers.remove(applied.definition.id)
@@ -221,30 +197,17 @@ internal class StyleReconciler {
   ): Boolean {
     if (previousId != null) return ids.idAbove(previousId) != id
     if (nextDesiredId != null) return ids.positionBefore(id) != nextDesiredId
-    val before = beforeLayerId(ids, anchor, previousId = null, desiredId = id)
+    val before = beforeLayerId(ids, anchor, previousId = null)
     return before != id && ids.positionBefore(id) != before
   }
 
-  private fun beforeLayerId(
-    ids: List<String>,
-    anchor: Anchor,
-    previousId: String?,
-    desiredId: String? = null,
-  ): String {
+  private fun beforeLayerId(ids: List<String>, anchor: Anchor, previousId: String?): String {
     if (previousId != null) return ids.idAbove(previousId)
-    if (anchor is Anchor.Replace && anchor in replacedLayers) {
-      val firstReplacement = ids.firstOrNull { layers[it]?.anchor == anchor }
-      if (firstReplacement != null && firstReplacement != desiredId) return firstReplacement
-      if (desiredId != null && desiredId in ids) {
-        return ids.positionBefore(desiredId)
-      }
-    }
     return when (anchor) {
       is Anchor.Top -> ""
       is Anchor.Bottom -> ids.firstOrNull().orEmpty()
       is Anchor.Above -> ids.idAbove(anchor.layerId)
       is Anchor.Below -> anchor.layerId
-      is Anchor.Replace -> ids.idAbove(anchor.layerId)
     }
   }
 

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
@@ -284,18 +284,13 @@ class MapPresentationTest {
       fixture.state.updateLoadedStyle(fixture.adapter, binding)
       fixture.state.markStyleReady(fixture.adapter)
       val base = checkNotNull(fixture.state.style.layers["base"])
-      suspend fun apply(ids: List<String>, replaceBase: Boolean = false) {
+      suspend fun apply(ids: List<String>) {
         val revision =
           DesiredStyleRevision(
             if (ids.isEmpty()) emptyList()
             else listOf(attributedVectorSource("added", "attribution").definition()),
             ids.map { id ->
-              DesiredStyleLayer(
-                BackgroundLayer(id).definition(),
-                if (replaceBase) Anchor.Replace("base") else Anchor.Top,
-                null,
-                null,
-              )
+              DesiredStyleLayer(BackgroundLayer(id).definition(), Anchor.Top, null, null)
             },
             emptyList(),
           )
@@ -312,13 +307,10 @@ class MapPresentationTest {
       assertEquals(listOf("base", "b", "a"), fixture.state.style.layers.map { it.id })
       assertSame(a, fixture.state.style.layers["a"])
       assertSame(base, fixture.state.style.layers["base"])
-      apply(listOf("replacement"), replaceBase = true)
-      assertEquals(listOf("replacement"), fixture.state.style.layers.map { it.id })
-      assertFailsWith<IllegalStateException> { base.getProperty("background-opacity") }
       apply(emptyList())
       assertEquals(listOf("base"), fixture.state.style.layers.map { it.id })
       assertTrue(fixture.state.style.sources.none())
-      assertFailsWith<IllegalStateException> { base.getProperty("background-opacity") }
+      assertSame(base, fixture.state.style.layers["base"])
       assertFailsWith<IllegalStateException> { a.getProperty("background-opacity") }
     } finally {
       fixture.close()

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/style/StyleCompositionOrderTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/style/StyleCompositionOrderTest.kt
@@ -40,7 +40,6 @@ class StyleCompositionOrderTest {
         Anchor.Bottom,
         Anchor.Above("water"),
         Anchor.Below("roads"),
-        Anchor.Replace("park"),
       )
     for (anchor in anchors) {
       val source =

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserStyleConformanceTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserStyleConformanceTest.kt
@@ -78,7 +78,7 @@ class BrowserStyleConformanceTest {
             tiles = listOf("https://example.invalid/{z}/{x}/{y}.pbf"),
             options = TileSetOptions(minZoom = 24, maxZoom = 24),
           )
-        Anchor.Replace("base-fill") {
+        Anchor.Below("base-fill") {
           if (showLayer) {
             FillLayer(
               id = "switching-source-layer",
@@ -95,21 +95,21 @@ class BrowserStyleConformanceTest {
       liveSourceLayer() == "places"
     }
     assertEquals(
-      listOf("base-background", "switching-source-layer"),
+      listOf("base-background", "switching-source-layer", "base-fill"),
       style?.layerIds(),
     )
 
     sourceLayer = "roads"
-    waitUntilMap("the replacement source layer to reach the live style") {
+    waitUntilMap("the recreated source layer to reach the live style") {
       liveSourceLayer() == "roads"
     }
     assertEquals(
-      listOf("base-background", "switching-source-layer"),
+      listOf("base-background", "switching-source-layer", "base-fill"),
       style?.layerIds(),
     )
 
     showLayer = false
-    waitUntilMap("the replaced base layer to be restored") {
+    waitUntilMap("the removed layer to leave the live style") {
       style?.layerIds() == listOf("base-background", "base-fill")
     }
     assertTrue(failures.isEmpty(), "the map reported load failures: $failures")


### PR DESCRIPTION
## Description

`Anchor.Replace` existed because base-style layers could not be written from the composition. `LayerHandle` covers that now through `mapState.style.layers`, so this removes `Replace` and the reconciler paths that removed and restored base layers for it. The composition never modifies the base style; the docs point at `LayerHandle` instead. Part of #958.

## Validation

- `mise run check`: passed.
- `mise run test:desktop`: passed. Includes the edited `StyleCompositionOrderTest`, `MapPresentationTest`, and `MlnFfiStyleSwitchTest` (via `androidJvmTest`).
- `caffeinate mise run test:js`: passed, including the rewritten `BrowserStyleConformanceTest`.
- `mise run build:docs`: passed on the initial commit; the later doc edits only remove text and link to the `LayerHandle` API reference, verified by the docs CI job.
- Not run: Android host/device and iOS suites.

## AI assistance

Claude Fable 5.1 via Claude Code (workflow-driven implementation), pending author review.

