### PR TITLE
Prototype: write MapLibre expressions as ordinary Kotlin

### DIFF
--- a/buildSrc/src/main/kotlin/applyMapLibreExprPlugin.kt
+++ b/buildSrc/src/main/kotlin/applyMapLibreExprPlugin.kt
@@ -1,0 +1,30 @@
+import org.gradle.api.Project
+import org.gradle.api.tasks.bundling.Jar
+import org.gradle.kotlin.dsl.named
+import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.tasks.AbstractKotlinCompile
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
+
+/**
+ * Applies the in-repo MapLibre `expr { }` compiler plugin to Kotlin compilations in this project.
+ *
+ * JVM, JS, Android, and metadata compilations use `pluginClasspath`. Native compilations get
+ * `-Xplugin` because they use a different task type.
+ */
+fun Project.applyMapLibreExprCompilerPlugin() {
+  val compilerPath = ":lib:maplibre-compose-expr-compiler"
+  val compiler = rootProject.findProject(compilerPath) ?: return
+  evaluationDependsOn(compilerPath)
+
+  val jar = compiler.tasks.named("jar", Jar::class)
+
+  tasks.withType<AbstractKotlinCompile<*>>().configureEach { pluginClasspath.from(jar) }
+
+  tasks.withType<KotlinCompilationTask<*>>().configureEach {
+    dependsOn(jar)
+    if (this !is AbstractKotlinCompile<*>) {
+      val pluginArg = jar.flatMap { it.archiveFile }.map { "-Xplugin=${it.asFile.absolutePath}" }
+      compilerOptions.freeCompilerArgs.add(pluginArg)
+    }
+  }
+}

--- a/demo-app/common/build.gradle.kts
+++ b/demo-app/common/build.gradle.kts
@@ -7,6 +7,8 @@ plugins {
   id(libs.plugins.compose.get().pluginId)
 }
 
+applyMapLibreExprCompilerPlugin()
+
 kotlin {
   jvmToolchain(libs.versions.java.toolchain.get().toInt())
 

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Expressions.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Expressions.kt
@@ -5,16 +5,7 @@ package org.maplibre.compose.docsnippets
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import org.maplibre.compose.expressions.dsl.asNumber
-import org.maplibre.compose.expressions.dsl.condition
-import org.maplibre.compose.expressions.dsl.const
-import org.maplibre.compose.expressions.dsl.exponential
-import org.maplibre.compose.expressions.dsl.feature
-import org.maplibre.compose.expressions.dsl.gt
-import org.maplibre.compose.expressions.dsl.interpolate
-import org.maplibre.compose.expressions.dsl.step
-import org.maplibre.compose.expressions.dsl.switch
-import org.maplibre.compose.expressions.dsl.zoom
+import org.maplibre.compose.expressions.kotlin.expr
 import org.maplibre.compose.layers.CircleLayer
 import org.maplibre.compose.map.MaplibreMap
 import org.maplibre.compose.map.rememberMapState
@@ -33,8 +24,8 @@ fun Expressions() {
     CircleLayer(
       id = "quakes-constant",
       source = earthquakes,
-      radius = const(4.dp),
-      color = const(Color.Red),
+      radius = expr { 4.dp },
+      color = expr { Color.Red },
     )
     // #endregion constants
 
@@ -43,17 +34,22 @@ fun Expressions() {
       id = "quakes-by-magnitude",
       source = earthquakes,
       radius =
-        step(
-          input = feature["mag"].asNumber(),
-          fallback = const(4.dp),
-          4 to const(8.dp),
-          6 to const(16.dp),
-        ),
+        expr {
+          val mag = feature.number("mag")
+          when {
+            mag >= 6 -> 16.dp
+            mag >= 4 -> 8.dp
+            else -> 4.dp
+          }
+        },
       color =
-        switch(
-          condition(test = feature["mag"].asNumber() gt const(5), output = const(Color.Red)),
-          fallback = const(Color.Yellow),
-        ),
+        expr {
+          if (feature.number("mag") > 5) {
+            Color.Red
+          } else {
+            Color.Yellow
+          }
+        },
     )
     // #endregion feature-data
 
@@ -62,12 +58,9 @@ fun Expressions() {
       id = "quakes-by-zoom",
       source = earthquakes,
       radius =
-        interpolate(
-          type = exponential(2f),
-          input = zoom(),
-          5 to const(2.dp),
-          10 to const(8.dp),
-        ),
+        expr {
+          interpolate(exponential(2), zoom, 5 to 2.dp, 10 to 8.dp)
+        },
     )
     // #endregion zoom
 
@@ -75,7 +68,7 @@ fun Expressions() {
     CircleLayer(
       id = "large-quakes",
       source = earthquakes,
-      filter = feature["mag"].asNumber() gt const(5),
+      filter = expr { feature.number("mag") > 5 },
     )
     // #endregion filter
   }

--- a/docs/src/content/docs/expressions.mdx
+++ b/docs/src/content/docs/expressions.mdx
@@ -1,6 +1,6 @@
 ---
 title: Expressions in Kotlin
-description: The expression DSL that computes layer properties from feature data and zoom.
+description: Write layer expressions as ordinary Kotlin. A compiler plugin lowers them to MapLibre style JSON.
 ---
 
 import { Code } from "@astrojs/starlight/components";
@@ -12,25 +12,28 @@ import expressions from "../../../../demo-app/common/src/commonMain/kotlin/org/m
 Layer properties in MapLibre are not plain values. Each property takes an
 expression: a formula that the map evaluates while it renders, per feature and
 per zoom level. The [MapLibre Style Specification][spec-expressions] defines
-expressions as JSON arrays. MapLibre Compose provides a Kotlin DSL that builds
-them with type checking, in <Api of="org.maplibre.compose.expressions.dsl" />.
+expressions as JSON arrays.
 
-The DSL uses Compose types when a Compose type matches the property: `Dp` for
-sizes, `Color` for colors, and `DpOffset` for offsets.
+MapLibre Compose captures ordinary Kotlin inside
+<Api of="org.maplibre.compose.expressions.kotlin.expr" />. The compiler plugin
+rewrites `if`, `when`, operators, and helpers such as `feature` and `zoom` into
+that JSON. Layer parameters still take
+<Api of="org.maplibre.compose.expressions.ast.Expression" />.
+
+The Kotlin types match the property: `Dp` for sizes, `Color` for colors, and
+`Boolean` for filters.
 
 ## Constants
 
-A constant value must also be an expression. Wrap a plain value in
-<Api of="const" />:
+A constant is still an expression. Write the Kotlin value inside `expr`:
 
 <Code code={rememberedMapStyle(region(expressions, "constants"))} lang="kotlin" title="App.kt" />
 
 ## Read feature data
 
-<Api of="feature" /> accesses the properties of the feature being rendered.
-The result is untyped, so convert it with functions such as `asNumber()` or
-`asString()`. Functions such as <Api of="step" /> and <Api of="switch" />
-select an output from the value:
+<Api of="org.maplibre.compose.expressions.kotlin.FeatureExpr" /> is the feature
+being rendered. `feature["mag"]` is untyped. `feature.number("mag")` asserts a
+number. Kotlin `if` and `when` choose an output per feature:
 
 <Code code={rememberedMapStyle(region(expressions, "feature-data"))} lang="kotlin" title="App.kt" />
 
@@ -39,8 +42,8 @@ radius and a color computed from its own magnitude.
 
 ## React to zoom
 
-<Api of="zoom" /> is the current zoom level. <Api of="interpolate" /> computes
-a smooth value between stops:
+`zoom` is the current zoom level. `interpolate` computes a smooth value between
+stops:
 
 <Code code={rememberedMapStyle(region(expressions, "zoom"))} lang="kotlin" title="App.kt" />
 
@@ -53,13 +56,13 @@ features for which it is true:
 
 ## Where the code runs
 
-Kotlin code outside an expression runs during composition and produces an
-expression. The expression runs inside the map renderer, once per feature. A
-Kotlin `if` selects which expression to build; an expression `switch` selects
-a value per feature. Use Kotlin for decisions that depend on app state, and
-expressions for decisions that depend on feature data or zoom.
+The `expr` block is not executed during composition. The compiler plugin
+rewrites it into an expression tree. That tree runs inside the map renderer,
+once per feature. A Kotlin `if` inside `expr` is a per-feature `case`. A Kotlin
+`if` outside `expr` still selects which expression to build from app state.
 
-The API reference documents the full set of expression functions under
-<Api of="org.maplibre.compose.expressions.dsl" />.
+MapLibre-specific operations that have no Kotlin equivalent stay as helpers on
+<Api of="org.maplibre.compose.expressions.kotlin.ExprScope" />: `interpolate`,
+`step`, `format`, `image`, `collator`, and typed feature accessors.
 
 [spec-expressions]: https://maplibre.org/maplibre-style-spec/expressions/

--- a/docs/src/content/docs/expressions.mdx
+++ b/docs/src/content/docs/expressions.mdx
@@ -63,6 +63,13 @@ once per feature. A Kotlin `if` inside `expr` is a per-feature `case`. A Kotlin
 
 MapLibre-specific operations that have no Kotlin equivalent stay as helpers on
 <Api of="org.maplibre.compose.expressions.kotlin.ExprScope" />: `interpolate`,
-`step`, `format`, `image`, `collator`, and typed feature accessors.
+`step`, `match`, `format`, `image`, `collator`, and typed feature accessors.
+
+Values captured from outside the block are frozen when the tree is built. The
+plugin accepts Boolean, Number, String, Color, Dp, Offset, Duration, enum,
+GeoJSON, lists of those, and an already-built expression. A type it cannot
+encode, or a Kotlin function that takes feature or zoom data, is a compile
+error. MapLibre also cannot build an `Offset` or `listOf` from feature numbers;
+those constructors stay composition-time.
 
 [spec-expressions]: https://maplibre.org/maplibre-style-spec/expressions/

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -105,6 +105,7 @@ kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-cor
 kotlinx-coroutines-playServices = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-play-services", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-swing = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-swing", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
+kotlin-compilerEmbeddable = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "gradle-kotlin" }
 kotlinx-atomicfu = { module = "org.jetbrains.kotlinx:atomicfu", version.ref = "kotlinx-atomicfu" }
 kotlinx-io-core = { module = "org.jetbrains.kotlinx:kotlinx-io-core", version.ref = "kotlinx-io" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }

--- a/lib/maplibre-compose-expr-compiler/PROTOTYPE.md
+++ b/lib/maplibre-compose-expr-compiler/PROTOTYPE.md
@@ -1,0 +1,96 @@
+# Expression compiler plugin prototype
+
+This is a throwaway exploration. It should compile and run, but it is not a
+merge candidate. The goal is to see whether users can write MapLibre expressions
+as ordinary Kotlin, with `if` / `when` and operators, instead of the `const` /
+`switch` / `gt` DSL.
+
+The idea comes from
+[kotlin-expr-tree-kcp](https://github.com/Kronos-orm/kotlin-expr-tree-kcp): a K2
+plugin captures a typed Kotlin lambda. This prototype lowers that lambda
+straight to the existing `Expression` AST, so layer properties and JSON encoding
+stay the same.
+
+## What went well
+
+- Keeping the current AST as the lowering target meant layers, compile context
+  (images, text units), and `toStyleJson()` did not need a rewrite.
+- Typing `expr { }` as real Kotlin (`Boolean`, `Color`, `Dp`, `Double`) is what
+  makes `if (mag > 5) Color.Red else Color.Yellow` type-check. That is the whole
+  point of a compiler plugin: `if` needs a `Boolean`, so the lambda cannot use
+  `Expression<BooleanValue>` as the user-facing type.
+- `ExprEmit` is a small, overload-free runtime API. The IR phase only has to
+  emit `lit` / `op` / `interpolate` / `step` / `match`. That avoided picking
+  among the DSL's many overloads from IR.
+- Reusing Kotlin's own functions covers a large part of the style spec: `+` /
+  `*` / `>`, `kotlin.math.sqrt`, `String.uppercase()`, `List.contains`.
+- Local `val` inlining and captured outer values (`val threshold = 5.0`) fall
+  out of IR `IrGetValue` handling.
+
+## What did not go well
+
+- Kotlin compiler plugin APIs are unstable and version-locked to
+  `kotlin-compiler-embeddable` 2.4.10. A FIR checker plus registry (the kcp
+  design) would give better diagnostics; this prototype is IR-only, so
+  unsupported constructs fail while generating IR, not during analysis.
+- Primitive comparisons lower in several IR shapes (`greater`, `compareTo`,
+  `IrWhen` with `ANDAND` / `OROR`). The visitor has to special-case each.
+- `when` always becomes `case`, not `match`. That is correct but misses the more
+  compact `match` encoding the old DSL used for label dispatch.
+- Interface members declared as `fun Any?.asNumber()` are awkward in IR
+  (dispatch receiver is the scope, extension receiver is the value).
+- Native compilations do not share `AbstractKotlinCompile.pluginClasspath`. The
+  Gradle helper passes `-Xplugin` there. IDE highlighting also will not show the
+  rewritten tree.
+- `Options.build` is internal, so formatted spans and collators go through
+  `ExprEmit` helpers instead of the public DSL.
+- A real replacement would hide the old DSL. This prototype cannot: layer
+  defaults and existing tests still call `const`, and `allWarningsAsErrors`
+  would turn a package-wide `@Deprecated` into a red build.
+
+## Major decisions
+
+1. **IR-only plugin, not FIR extract + generic tree.** kcp builds a portable
+   `ExprTree` ADT. MapLibre already has an AST that serializes to style JSON, so
+   a second tree would be waste. The plugin walks the lambda IR and emits
+   `ExprEmit` calls.
+2. **`expr { }` returns `Expression<T>`, layers stay unchanged.** The user API
+   is the lambda. The engine API is still the sealed `Expression` type.
+3. **Overloads of `expr` per Kotlin return type** (`Boolean`, `Color`, `Dp`, …)
+   instead of one generic. That keeps layer property types inferable without
+   casts.
+4. **Helpers stay on `ExprScope` for operations Kotlin does not have:**
+   `interpolate`, `step`, `feature`, `zoom`, `format`, `image`, `collator`,
+   `bind` (MapLibre `let`).
+5. **Old DSL stays public as the implementation and escape hatch.** A later
+   design could mark it `internal` once the plugin is the only consumer.
+6. **Default CI tiers only.** This is shared Kotlin plus a JVM compiler plugin.
+   It does not change ABI, pointer layout, or native loading.
+
+## Mapping (Kotlin → MapLibre)
+
+| Kotlin in `expr { }`          | Style spec                   |
+| ----------------------------- | ---------------------------- |
+| `if` / `when`                 | `case`                       |
+| `&&` / `\|\|` / `!`           | `all` / `any` / `!`          |
+| `?:`                          | `coalesce`                   |
+| `+` `-` `*` `/` `%` (numbers) | same                         |
+| `+` (strings) / templates     | `concat`                     |
+| `>` `<` `==`                  | same                         |
+| `kotlin.math.*`               | same names (`pow` → `^`)     |
+| `String.uppercase()`          | `upcase`                     |
+| `feature["key"]`              | `get`                        |
+| `feature.number("key")`       | `number` + `get`             |
+| `zoom`                        | `zoom`                       |
+| `interpolate` / `step`        | same                         |
+| captured outer value          | `literal` via `ExprEmit.lit` |
+
+Rejected in the lambda: `var`, loops, `try`, user functions that are not
+inlined, side effects. MapLibre expressions are pure JSON.
+
+## How to apply
+
+The consuming Gradle project calls `applyMapLibreExprCompilerPlugin()` from
+`buildSrc`. That puts `:lib:maplibre-compose-expr-compiler` on the Kotlin
+`pluginClasspath`. Without the plugin, `expr { }` still type-checks and then
+throws at runtime.

--- a/lib/maplibre-compose-expr-compiler/PROTOTYPE.md
+++ b/lib/maplibre-compose-expr-compiler/PROTOTYPE.md
@@ -103,6 +103,12 @@ These are engine or Kotlin constraints, not missing visitor branches.
     by equality. Interning `BooleanLiteral.True`/`False` on the companion also
     fails: constructing those instances re-enters the companion before the
     fields are assigned, and `of(true)` returns `undefined`. Do not intern them.
+    Boolean IR constants now call typed `litBoolean(Boolean)`, which goes
+    through `const(Boolean)` and never boxes as `Any?`.
+11. **Dokka `failOnWarning` rejects an unresolved `[EnumValue]` KDoc link.**
+    `ExprScope` does not import that type, and `ExprScopeStubs.asEnum` inherits
+    the same comment. A fully qualified destination still warned. Write the type
+    name in prose instead of a link.
 
 Const-able types: Boolean, Number, String, Color, Dp, Offset, DpOffset,
 DpPadding, TextUnit, Duration, ProjectionTransition, EnumValue, ImageBitmap,

--- a/lib/maplibre-compose-expr-compiler/PROTOTYPE.md
+++ b/lib/maplibre-compose-expr-compiler/PROTOTYPE.md
@@ -98,9 +98,11 @@ These are engine or Kotlin constraints, not missing visitor branches.
    `org.maplibre.compose.expressions.kotlin`, so a prefix match treated
    `themeRed()` as an expr helper. Only `ExprScope` / `FeatureExpr` owners
    count.
-10. **Kotlin/JS does not treat a JS `boolean` as `is Boolean`.** `ExprEmit.lit`
-    takes `Any?`. `lit(true)` fell through on JS and returned `undefined`. Match
-    `true`/`false` by equality before the type check.
+10. **Kotlin/JS boolean literals are two separate holes.** `is Boolean` does not
+    match a primitive JS `boolean`, so `lit(Any?)` must match `true` / `false`
+    by equality. Interning `BooleanLiteral.True`/`False` on the companion also
+    fails: constructing those instances re-enters the companion before the
+    fields are assigned, and `of(true)` returns `undefined`. Do not intern them.
 
 Const-able types: Boolean, Number, String, Color, Dp, Offset, DpOffset,
 DpPadding, TextUnit, Duration, ProjectionTransition, EnumValue, ImageBitmap,

--- a/lib/maplibre-compose-expr-compiler/PROTOTYPE.md
+++ b/lib/maplibre-compose-expr-compiler/PROTOTYPE.md
@@ -27,27 +27,82 @@ stay the same.
   `*` / `>`, `kotlin.math.sqrt`, `String.uppercase()`, `List.contains`.
 - Local `val` inlining and captured outer values (`val threshold = 5.0`) fall
   out of IR `IrGetValue` handling.
+- Subject `when (feature.string("kind")) { "park" -> ... }` can become `match`
+  when every branch is equality against a composition-time label. Comparison
+  `when { mag >= 6 -> ... }` stays `case`.
+- A GeoJSON literal is a bare JSON object. `within` / `distance` need that
+  shape; wrapping it in `["literal", ...]` would be the wrong type.
+- Compile-time const-able checking is possible from IR types. The plugin reports
+  through `MessageCollector` and keeps walking so one `expr` can produce several
+  errors.
 
 ## What did not go well
 
 - Kotlin compiler plugin APIs are unstable and version-locked to
   `kotlin-compiler-embeddable` 2.4.10. A FIR checker plus registry (the kcp
   design) would give better diagnostics; this prototype is IR-only, so
-  unsupported constructs fail while generating IR, not during analysis.
+  unsupported constructs fail while generating IR, not during analysis. The IDE
+  still type-checks the stubs and does not show the rewritten tree.
 - Primitive comparisons lower in several IR shapes (`greater`, `compareTo`,
   `IrWhen` with `ANDAND` / `OROR`). The visitor has to special-case each.
-- `when` always becomes `case`, not `match`. That is correct but misses the more
-  compact `match` encoding the old DSL used for label dispatch.
 - Interface members declared as `fun Any?.asNumber()` are awkward in IR
   (dispatch receiver is the scope, extension receiver is the value).
+- Reified `asEnum<SymbolAnchor>()` cannot be an interface member. The prototype
+  takes `List<String>` of style-spec names. Callers write
+  `SymbolAnchor.entries.map { it.literal.value }`.
+- `Color` is a value class, so `vararg fallbacks: Color` is not usable on
+  common. `asColor` / `convertToColor` take `Any?` fallbacks instead.
+- Compose's `Int.dp` / `Double.sp` / `kotlin.time`'s `Double.seconds` win
+  overload resolution over `ExprScope` extensions on `Number`. The plugin has to
+  recognize those getters in IR. Map-time `.seconds` becomes `* 1000`;
+  composition-time `.seconds` freezes a `Duration`.
 - Native compilations do not share `AbstractKotlinCompile.pluginClasspath`. The
-  Gradle helper passes `-Xplugin` there. IDE highlighting also will not show the
-  rewritten tree.
+  Gradle helper passes `-Xplugin` there.
 - `Options.build` is internal, so formatted spans and collators go through
   `ExprEmit` helpers instead of the public DSL.
 - A real replacement would hide the old DSL. This prototype cannot: layer
   defaults and existing tests still call `const`, and `allWarningsAsErrors`
   would turn a package-wide `@Deprecated` into a red build.
+
+## Limitations the hard cases showed
+
+These are engine or Kotlin constraints, not missing visitor branches.
+
+1. **MapLibre has no array constructor for dynamic components.**
+   `Offset(feature.number("x"), feature.number("y"))`, `padding(...)` from
+   feature numbers, and `listOf(feature.string("a"))` cannot become style JSON.
+   `offset` / `padding` / `listOf` are composition-time only. The plugin rejects
+   map-evaluated arguments at compile time. `asOffset()` only _asserts_ that a
+   value is already a two-number array.
+2. **Text-unit offsets are the same hole.** `offset(12.sp, 4.sp)` works.
+   `offset(feature.number("x").sp, feature.number("y").em)` does not: the AST
+   stores two `TextUnit` values, not expressions.
+3. **`image(bitmap)` / `image(painter)` options are composition-time.** Size,
+   SDF, stretch, alpha, and `ColorFilter` are inputs to bitmap registration, not
+   map operators. A style-image _name_ can be map-evaluated:
+   `image(feature.string("icon"))`.
+4. **User functions cannot take map-evaluated arguments.**
+   `paint(feature.number("mag"))` would have to run Kotlin per feature. If every
+   argument is composition-time and the return type is const-able, `themeRed()`
+   becomes `const(themeRed())`.
+5. **`kotlin.math.PI` is a `Double`, not the `pi` operator.** Use `pi` / `e` /
+   `ln2` on the scope when the JSON should contain `["pi"]`.
+6. **The old `asPadding()` DSL asserts length 2.** That looks like a spec bug
+   (padding is four numbers). The plugin emits length 4.
+7. **`var`, loops, `try`, and assignment** have no style-spec form. The plugin
+   reports them as errors instead of aborting IR generation.
+8. **`null` is typed as `Nothing?`.** The first const-able check rejected it, so
+   `feature["kind"] != null` failed to compile. `Nothing` has to be treated as
+   `nil`.
+9. **Do not match helpers by package prefix.** Tests live in
+   `org.maplibre.compose.expressions.kotlin`, so a prefix match treated
+   `themeRed()` as an expr helper. Only `ExprScope` / `FeatureExpr` owners
+   count.
+
+Const-able types: Boolean, Number, String, Color, Dp, Offset, DpOffset,
+DpPadding, TextUnit, Duration, ProjectionTransition, EnumValue, ImageBitmap,
+Painter, GeoJSON, lists of those, and `Expression`. Anything else is a compile
+error, including a capture of `MapState` or a lambda.
 
 ## Major decisions
 
@@ -62,33 +117,46 @@ stay the same.
    `fun <T : ExpressionValue> expr(block: ExprScope.() -> Any?)` lets the layer
    property infer `T` (`color = expr { Color.Red }`).
 4. **Helpers stay on `ExprScope` for operations Kotlin does not have:**
-   `interpolate`, `step`, `feature`, `zoom`, `format`, `image`, `collator`,
-   `bind` (MapLibre `let`).
-5. **Old DSL stays public as the implementation and escape hatch.** A later
+   `interpolate`, `step`, `match`, `feature`, `zoom`, `format`, `image`,
+   `collator`, `bind` (MapLibre `let`).
+5. **Two evaluation times, checked in IR.** Map-evaluated: feature/zoom/helpers
+   and operators over those. Composition-time `lit`: a const, an outer capture,
+   or a Kotlin call whose arguments are all composition-time and whose return
+   type is const-able.
+6. **Old DSL stays public as the implementation and escape hatch.** A later
    design could mark it `internal` once the plugin is the only consumer.
-6. **Default CI tiers only.** This is shared Kotlin plus a JVM compiler plugin.
+7. **Default CI tiers only.** This is shared Kotlin plus a JVM compiler plugin.
    It does not change ABI, pointer layout, or native loading.
 
 ## Mapping (Kotlin → MapLibre)
 
-| Kotlin in `expr { }`          | Style spec                   |
-| ----------------------------- | ---------------------------- |
-| `if` / `when`                 | `case`                       |
-| `&&` / `\|\|` / `!`           | `all` / `any` / `!`          |
-| `?:`                          | `coalesce`                   |
-| `+` `-` `*` `/` `%` (numbers) | same                         |
-| `+` (strings) / templates     | `concat`                     |
-| `>` `<` `==`                  | same                         |
-| `kotlin.math.*`               | same names (`pow` → `^`)     |
-| `String.uppercase()`          | `upcase`                     |
-| `feature["key"]`              | `get`                        |
-| `feature.number("key")`       | `number` + `get`             |
-| `zoom`                        | `zoom`                       |
-| `interpolate` / `step`        | same                         |
-| captured outer value          | `literal` via `ExprEmit.lit` |
+| Kotlin in `expr { }`          | Style spec                    |
+| ----------------------------- | ----------------------------- |
+| `if` / comparison `when`      | `case`                        |
+| subject `when` / `match()`    | `match`                       |
+| `&&` / `\|\|` / `!`           | `all` / `any` / `!`           |
+| `?:`                          | `coalesce`                    |
+| `+` `-` `*` `/` `%` (numbers) | same                          |
+| `+` (strings) / templates     | `concat`                      |
+| `>` `<` `==`                  | same                          |
+| `eq(a, b, collator)`          | `==` with collator            |
+| `kotlin.math.*`               | same names (`pow` → `^`)      |
+| `ln2` / `pi` / `e`            | `ln2` / `pi` / `e`            |
+| `String.uppercase()`          | `upcase`                      |
+| `feature["key"]`              | `get`                         |
+| `feature.number("key")`       | `number` + `get`              |
+| `feature.properties()[k]`     | `get` on the properties map   |
+| `zoom`                        | `zoom`                        |
+| `interpolate` / `step`        | same                          |
+| `n.seconds` (map-time)        | `*` 1000                      |
+| `n.sp` / `n.em` (map-time)    | `TextUnitCalculation`         |
+| `image("marker")`             | `["image", "marker"]`         |
+| `image(bitmap, isSdf = true)` | one `image` + `BitmapLiteral` |
+| `feature.within(point)`       | `within` + GeoJSON object     |
+| captured const-able value     | `literal` via `ExprEmit.lit`  |
 
-Rejected in the lambda: `var`, loops, `try`, user functions that are not
-inlined, side effects. MapLibre expressions are pure JSON.
+Rejected in the lambda: `var`, loops, `try`, user functions on feature data,
+dynamic `listOf` / `Offset` construction, side effects.
 
 ## How to apply
 

--- a/lib/maplibre-compose-expr-compiler/PROTOTYPE.md
+++ b/lib/maplibre-compose-expr-compiler/PROTOTYPE.md
@@ -21,7 +21,8 @@ stay the same.
   `Expression<BooleanValue>` as the user-facing type.
 - `ExprEmit` is a small, overload-free runtime API. The IR phase only has to
   emit `lit` / `op` / `interpolate` / `step` / `match`. That avoided picking
-  among the DSL's many overloads from IR.
+  among the DSL's many overloads from IR. Vararg `Expression<*>` failed at
+  runtime (`Object[]` cannot cast to `Expression[]`); list parameters work.
 - Reusing Kotlin's own functions covers a large part of the style spec: `+` /
   `*` / `>`, `kotlin.math.sqrt`, `String.uppercase()`, `List.contains`.
 - Local `val` inlining and captured outer values (`val threshold = 5.0`) fall
@@ -56,9 +57,10 @@ stay the same.
    `ExprEmit` calls.
 2. **`expr { }` returns `Expression<T>`, layers stay unchanged.** The user API
    is the lambda. The engine API is still the sealed `Expression` type.
-3. **Overloads of `expr` per Kotlin return type** (`Boolean`, `Color`, `Dp`, …)
-   instead of one generic. That keeps layer property types inferable without
-   casts.
+3. **One generic `expr`.** Per-return-type overloads clashed on the JVM and
+   broke receiver resolution (`feature` was unresolved).
+   `fun <T : ExpressionValue> expr(block: ExprScope.() -> Any?)` lets the layer
+   property infer `T` (`color = expr { Color.Red }`).
 4. **Helpers stay on `ExprScope` for operations Kotlin does not have:**
    `interpolate`, `step`, `feature`, `zoom`, `format`, `image`, `collator`,
    `bind` (MapLibre `let`).

--- a/lib/maplibre-compose-expr-compiler/PROTOTYPE.md
+++ b/lib/maplibre-compose-expr-compiler/PROTOTYPE.md
@@ -105,7 +105,12 @@ These are engine or Kotlin constraints, not missing visitor branches.
     fields are assigned, and `of(true)` returns `undefined`. Do not intern them.
     Boolean IR constants now call typed `litBoolean(Boolean)`, which goes
     through `const(Boolean)` and never boxes as `Any?`.
-11. **Dokka `failOnWarning` rejects an unresolved `[EnumValue]` KDoc link.**
+11. **Kotlin/JS numbers are one `typeof === 'number'`.** `is Int` / `is Float` /
+    `is Double` all match, so `lit(2.5)` used to take the Int branch.
+    `IntCache[2.5]` is a hole (`array[2.5]` is `undefined`) and `compile()` then
+    throws. `lit(Any?)` now has one `Number` path: whole values become `Int`
+    literals, the rest `Float`.
+12. **Dokka `failOnWarning` rejects an unresolved `[EnumValue]` KDoc link.**
     `ExprScope` does not import that type, and `ExprScopeStubs.asEnum` inherits
     the same comment. A fully qualified destination still warned. Write the type
     name in prose instead of a link.

--- a/lib/maplibre-compose-expr-compiler/PROTOTYPE.md
+++ b/lib/maplibre-compose-expr-compiler/PROTOTYPE.md
@@ -98,6 +98,9 @@ These are engine or Kotlin constraints, not missing visitor branches.
    `org.maplibre.compose.expressions.kotlin`, so a prefix match treated
    `themeRed()` as an expr helper. Only `ExprScope` / `FeatureExpr` owners
    count.
+10. **Kotlin/JS does not treat a JS `boolean` as `is Boolean`.** `ExprEmit.lit`
+    takes `Any?`. `lit(true)` fell through on JS and returned `undefined`. Match
+    `true`/`false` by equality before the type check.
 
 Const-able types: Boolean, Number, String, Color, Dp, Offset, DpOffset,
 DpPadding, TextUnit, Duration, ProjectionTransition, EnumValue, ImageBitmap,

--- a/lib/maplibre-compose-expr-compiler/build.gradle.kts
+++ b/lib/maplibre-compose-expr-compiler/build.gradle.kts
@@ -1,0 +1,8 @@
+plugins { id(libs.plugins.kotlin.jvm.get().pluginId) }
+
+kotlin {
+  jvmToolchain(libs.versions.java.toolchain.get().toInt())
+  compilerOptions { allWarningsAsErrors = false }
+}
+
+dependencies { compileOnly(libs.kotlin.compilerEmbeddable) }

--- a/lib/maplibre-compose-expr-compiler/build.gradle.kts
+++ b/lib/maplibre-compose-expr-compiler/build.gradle.kts
@@ -5,4 +5,7 @@ kotlin {
   compilerOptions { allWarningsAsErrors = false }
 }
 
-dependencies { compileOnly(libs.kotlin.compilerEmbeddable) }
+dependencies {
+  compileOnly(libs.kotlin.compilerEmbeddable)
+  testImplementation(kotlin("test"))
+}

--- a/lib/maplibre-compose-expr-compiler/src/main/kotlin/org/maplibre/compose/expr/compiler/ConstableTypes.kt
+++ b/lib/maplibre-compose-expr-compiler/src/main/kotlin/org/maplibre/compose/expr/compiler/ConstableTypes.kt
@@ -1,0 +1,145 @@
+package org.maplibre.compose.expr.compiler
+
+import org.jetbrains.kotlin.ir.declarations.IrClass
+import org.jetbrains.kotlin.ir.types.IrSimpleType
+import org.jetbrains.kotlin.ir.types.IrType
+import org.jetbrains.kotlin.ir.types.IrTypeArgument
+import org.jetbrains.kotlin.ir.types.classFqName
+import org.jetbrains.kotlin.ir.types.getClass
+import org.jetbrains.kotlin.ir.types.isNullable
+import org.jetbrains.kotlin.ir.types.isUnit
+import org.jetbrains.kotlin.ir.types.makeNotNull
+import org.jetbrains.kotlin.ir.types.typeOrNull
+import org.jetbrains.kotlin.ir.util.fqNameWhenAvailable
+
+/**
+ * Types [ExprEmit.lit] can freeze at composition time. The plugin uses this list to reject captures
+ * during IR generation instead of throwing when the tree is built.
+ */
+internal object ConstableTypes {
+  val names: Set<String> =
+    setOf(
+      "kotlin.Boolean",
+      "kotlin.Byte",
+      "kotlin.Short",
+      "kotlin.Int",
+      "kotlin.Long",
+      "kotlin.Float",
+      "kotlin.Double",
+      "kotlin.Number",
+      "kotlin.String",
+      "kotlin.time.Duration",
+      "androidx.compose.ui.graphics.Color",
+      "androidx.compose.ui.unit.Dp",
+      "androidx.compose.ui.unit.DpOffset",
+      "androidx.compose.ui.unit.DpSize",
+      "androidx.compose.ui.unit.TextUnit",
+      "androidx.compose.ui.geometry.Offset",
+      "androidx.compose.ui.graphics.ImageBitmap",
+      "androidx.compose.ui.graphics.painter.Painter",
+      "androidx.compose.ui.graphics.ColorFilter",
+      "org.maplibre.compose.util.DpPadding",
+      "org.maplibre.compose.util.ImageStretch",
+      "org.maplibre.compose.style.ProjectionTransition",
+      "org.maplibre.compose.expressions.ast.Expression",
+      "org.maplibre.spatialk.geojson.GeoJsonObject",
+      "org.maplibre.spatialk.geojson.Geometry",
+      "org.maplibre.spatialk.geojson.Feature",
+      "org.maplibre.spatialk.geojson.FeatureCollection",
+    )
+
+  val listLike: Set<String> =
+    setOf(
+      "kotlin.collections.List",
+      "kotlin.collections.MutableList",
+      "kotlin.collections.Collection",
+      "kotlin.Array",
+    )
+
+  val mapLike: Set<String> = setOf("kotlin.collections.Map", "kotlin.collections.MutableMap")
+
+  private val enumValueFq = "org.maplibre.compose.expressions.value.EnumValue"
+
+  private val subtypeRoots =
+    setOf(
+      "org.maplibre.compose.expressions.ast.Expression",
+      "org.maplibre.compose.expressions.value.EnumValue",
+      "org.maplibre.spatialk.geojson.GeoJsonObject",
+      "org.maplibre.spatialk.geojson.Geometry",
+      "androidx.compose.ui.graphics.painter.Painter",
+    )
+
+  fun isConstableFqName(fqName: String): Boolean = fqName in names
+
+  fun isListLikeFqName(fqName: String): Boolean = fqName in listLike
+
+  fun isMapLikeFqName(fqName: String): Boolean = fqName in mapLike
+
+  fun typeName(type: IrType): String =
+    type.classFqName?.asString()
+      ?: type.getClass()?.fqNameWhenAvailable?.asString()
+      ?: type.toString()
+
+  fun isConstable(type: IrType): Boolean {
+    if (type.isUnit()) return false
+    val unwrapped = if (type.isNullable()) type.makeNotNull() else type
+    // `null` is typed as Nothing?; freeze it as nil.
+    if (unwrapped.classFqName?.asString() == "kotlin.Nothing") return true
+    val fq = unwrapped.classFqName?.asString()
+    if (fq != null && fq in names) return true
+    if (fq != null && fq in listLike) {
+      val argument = unwrapped.singleTypeArgument() ?: return false
+      return argument.isStarProjection() || isConstable(argument)
+    }
+    val irClass = unwrapped.getClass() ?: return false
+    return irClass.inheritsAny(subtypeRoots + enumValueFq)
+  }
+
+  fun isMapLike(type: IrType): Boolean {
+    val unwrapped = if (type.isNullable()) type.makeNotNull() else type
+    val fq = unwrapped.classFqName?.asString() ?: return false
+    return fq in mapLike
+  }
+
+  fun isListLike(type: IrType): Boolean {
+    val unwrapped = if (type.isNullable()) type.makeNotNull() else type
+    val fq = unwrapped.classFqName?.asString() ?: return false
+    return fq in listLike
+  }
+
+  fun isStringLike(type: IrType): Boolean {
+    val unwrapped = if (type.isNullable()) type.makeNotNull() else type
+    return unwrapped.classFqName?.asString() == "kotlin.String"
+  }
+
+  fun isImageBitmap(type: IrType): Boolean =
+    typeName(type) == "androidx.compose.ui.graphics.ImageBitmap"
+
+  fun isPainter(type: IrType): Boolean {
+    val fq = typeName(type)
+    if (fq == "androidx.compose.ui.graphics.painter.Painter") return true
+    return type.getClass()?.inheritsAny(setOf("androidx.compose.ui.graphics.painter.Painter")) ==
+      true
+  }
+
+  private fun IrType.singleTypeArgument(): IrType? {
+    val simple = this as? IrSimpleType ?: return null
+    return simple.arguments.singleOrNull()?.typeOrNull
+  }
+
+  private fun IrTypeArgument.isStarProjection(): Boolean = typeOrNull == null
+
+  private fun IrClass.inheritsAny(roots: Set<String>): Boolean {
+    val seen = mutableSetOf<IrClass>()
+    fun walk(cls: IrClass): Boolean {
+      if (!seen.add(cls)) return false
+      val fq = cls.fqNameWhenAvailable?.asString()
+      if (fq != null && fq in roots) return true
+      return cls.superTypes.any { superType ->
+        val superFq = superType.classFqName?.asString()
+        (superFq != null && superFq in roots) || superType.getClass()?.let(::walk) == true
+      }
+    }
+    return walk(this)
+  }
+}

--- a/lib/maplibre-compose-expr-compiler/src/main/kotlin/org/maplibre/compose/expr/compiler/ExprDiagnostics.kt
+++ b/lib/maplibre-compose-expr-compiler/src/main/kotlin/org/maplibre/compose/expr/compiler/ExprDiagnostics.kt
@@ -1,0 +1,54 @@
+package org.maplibre.compose.expr.compiler
+
+internal object ExprDiagnostics {
+  const val PREFIX: String = "expr { }: "
+
+  fun notConstable(typeName: String): String =
+    PREFIX +
+      "Cannot capture $typeName as an expression literal. Constable types are Boolean, " +
+      "Number, String, Color, Dp, Offset, DpOffset, DpPadding, TextUnit, Duration, " +
+      "ProjectionTransition, EnumValue, ImageBitmap, Painter, GeoJSON, lists of those, " +
+      "or Expression."
+
+  fun mapArgsToKotlin(callee: String): String =
+    PREFIX +
+      "Cannot pass map-evaluated values to $callee. The map cannot run Kotlin per feature. " +
+      "Use an expr helper or an operator the plugin lowers."
+
+  fun varNotAllowed(): String =
+    PREFIX + "`var` is not allowed. MapLibre expressions are pure; use val."
+
+  fun loopNotAllowed(): String = PREFIX + "Loops are not allowed in expr { }."
+
+  fun tryNotAllowed(): String = PREFIX + "try/catch is not allowed in expr { }."
+
+  fun assignmentNotAllowed(): String = PREFIX + "Assignment is not allowed in expr { }."
+
+  fun nestedLambda(): String =
+    PREFIX + "Nested lambdas are only supported as the body of bind(name, value) { ... }."
+
+  fun emptyBlock(): String = PREFIX + "Block is empty."
+
+  fun unsupportedStatement(kind: String): String = PREFIX + "Unsupported statement: $kind."
+
+  fun receiverIsNotAValue(): String =
+    PREFIX + "The expr receiver is not a value; use feature, zoom, or a helper."
+
+  fun composeOnlyConstructor(name: String): String =
+    PREFIX +
+      "Cannot construct $name from map-evaluated numbers. MapLibre has no array constructor " +
+      "for dynamic components; offset, padding, and listOf need composition-time values."
+
+  fun stopInputMustBeConst(): String =
+    PREFIX + "interpolate/step stop inputs must be composition-time numbers."
+
+  fun imageOptionsMustBeConst(): String =
+    PREFIX + "image(bitmap/painter) options must be composition-time values."
+
+  fun textUnitOffsetMustBeConst(): String =
+    PREFIX +
+      "Text-unit offsets must be composition-time TextUnit values. MapLibre cannot build an " +
+      "em/sp pair from two map-evaluated numbers."
+
+  fun unsupportedHelper(name: String): String = PREFIX + "Unsupported expr helper $name."
+}

--- a/lib/maplibre-compose-expr-compiler/src/main/kotlin/org/maplibre/compose/expr/compiler/ExprIrLowering.kt
+++ b/lib/maplibre-compose-expr-compiler/src/main/kotlin/org/maplibre/compose/expr/compiler/ExprIrLowering.kt
@@ -1072,7 +1072,8 @@ internal class ExprIrLowering(
   }
 
   private fun emitLit(value: IrExpression): IrExpression {
-    val fn = emitFunction("lit")
+    val booleanConst = (value as? IrConst)?.value as? Boolean
+    val fn = emitFunction(if (booleanConst != null) "litBoolean" else "lit")
     return builder.irCall(fn).apply {
       arguments[0] = builder.irGetObject(emitClass)
       arguments[1] = value.deepCopyWithoutPatchingParents()

--- a/lib/maplibre-compose-expr-compiler/src/main/kotlin/org/maplibre/compose/expr/compiler/ExprIrLowering.kt
+++ b/lib/maplibre-compose-expr-compiler/src/main/kotlin/org/maplibre/compose/expr/compiler/ExprIrLowering.kt
@@ -1,0 +1,609 @@
+package org.maplibre.compose.expr.compiler
+
+import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
+import org.jetbrains.kotlin.ir.IrStatement
+import org.jetbrains.kotlin.ir.builders.IrBuilderWithScope
+import org.jetbrains.kotlin.ir.builders.irCall
+import org.jetbrains.kotlin.ir.builders.irGetObject
+import org.jetbrains.kotlin.ir.builders.irNull
+import org.jetbrains.kotlin.ir.builders.irString
+import org.jetbrains.kotlin.ir.builders.irVararg
+import org.jetbrains.kotlin.ir.declarations.IrClass
+import org.jetbrains.kotlin.ir.declarations.IrDeclarationWithName
+import org.jetbrains.kotlin.ir.declarations.IrFunction
+import org.jetbrains.kotlin.ir.declarations.IrPackageFragment
+import org.jetbrains.kotlin.ir.declarations.IrValueParameter
+import org.jetbrains.kotlin.ir.declarations.IrVariable
+import org.jetbrains.kotlin.ir.expressions.IrBlock
+import org.jetbrains.kotlin.ir.expressions.IrBlockBody
+import org.jetbrains.kotlin.ir.expressions.IrBody
+import org.jetbrains.kotlin.ir.expressions.IrBranch
+import org.jetbrains.kotlin.ir.expressions.IrCall
+import org.jetbrains.kotlin.ir.expressions.IrConst
+import org.jetbrains.kotlin.ir.expressions.IrConstructorCall
+import org.jetbrains.kotlin.ir.expressions.IrExpression
+import org.jetbrains.kotlin.ir.expressions.IrExpressionBody
+import org.jetbrains.kotlin.ir.expressions.IrFunctionExpression
+import org.jetbrains.kotlin.ir.expressions.IrGetEnumValue
+import org.jetbrains.kotlin.ir.expressions.IrGetField
+import org.jetbrains.kotlin.ir.expressions.IrGetObjectValue
+import org.jetbrains.kotlin.ir.expressions.IrGetValue
+import org.jetbrains.kotlin.ir.expressions.IrReturn
+import org.jetbrains.kotlin.ir.expressions.IrSpreadElement
+import org.jetbrains.kotlin.ir.expressions.IrStatementOrigin
+import org.jetbrains.kotlin.ir.expressions.IrStringConcatenation
+import org.jetbrains.kotlin.ir.expressions.IrTypeOperatorCall
+import org.jetbrains.kotlin.ir.expressions.IrVararg
+import org.jetbrains.kotlin.ir.expressions.IrWhen
+import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
+import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
+import org.jetbrains.kotlin.ir.symbols.IrValueSymbol
+import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
+import org.jetbrains.kotlin.ir.util.deepCopyWithoutPatchingParents
+import org.jetbrains.kotlin.ir.util.fqNameWhenAvailable
+import org.jetbrains.kotlin.ir.util.isVararg
+import org.jetbrains.kotlin.ir.util.parentAsClass
+import org.jetbrains.kotlin.name.CallableId
+import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.name.Name
+
+private val EMIT_CLASS_ID =
+  ClassId(FqName("org.maplibre.compose.expressions.kotlin"), Name.identifier("ExprEmit"))
+
+private val SCOPE_PACKAGES =
+  setOf(
+    "org.maplibre.compose.expressions.kotlin.ExprScope",
+    "org.maplibre.compose.expressions.kotlin.FeatureExpr",
+  )
+
+private val MATH_OPS =
+  setOf(
+    "sqrt",
+    "sin",
+    "cos",
+    "tan",
+    "asin",
+    "acos",
+    "atan",
+    "abs",
+    "absoluteValue",
+    "floor",
+    "ceil",
+    "round",
+    "min",
+    "max",
+    "ln",
+    "log10",
+    "log2",
+  )
+
+@OptIn(UnsafeDuringIrConstructionAPI::class)
+internal class ExprIrLowering(
+  private val context: IrPluginContext,
+  private val builder: IrBuilderWithScope,
+) {
+  private val emitClass: IrClassSymbol =
+    requireNotNull(context.referenceClass(EMIT_CLASS_ID)) {
+      "ExprEmit is not on the compilation classpath"
+    }
+
+  private val locals = mutableMapOf<IrValueSymbol, IrExpression>()
+  private var scopeReceiver: IrValueParameter? = null
+
+  fun lowerLambda(function: IrFunction): IrExpression {
+    scopeReceiver =
+      function.parameters.firstOrNull { it.kind.name.endsWith("Receiver") }
+        ?: function.parameters.firstOrNull()
+    val body = function.body ?: error("expr { } lambda has no body")
+    return lowerBody(body)
+  }
+
+  private fun lowerBody(body: IrBody): IrExpression {
+    val statements = body.statementList()
+    require(statements.isNotEmpty()) { "expr { } lambda is empty" }
+    statements.dropLast(1).forEach(::bindOrIgnore)
+    return asExpr(statements.last())
+  }
+
+  private fun bindOrIgnore(statement: IrStatement) {
+    if (statement is IrVariable) {
+      val initializer =
+        statement.initializer ?: error("local val ${statement.name} has no initializer")
+      locals[statement.symbol] = lowerExpr(initializer)
+    } else if (statement is IrExpression) {
+      lowerExpr(statement)
+    } else {
+      error("Unsupported statement in expr { }: ${statement::class.simpleName}")
+    }
+  }
+
+  private fun asExpr(statement: IrStatement): IrExpression =
+    when (statement) {
+      is IrVariable -> {
+        bindOrIgnore(statement)
+        locals.getValue(statement.symbol)
+      }
+      is IrExpression -> lowerExpr(statement)
+      else -> error("expr { } must end with an expression")
+    }
+
+  private fun lowerExpr(expression: IrExpression): IrExpression =
+    when (expression) {
+      is IrReturn -> lowerExpr(expression.value)
+      is IrBlock -> {
+        val statements = expression.statements
+        require(statements.isNotEmpty()) { "empty block in expr { }" }
+        statements.dropLast(1).forEach(::bindOrIgnore)
+        asExpr(statements.last())
+      }
+      is IrWhen -> lowerWhen(expression)
+      is IrCall -> lowerCall(expression)
+      is IrGetValue -> lowerGetValue(expression)
+      is IrStringConcatenation -> emitOp("concat", expression.arguments.map(::lowerExpr))
+      is IrTypeOperatorCall -> lowerExpr(expression.argument)
+      is IrConst,
+      is IrConstructorCall,
+      is IrGetObjectValue,
+      is IrGetEnumValue,
+      is IrGetField -> emitLit(expression)
+      is IrFunctionExpression -> error("Nested lambdas in expr { } are only supported via bind { }")
+      else -> emitLit(expression)
+    }
+
+  private fun lowerGetValue(expression: IrGetValue): IrExpression {
+    locals[expression.symbol]?.let {
+      return it
+    }
+    if (expression.symbol == scopeReceiver?.symbol) {
+      error("The expr { } receiver is not a value; use feature, zoom, or a helper")
+    }
+    return emitLit(expression)
+  }
+
+  private fun lowerWhen(expression: IrWhen): IrExpression {
+    when (expression.origin) {
+      IrStatementOrigin.ANDAND -> {
+        val first = expression.branches.first()
+        return emitOp("all", listOf(lowerExpr(first.condition), lowerExpr(first.result)))
+      }
+      IrStatementOrigin.OROR -> {
+        val first = expression.branches.first()
+        return emitOp(
+          "any",
+          listOf(lowerExpr(first.condition), lowerExpr(expression.branches.last().result)),
+        )
+      }
+      IrStatementOrigin.ELVIS -> {
+        val first = expression.branches.first()
+        return emitOp(
+          "coalesce",
+          listOf(lowerExpr(first.result), lowerExpr(expression.branches.last().result)),
+        )
+      }
+      else -> Unit
+    }
+    val tests = expression.branches.filterNot { it.isElseBranch() }
+    val fallback =
+      expression.branches.firstOrNull { it.isElseBranch() }?.let { lowerExpr(it.result) }
+        ?: emitLitNull()
+    val args = buildList {
+      for (branch in tests) {
+        add(lowerExpr(branch.condition))
+        add(lowerExpr(branch.result))
+      }
+      add(fallback)
+    }
+    return emitOp("case", args)
+  }
+
+  private fun IrBranch.isElseBranch(): Boolean {
+    val condition = condition
+    return condition is IrConst && condition.value == true
+  }
+
+  private fun lowerCall(expression: IrCall): IrExpression {
+    val owner = expression.symbol.owner
+    val name = owner.name.asString()
+    val parentFq = owner.parentFqName()
+    val callableFq = owner.fqNameWhenAvailable?.asString().orEmpty()
+
+    if (
+      parentFq in SCOPE_PACKAGES ||
+        callableFq.startsWith("org.maplibre.compose.expressions.kotlin.")
+    ) {
+      return lowerScopeCall(name, expression)
+    }
+    operatorLowering(name, expression)?.let {
+      return it
+    }
+    stdlibLowering(name, expression)?.let {
+      return it
+    }
+    return emitLit(expression)
+  }
+
+  private fun lowerScopeCall(name: String, expression: IrCall): IrExpression {
+    val args = valueArgs(expression)
+    return when (name) {
+      "getFeature",
+      "<get-feature>" -> error("Use feature[\"key\"] or feature.number(\"key\")")
+      "getZoom",
+      "<get-zoom>" -> emitOp("zoom")
+      "getHeatmapDensity",
+      "<get-heatmapDensity>" -> emitOp("heatmap-density")
+      "getElevation",
+      "<get-elevation>" -> emitOp("elevation")
+      "linear" -> emitOp("linear")
+      "exponential" -> emitOp("exponential", args.map(::lowerExpr))
+      "cubicBezier" -> emitOp("cubic-bezier", args.map(::lowerExpr))
+      "interpolate" -> emitInterpolate("interpolate", args)
+      "interpolateHcl" -> emitInterpolate("interpolate-hcl", args)
+      "interpolateLab" -> emitInterpolate("interpolate-lab", args)
+      "step" -> emitStep(args)
+      "rgb" -> emitOp(if (args.size >= 4) "rgba" else "rgb", args.map(::lowerExpr))
+      "toRgba" -> emitOp("to-rgba", listOf(lowerReceiver(expression)))
+      "format" -> emitFormat(args)
+      "span" -> args.firstOrNull()?.let(::lowerExpr) ?: emitLitNull()
+      "image" -> emitOp("image", args.map(::lowerExpr))
+      "bind" -> emitBind(args)
+      "asNumber" -> emitOp("number", listOf(lowerReceiver(expression)) + args.map(::lowerExpr))
+      "asString" -> emitOp("string", listOf(lowerReceiver(expression)) + args.map(::lowerExpr))
+      "asBoolean" -> emitOp("boolean", listOf(lowerReceiver(expression)) + args.map(::lowerExpr))
+      "asColor",
+      "convertToColor" ->
+        emitOp("to-color", listOf(lowerReceiver(expression)) + args.map(::lowerExpr))
+      "asMap" -> emitOp("object", listOf(lowerReceiver(expression)) + args.map(::lowerExpr))
+      "asList" -> emitOp("array", listOf(lowerReceiver(expression)))
+      "convertToNumber" ->
+        emitOp("to-number", listOf(lowerReceiver(expression)) + args.map(::lowerExpr))
+      "convertToString" -> emitOp("to-string", listOf(lowerReceiver(expression)))
+      "convertToBoolean" -> emitOp("to-boolean", listOf(lowerReceiver(expression)))
+      "typeOf" -> emitOp("typeof", listOf(lowerReceiver(expression)))
+      "collator" -> emitCollator(args)
+      "formatToString" -> emitNumberFormat(expression, args)
+      "offset" -> emitLit(expression)
+      "dpOffset" -> emitLit(expression)
+      "padding" -> emitLit(expression)
+      "textVariableAnchorOffset" -> emitOp("literal", args.flatMap(::flattenPair))
+      "get" -> emitOp("get", args.map(::lowerExpr))
+      "has" -> emitOp("has", args.map(::lowerExpr))
+      "properties" -> emitOp("properties")
+      "state" -> emitOp("feature-state", args.map(::lowerExpr))
+      "geometryType" -> emitOp("geometry-type")
+      "id" -> emitOp("id")
+      "lineProgress" -> emitOp("line-progress")
+      "accumulated" -> emitOp("accumulated")
+      "within" -> emitOp("within", args.map(::lowerExpr))
+      "distance" -> emitOp("distance", args.map(::lowerExpr))
+      "number" -> emitOp("number", listOf(emitOp("get", args.map(::lowerExpr))))
+      "string" -> emitOp("string", listOf(emitOp("get", args.map(::lowerExpr))))
+      "boolean" -> emitOp("boolean", listOf(emitOp("get", args.map(::lowerExpr))))
+      else -> error("Unsupported expr helper $name")
+    }
+  }
+
+  private fun operatorLowering(name: String, expression: IrCall): IrExpression? {
+    val operands = allOperands(expression)
+    if (
+      name == "compareTo" ||
+        name == "greater" ||
+        name == "less" ||
+        name == "greaterOrEqual" ||
+        name == "lessOrEqual"
+    ) {
+      val op =
+        when (expression.origin) {
+          IrStatementOrigin.GT -> ">"
+          IrStatementOrigin.GTEQ -> ">="
+          IrStatementOrigin.LT -> "<"
+          IrStatementOrigin.LTEQ -> "<="
+          IrStatementOrigin.EQEQ,
+          IrStatementOrigin.EQEQEQ -> "=="
+          else ->
+            when (name) {
+              "greater" -> ">"
+              "greaterOrEqual" -> ">="
+              "less" -> "<"
+              "lessOrEqual" -> "<="
+              else -> return null
+            }
+        }
+      return emitOp(op, operands.map(::lowerExpr))
+    }
+    val op =
+      when (name) {
+        "plus" -> if (expression.type.toString().contains("String")) "concat" else "+"
+        "minus" -> "-"
+        "times" -> "*"
+        "div" -> "/"
+        "rem" -> "%"
+        "unaryMinus" -> "-"
+        "not" -> "!"
+        "EQEQ",
+        "EQEQEQ",
+        "ieee754equals",
+        "equals" -> "=="
+        "ENEQ",
+        "ENEQEQ" -> "!="
+        "and" -> "all"
+        "or" -> "any"
+        "contains" ->
+          return emitOp("in", listOf(lowerExpr(operands.last()), lowerExpr(operands.first())))
+        else -> return null
+      }
+    return emitOp(op, operands.map(::lowerExpr))
+  }
+
+  private fun stdlibLowering(name: String, expression: IrCall): IrExpression? {
+    val operands = allOperands(expression)
+    when (name) {
+      "pow" -> return emitOp("^", operands.map(::lowerExpr))
+      "toDouble",
+      "toFloat",
+      "toInt",
+      "toLong" -> return operands.firstOrNull()?.let(::lowerExpr) ?: emitLit(expression)
+      "<get-dp>",
+      "getDp",
+      "<get-sp>",
+      "getSp",
+      "<get-em>",
+      "getEm" -> return lowerReceiverOrLit(expression)
+      "uppercase",
+      "uppercaseChar" -> return emitOp("upcase", listOf(lowerReceiverOrFirst(expression, operands)))
+      "lowercase",
+      "lowercaseChar" ->
+        return emitOp("downcase", listOf(lowerReceiverOrFirst(expression, operands)))
+      "substring",
+      "subList",
+      "slice" -> return emitOp("slice", operands.map(::lowerExpr))
+      "split" -> return emitOp("split", operands.map(::lowerExpr))
+      "length",
+      "<get-length>",
+      "<get-size>",
+      "count" -> return emitOp("length", listOf(lowerReceiverOrFirst(expression, operands)))
+      "indexOf" -> {
+        val receiver = operands.first()
+        val needle = operands[1]
+        val rest = operands.drop(2)
+        return emitOp(
+          "index-of",
+          listOf(lowerExpr(needle), lowerExpr(receiver)) + rest.map(::lowerExpr),
+        )
+      }
+      "joinToString" -> {
+        val receiver = operands.first()
+        val sep = operands.getOrNull(1)
+        return emitOp("join", listOf(lowerExpr(receiver)) + listOfNotNull(sep?.let(::lowerExpr)))
+      }
+      "get" -> {
+        if (operands.size >= 2) {
+          return emitOp("at", listOf(lowerExpr(operands.last()), lowerExpr(operands.first())))
+        }
+      }
+    }
+    if (name in MATH_OPS) {
+      val mapped = if (name == "absoluteValue") "abs" else name
+      return emitOp(mapped, operands.map(::lowerExpr))
+    }
+    return null
+  }
+
+  private fun emitInterpolate(kind: String, args: List<IrExpression>): IrExpression {
+    require(args.size >= 2) { "$kind needs a type and an input" }
+    val type = lowerExpr(args[0])
+    val input = lowerExpr(args[1])
+    val stops = args.drop(2).flatMap(::flattenPair)
+    return emitNamedVararg("interpolate", listOf(builder.irString(kind), type, input), stops)
+  }
+
+  private fun emitStep(args: List<IrExpression>): IrExpression {
+    require(args.size >= 2) { "step needs an input and a fallback" }
+    val input = lowerExpr(args[0])
+    val fallback = lowerExpr(args[1])
+    val stops = args.drop(2).flatMap(::flattenPair)
+    return emitNamedVararg("step", listOf(input, fallback), stops)
+  }
+
+  private fun emitFormat(args: List<IrExpression>): IrExpression {
+    val pieces = args.flatMap { listOf(lowerExpr(it), emitSpanOptions()) }
+    return emitNamedVararg("formatSpans", emptyList(), pieces)
+  }
+
+  private fun emitSpanOptions(): IrExpression {
+    val fn = emitFunction("spanOptions")
+    return builder.irCall(fn).apply {
+      arguments[0] = builder.irGetObject(emitClass)
+      arguments[1] = builder.irNull()
+      arguments[2] = builder.irNull()
+      arguments[3] = builder.irNull()
+    }
+  }
+
+  private fun emitBind(args: List<IrExpression>): IrExpression {
+    require(args.size >= 3) { "bind(name, value) { ... }" }
+    val name = lowerExpr(args[0])
+    val value = lowerExpr(args[1])
+    val bodyLambda = args[2] as? IrFunctionExpression ?: error("bind body must be a lambda")
+    val param = bodyLambda.function.parameters.last()
+    locals[param.symbol] = emitOp("var", listOf(name))
+    val body = lowerBody(bodyLambda.function.body ?: error("bind lambda has no body"))
+    return emitOp("let", listOf(name, value, body))
+  }
+
+  private fun emitCollator(args: List<IrExpression>): IrExpression {
+    val keys = listOf("case-sensitive", "diacritic-sensitive", "locale")
+    val optionArgs = buildList {
+      args.forEachIndexed { index, arg ->
+        if (index < keys.size) {
+          add(builder.irString(keys[index]))
+          add(lowerExpr(arg))
+        }
+      }
+    }
+    return emitOp("collator", listOf(emitNamedVararg("namedOptions", emptyList(), optionArgs)))
+  }
+
+  private fun emitNumberFormat(expression: IrCall, args: List<IrExpression>): IrExpression {
+    val keys = listOf("locale", "currency", "min-fraction-digits", "max-fraction-digits")
+    val optionArgs = buildList {
+      args.forEachIndexed { index, arg ->
+        if (index < keys.size) {
+          add(builder.irString(keys[index]))
+          add(lowerExpr(arg))
+        }
+      }
+    }
+    return emitOp(
+      "number-format",
+      listOf(lowerReceiver(expression), emitNamedVararg("namedOptions", emptyList(), optionArgs)),
+    )
+  }
+
+  private fun flattenPair(expression: IrExpression): List<IrExpression> {
+    if (expression is IrVararg) {
+      return expression.elements.flatMap { element ->
+        when (element) {
+          is IrExpression -> flattenPair(element)
+          is IrSpreadElement -> flattenPair(element.expression)
+          else -> error("Unsupported vararg element")
+        }
+      }
+    }
+    if (expression is IrCall && expression.symbol.owner.name.asString() == "to") {
+      return allOperands(expression).map(::lowerExpr)
+    }
+    if (
+      expression is IrConstructorCall &&
+        expression.symbol.owner.parentAsClass.fqNameWhenAvailable?.asString() == "kotlin.Pair"
+    ) {
+      return expression.arguments.filterNotNull().map(::lowerExpr)
+    }
+    return listOf(lowerExpr(expression))
+  }
+
+  private fun valueArgs(expression: IrCall): List<IrExpression> {
+    val owner = expression.symbol.owner
+    val result = mutableListOf<IrExpression>()
+    owner.parameters.forEachIndexed { index, parameter ->
+      if (parameter.kind.name.endsWith("Receiver") || parameter.kind.name == "Context")
+        return@forEachIndexed
+      val arg = expression.arguments.getOrNull(index) ?: return@forEachIndexed
+      if (parameter.isVararg && arg is IrVararg) {
+        arg.elements.forEach { element ->
+          when (element) {
+            is IrExpression -> result += element
+            is IrSpreadElement -> result += element.expression
+          }
+        }
+      } else {
+        result += arg
+      }
+    }
+    return result
+  }
+
+  private fun allOperands(expression: IrCall): List<IrExpression> {
+    val owner = expression.symbol.owner
+    val result = mutableListOf<IrExpression>()
+    owner.parameters.forEachIndexed { index, parameter ->
+      if (parameter.kind.name == "Context") return@forEachIndexed
+      val arg = expression.arguments.getOrNull(index) ?: return@forEachIndexed
+      if (isScopeReceiver(arg)) return@forEachIndexed
+      if (parameter.isVararg && arg is IrVararg) {
+        arg.elements.forEach { element -> if (element is IrExpression) result += element }
+      } else {
+        result += arg
+      }
+    }
+    return result
+  }
+
+  private fun lowerReceiver(expression: IrCall): IrExpression {
+    val owner = expression.symbol.owner
+    owner.parameters.forEachIndexed { index, parameter ->
+      if (parameter.kind.name != "ExtensionReceiver") return@forEachIndexed
+      val arg = expression.arguments[index]
+      if (arg != null && !isScopeReceiver(arg)) return lowerExpr(arg)
+    }
+    owner.parameters.forEachIndexed { index, parameter ->
+      if (parameter.kind.name != "DispatchReceiver") return@forEachIndexed
+      val arg = expression.arguments[index]
+      if (arg != null && !isScopeReceiver(arg)) return lowerExpr(arg)
+    }
+    return valueArgs(expression).firstOrNull()?.let(::lowerExpr)
+      ?: error("Call ${expression.symbol.owner.name} has no receiver")
+  }
+
+  private fun lowerReceiverOrLit(expression: IrCall): IrExpression =
+    try {
+      lowerReceiver(expression)
+    } catch (_: IllegalStateException) {
+      emitLit(expression)
+    }
+
+  private fun lowerReceiverOrFirst(expression: IrCall, operands: List<IrExpression>): IrExpression =
+    try {
+      lowerReceiver(expression)
+    } catch (_: IllegalStateException) {
+      operands.firstOrNull()?.let(::lowerExpr) ?: emitLit(expression)
+    }
+
+  private fun isScopeReceiver(expression: IrExpression?): Boolean {
+    val get = expression as? IrGetValue ?: return false
+    return get.symbol == scopeReceiver?.symbol
+  }
+
+  private fun emitOp(name: String, args: List<IrExpression> = emptyList()): IrExpression {
+    val fn = emitFunction("op")
+    return builder.irCall(fn).apply {
+      arguments[0] = builder.irGetObject(emitClass)
+      arguments[1] = builder.irString(name)
+      arguments[2] = builder.irVararg(context.irBuiltIns.anyNType, args)
+    }
+  }
+
+  private fun emitLit(value: IrExpression): IrExpression {
+    val fn = emitFunction("lit")
+    return builder.irCall(fn).apply {
+      arguments[0] = builder.irGetObject(emitClass)
+      arguments[1] = value.deepCopyWithoutPatchingParents()
+    }
+  }
+
+  private fun emitLitNull(): IrExpression = emitLit(builder.irNull())
+
+  private fun emitNamedVararg(
+    functionName: String,
+    prefix: List<IrExpression>,
+    varargArgs: List<IrExpression>,
+  ): IrExpression {
+    val fn = emitFunction(functionName)
+    return builder.irCall(fn).apply {
+      var slot = 0
+      arguments[slot++] = builder.irGetObject(emitClass)
+      prefix.forEach { arguments[slot++] = it }
+      arguments[slot] = builder.irVararg(context.irBuiltIns.anyNType, varargArgs)
+    }
+  }
+
+  private fun emitFunction(name: String): IrSimpleFunctionSymbol {
+    val id = CallableId(EMIT_CLASS_ID, Name.identifier(name))
+    return context.referenceFunctions(id).singleOrNull() ?: error("ExprEmit.$name not found")
+  }
+}
+
+private fun IrDeclarationWithName.parentFqName(): String =
+  when (val parent = parent) {
+    is IrClass -> parent.fqNameWhenAvailable?.asString().orEmpty()
+    is IrPackageFragment -> parent.packageFqName.asString()
+    is IrDeclarationWithName -> parent.fqNameWhenAvailable?.asString().orEmpty()
+    else -> ""
+  }
+
+private fun IrBody.statementList(): List<IrStatement> =
+  when (this) {
+    is IrBlockBody -> statements
+    is IrExpressionBody -> listOf(expression)
+    else -> error("Unsupported body ${this::class.simpleName}")
+  }

--- a/lib/maplibre-compose-expr-compiler/src/main/kotlin/org/maplibre/compose/expr/compiler/ExprIrLowering.kt
+++ b/lib/maplibre-compose-expr-compiler/src/main/kotlin/org/maplibre/compose/expr/compiler/ExprIrLowering.kt
@@ -1,6 +1,10 @@
 package org.maplibre.compose.expr.compiler
 
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
+import org.jetbrains.kotlin.cli.common.messages.CompilerMessageLocation
+import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
+import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.ir.IrElement
 import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.builders.IrBuilderWithScope
 import org.jetbrains.kotlin.ir.builders.irCall
@@ -10,6 +14,7 @@ import org.jetbrains.kotlin.ir.builders.irString
 import org.jetbrains.kotlin.ir.builders.irVararg
 import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrDeclarationWithName
+import org.jetbrains.kotlin.ir.declarations.IrFile
 import org.jetbrains.kotlin.ir.declarations.IrFunction
 import org.jetbrains.kotlin.ir.declarations.IrPackageFragment
 import org.jetbrains.kotlin.ir.declarations.IrValueParameter
@@ -28,10 +33,13 @@ import org.jetbrains.kotlin.ir.expressions.IrGetEnumValue
 import org.jetbrains.kotlin.ir.expressions.IrGetField
 import org.jetbrains.kotlin.ir.expressions.IrGetObjectValue
 import org.jetbrains.kotlin.ir.expressions.IrGetValue
+import org.jetbrains.kotlin.ir.expressions.IrLoop
 import org.jetbrains.kotlin.ir.expressions.IrReturn
+import org.jetbrains.kotlin.ir.expressions.IrSetValue
 import org.jetbrains.kotlin.ir.expressions.IrSpreadElement
 import org.jetbrains.kotlin.ir.expressions.IrStatementOrigin
 import org.jetbrains.kotlin.ir.expressions.IrStringConcatenation
+import org.jetbrains.kotlin.ir.expressions.IrTry
 import org.jetbrains.kotlin.ir.expressions.IrTypeOperatorCall
 import org.jetbrains.kotlin.ir.expressions.IrVararg
 import org.jetbrains.kotlin.ir.expressions.IrWhen
@@ -39,6 +47,7 @@ import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
 import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
 import org.jetbrains.kotlin.ir.symbols.IrValueSymbol
 import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
+import org.jetbrains.kotlin.ir.types.classFqName
 import org.jetbrains.kotlin.ir.util.deepCopyWithoutPatchingParents
 import org.jetbrains.kotlin.ir.util.fqNameWhenAvailable
 import org.jetbrains.kotlin.ir.util.isVararg
@@ -78,10 +87,20 @@ private val MATH_OPS =
     "log2",
   )
 
+private val COMPOSE_ONLY_HELPERS =
+  setOf("offset", "dpOffset", "padding", "projectionTransition", "textVariableAnchorOffset")
+
+private val UNIT_IDENTITY = setOf("<get-dp>", "getDp", "<get-milliseconds>", "getMilliseconds")
+private val UNIT_SECONDS = setOf("<get-seconds>", "getSeconds")
+private val UNIT_SP = setOf("<get-sp>", "getSp")
+private val UNIT_EM = setOf("<get-em>", "getEm")
+
 @OptIn(UnsafeDuringIrConstructionAPI::class)
 internal class ExprIrLowering(
   private val context: IrPluginContext,
   private val builder: IrBuilderWithScope,
+  private val file: IrFile,
+  private val messageCollector: MessageCollector,
 ) {
   private val emitClass: IrClassSymbol =
     requireNotNull(context.referenceClass(EMIT_CLASS_ID)) {
@@ -89,6 +108,7 @@ internal class ExprIrLowering(
     }
 
   private val locals = mutableMapOf<IrValueSymbol, IrExpression>()
+  private val mapLocals = mutableSetOf<IrValueSymbol>()
   private var scopeReceiver: IrValueParameter? = null
 
   fun lowerLambda(function: IrFunction): IrExpression {
@@ -101,31 +121,54 @@ internal class ExprIrLowering(
 
   private fun lowerBody(body: IrBody): IrExpression {
     val statements = body.statementList()
-    require(statements.isNotEmpty()) { "expr { } lambda is empty" }
+    if (statements.isEmpty()) {
+      report(body, ExprDiagnostics.emptyBlock())
+      return emitLitNull()
+    }
     statements.dropLast(1).forEach(::bindOrIgnore)
     return asExpr(statements.last())
   }
 
   private fun bindOrIgnore(statement: IrStatement) {
-    if (statement is IrVariable) {
-      val initializer =
-        statement.initializer ?: error("local val ${statement.name} has no initializer")
-      locals[statement.symbol] = lowerExpr(initializer)
-    } else if (statement is IrExpression) {
-      lowerExpr(statement)
-    } else {
-      error("Unsupported statement in expr { }: ${statement::class.simpleName}")
+    when (statement) {
+      is IrVariable -> bindVariable(statement)
+      is IrLoop -> report(statement, ExprDiagnostics.loopNotAllowed())
+      is IrTry -> report(statement, ExprDiagnostics.tryNotAllowed())
+      is IrSetValue -> report(statement, ExprDiagnostics.assignmentNotAllowed())
+      is IrExpression -> lowerExpr(statement)
+      else ->
+        report(statement, ExprDiagnostics.unsupportedStatement(statement::class.simpleName ?: "?"))
     }
+  }
+
+  private fun bindVariable(statement: IrVariable) {
+    if (statement.isVar) {
+      report(statement, ExprDiagnostics.varNotAllowed())
+    }
+    val initializer = statement.initializer
+    if (initializer == null) {
+      report(
+        statement,
+        ExprDiagnostics.unsupportedStatement("val ${statement.name} without initializer"),
+      )
+      locals[statement.symbol] = emitLitNull()
+      return
+    }
+    if (isMapEvaluated(initializer)) mapLocals += statement.symbol
+    locals[statement.symbol] = lowerExpr(initializer)
   }
 
   private fun asExpr(statement: IrStatement): IrExpression =
     when (statement) {
       is IrVariable -> {
         bindOrIgnore(statement)
-        locals.getValue(statement.symbol)
+        locals[statement.symbol] ?: emitLitNull()
       }
       is IrExpression -> lowerExpr(statement)
-      else -> error("expr { } must end with an expression")
+      else -> {
+        report(statement, ExprDiagnostics.unsupportedStatement(statement::class.simpleName ?: "?"))
+        emitLitNull()
+      }
     }
 
   private fun lowerExpr(expression: IrExpression): IrExpression =
@@ -133,22 +176,41 @@ internal class ExprIrLowering(
       is IrReturn -> lowerExpr(expression.value)
       is IrBlock -> {
         val statements = expression.statements
-        require(statements.isNotEmpty()) { "empty block in expr { }" }
-        statements.dropLast(1).forEach(::bindOrIgnore)
-        asExpr(statements.last())
+        if (statements.isEmpty()) {
+          report(expression, ExprDiagnostics.emptyBlock())
+          emitLitNull()
+        } else {
+          statements.dropLast(1).forEach(::bindOrIgnore)
+          asExpr(statements.last())
+        }
       }
       is IrWhen -> lowerWhen(expression)
       is IrCall -> lowerCall(expression)
       is IrGetValue -> lowerGetValue(expression)
       is IrStringConcatenation -> emitOp("concat", expression.arguments.map(::lowerExpr))
       is IrTypeOperatorCall -> lowerExpr(expression.argument)
+      is IrLoop -> {
+        report(expression, ExprDiagnostics.loopNotAllowed())
+        emitLitNull()
+      }
+      is IrTry -> {
+        report(expression, ExprDiagnostics.tryNotAllowed())
+        emitLitNull()
+      }
+      is IrSetValue -> {
+        report(expression, ExprDiagnostics.assignmentNotAllowed())
+        emitLitNull()
+      }
       is IrConst,
       is IrConstructorCall,
       is IrGetObjectValue,
       is IrGetEnumValue,
-      is IrGetField -> emitLit(expression)
-      is IrFunctionExpression -> error("Nested lambdas in expr { } are only supported via bind { }")
-      else -> emitLit(expression)
+      is IrGetField -> emitCapture(expression)
+      is IrFunctionExpression -> {
+        report(expression, ExprDiagnostics.nestedLambda())
+        emitLitNull()
+      }
+      else -> emitCapture(expression)
     }
 
   private fun lowerGetValue(expression: IrGetValue): IrExpression {
@@ -156,9 +218,10 @@ internal class ExprIrLowering(
       return it
     }
     if (expression.symbol == scopeReceiver?.symbol) {
-      error("The expr { } receiver is not a value; use feature, zoom, or a helper")
+      report(expression, ExprDiagnostics.receiverIsNotAValue())
+      return emitLitNull()
     }
-    return emitLit(expression)
+    return emitCapture(expression)
   }
 
   private fun lowerWhen(expression: IrWhen): IrExpression {
@@ -183,6 +246,9 @@ internal class ExprIrLowering(
       }
       else -> Unit
     }
+    matchFromEqualityWhen(expression)?.let {
+      return it
+    }
     val tests = expression.branches.filterNot { it.isElseBranch() }
     val fallback =
       expression.branches.firstOrNull { it.isElseBranch() }?.let { lowerExpr(it.result) }
@@ -197,6 +263,61 @@ internal class ExprIrLowering(
     return emitOp("case", args)
   }
 
+  private fun matchFromEqualityWhen(expression: IrWhen): IrExpression? {
+    val tests = expression.branches.filterNot { it.isElseBranch() }
+    if (tests.isEmpty()) return null
+    data class Eq(val subject: IrExpression, val label: IrExpression, val result: IrExpression)
+    val eqs = tests.map { branch ->
+      val eq = asEquality(branch.condition) ?: return null
+      Eq(eq.first, eq.second, branch.result)
+    }
+    if (!eqs.all { sameSubject(eqs[0].subject, it.subject) }) return null
+    val fallback =
+      expression.branches.firstOrNull { it.isElseBranch() }?.let { lowerExpr(it.result) }
+        ?: emitLitNull()
+    val labelsAndOutputs = eqs.flatMap { listOf(lowerExpr(it.label), lowerExpr(it.result)) }
+    return emitNamedVararg("match", listOf(lowerExpr(eqs[0].subject), fallback), labelsAndOutputs)
+  }
+
+  private fun asEquality(condition: IrExpression): Pair<IrExpression, IrExpression>? {
+    val call = condition as? IrCall ?: return null
+    val name = call.symbol.owner.name.asString()
+    val isEq =
+      call.origin == IrStatementOrigin.EQEQ ||
+        call.origin == IrStatementOrigin.EQEQEQ ||
+        name == "equals" ||
+        name == "EQEQ" ||
+        name == "ieee754equals"
+    if (!isEq) return null
+    val ops = allOperands(call)
+    if (ops.size != 2) return null
+    val (a, b) = ops
+    return when {
+      !isMapEvaluated(b) -> a to b
+      !isMapEvaluated(a) -> b to a
+      else -> null
+    }
+  }
+
+  private fun sameSubject(a: IrExpression, b: IrExpression): Boolean {
+    val ga = a as? IrGetValue
+    val gb = b as? IrGetValue
+    if (ga != null && gb != null) return ga.symbol == gb.symbol
+    val ca = a as? IrCall
+    val cb = b as? IrCall
+    if (ca != null && cb != null) {
+      if (ca.symbol != cb.symbol) return false
+      val ao = allOperands(ca)
+      val bo = allOperands(cb)
+      if (ao.size != bo.size) return false
+      return ao.zip(bo).all { (left, right) -> sameSubject(left, right) }
+    }
+    val la = a as? IrConst
+    val lb = b as? IrConst
+    if (la != null && lb != null) return la.value == lb.value
+    return false
+  }
+
   private fun IrBranch.isElseBranch(): Boolean {
     val condition = condition
     return condition is IrConst && condition.value == true
@@ -206,12 +327,8 @@ internal class ExprIrLowering(
     val owner = expression.symbol.owner
     val name = owner.name.asString()
     val parentFq = owner.parentFqName()
-    val callableFq = owner.fqNameWhenAvailable?.asString().orEmpty()
 
-    if (
-      parentFq in SCOPE_PACKAGES ||
-        callableFq.startsWith("org.maplibre.compose.expressions.kotlin.")
-    ) {
+    if (parentFq in SCOPE_PACKAGES) {
       return lowerScopeCall(name, expression)
     }
     operatorLowering(name, expression)?.let {
@@ -220,20 +337,29 @@ internal class ExprIrLowering(
     stdlibLowering(name, expression)?.let {
       return it
     }
-    return emitLit(expression)
+    return emitCapture(expression)
   }
 
   private fun lowerScopeCall(name: String, expression: IrCall): IrExpression {
     val args = valueArgs(expression)
     return when (name) {
       "getFeature",
-      "<get-feature>" -> error("Use feature[\"key\"] or feature.number(\"key\")")
+      "<get-feature>" -> {
+        report(expression, ExprDiagnostics.receiverIsNotAValue())
+        emitLitNull()
+      }
       "getZoom",
       "<get-zoom>" -> emitOp("zoom")
       "getHeatmapDensity",
       "<get-heatmapDensity>" -> emitOp("heatmap-density")
       "getElevation",
       "<get-elevation>" -> emitOp("elevation")
+      "getLn2",
+      "<get-ln2>" -> emitOp("ln2")
+      "getPi",
+      "<get-pi>" -> emitOp("pi")
+      "getE",
+      "<get-e>" -> emitOp("e")
       "linear" -> emitOp("linear")
       "exponential" -> emitOp("exponential", args.map(::lowerExpr))
       "cubicBezier" -> emitOp("cubic-bezier", args.map(::lowerExpr))
@@ -241,11 +367,13 @@ internal class ExprIrLowering(
       "interpolateHcl" -> emitInterpolate("interpolate-hcl", args)
       "interpolateLab" -> emitInterpolate("interpolate-lab", args)
       "step" -> emitStep(args)
+      "match" -> emitMatch(args)
+      "nil" -> emitLitNull()
       "rgb" -> emitOp(if (args.size >= 4) "rgba" else "rgb", args.map(::lowerExpr))
       "toRgba" -> emitOp("to-rgba", listOf(lowerReceiver(expression)))
       "format" -> emitFormat(args)
-      "span" -> args.firstOrNull()?.let(::lowerExpr) ?: emitLitNull()
-      "image" -> emitOp("image", args.map(::lowerExpr))
+      "span" -> emitSpanValue(args)
+      "image" -> emitImage(expression, args)
       "bind" -> emitBind(args)
       "asNumber" -> emitOp("number", listOf(lowerReceiver(expression)) + args.map(::lowerExpr))
       "asString" -> emitOp("string", listOf(lowerReceiver(expression)) + args.map(::lowerExpr))
@@ -253,21 +381,59 @@ internal class ExprIrLowering(
       "asColor",
       "convertToColor" ->
         emitOp("to-color", listOf(lowerReceiver(expression)) + args.map(::lowerExpr))
+      "asEnum" -> emitAsEnum(expression, args)
       "asMap" -> emitOp("object", listOf(lowerReceiver(expression)) + args.map(::lowerExpr))
-      "asList" -> emitOp("array", listOf(lowerReceiver(expression)))
+      "asList" -> emitAsList(expression, args)
+      "asVector" ->
+        emitOp(
+          "array",
+          listOf(lowerReceiver(expression), emitLit(builder.irString("number"))) +
+            args.map(::lowerExpr),
+        )
+      "asOffset",
+      "asDpOffset" ->
+        emitOp(
+          "array",
+          listOf(lowerReceiver(expression), emitLit(builder.irString("number")), emitLitOf(2)),
+        )
+      "asPadding" ->
+        emitOp(
+          "array",
+          listOf(lowerReceiver(expression), emitLit(builder.irString("number")), emitLitOf(4)),
+        )
       "convertToNumber" ->
         emitOp("to-number", listOf(lowerReceiver(expression)) + args.map(::lowerExpr))
       "convertToString" -> emitOp("to-string", listOf(lowerReceiver(expression)))
       "convertToBoolean" -> emitOp("to-boolean", listOf(lowerReceiver(expression)))
       "typeOf" -> emitOp("typeof", listOf(lowerReceiver(expression)))
+      "getDp",
+      "<get-dp>" -> lowerReceiver(expression)
+      "getMilliseconds",
+      "<get-milliseconds>" -> lowerReceiver(expression)
+      "getSeconds",
+      "<get-seconds>" -> emitOp("*", listOf(lowerReceiver(expression), emitLitOf(1000)))
+      "getSp",
+      "<get-sp>" -> emitTextUnit(lowerReceiver(expression), "sp")
+      "getEm",
+      "<get-em>" -> emitTextUnit(lowerReceiver(expression), "em")
       "collator" -> emitCollator(args)
+      "resolvedLocale" -> emitOp("resolved-locale", args.map(::lowerExpr))
+      "isScriptSupported" -> emitOp("is-supported-script", listOf(lowerReceiver(expression)))
+      "eq" -> emitOp("==", args.map(::lowerExpr))
+      "neq" -> emitOp("!=", args.map(::lowerExpr))
+      "gt" -> emitOp(">", args.map(::lowerExpr))
+      "gte" -> emitOp(">=", args.map(::lowerExpr))
+      "lt" -> emitOp("<", args.map(::lowerExpr))
+      "lte" -> emitOp("<=", args.map(::lowerExpr))
       "formatToString" -> emitNumberFormat(expression, args)
-      "offset" -> emitLit(expression)
-      "dpOffset" -> emitLit(expression)
-      "padding" -> emitLit(expression)
-      "textVariableAnchorOffset" -> emitOp("literal", args.flatMap(::flattenPair))
-      "get" -> emitOp("get", args.map(::lowerExpr))
-      "has" -> emitOp("has", args.map(::lowerExpr))
+      "offset" -> emitOffset(expression, args)
+      "dpOffset" -> emitComposeHelper("dpOffset", expression, args, "DpOffset")
+      "padding" -> emitComposeHelper("padding", expression, args, "DpPadding")
+      "projectionTransition" ->
+        emitComposeHelper("projectionTransition", expression, args, "ProjectionTransition")
+      "textVariableAnchorOffset" -> emitTextVariableAnchorOffset(expression, args)
+      "get" -> emitGet(expression, args)
+      "has" -> emitHas(expression, args)
       "properties" -> emitOp("properties")
       "state" -> emitOp("feature-state", args.map(::lowerExpr))
       "geometryType" -> emitOp("geometry-type")
@@ -279,8 +445,172 @@ internal class ExprIrLowering(
       "number" -> emitOp("number", listOf(emitOp("get", args.map(::lowerExpr))))
       "string" -> emitOp("string", listOf(emitOp("get", args.map(::lowerExpr))))
       "boolean" -> emitOp("boolean", listOf(emitOp("get", args.map(::lowerExpr))))
-      else -> error("Unsupported expr helper $name")
+      else -> {
+        report(expression, ExprDiagnostics.unsupportedHelper(name))
+        emitLitNull()
+      }
     }
+  }
+
+  private fun emitGet(expression: IrCall, args: List<IrExpression>): IrExpression {
+    val parent = expression.symbol.owner.parentFqName()
+    if (parent.contains("FeatureExpr")) {
+      return emitOp("get", args.map(::lowerExpr))
+    }
+    return emitOp("get", args.map(::lowerExpr) + listOf(lowerReceiver(expression)))
+  }
+
+  private fun emitHas(expression: IrCall, args: List<IrExpression>): IrExpression {
+    val parent = expression.symbol.owner.parentFqName()
+    if (parent.contains("FeatureExpr")) {
+      return emitOp("has", args.map(::lowerExpr))
+    }
+    return emitOp("has", args.map(::lowerExpr) + listOf(lowerReceiver(expression)))
+  }
+
+  private fun emitAsList(expression: IrCall, args: List<IrExpression>): IrExpression {
+    val type = args.getOrNull(0) ?: builder.irNull()
+    val length = args.getOrNull(1) ?: builder.irNull()
+    return emitOp("array", listOf(lowerReceiver(expression), lowerExpr(type), lowerExpr(length)))
+  }
+
+  private fun emitAsEnum(expression: IrCall, args: List<IrExpression>): IrExpression {
+    val value = lowerReceiver(expression)
+    val entries = args.firstOrNull()?.let(::lowerExpr) ?: emitLitNull()
+    val fallbacks = args.drop(1)
+    val caseArgs = buildList {
+      add(emitOp("in", listOf(value, entries)))
+      add(value)
+      fallbacks.forEach { fallback ->
+        val lowered = lowerExpr(fallback)
+        add(emitOp("in", listOf(lowered, entries)))
+        add(lowered)
+      }
+      add(emitLitNull())
+    }
+    return emitOp("string", listOf(emitOp("case", caseArgs)))
+  }
+
+  private fun emitOffset(expression: IrCall, args: List<IrExpression>): IrExpression {
+    val firstType = args.firstOrNull()?.type
+    val isTextUnit = firstType?.classFqName?.asString() == "androidx.compose.ui.unit.TextUnit"
+    if (args.any(::isMapEvaluated)) {
+      report(
+        expression,
+        if (isTextUnit) ExprDiagnostics.textUnitOffsetMustBeConst()
+        else ExprDiagnostics.composeOnlyConstructor("Offset"),
+      )
+      return emitLitNull()
+    }
+    return if (isTextUnit) {
+      emitPassthrough("textUnitOffset", args)
+    } else {
+      emitPassthrough("numberOffset", args)
+    }
+  }
+
+  private fun emitComposeHelper(
+    emitName: String,
+    expression: IrCall,
+    args: List<IrExpression>,
+    typeName: String,
+  ): IrExpression {
+    if (args.any(::isMapEvaluated)) {
+      report(expression, ExprDiagnostics.composeOnlyConstructor(typeName))
+      return emitLitNull()
+    }
+    return emitPassthrough(emitName, args)
+  }
+
+  private fun emitTextVariableAnchorOffset(
+    expression: IrCall,
+    args: List<IrExpression>,
+  ): IrExpression {
+    if (args.any(::isMapEvaluated)) {
+      report(expression, ExprDiagnostics.composeOnlyConstructor("textVariableAnchorOffset"))
+      return emitLitNull()
+    }
+    val fn = emitFunction("textVariableAnchorOffset")
+    return builder.irCall(fn).apply {
+      arguments[0] = builder.irGetObject(emitClass)
+      arguments[1] = irListOfCopied(args)
+    }
+  }
+
+  private fun emitImage(expression: IrCall, args: List<IrExpression>): IrExpression {
+    val first = args.firstOrNull() ?: return emitLitNull()
+    return when {
+      ConstableTypes.isImageBitmap(first.type) -> {
+        if (args.any(::isMapEvaluated)) {
+          report(expression, ExprDiagnostics.imageOptionsMustBeConst())
+          emitLitNull()
+        } else {
+          emitPassthrough("imageBitmap", args)
+        }
+      }
+      ConstableTypes.isPainter(first.type) -> {
+        if (args.any(::isMapEvaluated)) {
+          report(expression, ExprDiagnostics.imageOptionsMustBeConst())
+          emitLitNull()
+        } else {
+          emitPassthrough("imagePainter", args)
+        }
+      }
+      else -> {
+        val fn = emitFunction("imageName")
+        builder.irCall(fn).apply {
+          arguments[0] = builder.irGetObject(emitClass)
+          arguments[1] = lowerExpr(first)
+        }
+      }
+    }
+  }
+
+  private fun emitSpanValue(args: List<IrExpression>): IrExpression =
+    args.firstOrNull()?.let(::lowerExpr) ?: emitLitNull()
+
+  private fun emitFormat(args: List<IrExpression>): IrExpression {
+    val pieces = args.flatMap { arg ->
+      val spanCall = arg as? IrCall
+      if (spanCall != null && spanCall.symbol.owner.name.asString() == "span") {
+        val value =
+          namedArg(spanCall, "text")
+            ?: namedArg(spanCall, "image")
+            ?: valueArgs(spanCall).firstOrNull()
+        val font = namedArg(spanCall, "font")
+        val color = namedArg(spanCall, "textColor")
+        val size = namedArg(spanCall, "textSize")
+        listOf(
+          value?.let(::lowerExpr) ?: emitLitNull(),
+          emitSpanOptions(font, color, size),
+        )
+      } else {
+        listOf(lowerExpr(arg), emitSpanOptions(null, null, null))
+      }
+    }
+    return emitNamedVararg("formatSpans", emptyList(), pieces)
+  }
+
+  private fun emitSpanOptions(
+    font: IrExpression?,
+    color: IrExpression?,
+    size: IrExpression?,
+  ): IrExpression {
+    val fn = emitFunction("spanOptions")
+    return builder.irCall(fn).apply {
+      arguments[0] = builder.irGetObject(emitClass)
+      arguments[1] = font?.let(::lowerExpr) ?: builder.irNull()
+      arguments[2] = color?.let(::lowerExpr) ?: builder.irNull()
+      arguments[3] = size?.let(::lowerExpr) ?: builder.irNull()
+    }
+  }
+
+  private fun emitMatch(args: List<IrExpression>): IrExpression {
+    require(args.size >= 2) { "match needs an input and a fallback" }
+    val input = lowerExpr(args.first())
+    val fallback = lowerExpr(args.last())
+    val cases = args.drop(1).dropLast(1).flatMap(::flattenPair)
+    return emitNamedVararg("match", listOf(input, fallback), cases)
   }
 
   private fun operatorLowering(name: String, expression: IrCall): IrExpression? {
@@ -313,7 +643,7 @@ internal class ExprIrLowering(
     }
     val op =
       when (name) {
-        "plus" -> if (expression.type.toString().contains("String")) "concat" else "+"
+        "plus" -> if (ConstableTypes.isStringLike(expression.type)) "concat" else "+"
         "minus" -> "-"
         "times" -> "*"
         "div" -> "/"
@@ -328,8 +658,19 @@ internal class ExprIrLowering(
         "ENEQEQ" -> "!="
         "and" -> "all"
         "or" -> "any"
-        "contains" ->
-          return emitOp("in", listOf(lowerExpr(operands.last()), lowerExpr(operands.first())))
+        "contains",
+        "containsKey" -> {
+          val receiver = operands.first()
+          val needle = operands.getOrNull(1) ?: return null
+          val opName = if (name == "containsKey") "has" else "in"
+          val ordered =
+            if (name == "containsKey" || ConstableTypes.isMapLike(receiver.type)) {
+              listOf(lowerExpr(needle), lowerExpr(receiver))
+            } else {
+              listOf(lowerExpr(needle), lowerExpr(receiver))
+            }
+          return emitOp(opName, ordered)
+        }
         else -> return null
       }
     return emitOp(op, operands.map(::lowerExpr))
@@ -342,13 +683,7 @@ internal class ExprIrLowering(
       "toDouble",
       "toFloat",
       "toInt",
-      "toLong" -> return operands.firstOrNull()?.let(::lowerExpr) ?: emitLit(expression)
-      "<get-dp>",
-      "getDp",
-      "<get-sp>",
-      "getSp",
-      "<get-em>",
-      "getEm" -> return lowerReceiverOrLit(expression)
+      "toLong" -> return operands.firstOrNull()?.let(::lowerExpr) ?: emitCapture(expression)
       "uppercase",
       "uppercaseChar" -> return emitOp("upcase", listOf(lowerReceiverOrFirst(expression, operands)))
       "lowercase",
@@ -371,15 +706,55 @@ internal class ExprIrLowering(
           listOf(lowerExpr(needle), lowerExpr(receiver)) + rest.map(::lowerExpr),
         )
       }
-      "joinToString" -> {
+      "joinToString",
+      "join" -> {
         val receiver = operands.first()
         val sep = operands.getOrNull(1)
         return emitOp("join", listOf(lowerExpr(receiver)) + listOfNotNull(sep?.let(::lowerExpr)))
       }
       "get" -> {
         if (operands.size >= 2) {
-          return emitOp("at", listOf(lowerExpr(operands.last()), lowerExpr(operands.first())))
+          val receiver = operands.first()
+          val key = operands[1]
+          return if (ConstableTypes.isMapLike(receiver.type)) {
+            emitOp("get", listOf(lowerExpr(key), lowerExpr(receiver)))
+          } else {
+            emitOp("at", listOf(lowerExpr(key), lowerExpr(receiver)))
+          }
         }
+      }
+      "containsKey" -> {
+        if (operands.size >= 2) {
+          return emitOp("has", listOf(lowerExpr(operands[1]), lowerExpr(operands[0])))
+        }
+      }
+    }
+    if (name in UNIT_IDENTITY) {
+      return if (isMapEvaluated(lowerableReceiver(expression, operands))) {
+        lowerReceiverOrFirst(expression, operands)
+      } else {
+        emitCapture(expression)
+      }
+    }
+    if (name in UNIT_SECONDS) {
+      return if (isMapEvaluated(lowerableReceiver(expression, operands))) {
+        emitOp("*", listOf(lowerReceiverOrFirst(expression, operands), emitLitOf(1000)))
+      } else {
+        emitCapture(expression)
+      }
+    }
+    if (name in UNIT_SP) {
+      return if (isMapEvaluated(lowerableReceiver(expression, operands))) {
+        emitTextUnit(lowerReceiverOrFirst(expression, operands), "sp")
+      } else {
+        emitCapture(expression)
+      }
+    }
+    if (name in UNIT_EM) {
+      return if (isMapEvaluated(lowerableReceiver(expression, operands))) {
+        emitTextUnit(lowerReceiverOrFirst(expression, operands), "em")
+      } else {
+        emitCapture(expression)
       }
     }
     if (name in MATH_OPS) {
@@ -389,11 +764,14 @@ internal class ExprIrLowering(
     return null
   }
 
+  private fun lowerableReceiver(expression: IrCall, operands: List<IrExpression>): IrExpression =
+    receiverExpression(expression) ?: operands.firstOrNull() ?: expression
+
   private fun emitInterpolate(kind: String, args: List<IrExpression>): IrExpression {
     require(args.size >= 2) { "$kind needs a type and an input" }
     val type = lowerExpr(args[0])
     val input = lowerExpr(args[1])
-    val stops = args.drop(2).flatMap(::flattenPair)
+    val stops = args.drop(2).flatMap(::flattenStop)
     return emitNamedVararg("interpolate", listOf(builder.irString(kind), type, input), stops)
   }
 
@@ -401,23 +779,8 @@ internal class ExprIrLowering(
     require(args.size >= 2) { "step needs an input and a fallback" }
     val input = lowerExpr(args[0])
     val fallback = lowerExpr(args[1])
-    val stops = args.drop(2).flatMap(::flattenPair)
+    val stops = args.drop(2).flatMap(::flattenStop)
     return emitNamedVararg("step", listOf(input, fallback), stops)
-  }
-
-  private fun emitFormat(args: List<IrExpression>): IrExpression {
-    val pieces = args.flatMap { listOf(lowerExpr(it), emitSpanOptions()) }
-    return emitNamedVararg("formatSpans", emptyList(), pieces)
-  }
-
-  private fun emitSpanOptions(): IrExpression {
-    val fn = emitFunction("spanOptions")
-    return builder.irCall(fn).apply {
-      arguments[0] = builder.irGetObject(emitClass)
-      arguments[1] = builder.irNull()
-      arguments[2] = builder.irNull()
-      arguments[3] = builder.irNull()
-    }
   }
 
   private fun emitBind(args: List<IrExpression>): IrExpression {
@@ -427,6 +790,7 @@ internal class ExprIrLowering(
     val bodyLambda = args[2] as? IrFunctionExpression ?: error("bind body must be a lambda")
     val param = bodyLambda.function.parameters.last()
     locals[param.symbol] = emitOp("var", listOf(name))
+    mapLocals += param.symbol
     val body = lowerBody(bodyLambda.function.body ?: error("bind lambda has no body"))
     return emitOp("let", listOf(name, value, body))
   }
@@ -460,13 +824,27 @@ internal class ExprIrLowering(
     )
   }
 
+  private fun flattenStop(expression: IrExpression): List<IrExpression> {
+    if (expression is IrCall && expression.symbol.owner.name.asString() == "to") {
+      val ops = allOperands(expression)
+      if (ops.isNotEmpty() && isMapEvaluated(ops[0])) {
+        report(ops[0], ExprDiagnostics.stopInputMustBeConst())
+      }
+      return ops.map(::lowerExpr)
+    }
+    return flattenPair(expression)
+  }
+
   private fun flattenPair(expression: IrExpression): List<IrExpression> {
     if (expression is IrVararg) {
       return expression.elements.flatMap { element ->
         when (element) {
           is IrExpression -> flattenPair(element)
           is IrSpreadElement -> flattenPair(element.expression)
-          else -> error("Unsupported vararg element")
+          else -> {
+            report(expression, ExprDiagnostics.unsupportedStatement("vararg"))
+            emptyList()
+          }
         }
       }
     }
@@ -480,6 +858,127 @@ internal class ExprIrLowering(
       return expression.arguments.filterNotNull().map(::lowerExpr)
     }
     return listOf(lowerExpr(expression))
+  }
+
+  private fun isMapEvaluated(expression: IrExpression): Boolean =
+    when (expression) {
+      is IrConst,
+      is IrGetObjectValue,
+      is IrGetEnumValue,
+      is IrGetField -> false
+      is IrGetValue -> expression.symbol != scopeReceiver?.symbol && expression.symbol in mapLocals
+      is IrCall -> isMapEvaluatedCall(expression)
+      is IrWhen ->
+        expression.branches.any { isMapEvaluated(it.condition) || isMapEvaluated(it.result) }
+      is IrStringConcatenation -> expression.arguments.any(::isMapEvaluated)
+      is IrConstructorCall -> expression.arguments.filterNotNull().any(::isMapEvaluated)
+      is IrTypeOperatorCall -> isMapEvaluated(expression.argument)
+      is IrBlock ->
+        expression.statements.any { statement ->
+          when (statement) {
+            is IrVariable -> statement.initializer?.let(::isMapEvaluated) == true
+            is IrExpression -> isMapEvaluated(statement)
+            else -> false
+          }
+        }
+      is IrReturn -> isMapEvaluated(expression.value)
+      is IrVararg ->
+        expression.elements.any { element -> element is IrExpression && isMapEvaluated(element) }
+      else -> false
+    }
+
+  private fun isMapEvaluatedCall(expression: IrCall): Boolean {
+    val owner = expression.symbol.owner
+    val name = owner.name.asString()
+    val parentFq = owner.parentFqName()
+    val operands = allOperands(expression)
+    if (parentFq in SCOPE_PACKAGES) {
+      if (name in COMPOSE_ONLY_HELPERS) return operands.any(::isMapEvaluated)
+      if (name == "image") {
+        val first = operands.firstOrNull()
+        if (
+          first != null &&
+            (ConstableTypes.isImageBitmap(first.type) || ConstableTypes.isPainter(first.type))
+        ) {
+          return false
+        }
+      }
+      return true
+    }
+    if (isRecognizedLowering(name, expression)) {
+      return operands.any(::isMapEvaluated)
+    }
+    return operands.any(::isMapEvaluated)
+  }
+
+  private fun isRecognizedLowering(name: String, expression: IrCall): Boolean {
+    if (name in MATH_OPS) return true
+    if (
+      name in
+        setOf(
+          "plus",
+          "minus",
+          "times",
+          "div",
+          "rem",
+          "unaryMinus",
+          "not",
+          "and",
+          "or",
+          "equals",
+          "compareTo",
+          "greater",
+          "less",
+          "greaterOrEqual",
+          "lessOrEqual",
+          "contains",
+          "containsKey",
+          "pow",
+          "uppercase",
+          "lowercase",
+          "substring",
+          "split",
+          "indexOf",
+          "joinToString",
+          "join",
+          "get",
+          "length",
+        )
+    ) {
+      return true
+    }
+    if (name in UNIT_IDENTITY + UNIT_SECONDS + UNIT_SP + UNIT_EM) return true
+    return expression.origin == IrStatementOrigin.EQEQ ||
+      expression.origin == IrStatementOrigin.EXCLEQ
+  }
+
+  private fun emitCapture(expression: IrExpression): IrExpression {
+    if (isMapEvaluated(expression)) {
+      val callee =
+        (expression as? IrCall)?.symbol?.owner?.name?.asString()
+          ?: expression::class.simpleName
+          ?: "this value"
+      val fq = expression.type.classFqName?.asString().orEmpty()
+      val message =
+        if (
+          fq.endsWith("Offset") ||
+            fq.endsWith("DpPadding") ||
+            fq.endsWith("DpSize") ||
+            callee == "listOf" ||
+            callee == "mutableListOf"
+        ) {
+          ExprDiagnostics.composeOnlyConstructor(fq.ifEmpty { callee })
+        } else {
+          ExprDiagnostics.mapArgsToKotlin(callee)
+        }
+      report(expression, message)
+      return emitLitNull()
+    }
+    if (!ConstableTypes.isConstable(expression.type)) {
+      report(expression, ExprDiagnostics.notConstable(ConstableTypes.typeName(expression.type)))
+      return emitLitNull()
+    }
+    return emitLit(expression)
   }
 
   private fun valueArgs(expression: IrCall): List<IrExpression> {
@@ -503,6 +1002,14 @@ internal class ExprIrLowering(
     return result
   }
 
+  private fun namedArg(expression: IrCall, name: String): IrExpression? {
+    val owner = expression.symbol.owner
+    owner.parameters.forEachIndexed { index, parameter ->
+      if (parameter.name.asString() == name) return expression.arguments.getOrNull(index)
+    }
+    return null
+  }
+
   private fun allOperands(expression: IrCall): List<IrExpression> {
     val owner = expression.symbol.owner
     val result = mutableListOf<IrExpression>()
@@ -519,35 +1026,36 @@ internal class ExprIrLowering(
     return result
   }
 
-  private fun lowerReceiver(expression: IrCall): IrExpression {
+  private fun receiverExpression(expression: IrCall): IrExpression? {
     val owner = expression.symbol.owner
     owner.parameters.forEachIndexed { index, parameter ->
       if (parameter.kind.name != "ExtensionReceiver") return@forEachIndexed
       val arg = expression.arguments[index]
-      if (arg != null && !isScopeReceiver(arg)) return lowerExpr(arg)
+      if (arg != null && !isScopeReceiver(arg)) return arg
     }
     owner.parameters.forEachIndexed { index, parameter ->
       if (parameter.kind.name != "DispatchReceiver") return@forEachIndexed
       val arg = expression.arguments[index]
-      if (arg != null && !isScopeReceiver(arg)) return lowerExpr(arg)
+      if (arg != null && !isScopeReceiver(arg)) return arg
     }
-    return valueArgs(expression).firstOrNull()?.let(::lowerExpr)
-      ?: error("Call ${expression.symbol.owner.name} has no receiver")
+    return null
   }
 
-  private fun lowerReceiverOrLit(expression: IrCall): IrExpression =
-    try {
-      lowerReceiver(expression)
-    } catch (_: IllegalStateException) {
-      emitLit(expression)
-    }
+  private fun lowerReceiver(expression: IrCall): IrExpression =
+    receiverExpression(expression)?.let(::lowerExpr)
+      ?: valueArgs(expression).firstOrNull()?.let(::lowerExpr)
+      ?: run {
+        report(
+          expression,
+          ExprDiagnostics.unsupportedHelper(expression.symbol.owner.name.asString()),
+        )
+        emitLitNull()
+      }
 
   private fun lowerReceiverOrFirst(expression: IrCall, operands: List<IrExpression>): IrExpression =
-    try {
-      lowerReceiver(expression)
-    } catch (_: IllegalStateException) {
-      operands.firstOrNull()?.let(::lowerExpr) ?: emitLit(expression)
-    }
+    receiverExpression(expression)?.let(::lowerExpr)
+      ?: operands.firstOrNull()?.let(::lowerExpr)
+      ?: emitCapture(expression)
 
   private fun isScopeReceiver(expression: IrExpression?): Boolean {
     val get = expression as? IrGetValue ?: return false
@@ -572,6 +1080,37 @@ internal class ExprIrLowering(
   }
 
   private fun emitLitNull(): IrExpression = emitLit(builder.irNull())
+
+  private fun emitLitOf(value: Int): IrExpression {
+    val const =
+      context.irBuiltIns.intType.let {
+        org.jetbrains.kotlin.ir.expressions.impl.IrConstImpl.int(
+          builder.startOffset,
+          builder.endOffset,
+          it,
+          value,
+        )
+      }
+    return emitLit(const)
+  }
+
+  private fun emitTextUnit(value: IrExpression, type: String): IrExpression {
+    val fn = emitFunction("textUnit")
+    return builder.irCall(fn).apply {
+      arguments[0] = builder.irGetObject(emitClass)
+      arguments[1] = value
+      arguments[2] = builder.irString(type)
+    }
+  }
+
+  private fun emitPassthrough(functionName: String, args: List<IrExpression>): IrExpression {
+    val fn = emitFunction(functionName)
+    return builder.irCall(fn).apply {
+      var slot = 0
+      arguments[slot++] = builder.irGetObject(emitClass)
+      args.forEach { arguments[slot++] = it.deepCopyWithoutPatchingParents() }
+    }
+  }
 
   private fun emitNamedVararg(
     functionName: String,
@@ -601,9 +1140,28 @@ internal class ExprIrLowering(
     }
   }
 
+  private fun irListOfCopied(values: List<IrExpression>): IrExpression =
+    irListOf(values.map { it.deepCopyWithoutPatchingParents() })
+
   private fun emitFunction(name: String): IrSimpleFunctionSymbol {
     val id = CallableId(EMIT_CLASS_ID, Name.identifier(name))
     return context.referenceFunctions(id).singleOrNull() ?: error("ExprEmit.$name not found")
+  }
+
+  private fun report(element: IrElement, message: String) {
+    val offset = element.startOffset
+    val location =
+      if (offset >= 0) {
+        CompilerMessageLocation.create(
+          file.fileEntry.name,
+          file.fileEntry.getLineNumber(offset) + 1,
+          file.fileEntry.getColumnNumber(offset) + 1,
+          null,
+        )
+      } else {
+        CompilerMessageLocation.create(file.fileEntry.name, -1, -1, null)
+      }
+    messageCollector.report(CompilerMessageSeverity.ERROR, message, location)
   }
 }
 

--- a/lib/maplibre-compose-expr-compiler/src/main/kotlin/org/maplibre/compose/expr/compiler/ExprIrLowering.kt
+++ b/lib/maplibre-compose-expr-compiler/src/main/kotlin/org/maplibre/compose/expr/compiler/ExprIrLowering.kt
@@ -559,7 +559,7 @@ internal class ExprIrLowering(
     return builder.irCall(fn).apply {
       arguments[0] = builder.irGetObject(emitClass)
       arguments[1] = builder.irString(name)
-      arguments[2] = builder.irVararg(context.irBuiltIns.anyNType, args)
+      arguments[2] = irListOf(args)
     }
   }
 
@@ -583,7 +583,21 @@ internal class ExprIrLowering(
       var slot = 0
       arguments[slot++] = builder.irGetObject(emitClass)
       prefix.forEach { arguments[slot++] = it }
-      arguments[slot] = builder.irVararg(context.irBuiltIns.anyNType, varargArgs)
+      arguments[slot] = irListOf(varargArgs)
+    }
+  }
+
+  private fun irListOf(values: List<IrExpression>): IrExpression {
+    val listOf =
+      context
+        .referenceFunctions(CallableId(FqName("kotlin.collections"), Name.identifier("listOf")))
+        .single { symbol ->
+          val parameters = symbol.owner.parameters
+          parameters.size == 1 && parameters.single().isVararg
+        }
+    return builder.irCall(listOf).apply {
+      typeArguments[0] = context.irBuiltIns.anyNType
+      arguments[0] = builder.irVararg(context.irBuiltIns.anyNType, values)
     }
   }
 

--- a/lib/maplibre-compose-expr-compiler/src/main/kotlin/org/maplibre/compose/expr/compiler/MapLibreExprCompilerPluginRegistrar.kt
+++ b/lib/maplibre-compose-expr-compiler/src/main/kotlin/org/maplibre/compose/expr/compiler/MapLibreExprCompilerPluginRegistrar.kt
@@ -1,8 +1,10 @@
 package org.maplibre.compose.expr.compiler
 
 import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
+import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.jetbrains.kotlin.config.CommonConfigurationKeys
 import org.jetbrains.kotlin.config.CompilerConfiguration
 
 @OptIn(ExperimentalCompilerApi::class)
@@ -11,7 +13,9 @@ class MapLibreExprCompilerPluginRegistrar : CompilerPluginRegistrar() {
   override val supportsK2: Boolean = true
 
   override fun ExtensionStorage.registerExtensions(configuration: CompilerConfiguration) {
-    IrGenerationExtension.registerExtension(MapLibreExprIrGenerationExtension())
+    val collector =
+      configuration.get(CommonConfigurationKeys.MESSAGE_COLLECTOR_KEY, MessageCollector.NONE)
+    IrGenerationExtension.registerExtension(MapLibreExprIrGenerationExtension(collector))
   }
 
   companion object {

--- a/lib/maplibre-compose-expr-compiler/src/main/kotlin/org/maplibre/compose/expr/compiler/MapLibreExprCompilerPluginRegistrar.kt
+++ b/lib/maplibre-compose-expr-compiler/src/main/kotlin/org/maplibre/compose/expr/compiler/MapLibreExprCompilerPluginRegistrar.kt
@@ -1,0 +1,20 @@
+package org.maplibre.compose.expr.compiler
+
+import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
+import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.jetbrains.kotlin.config.CompilerConfiguration
+
+@OptIn(ExperimentalCompilerApi::class)
+class MapLibreExprCompilerPluginRegistrar : CompilerPluginRegistrar() {
+  override val pluginId: String = PLUGIN_ID
+  override val supportsK2: Boolean = true
+
+  override fun ExtensionStorage.registerExtensions(configuration: CompilerConfiguration) {
+    IrGenerationExtension.registerExtension(MapLibreExprIrGenerationExtension())
+  }
+
+  companion object {
+    const val PLUGIN_ID: String = "org.maplibre.compose.expr"
+  }
+}

--- a/lib/maplibre-compose-expr-compiler/src/main/kotlin/org/maplibre/compose/expr/compiler/MapLibreExprIrGenerationExtension.kt
+++ b/lib/maplibre-compose-expr-compiler/src/main/kotlin/org/maplibre/compose/expr/compiler/MapLibreExprIrGenerationExtension.kt
@@ -3,6 +3,8 @@ package org.maplibre.compose.expr.compiler
 import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
+import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.ir.declarations.IrFile
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
 import org.jetbrains.kotlin.ir.expressions.IrCall
 import org.jetbrains.kotlin.ir.expressions.IrExpression
@@ -14,27 +16,34 @@ import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
 
 internal const val EXPR_FQ_NAME = "org.maplibre.compose.expressions.kotlin.expr"
 
-internal class MapLibreExprIrGenerationExtension : IrGenerationExtension {
+internal class MapLibreExprIrGenerationExtension(private val messageCollector: MessageCollector) :
+  IrGenerationExtension {
   @OptIn(UnsafeDuringIrConstructionAPI::class)
   override fun generate(moduleFragment: IrModuleFragment, pluginContext: IrPluginContext) {
-    moduleFragment.transform(
-      object : IrElementTransformerVoid() {
-        override fun visitCall(expression: IrCall): IrExpression {
-          expression.transformChildrenVoid()
-          val ownerName = expression.symbol.owner.fqNameWhenAvailable?.asString()
-          if (ownerName != EXPR_FQ_NAME) return expression
-          val lambda =
-            expression.arguments.lastOrNull() as? IrFunctionExpression ?: return expression
-          val builder =
-            pluginContext.irBuiltIns.createIrBuilder(
-              expression.symbol,
-              expression.startOffset,
-              expression.endOffset,
-            )
-          return ExprIrLowering(pluginContext, builder).lowerLambda(lambda.function)
-        }
-      },
-      null,
-    )
+    moduleFragment.files.forEach { file ->
+      file.transform(ExprCallTransformer(pluginContext, file, messageCollector), null)
+    }
+  }
+}
+
+@OptIn(UnsafeDuringIrConstructionAPI::class)
+private class ExprCallTransformer(
+  private val pluginContext: IrPluginContext,
+  private val file: IrFile,
+  private val messageCollector: MessageCollector,
+) : IrElementTransformerVoid() {
+  override fun visitCall(expression: IrCall): IrExpression {
+    expression.transformChildrenVoid()
+    val ownerName = expression.symbol.owner.fqNameWhenAvailable?.asString()
+    if (ownerName != EXPR_FQ_NAME) return expression
+    val lambda = expression.arguments.lastOrNull() as? IrFunctionExpression ?: return expression
+    val builder =
+      pluginContext.irBuiltIns.createIrBuilder(
+        expression.symbol,
+        expression.startOffset,
+        expression.endOffset,
+      )
+    return ExprIrLowering(pluginContext, builder, file, messageCollector)
+      .lowerLambda(lambda.function)
   }
 }

--- a/lib/maplibre-compose-expr-compiler/src/main/kotlin/org/maplibre/compose/expr/compiler/MapLibreExprIrGenerationExtension.kt
+++ b/lib/maplibre-compose-expr-compiler/src/main/kotlin/org/maplibre/compose/expr/compiler/MapLibreExprIrGenerationExtension.kt
@@ -1,0 +1,40 @@
+package org.maplibre.compose.expr.compiler
+
+import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
+import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
+import org.jetbrains.kotlin.backend.common.lower.createIrBuilder
+import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
+import org.jetbrains.kotlin.ir.expressions.IrCall
+import org.jetbrains.kotlin.ir.expressions.IrExpression
+import org.jetbrains.kotlin.ir.expressions.IrFunctionExpression
+import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
+import org.jetbrains.kotlin.ir.util.fqNameWhenAvailable
+import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
+import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
+
+internal const val EXPR_FQ_NAME = "org.maplibre.compose.expressions.kotlin.expr"
+
+internal class MapLibreExprIrGenerationExtension : IrGenerationExtension {
+  @OptIn(UnsafeDuringIrConstructionAPI::class)
+  override fun generate(moduleFragment: IrModuleFragment, pluginContext: IrPluginContext) {
+    moduleFragment.transform(
+      object : IrElementTransformerVoid() {
+        override fun visitCall(expression: IrCall): IrExpression {
+          expression.transformChildrenVoid()
+          val ownerName = expression.symbol.owner.fqNameWhenAvailable?.asString()
+          if (ownerName != EXPR_FQ_NAME) return expression
+          val lambda =
+            expression.arguments.lastOrNull() as? IrFunctionExpression ?: return expression
+          val builder =
+            pluginContext.irBuiltIns.createIrBuilder(
+              expression.symbol,
+              expression.startOffset,
+              expression.endOffset,
+            )
+          return ExprIrLowering(pluginContext, builder).lowerLambda(lambda.function)
+        }
+      },
+      null,
+    )
+  }
+}

--- a/lib/maplibre-compose-expr-compiler/src/main/resources/META-INF/services/org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
+++ b/lib/maplibre-compose-expr-compiler/src/main/resources/META-INF/services/org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
@@ -1,0 +1,1 @@
+org.maplibre.compose.expr.compiler.MapLibreExprCompilerPluginRegistrar

--- a/lib/maplibre-compose-expr-compiler/src/test/kotlin/org/maplibre/compose/expr/compiler/ConstableTypesTest.kt
+++ b/lib/maplibre-compose-expr-compiler/src/test/kotlin/org/maplibre/compose/expr/compiler/ConstableTypesTest.kt
@@ -1,0 +1,47 @@
+package org.maplibre.compose.expr.compiler
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ConstableTypesTest {
+  @Test
+  fun accepts_types_expr_emit_can_freeze() {
+    for (name in
+      listOf(
+        "kotlin.Boolean",
+        "kotlin.Int",
+        "kotlin.Double",
+        "kotlin.String",
+        "kotlin.time.Duration",
+        "androidx.compose.ui.graphics.Color",
+        "androidx.compose.ui.unit.Dp",
+        "androidx.compose.ui.geometry.Offset",
+        "org.maplibre.compose.expressions.ast.Expression",
+        "org.maplibre.spatialk.geojson.Geometry",
+        "org.maplibre.spatialk.geojson.GeoJsonObject",
+      )) {
+      assertTrue(ConstableTypes.isConstableFqName(name), name)
+    }
+  }
+
+  @Test
+  fun rejects_types_that_cannot_become_style_json() {
+    for (name in
+      listOf(
+        "kotlin.Function1",
+        "java.util.HashMap",
+        "org.maplibre.compose.map.MapState",
+        "kotlin.collections.Iterator",
+      )) {
+      assertFalse(ConstableTypes.isConstableFqName(name), name)
+    }
+  }
+
+  @Test
+  fun treats_list_and_map_as_container_shapes() {
+    assertTrue(ConstableTypes.isListLikeFqName("kotlin.collections.List"))
+    assertTrue(ConstableTypes.isMapLikeFqName("kotlin.collections.Map"))
+    assertFalse(ConstableTypes.isListLikeFqName("kotlin.String"))
+  }
+}

--- a/lib/maplibre-compose/MODULE.md
+++ b/lib/maplibre-compose/MODULE.md
@@ -31,9 +31,15 @@ Composables and related utilities to add sources to the map.
 
 The abstract syntax tree (AST) for the expression language.
 
+# Package org.maplibre.compose.expressions.kotlin
+
+Ordinary Kotlin inside `expr { }`. The compiler plugin lowers that block to the
+expression AST.
+
 # Package org.maplibre.compose.expressions.dsl
 
-The Kotlin DSL for creating MapLibre expressions.
+The Kotlin DSL that the compiler plugin lowers to, and an escape hatch for
+hand-built expressions.
 
 # Package org.maplibre.compose.expressions.value
 

--- a/lib/maplibre-compose/build.gradle.kts
+++ b/lib/maplibre-compose/build.gradle.kts
@@ -8,6 +8,8 @@ plugins {
   id(libs.plugins.mavenPublish.get().pluginId)
 }
 
+applyMapLibreExprCompilerPlugin()
+
 mavenPublishing {
   pom {
     name = "MapLibre Compose"

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/ast/BooleanLiteral.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/ast/BooleanLiteral.kt
@@ -8,9 +8,9 @@ public data class BooleanLiteral private constructor(override val value: Boolean
   override fun visit(block: (Expression<*>) -> Unit): Unit = block(this)
 
   public companion object {
-    private val True: BooleanLiteral = BooleanLiteral(true)
-    private val False: BooleanLiteral = BooleanLiteral(false)
-
-    public fun of(value: Boolean): BooleanLiteral = if (value) True else False
+    // Do not intern True/False. On Kotlin/JS the companion initializes those
+    // instances by constructing BooleanLiteral, which re-enters the companion
+    // before the fields are assigned, so of(true) can return undefined.
+    public fun of(value: Boolean): BooleanLiteral = BooleanLiteral(value)
   }
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/ast/Expression.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/ast/Expression.kt
@@ -5,9 +5,11 @@ import org.maplibre.compose.expressions.value.ExpressionValue
 /**
  * An [Expression] that evaluates to a value of type [T].
  *
- * The functions to create expressions are defined in the
+ * Write expressions with ordinary Kotlin inside
+ * [expr][org.maplibre.compose.expressions.kotlin.expr]. The compiler plugin lowers that block to
+ * this AST. The functions in
  * [`org.maplibre.compose.expressions.dsl`](https://maplibre.org/maplibre-compose/api/lib/maplibre-compose/org.maplibre.compose.expressions.dsl/index.html)
- * package.
+ * remain as the lowering target and as an escape hatch.
  *
  * Most functions are named the same as in the
  * [MapLibre style specification](https://maplibre.org/maplibre-style-spec/expressions/), a few have

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/ast/GeoJsonLiteral.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/ast/GeoJsonLiteral.kt
@@ -1,0 +1,19 @@
+package org.maplibre.compose.expressions.ast
+
+import kotlinx.serialization.json.JsonObject
+import org.maplibre.compose.expressions.value.GeoJsonValue
+
+/**
+ * A [Literal] GeoJSON object for [within][org.maplibre.compose.expressions.dsl.Feature.within] and
+ * [distance][org.maplibre.compose.expressions.dsl.Feature.distance].
+ *
+ * The style spec takes the object as a function argument, not wrapped in `["literal", ...]`.
+ */
+public data class GeoJsonLiteral private constructor(override val value: JsonObject) :
+  CompiledLiteral<GeoJsonValue, JsonObject> {
+  override fun visit(block: (Expression<*>) -> Unit): Unit = block(this)
+
+  public companion object {
+    public fun of(value: JsonObject): GeoJsonLiteral = GeoJsonLiteral(value)
+  }
+}

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/dsl/literals.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/dsl/literals.kt
@@ -8,6 +8,8 @@ import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.TextUnitType
 import kotlin.jvm.JvmName
 import kotlin.time.Duration
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
 import org.maplibre.compose.expressions.ast.BooleanLiteral
 import org.maplibre.compose.expressions.ast.ColorLiteral
 import org.maplibre.compose.expressions.ast.DpLiteral
@@ -16,6 +18,7 @@ import org.maplibre.compose.expressions.ast.DpPaddingLiteral
 import org.maplibre.compose.expressions.ast.EnumLiteral
 import org.maplibre.compose.expressions.ast.Expression
 import org.maplibre.compose.expressions.ast.FloatLiteral
+import org.maplibre.compose.expressions.ast.GeoJsonLiteral
 import org.maplibre.compose.expressions.ast.IntLiteral
 import org.maplibre.compose.expressions.ast.ListLiteral
 import org.maplibre.compose.expressions.ast.Literal
@@ -29,6 +32,7 @@ import org.maplibre.compose.expressions.ast.TextUnitOffsetCalculation
 import org.maplibre.compose.expressions.value.DpPaddingValue
 import org.maplibre.compose.expressions.value.EnumValue
 import org.maplibre.compose.expressions.value.ExpressionValue
+import org.maplibre.compose.expressions.value.GeoJsonValue
 import org.maplibre.compose.expressions.value.StringValue
 import org.maplibre.compose.expressions.value.SymbolAnchor
 import org.maplibre.compose.expressions.value.TextUnitOffsetValue
@@ -36,6 +40,8 @@ import org.maplibre.compose.expressions.value.TextVariableAnchorOffsetValue
 import org.maplibre.compose.expressions.value.VectorValue
 import org.maplibre.compose.style.ProjectionTransition
 import org.maplibre.compose.util.DpPadding
+import org.maplibre.spatialk.geojson.GeoJsonObject
+import org.maplibre.spatialk.geojson.toJson
 
 /** Creates a literal expression for a [String] value. */
 public fun const(string: String): StringLiteral = StringLiteral.of(string)
@@ -83,6 +89,14 @@ public fun const(padding: DpPadding): DpPaddingLiteral = DpPaddingLiteral.of(pad
 /** Creates a literal expression for a [ProjectionTransition] value. */
 public fun const(transition: ProjectionTransition): ProjectionTransitionLiteral =
   ProjectionTransitionLiteral.of(transition)
+
+/**
+ * Creates a literal GeoJSON object for
+ * [feature.within][org.maplibre.compose.expressions.dsl.Feature.within] and
+ * [feature.distance][org.maplibre.compose.expressions.dsl.Feature.distance].
+ */
+public fun const(geoJson: GeoJsonObject): Expression<GeoJsonValue> =
+  GeoJsonLiteral.of(Json.parseToJsonElement(geoJson.toJson()) as JsonObject)
 
 /** Creates a literal expression for a list. */
 public fun <T : ExpressionValue> const(list: List<Literal<T, *>>): ListLiteral<T> =

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/kotlin/Expr.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/kotlin/Expr.kt
@@ -8,7 +8,9 @@ import org.maplibre.compose.expressions.value.ExpressionValue
  *
  * The compiler plugin rewrites the [block] into the [Expression] AST. The block type-checks as
  * normal Kotlin: `if`/`when`, operators, `kotlin.math`, and string/list methods are evaluated by
- * the map, not during composition.
+ * the map, not during composition. Captured outer values must be const-able (Boolean, Number,
+ * String, Color, Dp, Offset, Duration, enum, GeoJSON, lists of those, or an [Expression]); anything
+ * else is a compile error.
  *
  * [T] is inferred from the layer property (`color = expr { Color.Red }` is
  * `Expression<ColorValue>`). Without the plugin this function throws.

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/kotlin/Expr.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/kotlin/Expr.kt
@@ -1,0 +1,22 @@
+package org.maplibre.compose.expressions.kotlin
+
+import org.maplibre.compose.expressions.ast.Expression
+import org.maplibre.compose.expressions.value.ExpressionValue
+
+/**
+ * Builds a MapLibre style expression from ordinary Kotlin.
+ *
+ * The compiler plugin rewrites the [block] into the [Expression] AST. The block type-checks as
+ * normal Kotlin: `if`/`when`, operators, `kotlin.math`, and string/list methods are evaluated by
+ * the map, not during composition.
+ *
+ * [T] is inferred from the layer property (`color = expr { Color.Red }` is
+ * `Expression<ColorValue>`). Without the plugin this function throws.
+ */
+public fun <T : ExpressionValue> expr(block: ExprScope.() -> Any?): Expression<T> = pluginRequired()
+
+internal fun pluginRequired(): Nothing =
+  error(
+    "expr { } requires the MapLibre Compose compiler plugin. " +
+      "Apply applyMapLibreExprCompilerPlugin() in the consuming Gradle project."
+  )

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/kotlin/ExprEmit.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/kotlin/ExprEmit.kt
@@ -44,10 +44,10 @@ public object ExprEmit {
       value == false -> litBoolean(false)
       value is Expression<*> -> value
       value is Boolean -> litBoolean(value)
-      value is Int -> const(value)
+      // Kotlin/JS compiles `is Int`, `is Float`, and `is Double` to `typeof === 'number'`.
+      // The Int branch then indexes IntCache with 2.5 and returns undefined.
       value is Long -> const(value.toInt())
-      value is Float -> const(value)
-      value is Double -> const(value.toFloat())
+      value is Number -> numberLiteral(value)
       value is String -> const(value)
       value is Color -> const(value)
       value is Dp -> const(value)
@@ -226,6 +226,17 @@ public object ExprEmit {
         }
       }
       else -> error("Cannot capture a list of ${first?.let { it::class.simpleName }}")
+    }
+  }
+
+  private fun numberLiteral(value: Number): Expression<*> {
+    val d = value.toDouble()
+    return if (
+      d.isFinite() && d == kotlin.math.floor(d) && d >= Int.MIN_VALUE && d <= Int.MAX_VALUE
+    ) {
+      const(d.toInt())
+    } else {
+      const(d.toFloat())
     }
   }
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/kotlin/ExprEmit.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/kotlin/ExprEmit.kt
@@ -55,21 +55,22 @@ public object ExprEmit {
         )
     }
 
-  public fun op(name: String, vararg args: Expression<*>): Expression<*> =
-    FunctionCall.of(name, args.asList())
+  public fun op(name: String, args: List<*>): Expression<*> =
+    FunctionCall.of(name, args.map { it as Expression<*> })
 
   public fun match(
     input: Expression<*>,
     fallback: Expression<*>,
-    vararg labelsAndOutputs: Expression<*>,
+    labelsAndOutputs: List<*>,
   ): Expression<*> {
+    val labels = labelsAndOutputs.map { it as Expression<*> }
     val args =
-      buildList(labelsAndOutputs.size + 2) {
+      buildList(labels.size + 2) {
         add(input)
-        addAll(labelsAndOutputs)
+        addAll(labels)
         add(fallback)
       }
-    val caseCount = labelsAndOutputs.size / 2
+    val caseCount = labels.size / 2
     return FunctionCall.of(
       "match",
       args,
@@ -81,33 +82,29 @@ public object ExprEmit {
     kind: String,
     type: Expression<*>,
     input: Expression<*>,
-    vararg stops: Expression<*>,
+    stops: List<*>,
   ): Expression<*> {
     val args =
       buildList(stops.size + 2) {
         add(type)
         add(input)
-        addAll(stops)
+        addAll(stops.map { it as Expression<*> })
       }
     return FunctionCall.of(kind, args)
   }
 
-  public fun step(
-    input: Expression<*>,
-    fallback: Expression<*>,
-    vararg stops: Expression<*>,
-  ): Expression<*> {
+  public fun step(input: Expression<*>, fallback: Expression<*>, stops: List<*>): Expression<*> {
     val args =
       buildList(stops.size + 2) {
         add(input)
         add(fallback)
-        addAll(stops)
+        addAll(stops.map { it as Expression<*> })
       }
     return FunctionCall.of("step", args)
   }
 
-  public fun formatSpans(vararg valuesAndOptions: Expression<*>): Expression<*> =
-    FunctionCall.of("format", valuesAndOptions.asList())
+  public fun formatSpans(valuesAndOptions: List<*>): Expression<*> =
+    FunctionCall.of("format", valuesAndOptions.map { it as Expression<*> })
 
   public fun spanOptions(
     textFont: Expression<*>?,
@@ -119,7 +116,7 @@ public object ExprEmit {
     textSize?.let { put("font-scale", it) }
   }
 
-  public fun namedOptions(vararg keysAndValues: Any?): Expression<*> = Options.build {
+  public fun namedOptions(keysAndValues: List<*>): Expression<*> = Options.build {
     var i = 0
     while (i < keysAndValues.size) {
       val key = keysAndValues[i] as String

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/kotlin/ExprEmit.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/kotlin/ExprEmit.kt
@@ -2,23 +2,31 @@ package org.maplibre.compose.expressions.kotlin
 
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.TextUnitType
 import kotlin.time.Duration
 import org.maplibre.compose.expressions.ast.Expression
 import org.maplibre.compose.expressions.ast.FunctionCall
 import org.maplibre.compose.expressions.ast.Options
+import org.maplibre.compose.expressions.ast.TextUnitCalculation
+import org.maplibre.compose.expressions.ast.TextUnitOffsetCalculation
 import org.maplibre.compose.expressions.dsl.const
 import org.maplibre.compose.expressions.dsl.image
 import org.maplibre.compose.expressions.dsl.nil
 import org.maplibre.compose.expressions.dsl.span
 import org.maplibre.compose.expressions.value.EnumValue
 import org.maplibre.compose.expressions.value.ExpressionValue
+import org.maplibre.compose.expressions.value.FloatValue
 import org.maplibre.compose.style.ProjectionTransition
 import org.maplibre.compose.util.DpPadding
+import org.maplibre.compose.util.ImageStretch
+import org.maplibre.spatialk.geojson.GeoJsonObject
 
 /**
  * Stable call target for the compiler plugin. Each method has a simple JVM signature so IR
@@ -44,6 +52,7 @@ public object ExprEmit {
       is Duration -> const(value)
       is ProjectionTransition -> const(value)
       is EnumValue<*> -> value.literal
+      is GeoJsonObject -> const(value)
       is ImageBitmap -> image(value)
       is Painter -> image(value)
       is List<*> -> listLiteral(value)
@@ -51,7 +60,7 @@ public object ExprEmit {
         error(
           "Cannot capture ${value::class.simpleName} as an expression literal. " +
             "Pass a Boolean, Number, String, Color, Dp, Offset, Duration, enum, " +
-            "list of those, or an Expression."
+            "GeoJSON, list of those, or an Expression."
         )
     }
 
@@ -125,6 +134,61 @@ public object ExprEmit {
       i += 2
     }
   }
+
+  public fun textUnit(value: Expression<*>, type: String): Expression<*> {
+    val unit =
+      when (type.lowercase()) {
+        "sp" -> TextUnitType.Sp
+        "em" -> TextUnitType.Em
+        else -> error("Text unit type must be sp or em, was $type")
+      }
+    return TextUnitCalculation.of(value.cast<FloatValue>(), unit)
+  }
+
+  public fun textUnitOffset(x: TextUnit, y: TextUnit): Expression<*> =
+    TextUnitOffsetCalculation.of(x, y)
+
+  public fun imageName(name: Expression<*>): Expression<*> = image(name.cast())
+
+  public fun imageBitmap(
+    bitmap: ImageBitmap,
+    isSdf: Boolean,
+    stretch: ImageStretch?,
+  ): Expression<*> = image(bitmap, isSdf, stretch)
+
+  public fun numberOffset(x: Number, y: Number): Expression<*> =
+    const(Offset(x.toFloat(), y.toFloat()))
+
+  public fun dpOffset(x: Dp, y: Dp): Expression<*> = const(DpOffset(x, y))
+
+  public fun padding(left: Dp, top: Dp, right: Dp, bottom: Dp): Expression<*> =
+    const(DpPadding(left = left, top = top, right = right, bottom = bottom))
+
+  public fun projectionTransition(from: Any, to: Any, progress: Number): Expression<*> =
+    const(
+      ProjectionTransition(
+        from as org.maplibre.compose.expressions.value.ProjectionType,
+        to as org.maplibre.compose.expressions.value.ProjectionType,
+        progress.toFloat(),
+      )
+    )
+
+  public fun textVariableAnchorOffset(pairs: List<*>): Expression<*> {
+    val typed = pairs.map { pair ->
+      val (anchor, offset) = pair as Pair<*, *>
+      (anchor as org.maplibre.compose.expressions.value.SymbolAnchor) to (offset as Offset)
+    }
+    return org.maplibre.compose.expressions.dsl.textVariableAnchorOffset(*typed.toTypedArray())
+  }
+
+  public fun imagePainter(
+    painter: Painter,
+    size: DpSize?,
+    drawAsSdf: Boolean,
+    stretch: ImageStretch?,
+    alpha: Float,
+    colorFilter: ColorFilter?,
+  ): Expression<*> = image(painter, size, drawAsSdf, stretch, alpha, colorFilter)
 
   public fun formattedSpan(
     value: Expression<*>,

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/kotlin/ExprEmit.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/kotlin/ExprEmit.kt
@@ -1,0 +1,164 @@
+package org.maplibre.compose.expressions.kotlin
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.TextUnit
+import kotlin.time.Duration
+import org.maplibre.compose.expressions.ast.Expression
+import org.maplibre.compose.expressions.ast.FunctionCall
+import org.maplibre.compose.expressions.ast.Options
+import org.maplibre.compose.expressions.dsl.const
+import org.maplibre.compose.expressions.dsl.image
+import org.maplibre.compose.expressions.dsl.nil
+import org.maplibre.compose.expressions.dsl.span
+import org.maplibre.compose.expressions.value.EnumValue
+import org.maplibre.compose.expressions.value.ExpressionValue
+import org.maplibre.compose.style.ProjectionTransition
+import org.maplibre.compose.util.DpPadding
+
+/**
+ * Stable call target for the compiler plugin. Each method has a simple JVM signature so IR
+ * generation does not have to pick among DSL overloads.
+ */
+public object ExprEmit {
+  public fun lit(value: Any?): Expression<*> =
+    when (value) {
+      null -> nil()
+      is Expression<*> -> value
+      is Boolean -> const(value)
+      is Int -> const(value)
+      is Long -> const(value.toInt())
+      is Float -> const(value)
+      is Double -> const(value.toFloat())
+      is String -> const(value)
+      is Color -> const(value)
+      is Dp -> const(value)
+      is DpOffset -> const(value)
+      is Offset -> const(value)
+      is DpPadding -> const(value)
+      is TextUnit -> const(value)
+      is Duration -> const(value)
+      is ProjectionTransition -> const(value)
+      is EnumValue<*> -> value.literal
+      is ImageBitmap -> image(value)
+      is Painter -> image(value)
+      is List<*> -> listLiteral(value)
+      else ->
+        error(
+          "Cannot capture ${value::class.simpleName} as an expression literal. " +
+            "Pass a Boolean, Number, String, Color, Dp, Offset, Duration, enum, " +
+            "list of those, or an Expression."
+        )
+    }
+
+  public fun op(name: String, vararg args: Expression<*>): Expression<*> =
+    FunctionCall.of(name, args.asList())
+
+  public fun match(
+    input: Expression<*>,
+    fallback: Expression<*>,
+    vararg labelsAndOutputs: Expression<*>,
+  ): Expression<*> {
+    val args =
+      buildList(labelsAndOutputs.size + 2) {
+        add(input)
+        addAll(labelsAndOutputs)
+        add(fallback)
+      }
+    val caseCount = labelsAndOutputs.size / 2
+    return FunctionCall.of(
+      "match",
+      args,
+      isLiteralArg = { i -> i in 1..(caseCount * 2) && i % 2 == 1 },
+    )
+  }
+
+  public fun interpolate(
+    kind: String,
+    type: Expression<*>,
+    input: Expression<*>,
+    vararg stops: Expression<*>,
+  ): Expression<*> {
+    val args =
+      buildList(stops.size + 2) {
+        add(type)
+        add(input)
+        addAll(stops)
+      }
+    return FunctionCall.of(kind, args)
+  }
+
+  public fun step(
+    input: Expression<*>,
+    fallback: Expression<*>,
+    vararg stops: Expression<*>,
+  ): Expression<*> {
+    val args =
+      buildList(stops.size + 2) {
+        add(input)
+        add(fallback)
+        addAll(stops)
+      }
+    return FunctionCall.of("step", args)
+  }
+
+  public fun formatSpans(vararg valuesAndOptions: Expression<*>): Expression<*> =
+    FunctionCall.of("format", valuesAndOptions.asList())
+
+  public fun spanOptions(
+    textFont: Expression<*>?,
+    textColor: Expression<*>?,
+    textSize: Expression<*>?,
+  ): Expression<*> = Options.build {
+    textFont?.let { put("text-font", it) }
+    textColor?.let { put("text-color", it) }
+    textSize?.let { put("font-scale", it) }
+  }
+
+  public fun namedOptions(vararg keysAndValues: Any?): Expression<*> = Options.build {
+    var i = 0
+    while (i < keysAndValues.size) {
+      val key = keysAndValues[i] as String
+      val value = keysAndValues[i + 1] as Expression<*>?
+      if (value != null) put(key, value)
+      i += 2
+    }
+  }
+
+  public fun formattedSpan(
+    value: Expression<*>,
+    textFont: String?,
+    textColor: Color?,
+    textSize: TextUnit?,
+  ): Expression<*> =
+    span(
+        value = value.cast(),
+        textFont = textFont?.let { const(it) },
+        textColor = textColor?.let { const(it) },
+        textSize = textSize?.let { const(it) },
+      )
+      .value
+
+  @Suppress("UNCHECKED_CAST")
+  private fun listLiteral(values: List<*>): Expression<*> {
+    if (values.isEmpty()) return const(emptyList<String>())
+    return when (val first = values.first()) {
+      is String -> const(values as List<String>)
+      is Number -> const(values as List<Number>)
+      is EnumValue<*> -> const(values.map { (it as EnumValue<*>).literal })
+      is Expression<*> -> {
+        val literals = values.map { it as Expression<*> }
+        if (literals.all { it is org.maplibre.compose.expressions.ast.Literal<*, *> }) {
+          const(literals as List<org.maplibre.compose.expressions.ast.Literal<ExpressionValue, *>>)
+        } else {
+          error("List literals must contain only compile-time values")
+        }
+      }
+      else -> error("Cannot capture a list of ${first?.let { it::class.simpleName }}")
+    }
+  }
+}

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/kotlin/ExprEmit.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/kotlin/ExprEmit.kt
@@ -36,6 +36,10 @@ public object ExprEmit {
   public fun lit(value: Any?): Expression<*> =
     when (value) {
       null -> nil()
+      // Kotlin/JS keeps booleans as primitive `boolean`. `is Boolean` does not match that box,
+      // so `lit(true)` would fall through and return nothing. Equality does match.
+      true -> const(true)
+      false -> const(false)
       is Expression<*> -> value
       is Boolean -> const(value)
       is Int -> const(value)

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/kotlin/ExprEmit.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/kotlin/ExprEmit.kt
@@ -11,7 +11,6 @@ import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.TextUnitType
 import kotlin.time.Duration
-import org.maplibre.compose.expressions.ast.BooleanLiteral
 import org.maplibre.compose.expressions.ast.Expression
 import org.maplibre.compose.expressions.ast.FunctionCall
 import org.maplibre.compose.expressions.ast.Options
@@ -34,33 +33,35 @@ import org.maplibre.spatialk.geojson.GeoJsonObject
  * generation does not have to pick among DSL overloads.
  */
 public object ExprEmit {
+  /** Typed boolean path. `lit(Any?)` boxing loses `is Boolean` on Kotlin/JS primitives. */
+  public fun litBoolean(value: Boolean): Expression<*> = const(value)
+
   public fun lit(value: Any?): Expression<*> =
-    when (value) {
-      null -> nil()
-      // Kotlin/JS keeps booleans as primitive `boolean`. `is Boolean` does not match that box,
-      // and BooleanLiteral's interned True/False can be unread during companion init.
-      true -> BooleanLiteral.of(true)
-      false -> BooleanLiteral.of(false)
-      is Expression<*> -> value
-      is Boolean -> BooleanLiteral.of(value)
-      is Int -> const(value)
-      is Long -> const(value.toInt())
-      is Float -> const(value)
-      is Double -> const(value.toFloat())
-      is String -> const(value)
-      is Color -> const(value)
-      is Dp -> const(value)
-      is DpOffset -> const(value)
-      is Offset -> const(value)
-      is DpPadding -> const(value)
-      is TextUnit -> const(value)
-      is Duration -> const(value)
-      is ProjectionTransition -> const(value)
-      is EnumValue<*> -> value.literal
-      is GeoJsonObject -> const(value)
-      is ImageBitmap -> image(value)
-      is Painter -> image(value)
-      is List<*> -> listLiteral(value)
+    when {
+      value == null -> nil()
+      // Equality, not `is Boolean`: Kotlin/JS stores `true` as a primitive `boolean`.
+      value == true -> litBoolean(true)
+      value == false -> litBoolean(false)
+      value is Expression<*> -> value
+      value is Boolean -> litBoolean(value)
+      value is Int -> const(value)
+      value is Long -> const(value.toInt())
+      value is Float -> const(value)
+      value is Double -> const(value.toFloat())
+      value is String -> const(value)
+      value is Color -> const(value)
+      value is Dp -> const(value)
+      value is DpOffset -> const(value)
+      value is Offset -> const(value)
+      value is DpPadding -> const(value)
+      value is TextUnit -> const(value)
+      value is Duration -> const(value)
+      value is ProjectionTransition -> const(value)
+      value is EnumValue<*> -> value.literal
+      value is GeoJsonObject -> const(value)
+      value is ImageBitmap -> image(value)
+      value is Painter -> image(value)
+      value is List<*> -> listLiteral(value)
       else ->
         error(
           "Cannot capture ${value::class.simpleName} as an expression literal. " +

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/kotlin/ExprEmit.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/kotlin/ExprEmit.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.TextUnitType
 import kotlin.time.Duration
+import org.maplibre.compose.expressions.ast.BooleanLiteral
 import org.maplibre.compose.expressions.ast.Expression
 import org.maplibre.compose.expressions.ast.FunctionCall
 import org.maplibre.compose.expressions.ast.Options
@@ -37,11 +38,11 @@ public object ExprEmit {
     when (value) {
       null -> nil()
       // Kotlin/JS keeps booleans as primitive `boolean`. `is Boolean` does not match that box,
-      // so `lit(true)` would fall through and return nothing. Equality does match.
-      true -> const(true)
-      false -> const(false)
+      // and BooleanLiteral's interned True/False can be unread during companion init.
+      true -> BooleanLiteral.of(true)
+      false -> BooleanLiteral.of(false)
       is Expression<*> -> value
-      is Boolean -> const(value)
+      is Boolean -> BooleanLiteral.of(value)
       is Int -> const(value)
       is Long -> const(value.toInt())
       is Float -> const(value)

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/kotlin/ExprScope.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/kotlin/ExprScope.kt
@@ -136,9 +136,8 @@ public interface ExprScope {
   public fun Any?.asColor(vararg fallbacks: Any?): Color
 
   /**
-   * Asserts the value is one of [entries] (style-spec strings, or
-   * [EnumValue][org.maplibre.compose.expressions.value.EnumValue] names via `entries.map {
-   * it.literal.value }`). Reified `asEnum<T>()` is not possible on an interface.
+   * Asserts the value is one of [entries] (style-spec strings, or EnumValue names via `entries.map
+   * { it.literal.value }`). Reified `asEnum<T>()` is not possible on an interface.
    */
   public fun Any?.asEnum(entries: List<String>, vararg fallbacks: Any?): String
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/kotlin/ExprScope.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/kotlin/ExprScope.kt
@@ -2,12 +2,19 @@ package org.maplibre.compose.expressions.kotlin
 
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.TextUnit
+import kotlin.time.Duration
+import org.maplibre.compose.expressions.value.ExpressionType
+import org.maplibre.compose.style.ProjectionTransition
 import org.maplibre.compose.util.DpPadding
+import org.maplibre.compose.util.ImageStretch
+import org.maplibre.spatialk.geojson.GeoJsonObject
 
 /** Marker for the `expr { }` receiver. Methods exist so the block type-checks as Kotlin. */
 @DslMarker public annotation class ExprDsl
@@ -47,6 +54,15 @@ public interface ExprScope {
   /** Terrain elevation in meters. Only valid as the input to a color-relief layer color. */
   public val elevation: Double
 
+  /** MapLibre `ln2` operator, not the Kotlin `ln(2)` literal. */
+  public val ln2: Double
+
+  /** MapLibre `pi` operator. `kotlin.math.PI` still freezes as a composition-time number. */
+  public val pi: Double
+
+  /** MapLibre `e` operator. */
+  public val e: Double
+
   public fun linear(): Interpolation
 
   public fun exponential(base: Number): Interpolation
@@ -73,6 +89,10 @@ public interface ExprScope {
 
   public fun <T> step(input: Double, fallback: T, vararg stops: Pair<Number, T>): T
 
+  public fun <T> match(input: Any?, vararg cases: Pair<Any, T>, fallback: T): T
+
+  public fun <T> nil(): T
+
   public fun rgb(red: Number, green: Number, blue: Number, alpha: Number = 1.0): Color
 
   public fun Color.toRgba(): List<Double>
@@ -86,11 +106,24 @@ public interface ExprScope {
     textSize: TextUnit? = null,
   ): FormattedSpan
 
+  public fun span(image: ImageRef): FormattedSpan
+
   public fun image(name: String): ImageRef
 
-  public fun image(bitmap: ImageBitmap): ImageRef
+  public fun image(
+    bitmap: ImageBitmap,
+    isSdf: Boolean = false,
+    stretch: ImageStretch? = null,
+  ): ImageRef
 
-  public fun image(painter: Painter): ImageRef
+  public fun image(
+    painter: Painter,
+    size: DpSize? = null,
+    drawAsSdf: Boolean = false,
+    stretch: ImageStretch? = null,
+    alpha: Float = 1f,
+    colorFilter: ColorFilter? = null,
+  ): ImageRef
 
   public fun <T, R> bind(name: String, value: T, body: (T) -> R): R
 
@@ -100,11 +133,25 @@ public interface ExprScope {
 
   public fun Any?.asBoolean(vararg fallbacks: Boolean): Boolean
 
-  public fun Any?.asColor(vararg fallbacks: String): Color
+  public fun Any?.asColor(vararg fallbacks: Any?): Color
 
-  public fun Any?.asMap(): Map<String, Any?>
+  /**
+   * Asserts the value is one of [entries] (style-spec strings, or [EnumValue] names via
+   * `entries.map { it.literal.value }`). Reified `asEnum<T>()` is not possible on an interface.
+   */
+  public fun Any?.asEnum(entries: List<String>, vararg fallbacks: Any?): String
 
-  public fun Any?.asList(): List<Any?>
+  public fun Any?.asMap(vararg fallbacks: Any?): Map<String, Any?>
+
+  public fun Any?.asList(type: ExpressionType? = null, length: Int? = null): List<Any?>
+
+  public fun Any?.asVector(length: Int? = null): List<Double>
+
+  public fun Any?.asOffset(): Offset
+
+  public fun Any?.asDpOffset(): DpOffset
+
+  public fun Any?.asPadding(): DpPadding
 
   public fun Any?.convertToNumber(vararg fallbacks: Number): Double
 
@@ -112,15 +159,41 @@ public interface ExprScope {
 
   public fun Any?.convertToBoolean(): Boolean
 
-  public fun Any?.convertToColor(vararg fallbacks: String): Color
+  public fun Any?.convertToColor(vararg fallbacks: Any?): Color
 
   public fun Any?.typeOf(): String
+
+  public val Number.dp: Dp
+
+  public val Number.milliseconds: Duration
+
+  public val Number.seconds: Duration
+
+  public val Number.sp: TextUnit
+
+  public val Number.em: TextUnit
 
   public fun collator(
     caseSensitive: Boolean = false,
     diacriticSensitive: Boolean = false,
     locale: String? = null,
   ): Collator
+
+  public fun resolvedLocale(collator: Collator): String
+
+  public fun String.isScriptSupported(): Boolean
+
+  public fun eq(left: String, right: String, collator: Collator): Boolean
+
+  public fun neq(left: String, right: String, collator: Collator): Boolean
+
+  public fun gt(left: String, right: String, collator: Collator): Boolean
+
+  public fun gte(left: String, right: String, collator: Collator): Boolean
+
+  public fun lt(left: String, right: String, collator: Collator): Boolean
+
+  public fun lte(left: String, right: String, collator: Collator): Boolean
 
   public fun Number.formatToString(
     locale: String? = null,
@@ -131,11 +204,23 @@ public interface ExprScope {
 
   public fun offset(x: Number, y: Number): Offset
 
+  public fun offset(x: TextUnit, y: TextUnit): Offset
+
   public fun dpOffset(x: Dp, y: Dp): DpOffset
 
   public fun padding(left: Dp, top: Dp, right: Dp, bottom: Dp): DpPadding
 
+  public fun projectionTransition(
+    from: Any,
+    to: Any,
+    progress: Number,
+  ): ProjectionTransition
+
   public fun textVariableAnchorOffset(vararg anchorsAndOffsets: Pair<Any, Offset>): List<Any>
+
+  public operator fun Map<String, Any?>.get(key: String): Any?
+
+  public fun Map<String, Any?>.has(key: String): Boolean
 }
 
 /**
@@ -159,9 +244,9 @@ public interface FeatureExpr {
 
   public fun accumulated(): Any?
 
-  public fun within(geometry: Any): Boolean
+  public fun within(geometry: GeoJsonObject): Boolean
 
-  public fun distance(geometry: Any): Double
+  public fun distance(geometry: GeoJsonObject): Double
 
   public fun number(key: String): Double
 
@@ -180,6 +265,15 @@ internal object ExprScopeStubs : ExprScope {
     get() = pluginRequired()
 
   override val elevation: Double
+    get() = pluginRequired()
+
+  override val ln2: Double
+    get() = pluginRequired()
+
+  override val pi: Double
+    get() = pluginRequired()
+
+  override val e: Double
     get() = pluginRequired()
 
   override fun linear(): Interpolation = pluginRequired()
@@ -210,6 +304,10 @@ internal object ExprScopeStubs : ExprScope {
   override fun <T> step(input: Double, fallback: T, vararg stops: Pair<Number, T>): T =
     pluginRequired()
 
+  override fun <T> match(input: Any?, vararg cases: Pair<Any, T>, fallback: T): T = pluginRequired()
+
+  override fun <T> nil(): T = pluginRequired()
+
   override fun rgb(red: Number, green: Number, blue: Number, alpha: Number): Color =
     pluginRequired()
 
@@ -224,11 +322,21 @@ internal object ExprScopeStubs : ExprScope {
     textSize: TextUnit?,
   ): FormattedSpan = pluginRequired()
 
+  override fun span(image: ImageRef): FormattedSpan = pluginRequired()
+
   override fun image(name: String): ImageRef = pluginRequired()
 
-  override fun image(bitmap: ImageBitmap): ImageRef = pluginRequired()
+  override fun image(bitmap: ImageBitmap, isSdf: Boolean, stretch: ImageStretch?): ImageRef =
+    pluginRequired()
 
-  override fun image(painter: Painter): ImageRef = pluginRequired()
+  override fun image(
+    painter: Painter,
+    size: DpSize?,
+    drawAsSdf: Boolean,
+    stretch: ImageStretch?,
+    alpha: Float,
+    colorFilter: ColorFilter?,
+  ): ImageRef = pluginRequired()
 
   override fun <T, R> bind(name: String, value: T, body: (T) -> R): R = pluginRequired()
 
@@ -238,11 +346,21 @@ internal object ExprScopeStubs : ExprScope {
 
   override fun Any?.asBoolean(vararg fallbacks: Boolean): Boolean = pluginRequired()
 
-  override fun Any?.asColor(vararg fallbacks: String): Color = pluginRequired()
+  override fun Any?.asColor(vararg fallbacks: Any?): Color = pluginRequired()
 
-  override fun Any?.asMap(): Map<String, Any?> = pluginRequired()
+  override fun Any?.asEnum(entries: List<String>, vararg fallbacks: Any?): String = pluginRequired()
 
-  override fun Any?.asList(): List<Any?> = pluginRequired()
+  override fun Any?.asMap(vararg fallbacks: Any?): Map<String, Any?> = pluginRequired()
+
+  override fun Any?.asList(type: ExpressionType?, length: Int?): List<Any?> = pluginRequired()
+
+  override fun Any?.asVector(length: Int?): List<Double> = pluginRequired()
+
+  override fun Any?.asOffset(): Offset = pluginRequired()
+
+  override fun Any?.asDpOffset(): DpOffset = pluginRequired()
+
+  override fun Any?.asPadding(): DpPadding = pluginRequired()
 
   override fun Any?.convertToNumber(vararg fallbacks: Number): Double = pluginRequired()
 
@@ -250,15 +368,46 @@ internal object ExprScopeStubs : ExprScope {
 
   override fun Any?.convertToBoolean(): Boolean = pluginRequired()
 
-  override fun Any?.convertToColor(vararg fallbacks: String): Color = pluginRequired()
+  override fun Any?.convertToColor(vararg fallbacks: Any?): Color = pluginRequired()
 
   override fun Any?.typeOf(): String = pluginRequired()
+
+  override val Number.dp: Dp
+    get() = pluginRequired()
+
+  override val Number.milliseconds: Duration
+    get() = pluginRequired()
+
+  override val Number.seconds: Duration
+    get() = pluginRequired()
+
+  override val Number.sp: TextUnit
+    get() = pluginRequired()
+
+  override val Number.em: TextUnit
+    get() = pluginRequired()
 
   override fun collator(
     caseSensitive: Boolean,
     diacriticSensitive: Boolean,
     locale: String?,
   ): Collator = pluginRequired()
+
+  override fun resolvedLocale(collator: Collator): String = pluginRequired()
+
+  override fun String.isScriptSupported(): Boolean = pluginRequired()
+
+  override fun eq(left: String, right: String, collator: Collator): Boolean = pluginRequired()
+
+  override fun neq(left: String, right: String, collator: Collator): Boolean = pluginRequired()
+
+  override fun gt(left: String, right: String, collator: Collator): Boolean = pluginRequired()
+
+  override fun gte(left: String, right: String, collator: Collator): Boolean = pluginRequired()
+
+  override fun lt(left: String, right: String, collator: Collator): Boolean = pluginRequired()
+
+  override fun lte(left: String, right: String, collator: Collator): Boolean = pluginRequired()
 
   override fun Number.formatToString(
     locale: String?,
@@ -269,12 +418,24 @@ internal object ExprScopeStubs : ExprScope {
 
   override fun offset(x: Number, y: Number): Offset = pluginRequired()
 
+  override fun offset(x: TextUnit, y: TextUnit): Offset = pluginRequired()
+
   override fun dpOffset(x: Dp, y: Dp): DpOffset = pluginRequired()
 
   override fun padding(left: Dp, top: Dp, right: Dp, bottom: Dp): DpPadding = pluginRequired()
 
+  override fun projectionTransition(
+    from: Any,
+    to: Any,
+    progress: Number,
+  ): ProjectionTransition = pluginRequired()
+
   override fun textVariableAnchorOffset(vararg anchorsAndOffsets: Pair<Any, Offset>): List<Any> =
     pluginRequired()
+
+  override fun Map<String, Any?>.get(key: String): Any? = pluginRequired()
+
+  override fun Map<String, Any?>.has(key: String): Boolean = pluginRequired()
 }
 
 @Suppress("unused")
@@ -295,9 +456,9 @@ internal object FeatureExprStubs : FeatureExpr {
 
   override fun accumulated(): Any? = pluginRequired()
 
-  override fun within(geometry: Any): Boolean = pluginRequired()
+  override fun within(geometry: GeoJsonObject): Boolean = pluginRequired()
 
-  override fun distance(geometry: Any): Double = pluginRequired()
+  override fun distance(geometry: GeoJsonObject): Double = pluginRequired()
 
   override fun number(key: String): Double = pluginRequired()
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/kotlin/ExprScope.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/kotlin/ExprScope.kt
@@ -1,0 +1,307 @@
+package org.maplibre.compose.expressions.kotlin
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.TextUnit
+import org.maplibre.compose.util.DpPadding
+
+/** Marker for the `expr { }` receiver. Methods exist so the block type-checks as Kotlin. */
+@DslMarker public annotation class ExprDsl
+
+/** Interpolation curve used by [ExprScope.interpolate] and friends. */
+public class Interpolation internal constructor()
+
+/** Formatted text produced by [ExprScope.format]. */
+public class FormattedText internal constructor()
+
+/** One styled run inside [ExprScope.format]. */
+public class FormattedSpan internal constructor()
+
+/** Image reference produced by [ExprScope.image]. */
+public class ImageRef internal constructor()
+
+/** Locale collator produced by [ExprScope.collator]. */
+public class Collator internal constructor()
+
+/**
+ * Receiver for [expr] lambdas. Properties and helpers return ordinary Kotlin types so `if`, `when`,
+ * and operators type-check. The compiler plugin captures the calls; these stubs never run.
+ */
+@ExprDsl
+public interface ExprScope {
+  /** Current feature being rendered. */
+  public val feature: FeatureExpr
+
+  /**
+   * Current map zoom. In layer paint properties, only valid as the input to [step]/[interpolate].
+   */
+  public val zoom: Double
+
+  /** Heatmap kernel density. Only valid as the input to a heatmap layer color. */
+  public val heatmapDensity: Double
+
+  /** Terrain elevation in meters. Only valid as the input to a color-relief layer color. */
+  public val elevation: Double
+
+  public fun linear(): Interpolation
+
+  public fun exponential(base: Number): Interpolation
+
+  public fun cubicBezier(x1: Number, y1: Number, x2: Number, y2: Number): Interpolation
+
+  public fun <T> interpolate(
+    type: Interpolation,
+    input: Double,
+    vararg stops: Pair<Number, T>,
+  ): T
+
+  public fun <T> interpolateHcl(
+    type: Interpolation,
+    input: Double,
+    vararg stops: Pair<Number, T>,
+  ): T
+
+  public fun <T> interpolateLab(
+    type: Interpolation,
+    input: Double,
+    vararg stops: Pair<Number, T>,
+  ): T
+
+  public fun <T> step(input: Double, fallback: T, vararg stops: Pair<Number, T>): T
+
+  public fun rgb(red: Number, green: Number, blue: Number, alpha: Number = 1.0): Color
+
+  public fun Color.toRgba(): List<Double>
+
+  public fun format(vararg spans: FormattedSpan): FormattedText
+
+  public fun span(
+    text: String,
+    font: List<String>? = null,
+    textColor: Color? = null,
+    textSize: TextUnit? = null,
+  ): FormattedSpan
+
+  public fun image(name: String): ImageRef
+
+  public fun image(bitmap: ImageBitmap): ImageRef
+
+  public fun image(painter: Painter): ImageRef
+
+  public fun <T, R> bind(name: String, value: T, body: (T) -> R): R
+
+  public fun Any?.asNumber(vararg fallbacks: Number): Double
+
+  public fun Any?.asString(vararg fallbacks: String): String
+
+  public fun Any?.asBoolean(vararg fallbacks: Boolean): Boolean
+
+  public fun Any?.asColor(vararg fallbacks: String): Color
+
+  public fun Any?.asMap(): Map<String, Any?>
+
+  public fun Any?.asList(): List<Any?>
+
+  public fun Any?.convertToNumber(vararg fallbacks: Number): Double
+
+  public fun Any?.convertToString(): String
+
+  public fun Any?.convertToBoolean(): Boolean
+
+  public fun Any?.convertToColor(vararg fallbacks: String): Color
+
+  public fun Any?.typeOf(): String
+
+  public fun collator(
+    caseSensitive: Boolean = false,
+    diacriticSensitive: Boolean = false,
+    locale: String? = null,
+  ): Collator
+
+  public fun Number.formatToString(
+    locale: String? = null,
+    currency: String? = null,
+    minFractionDigits: Int? = null,
+    maxFractionDigits: Int? = null,
+  ): String
+
+  public fun offset(x: Number, y: Number): Offset
+
+  public fun dpOffset(x: Dp, y: Dp): DpOffset
+
+  public fun padding(left: Dp, top: Dp, right: Dp, bottom: Dp): DpPadding
+
+  public fun textVariableAnchorOffset(vararg anchorsAndOffsets: Pair<Any, Offset>): List<Any>
+}
+
+/**
+ * Feature accessors typed as Kotlin values. Dynamic properties come back as [Any] and are converted
+ * with [ExprScope.asNumber], [ExprScope.asString], and similar helpers.
+ */
+public interface FeatureExpr {
+  public operator fun get(key: String): Any?
+
+  public fun has(key: String): Boolean
+
+  public fun properties(): Map<String, Any?>
+
+  public fun state(key: String): Any?
+
+  public fun geometryType(): String
+
+  public fun id(): Any?
+
+  public fun lineProgress(): Double
+
+  public fun accumulated(): Any?
+
+  public fun within(geometry: Any): Boolean
+
+  public fun distance(geometry: Any): Double
+
+  public fun number(key: String): Double
+
+  public fun string(key: String): String
+
+  public fun boolean(key: String): Boolean
+}
+
+@Suppress("unused")
+internal object ExprScopeStubs : ExprScope {
+  override val feature: FeatureExpr = FeatureExprStubs
+  override val zoom: Double
+    get() = pluginRequired()
+
+  override val heatmapDensity: Double
+    get() = pluginRequired()
+
+  override val elevation: Double
+    get() = pluginRequired()
+
+  override fun linear(): Interpolation = pluginRequired()
+
+  override fun exponential(base: Number): Interpolation = pluginRequired()
+
+  override fun cubicBezier(x1: Number, y1: Number, x2: Number, y2: Number): Interpolation =
+    pluginRequired()
+
+  override fun <T> interpolate(
+    type: Interpolation,
+    input: Double,
+    vararg stops: Pair<Number, T>,
+  ): T = pluginRequired()
+
+  override fun <T> interpolateHcl(
+    type: Interpolation,
+    input: Double,
+    vararg stops: Pair<Number, T>,
+  ): T = pluginRequired()
+
+  override fun <T> interpolateLab(
+    type: Interpolation,
+    input: Double,
+    vararg stops: Pair<Number, T>,
+  ): T = pluginRequired()
+
+  override fun <T> step(input: Double, fallback: T, vararg stops: Pair<Number, T>): T =
+    pluginRequired()
+
+  override fun rgb(red: Number, green: Number, blue: Number, alpha: Number): Color =
+    pluginRequired()
+
+  override fun Color.toRgba(): List<Double> = pluginRequired()
+
+  override fun format(vararg spans: FormattedSpan): FormattedText = pluginRequired()
+
+  override fun span(
+    text: String,
+    font: List<String>?,
+    textColor: Color?,
+    textSize: TextUnit?,
+  ): FormattedSpan = pluginRequired()
+
+  override fun image(name: String): ImageRef = pluginRequired()
+
+  override fun image(bitmap: ImageBitmap): ImageRef = pluginRequired()
+
+  override fun image(painter: Painter): ImageRef = pluginRequired()
+
+  override fun <T, R> bind(name: String, value: T, body: (T) -> R): R = pluginRequired()
+
+  override fun Any?.asNumber(vararg fallbacks: Number): Double = pluginRequired()
+
+  override fun Any?.asString(vararg fallbacks: String): String = pluginRequired()
+
+  override fun Any?.asBoolean(vararg fallbacks: Boolean): Boolean = pluginRequired()
+
+  override fun Any?.asColor(vararg fallbacks: String): Color = pluginRequired()
+
+  override fun Any?.asMap(): Map<String, Any?> = pluginRequired()
+
+  override fun Any?.asList(): List<Any?> = pluginRequired()
+
+  override fun Any?.convertToNumber(vararg fallbacks: Number): Double = pluginRequired()
+
+  override fun Any?.convertToString(): String = pluginRequired()
+
+  override fun Any?.convertToBoolean(): Boolean = pluginRequired()
+
+  override fun Any?.convertToColor(vararg fallbacks: String): Color = pluginRequired()
+
+  override fun Any?.typeOf(): String = pluginRequired()
+
+  override fun collator(
+    caseSensitive: Boolean,
+    diacriticSensitive: Boolean,
+    locale: String?,
+  ): Collator = pluginRequired()
+
+  override fun Number.formatToString(
+    locale: String?,
+    currency: String?,
+    minFractionDigits: Int?,
+    maxFractionDigits: Int?,
+  ): String = pluginRequired()
+
+  override fun offset(x: Number, y: Number): Offset = pluginRequired()
+
+  override fun dpOffset(x: Dp, y: Dp): DpOffset = pluginRequired()
+
+  override fun padding(left: Dp, top: Dp, right: Dp, bottom: Dp): DpPadding = pluginRequired()
+
+  override fun textVariableAnchorOffset(vararg anchorsAndOffsets: Pair<Any, Offset>): List<Any> =
+    pluginRequired()
+}
+
+@Suppress("unused")
+internal object FeatureExprStubs : FeatureExpr {
+  override fun get(key: String): Any? = pluginRequired()
+
+  override fun has(key: String): Boolean = pluginRequired()
+
+  override fun properties(): Map<String, Any?> = pluginRequired()
+
+  override fun state(key: String): Any? = pluginRequired()
+
+  override fun geometryType(): String = pluginRequired()
+
+  override fun id(): Any? = pluginRequired()
+
+  override fun lineProgress(): Double = pluginRequired()
+
+  override fun accumulated(): Any? = pluginRequired()
+
+  override fun within(geometry: Any): Boolean = pluginRequired()
+
+  override fun distance(geometry: Any): Double = pluginRequired()
+
+  override fun number(key: String): Double = pluginRequired()
+
+  override fun string(key: String): String = pluginRequired()
+
+  override fun boolean(key: String): Boolean = pluginRequired()
+}

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/kotlin/ExprScope.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/kotlin/ExprScope.kt
@@ -136,8 +136,9 @@ public interface ExprScope {
   public fun Any?.asColor(vararg fallbacks: Any?): Color
 
   /**
-   * Asserts the value is one of [entries] (style-spec strings, or [EnumValue] names via
-   * `entries.map { it.literal.value }`). Reified `asEnum<T>()` is not possible on an interface.
+   * Asserts the value is one of [entries] (style-spec strings, or
+   * [EnumValue][org.maplibre.compose.expressions.value.EnumValue] names via `entries.map {
+   * it.literal.value }`). Reified `asEnum<T>()` is not possible on an interface.
    */
   public fun Any?.asEnum(entries: List<String>, vararg fallbacks: Any?): String
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/util/ExpressionJson.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/util/ExpressionJson.kt
@@ -14,6 +14,7 @@ import org.maplibre.compose.expressions.ast.CompiledListLiteral
 import org.maplibre.compose.expressions.ast.CompiledOptions
 import org.maplibre.compose.expressions.ast.DpPaddingLiteral
 import org.maplibre.compose.expressions.ast.FloatLiteral
+import org.maplibre.compose.expressions.ast.GeoJsonLiteral
 import org.maplibre.compose.expressions.ast.NullLiteral
 import org.maplibre.compose.expressions.ast.OffsetLiteral
 import org.maplibre.compose.expressions.ast.ProjectionTransitionLiteral
@@ -53,6 +54,9 @@ private fun CompiledExpression<*>.normalizeJsonLike(inLiteral: Boolean): JsonEle
           JsonPrimitive(value.progress),
         )
       )
+
+    // Bare object: within/distance take GeoJSON as a function argument, not ["literal", ...].
+    is GeoJsonLiteral -> value
 
     is DpPaddingLiteral ->
       // Style order is top, right, bottom, left.

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/expressions/kotlin/ExprEmitTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/expressions/kotlin/ExprEmitTest.kt
@@ -1,0 +1,67 @@
+package org.maplibre.compose.expressions.kotlin
+
+import androidx.compose.ui.graphics.Color
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import org.maplibre.compose.expressions.ast.Expression
+import org.maplibre.compose.expressions.ast.ExpressionContext
+import org.maplibre.compose.util.toStyleJson
+
+class ExprEmitTest {
+  private fun json(expression: Expression<*>): String =
+    expression.compile(ExpressionContext.None).toStyleJson().toString()
+
+  @Test
+  fun lit_encodes_scalars() {
+    assertEquals("true", json(ExprEmit.lit(true)))
+    assertEquals("\"park\"", json(ExprEmit.lit("park")))
+    assertEquals("2.5", json(ExprEmit.lit(2.5)))
+  }
+
+  @Test
+  fun op_builds_function_calls() {
+    val get = ExprEmit.op("get", ExprEmit.lit("mag"))
+    val number = ExprEmit.op("number", get)
+    val cmp = ExprEmit.op(">", number, ExprEmit.lit(5))
+    assertEquals("[\"\u003e\",[\"number\",[\"get\",\"mag\"]],5]", json(cmp).replace("5.0", "5"))
+  }
+
+  @Test
+  fun case_and_match() {
+    val case =
+      ExprEmit.op(
+        "case",
+        ExprEmit.op(">", ExprEmit.lit(1), ExprEmit.lit(0)),
+        ExprEmit.lit(Color.Red),
+        ExprEmit.lit(Color.Yellow),
+      )
+    assertEquals("case", (case as org.maplibre.compose.expressions.ast.FunctionCall).name)
+
+    val match =
+      ExprEmit.match(
+        ExprEmit.lit("park"),
+        ExprEmit.lit(Color.Gray),
+        ExprEmit.lit("park"),
+        ExprEmit.lit(Color.Green),
+      )
+    assertEquals("match", (match as org.maplibre.compose.expressions.ast.FunctionCall).name)
+  }
+
+  @Test
+  fun interpolate_and_step() {
+    val interpolated =
+      ExprEmit.interpolate(
+        "interpolate",
+        ExprEmit.op("linear"),
+        ExprEmit.op("zoom"),
+        ExprEmit.lit(5),
+        ExprEmit.lit(2),
+        ExprEmit.lit(10),
+        ExprEmit.lit(8),
+      )
+    assertEquals(
+      "[\"interpolate\",[\"linear\"],[\"zoom\"],5,2,10,8]",
+      json(interpolated).replace(".0", ""),
+    )
+  }
+}

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/expressions/kotlin/ExprEmitTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/expressions/kotlin/ExprEmitTest.kt
@@ -17,7 +17,9 @@ class ExprEmitTest {
 
   @Test
   fun lit_encodes_scalars() {
+    assertEquals("true", json(ExprEmit.litBoolean(true)))
     assertEquals("true", json(ExprEmit.lit(true)))
+    assertEquals("false", json(ExprEmit.litBoolean(false)))
     assertEquals("\"park\"", json(ExprEmit.lit("park")))
     assertEquals("2.5", json(ExprEmit.lit(2.5)))
   }

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/expressions/kotlin/ExprEmitTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/expressions/kotlin/ExprEmitTest.kt
@@ -3,9 +3,13 @@ package org.maplibre.compose.expressions.kotlin
 import androidx.compose.ui.graphics.Color
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 import org.maplibre.compose.expressions.ast.Expression
 import org.maplibre.compose.expressions.ast.ExpressionContext
+import org.maplibre.compose.expressions.ast.FunctionCall
 import org.maplibre.compose.util.toStyleJson
+import org.maplibre.spatialk.geojson.Point
+import org.maplibre.spatialk.geojson.Position
 
 class ExprEmitTest {
   private fun json(expression: Expression<*>): String =
@@ -61,5 +65,20 @@ class ExprEmitTest {
       "[\"interpolate\",[\"linear\"],[\"zoom\"],5,2,10,8]",
       json(interpolated).replace(".0", ""),
     )
+  }
+
+  @Test
+  fun lit_encodes_geojson_as_a_bare_object() {
+    val point = Point(Position(longitude = 1.0, latitude = 2.0))
+    val encoded = json(ExprEmit.lit(point))
+    assertTrue(encoded.startsWith("{"), encoded)
+    assertTrue(encoded.contains("Point") || encoded.contains("point"), encoded)
+  }
+
+  @Test
+  fun image_name_is_a_single_image_operator() {
+    val encoded = json(ExprEmit.imageName(ExprEmit.lit("marker")))
+    assertEquals("""["image","marker"]""", encoded)
+    assertEquals("image", (ExprEmit.imageName(ExprEmit.lit("marker")) as FunctionCall).name)
   }
 }

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/expressions/kotlin/ExprEmitTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/expressions/kotlin/ExprEmitTest.kt
@@ -20,9 +20,9 @@ class ExprEmitTest {
 
   @Test
   fun op_builds_function_calls() {
-    val get = ExprEmit.op("get", ExprEmit.lit("mag"))
-    val number = ExprEmit.op("number", get)
-    val cmp = ExprEmit.op(">", number, ExprEmit.lit(5))
+    val get = ExprEmit.op("get", listOf(ExprEmit.lit("mag")))
+    val number = ExprEmit.op("number", listOf(get))
+    val cmp = ExprEmit.op(">", listOf(number, ExprEmit.lit(5)))
     assertEquals("[\"\u003e\",[\"number\",[\"get\",\"mag\"]],5]", json(cmp).replace("5.0", "5"))
   }
 
@@ -31,9 +31,11 @@ class ExprEmitTest {
     val case =
       ExprEmit.op(
         "case",
-        ExprEmit.op(">", ExprEmit.lit(1), ExprEmit.lit(0)),
-        ExprEmit.lit(Color.Red),
-        ExprEmit.lit(Color.Yellow),
+        listOf(
+          ExprEmit.op(">", listOf(ExprEmit.lit(1), ExprEmit.lit(0))),
+          ExprEmit.lit(Color.Red),
+          ExprEmit.lit(Color.Yellow),
+        ),
       )
     assertEquals("case", (case as org.maplibre.compose.expressions.ast.FunctionCall).name)
 
@@ -41,8 +43,7 @@ class ExprEmitTest {
       ExprEmit.match(
         ExprEmit.lit("park"),
         ExprEmit.lit(Color.Gray),
-        ExprEmit.lit("park"),
-        ExprEmit.lit(Color.Green),
+        listOf(ExprEmit.lit("park"), ExprEmit.lit(Color.Green)),
       )
     assertEquals("match", (match as org.maplibre.compose.expressions.ast.FunctionCall).name)
   }
@@ -52,12 +53,9 @@ class ExprEmitTest {
     val interpolated =
       ExprEmit.interpolate(
         "interpolate",
-        ExprEmit.op("linear"),
-        ExprEmit.op("zoom"),
-        ExprEmit.lit(5),
-        ExprEmit.lit(2),
-        ExprEmit.lit(10),
-        ExprEmit.lit(8),
+        ExprEmit.op("linear", emptyList<Expression<*>>()),
+        ExprEmit.op("zoom", emptyList<Expression<*>>()),
+        listOf(ExprEmit.lit(5), ExprEmit.lit(2), ExprEmit.lit(10), ExprEmit.lit(8)),
       )
     assertEquals(
       "[\"interpolate\",[\"linear\"],[\"zoom\"],5,2,10,8]",

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/expressions/kotlin/KotlinExprPluginTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/expressions/kotlin/KotlinExprPluginTest.kt
@@ -14,9 +14,12 @@ import org.maplibre.compose.expressions.value.ColorValue
 import org.maplibre.compose.expressions.value.DpValue
 import org.maplibre.compose.expressions.value.ExpressionValue
 import org.maplibre.compose.expressions.value.FloatValue
+import org.maplibre.compose.expressions.value.FormattedValue
 import org.maplibre.compose.expressions.value.IntValue
 import org.maplibre.compose.expressions.value.StringValue
 import org.maplibre.compose.util.toStyleJson
+import org.maplibre.spatialk.geojson.Point
+import org.maplibre.spatialk.geojson.Position
 
 class KotlinExprPluginTest {
   private fun json(expression: Expression<*>): String =
@@ -64,7 +67,7 @@ class KotlinExprPluginTest {
   }
 
   @Test
-  fun kotlin_when_becomes_case() {
+  fun kotlin_when_on_a_subject_becomes_match() {
     val encoded =
       json(
         expr<ColorValue> {
@@ -75,8 +78,24 @@ class KotlinExprPluginTest {
           }
         }
       )
-    assertTrue(encoded.startsWith("[\"case\","), encoded)
+    assertTrue(encoded.startsWith("[\"match\","), encoded)
     assertTrue(encoded.contains("park"), encoded)
+  }
+
+  @Test
+  fun kotlin_when_without_a_subject_stays_case() {
+    val encoded =
+      json(
+        expr<ColorValue> {
+          val mag = feature.number("mag")
+          when {
+            mag >= 6 -> Color.Red
+            mag >= 4 -> Color.Yellow
+            else -> Color.Gray
+          }
+        }
+      )
+    assertTrue(encoded.startsWith("[\"case\","), encoded)
   }
 
   @Test
@@ -147,5 +166,122 @@ class KotlinExprPluginTest {
   fun unused_expression_value_bound() {
     val unused: Expression<ExpressionValue> = expr { "ok" }
     assertEquals("\"ok\"", json(unused))
+  }
+
+  @Test
+  fun match_helper_and_nil() {
+    val encoded =
+      json(
+        expr<ColorValue> {
+          match(
+            feature.string("kind"),
+            "park" to Color.Green,
+            listOf("road", "path") to Color.Gray,
+            fallback = Color.Red,
+          )
+        }
+      )
+    assertTrue(encoded.startsWith("[\"match\","), encoded)
+    assertEquals("null", json(expr<ExpressionValue> { nil() }))
+  }
+
+  @Test
+  fun as_enum_and_collection_asserts() {
+    val encoded =
+      json(
+        expr<StringValue> {
+          feature["kind"].asEnum(listOf("park", "water"), "park")
+        }
+      )
+    assertTrue(encoded.contains("\"in\""), encoded)
+    assertTrue(encoded.contains("\"case\""), encoded)
+
+    val offset = json(expr<ExpressionValue> { feature["offset"].asOffset() })
+    assertTrue(offset.contains("\"array\""), offset)
+    assertTrue(offset.contains("2"), offset)
+
+    val padding = json(expr<ExpressionValue> { feature["pad"].asPadding() })
+    assertTrue(padding.contains("4"), padding)
+  }
+
+  @Test
+  fun map_get_and_has_after_as_map() {
+    val encoded =
+      json(
+        expr<BooleanValue> {
+          feature.properties().has("name") && feature.properties()["kind"] != null
+        }
+      )
+    assertTrue(encoded.contains("\"has\""), encoded)
+    assertTrue(encoded.contains("\"get\""), encoded)
+    assertTrue(encoded.contains("\"properties\""), encoded)
+  }
+
+  @Test
+  fun unit_conversions_and_map_constants() {
+    val seconds = json(expr<ExpressionValue> { feature.number("delay").seconds })
+    assertTrue(seconds.contains("1000") || seconds.contains("*"), seconds)
+
+    val sp = expr<ExpressionValue> { feature.number("size").sp }
+    assertTrue(sp is org.maplibre.compose.expressions.ast.TextUnitCalculation)
+
+    val constants = json(expr<FloatValue> { ln2 + pi + e })
+    assertTrue(constants.contains("\"ln2\""), constants)
+    assertTrue(constants.contains("\"pi\""), constants)
+    assertTrue(constants.contains("\"e\""), constants)
+  }
+
+  @Test
+  fun collator_compare_and_resolved_locale() {
+    val encoded =
+      json(
+        expr<BooleanValue> {
+          val locale = collator(locale = "en")
+          eq(feature.string("name"), "Park", locale) && resolvedLocale(locale).isScriptSupported()
+        }
+      )
+    assertTrue(encoded.contains("\"collator\"") || encoded.contains("=="), encoded)
+  }
+
+  @Test
+  fun format_keeps_span_options() {
+    val encoded =
+      json(
+        expr<FormattedValue> {
+          format(span(feature.string("name"), font = listOf("Open Sans"), textColor = Color.Red))
+        }
+      )
+    assertTrue(encoded.startsWith("[\"format\","), encoded)
+    assertTrue(encoded.contains("text-font") || encoded.contains("text-color"), encoded)
+  }
+
+  @Test
+  fun image_name_is_not_double_wrapped() {
+    val encoded = json(expr<ExpressionValue> { image("marker") })
+    assertEquals("""["image","marker"]""", encoded)
+  }
+
+  @Test
+  fun within_uses_a_geojson_literal() {
+    val ring = Point(Position(longitude = 0.0, latitude = 0.0))
+    val encoded = json(expr<BooleanValue> { feature.within(ring) })
+    assertTrue(encoded.startsWith("[\"within\","), encoded)
+    assertTrue(encoded.contains("Point") || encoded.contains("point"), encoded)
+  }
+
+  @Test
+  fun string_script_and_type_of() {
+    val encoded =
+      json(expr<StringValue> { feature.string("name").isScriptSupported().convertToString() })
+    assertTrue(encoded.contains("is-supported-script") || encoded.contains("to-string"), encoded)
+    val type = json(expr<StringValue> { feature["mag"].typeOf() })
+    assertTrue(type.contains("typeof"), type)
+  }
+
+  @Test
+  fun compose_function_with_constable_result_is_frozen() {
+    fun themeRed(): Color = Color.Red
+    val encoded = json(expr<ColorValue> { themeRed() })
+    assertTrue(encoded.contains("rgba("), encoded)
   }
 }

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/expressions/kotlin/KotlinExprPluginTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/expressions/kotlin/KotlinExprPluginTest.kt
@@ -1,0 +1,151 @@
+package org.maplibre.compose.expressions.kotlin
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import kotlin.math.sqrt
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.maplibre.compose.expressions.ast.CompiledFunctionCall
+import org.maplibre.compose.expressions.ast.Expression
+import org.maplibre.compose.expressions.ast.ExpressionContext
+import org.maplibre.compose.expressions.value.BooleanValue
+import org.maplibre.compose.expressions.value.ColorValue
+import org.maplibre.compose.expressions.value.DpValue
+import org.maplibre.compose.expressions.value.ExpressionValue
+import org.maplibre.compose.expressions.value.FloatValue
+import org.maplibre.compose.expressions.value.IntValue
+import org.maplibre.compose.expressions.value.StringValue
+import org.maplibre.compose.util.toStyleJson
+
+class KotlinExprPluginTest {
+  private fun json(expression: Expression<*>): String =
+    expression.compile(ExpressionContext.None).toStyleJson().toString()
+
+  private fun call(expression: Expression<*>): CompiledFunctionCall =
+    expression.compile(ExpressionContext.None) as CompiledFunctionCall
+
+  @Test
+  fun constants_become_literals() {
+    assertEquals("true", json(expr<BooleanValue> { true }))
+    assertEquals("1.5", json(expr<FloatValue> { 1.5 }))
+    assertEquals("\"park\"", json(expr<StringValue> { "park" }))
+    assertTrue(json(expr<ColorValue> { Color.Red }).contains("rgba("))
+    assertTrue(json(expr<DpValue> { 4.dp }).contains("4"))
+  }
+
+  @Test
+  fun arithmetic_uses_maplibre_operators() {
+    val sum = call(expr<IntValue> { 1 + 2 })
+    assertEquals("+", sum.name)
+  }
+
+  @Test
+  fun feature_property_and_comparison() {
+    val encoded = json(expr<BooleanValue> { feature.number("mag") > 5 })
+    assertTrue(encoded.contains("\"get\""), encoded)
+    assertTrue(encoded.contains("\"mag\""), encoded)
+  }
+
+  @Test
+  fun kotlin_if_becomes_case() {
+    val encoded =
+      json(
+        expr<ColorValue> {
+          if (feature.number("mag") > 5) {
+            Color.Red
+          } else {
+            Color.Yellow
+          }
+        }
+      )
+    assertTrue(encoded.startsWith("[\"case\","), encoded)
+    assertTrue(encoded.contains("\"get\""), encoded)
+  }
+
+  @Test
+  fun kotlin_when_becomes_case() {
+    val encoded =
+      json(
+        expr<ColorValue> {
+          when (feature.string("kind")) {
+            "park" -> Color.Green
+            "water" -> Color.Blue
+            else -> Color.Gray
+          }
+        }
+      )
+    assertTrue(encoded.startsWith("[\"case\","), encoded)
+    assertTrue(encoded.contains("park"), encoded)
+  }
+
+  @Test
+  fun boolean_and_or_not() {
+    val encoded = json(expr<BooleanValue> { feature.has("mag") && !feature.has("place") })
+    assertTrue(encoded.contains("\"all\"") || encoded.contains("\"case\""), encoded)
+    assertTrue(encoded.contains("\"has\""), encoded)
+  }
+
+  @Test
+  fun interpolate_and_zoom() {
+    val encoded = json(expr<FloatValue> { interpolate(exponential(2), zoom, 5 to 2.0, 10 to 8.0) })
+    assertTrue(encoded.startsWith("[\"interpolate\","), encoded)
+    assertTrue(encoded.contains("\"exponential\""), encoded)
+    assertTrue(encoded.contains("\"zoom\""), encoded)
+  }
+
+  @Test
+  fun step_on_feature() {
+    val encoded = json(expr<FloatValue> { step(feature.number("mag"), 4.0, 4 to 8.0, 6 to 16.0) })
+    assertTrue(encoded.startsWith("[\"step\","), encoded)
+  }
+
+  @Test
+  fun string_methods_and_concat() {
+    val encoded = json(expr<StringValue> { feature.string("name").uppercase() + " quake" })
+    assertTrue(encoded.contains("\"upcase\"") || encoded.contains("\"concat\""), encoded)
+  }
+
+  @Test
+  fun kotlin_math() {
+    val encoded = json(expr<FloatValue> { sqrt(feature.number("mag")) })
+    assertTrue(encoded.contains("\"sqrt\""), encoded)
+  }
+
+  @Test
+  fun captured_outer_value() {
+    val threshold = 5.0
+    val encoded = json(expr<BooleanValue> { feature.number("mag") > threshold })
+    assertTrue(encoded.contains("5"), encoded)
+  }
+
+  @Test
+  fun local_val_is_inlined() {
+    val encoded =
+      json(
+        expr<FloatValue> {
+          val mag = feature.number("mag")
+          mag * 2
+        }
+      )
+    assertTrue(encoded.contains("\"*\""), encoded)
+    assertTrue(encoded.contains("\"get\""), encoded)
+  }
+
+  @Test
+  fun filter_style_boolean() {
+    val encoded = json(expr<BooleanValue> { feature.number("mag") > 5 && feature.has("place") })
+    assertTrue(encoded.contains("\"get\"") || encoded.contains("\"has\""), encoded)
+  }
+
+  @Test
+  fun emit_api_matches_plugin_for_literals() {
+    assertEquals(json(ExprEmit.lit(3)), json(expr<IntValue> { 3 }))
+  }
+
+  @Test
+  fun unused_expression_value_bound() {
+    val unused: Expression<ExpressionValue> = expr { "ok" }
+    assertEquals("\"ok\"", json(unused))
+  }
+}

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/util/ExpressionJsonTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/util/ExpressionJsonTest.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 import kotlinx.serialization.json.float
 import kotlinx.serialization.json.jsonPrimitive
 import org.maplibre.compose.expressions.ast.BooleanLiteral
@@ -21,6 +22,8 @@ import org.maplibre.compose.expressions.ast.OffsetLiteral
 import org.maplibre.compose.expressions.ast.StringLiteral
 import org.maplibre.compose.expressions.dsl.const
 import org.maplibre.compose.expressions.dsl.padding
+import org.maplibre.spatialk.geojson.Point
+import org.maplibre.spatialk.geojson.Position
 
 /**
  * Written against values, not rendered text, wherever a whole number is involved: Kotlin renders
@@ -127,5 +130,13 @@ class ExpressionJsonTest {
   fun encodes_negative_padding_sides() {
     val padding = padding(left = 2.5.dp, top = (-2.5).dp, right = 0.1.dp, bottom = (-7.1).dp)
     assertEquals("""["literal",[-2.5,0.1,-7.1,2.5]]""", json(compiled(padding)))
+  }
+
+  @Test
+  fun encodes_geojson_as_a_bare_object_argument() {
+    val point = const(Point(Position(longitude = 0.0, latitude = 1.0)))
+    val encoded = json(compiled(point))
+    assertTrue(encoded.startsWith("{"), encoded)
+    assertTrue(encoded.contains("\"type\""), encoded)
   }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -44,6 +44,7 @@ include(
   ":demo-app:desktop-nucleus",
   ":lib",
   ":lib:maplibre-compose",
+  ":lib:maplibre-compose-expr-compiler",
   ":lib:maplibre-compose-material3",
   ":lib:maplibre-compose-runtime-opengl-android",
   ":lib:maplibre-compose-runtime-vulkan-android",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

**Throwaway draft.** Not intended to merge. It explores replacing the expression DSL with a Kotlin compiler plugin so users write `if` / `when`, operators, and `feature` / `zoom` as normal Kotlin. The plugin lowers that to the existing `Expression` AST.

Inspired by [kotlin-expr-tree-kcp](https://github.com/Kronos-orm/kotlin-expr-tree-kcp). Design notes: `lib/maplibre-compose-expr-compiler/PROTOTYPE.md`.

The plugin now checks const-able captures at compile time and covers the remaining style-spec surface, including the cases that fail for engine or Kotlin reasons rather than missing visitor branches.

### Sample usage

Constants:

```kotlin
CircleLayer(
  id = "quakes-constant",
  source = earthquakes,
  radius = expr { 4.dp },
  color = expr { Color.Red },
)
```

Feature data with `when` / `if` (evaluated per feature, not at composition):

```kotlin
CircleLayer(
  id = "quakes-by-magnitude",
  source = earthquakes,
  radius = expr {
    val mag = feature.number("mag")
    when {
      mag >= 6 -> 16.dp
      mag >= 4 -> 8.dp
      else -> 4.dp
    }
  },
  color = expr {
    if (feature.number("mag") > 5) Color.Red else Color.Yellow
  },
)
```

Subject `when` becomes `match`. Comparison `when` stays `case`:

```kotlin
val color: Expression<ColorValue> = expr {
  when (feature.string("kind")) {
    "park" -> Color.Green
    "water" -> Color.Blue
    else -> Color.Gray
  }
}
```

Zoom interpolation, format spans, GeoJSON, and a composition-time helper:

```kotlin
fun themeRed() = Color.Red
val radius = expr { interpolate(exponential(2), zoom, 5 to 2.dp, 10 to 8.dp) }
val label = expr {
  format(span(feature.string("name"), font = listOf("Open Sans"), textColor = Color.Red))
}
val inside = expr { feature.within(Point(Position(0.0, 0.0))) }
val painted = expr { themeRed() }
```

### Compile-time rejects

These are compile errors, not runtime throws from `ExprEmit.lit`:

```kotlin
// type is not const-able
expr { mapState }

// the map cannot run Kotlin per feature
fun paint(mag: Double) = if (mag > 5) Color.Red else Color.Yellow
expr { paint(feature.number("mag")) }

// MapLibre has no array constructor for dynamic components
expr { Offset(feature.number("x").toFloat(), feature.number("y").toFloat()) }
```

`var`, loops, and `try` are also compile errors.

### Limitations the hard cases showed

- MapLibre cannot build `Offset`, `padding`, or `listOf` from feature numbers. `asOffset()` only asserts an existing two-number array.
- Text-unit offsets (`offset(12.sp, 4.em)`) are composition-time `TextUnit` values only.
- `image(bitmap/painter)` options (size, SDF, stretch) register a bitmap at composition time. A style-image *name* can be map-evaluated.
- Reified `asEnum<T>()` cannot be an interface member. The helper takes `List<String>` of style-spec names.
- `kotlin.math.PI` freezes as a number. Scope `pi` / `e` / `ln2` emit the map operators.
- `null` is typed `Nothing?` in IR; that has to be treated as `nil`.
- Matching helpers by package prefix is wrong: tests live in `org.maplibre.compose.expressions.kotlin`.
- Kotlin/JS does not treat a primitive `boolean` as `is Boolean`. Boolean IR constants call typed `litBoolean(Boolean)`. Interning `BooleanLiteral.True`/`False` can return `undefined` during companion init.
- Kotlin/JS compiles `is Int` / `is Float` / `is Double` to `typeof === 'number'`. `lit(2.5)` used to take the Int branch; `IntCache[2.5]` is `undefined`. One `Number` path now keeps whole values as Int and the rest as Float.
- Dokka `failOnWarning` rejects an unresolved `[EnumValue]` KDoc link on `ExprScope.asEnum` (and the inherited stub). The comment now names the type in prose.

The old `const` / `switch` / `gt` DSL remains as the lowering target and escape hatch. Layer parameters are still `Expression<T>`.

## Validation

Draft CI on `68b23cdd` failed three jobs:

- **docs** and **android / 36** (`test:publishing`): Dokka `failOnWarning` on `[EnumValue]` in `ExprScope.asEnum`. The KDoc link is gone.
- **js / chromium**: `TypeError: Cannot read properties of undefined (reading 'compile_…')` on `lit_encodes_scalars` and `constants_become_literals`. After the boolean intern fix, the remaining hole was `lit(2.5)` matching `is Int` on JS and indexing `IntCache` with a fractional key.

Ran on Linux after `b12ba853`:

- `:lib:maplibre-compose-expr-compiler:test` — 3/3
- `:lib:maplibre-compose:jvmTest` for `expressions.kotlin` (32) and `ExpressionJsonTest` (10) — all passed
- `:lib:maplibre-compose:jsBrowserTest` with system Chrome — **515/515 passed**, including the two previously failing tests (ExprEmitTest 6, KotlinExprPluginTest 26)

Not run locally: `dokkaGenerate` (no Android SDK here), iOS, Android device, desktop GPU. No `ci:full`: shared Kotlin plus a JVM plugin, no ABI or native loading change.

## AI assistance

Cursor Grok 4.6 (cloud agent). I designed the Map vs Compose classification and the const-able check, then implemented the remaining DSL lowering, CI fixes, and tests.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e85d346d-0a91-4df6-bc7c-6218caf62006?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e85d346d-0a91-4df6-bc7c-6218caf62006&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

