### PR TITLE
Anchor layers by predicate

### DIFF
--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoStyle.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoStyle.kt
@@ -1,7 +1,6 @@
 package org.maplibre.compose.demoapp
 
 import org.maplibre.compose.demoapp.generated.Res
-import org.maplibre.compose.layers.Anchor
 import org.maplibre.compose.style.BaseStyle
 
 /**
@@ -28,10 +27,6 @@ interface DemoStyle {
    */
   val textFont: List<String>
     get() = listOf("Noto Sans Regular")
-
-  /** An anchor that keeps a demo's layers below the style's labels. */
-  val anchorBelowSymbols: Anchor
-    get() = Anchor.Below { it.type == "symbol" }
 }
 
 /**

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoStyle.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoStyle.kt
@@ -31,6 +31,7 @@ interface DemoStyle {
 
   /** An anchor that keeps a demo's layers below the style's labels. */
   val anchorBelowSymbols: Anchor
+    get() = Anchor.Below { it.type == "symbol" }
 }
 
 /**
@@ -51,8 +52,6 @@ enum class OpenFreeMap(override val isDark: Boolean = false) : DemoStyle {
   override val displayName = "$name (OpenFreeMap)"
 
   override val base = BaseStyle.Uri("https://tiles.openfreemap.org/styles/${name.lowercase()}")
-
-  override val anchorBelowSymbols = Anchor.Below("waterway_line_label")
 }
 
 enum class Protomaps(override val isDark: Boolean = false) : DemoStyle {
@@ -68,8 +67,6 @@ enum class Protomaps(override val isDark: Boolean = false) : DemoStyle {
     BaseStyle.Uri(
       "https://api.protomaps.com/styles/v5/${name.lowercase()}/en.json?key=$PROTOMAPS_API_KEY"
     )
-
-  override val anchorBelowSymbols = Anchor.Below("address_label")
 }
 
 enum class Versatiles(override val isDark: Boolean = false) : DemoStyle {
@@ -81,8 +78,6 @@ enum class Versatiles(override val isDark: Boolean = false) : DemoStyle {
 
   override val base = BaseStyle.Uri(Res.getUri("files/styles/${name.lowercase()}.json"))
 
-  override val anchorBelowSymbols = Anchor.Below("label-address-housenumber")
-
   // Versatiles names its fonts in snake case; "Noto Sans Regular" 404s here.
   override val textFont = listOf("noto_sans_regular")
 }
@@ -91,7 +86,6 @@ enum class OtherStyles(
   override val displayName: String,
   override val base: BaseStyle,
   override val isDark: Boolean = false,
-  override val anchorBelowSymbols: Anchor = Anchor.Top,
   override val textFont: List<String> = listOf("Noto Sans Regular"),
 ) : DemoStyle {
   // A raster style with no `glyphs` endpoint, so no font stack works here and the value is inert.

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/DataVizDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/DataVizDemo.kt
@@ -19,6 +19,7 @@ import org.maplibre.compose.expressions.dsl.interpolate
 import org.maplibre.compose.expressions.dsl.linear
 import org.maplibre.compose.expressions.dsl.not
 import org.maplibre.compose.expressions.dsl.step
+import org.maplibre.compose.layers.Anchor
 import org.maplibre.compose.layers.CircleLayer
 import org.maplibre.compose.layers.HeatmapLayer
 import org.maplibre.compose.layers.SymbolLayer
@@ -53,10 +54,12 @@ object DataVizDemo : Demo {
 
   @Composable
   override fun MapContent() {
-    when (mode) {
-      Mode.Points -> Points()
-      Mode.Heatmap -> Heatmap()
-      Mode.Clusters -> Clusters()
+    Anchor.Below({ it.type == "symbol" }) {
+      when (mode) {
+        Mode.Points -> Points()
+        Mode.Heatmap -> Heatmap()
+        Mode.Clusters -> Clusters()
+      }
     }
   }
 

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/MaterialStyleDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/MaterialStyleDemo.kt
@@ -55,7 +55,6 @@ import org.maplibre.compose.expressions.value.LineCap
 import org.maplibre.compose.expressions.value.LineJoin
 import org.maplibre.compose.expressions.value.SymbolPlacement
 import org.maplibre.compose.expressions.value.TextTransform
-import org.maplibre.compose.layers.Anchor
 import org.maplibre.compose.layers.BackgroundLayer
 import org.maplibre.compose.layers.FillExtrusionLayer
 import org.maplibre.compose.layers.FillLayer
@@ -86,8 +85,6 @@ private enum class Material(override val isDark: Boolean = false) : DemoStyle {
     putJsonObject("sources") {}
     putJsonArray("layers") {}
   }
-
-  override val anchorBelowSymbols = Anchor.Top
 }
 
 /**

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/TransitNetworkDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/TransitNetworkDemo.kt
@@ -73,6 +73,7 @@ import org.maplibre.compose.expressions.dsl.eq
 import org.maplibre.compose.expressions.dsl.feature
 import org.maplibre.compose.expressions.dsl.offset
 import org.maplibre.compose.expressions.value.SymbolAnchor
+import org.maplibre.compose.layers.Anchor
 import org.maplibre.compose.layers.CircleLayer
 import org.maplibre.compose.layers.LineLayer
 import org.maplibre.compose.layers.SymbolLayer
@@ -376,31 +377,33 @@ object TransitNetworkDemo : Demo {
     val routeSource = rememberGeoJsonSource(GeoJsonData.Features(network.routeLines))
     val terminalSource = rememberGeoJsonSource(GeoJsonData.Features(network.terminals))
 
-    LineLayer(
-      id = "transit-routes",
-      source = routeSource,
-      color = feature["color"].asString().convertToColor(),
-      width = const(3.dp),
-      opacity = if (selected == null) const(0.8f) else const(0.2f),
-    )
-    if (selected != null) {
+    Anchor.Below({ it.type == "symbol" }) {
       LineLayer(
-        id = "transit-route-selected",
+        id = "transit-routes",
         source = routeSource,
-        filter = feature["route"] eq const(selected),
         color = feature["color"].asString().convertToColor(),
-        width = const(4.dp),
+        width = const(3.dp),
+        opacity = if (selected == null) const(0.8f) else const(0.2f),
+      )
+      if (selected != null) {
+        LineLayer(
+          id = "transit-route-selected",
+          source = routeSource,
+          filter = feature["route"] eq const(selected),
+          color = feature["color"].asString().convertToColor(),
+          width = const(4.dp),
+        )
+      }
+
+      CircleLayer(
+        id = "transit-terminals",
+        source = terminalSource,
+        radius = const(4.dp),
+        color = const(Color.White),
+        strokeWidth = const(2.dp),
+        strokeColor = const(Color(0xFF37474F)),
       )
     }
-
-    CircleLayer(
-      id = "transit-terminals",
-      source = terminalSource,
-      radius = const(4.dp),
-      color = const(Color.White),
-      strokeWidth = const(2.dp),
-      strokeColor = const(Color(0xFF37474F)),
-    )
     SymbolLayer(
       id = "transit-terminal-names",
       source = terminalSource,

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Layers.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Layers.kt
@@ -99,8 +99,13 @@ fun Layers() {
     // #region anchors
     val anchoredAmtrakRoutes =
       rememberGeoJsonSource(GeoJsonData.Uri(Res.getUri("files/data/amtrak_routes.geojson")))
-    Anchor.Above("road_motorway") {
+    // Below the base style's labels, whatever the style names them
+    Anchor.Below({ it.type == "symbol" }) {
       LineLayer(id = "amtrak-routes", source = anchoredAmtrakRoutes)
+    }
+    // Above one base layer, named by its ID
+    Anchor.Above("road_motorway") {
+      LineLayer(id = "amtrak-routes-casing", source = anchoredAmtrakRoutes)
     }
     // #endregion anchors
 

--- a/docs/src/content/docs/composition.mdx
+++ b/docs/src/content/docs/composition.mdx
@@ -53,8 +53,10 @@ current state, and let the runtime reconcile it.
 When you assign `mapState.style.baseStyle`, the map loads the new style and evaluates
 the style block against it. Each evaluation declares your
 sources and layers against the new style. They persist across the switch
-without extra code. An `Anchor` that names a base layer applies only when that
-layer exists in the new style.
+without extra code. An `Anchor` resolves again against the new style's layers,
+so a predicate that matches by layer type lands in the equivalent place in each
+style, and one that matches nothing falls back to the top or bottom of the
+stack.
 
 To share one definition between several maps, write the style content as a
 composable function and call that function from each style block. The same
@@ -74,4 +76,4 @@ read. Content that runs on both hosts branches on it.
 Layers and sources have string IDs because the underlying MapLibre style
 identifies them by ID. Within one map, each layer ID must be unique, including
 against the base style's layers. A feature query takes layer IDs to limit its
-scope, and an `Anchor` names a base style layer by its ID.
+scope, and an `Anchor` can select a base style layer by its ID.

--- a/docs/src/content/docs/composition.mdx
+++ b/docs/src/content/docs/composition.mdx
@@ -53,10 +53,7 @@ current state, and let the runtime reconcile it.
 When you assign `mapState.style.baseStyle`, the map loads the new style and evaluates
 the style block against it. Each evaluation declares your
 sources and layers against the new style. They persist across the switch
-without extra code. An `Anchor` resolves again against the new style's layers,
-so a predicate that matches by layer type lands in the equivalent place in each
-style, and one that matches nothing falls back to the top or bottom of the
-stack.
+without extra code. An `Anchor` is resolved against the new style's layers.
 
 To share one definition between several maps, write the style content as a
 composable function and call that function from each style block. The same

--- a/docs/src/content/docs/layers.mdx
+++ b/docs/src/content/docs/layers.mdx
@@ -59,10 +59,10 @@ after the property. The default, null, uses the global transition that
 By default, your layers draw above the base style layers. <Api of="Anchor" />
 inserts a layer at another position: at the `Bottom`, at the `Top`, or `Above`
 or `Below` base layers that a predicate selects. The predicate receives a
-<Api of="LayerHandle" /> for each base layer, so it can match on the layer's
-type, ID, or properties. `Below` lands under the lowest matching layer and
-`Above` lands over the highest one. When nothing matches, `Below` places the
-layers at the top and `Above` places them at the bottom, without an error.
+<Api of="LayerHandle" /> for a base layer, so it can match on the layer's type,
+ID, or properties. `Below` lands under the lowest matching layer and `Above`
+lands over the highest one. When nothing matches, `Below` places the layers at
+the top and `Above` places them at the bottom, without an error.
 
 <Code code={rememberedMapStyle(region(layers, "anchors"))} lang="kotlin" title="App.kt" />
 

--- a/docs/src/content/docs/layers.mdx
+++ b/docs/src/content/docs/layers.mdx
@@ -58,8 +58,16 @@ after the property. The default, null, uses the global transition that
 
 By default, your layers draw above the base style layers. <Api of="Anchor" />
 inserts a layer at another position: at the `Bottom`, at the `Top`, or `Above`
-or `Below` a named base layer:
+or `Below` base layers that a predicate selects. The predicate receives a
+<Api of="LayerHandle" /> for each base layer, so it can match on the layer's
+type, ID, or properties. `Below` lands under the lowest matching layer and
+`Above` lands over the highest one. When nothing matches, `Below` places the
+layers at the top and `Above` places them at the bottom, without an error.
 
 <Code code={rememberedMapStyle(region(layers, "anchors"))} lang="kotlin" title="App.kt" />
+
+Only base style layers are candidates: a predicate never sees the layers that
+you declare, so anchor your own layers relative to each other by their order in
+the style block.
 
 [spec-layers]: https://maplibre.org/maplibre-style-spec/layers/

--- a/docs/src/content/docs/layers.mdx
+++ b/docs/src/content/docs/layers.mdx
@@ -58,16 +58,9 @@ after the property. The default, null, uses the global transition that
 
 By default, your layers draw above the base style layers. <Api of="Anchor" />
 inserts a layer at another position: at the `Bottom`, at the `Top`, or `Above`
-or `Below` base layers that a predicate selects. The predicate receives a
-<Api of="LayerHandle" /> for a base layer, so it can match on the layer's type,
-ID, or properties. `Below` lands under the lowest matching layer and `Above`
-lands over the highest one. When nothing matches, `Below` places the layers at
-the top and `Above` places them at the bottom, without an error.
+or `Below` a base style layer selected by ID or by a predicate over its
+<Api of="LayerHandle" />:
 
 <Code code={rememberedMapStyle(region(layers, "anchors"))} lang="kotlin" title="App.kt" />
-
-Only base style layers are candidates: a predicate never sees the layers that
-you declare, so anchor your own layers relative to each other by their order in
-the style block.
 
 [spec-layers]: https://maplibre.org/maplibre-style-spec/layers/

--- a/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MlnFfiMapCompositionTest.kt
+++ b/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MlnFfiMapCompositionTest.kt
@@ -56,8 +56,8 @@ import org.maplibre.compose.expressions.dsl.const
 import org.maplibre.compose.interaction.DragResponse
 import org.maplibre.compose.interaction.MapInteractions
 import org.maplibre.compose.interaction.PointerButton
-import org.maplibre.compose.layers.Anchor
 import org.maplibre.compose.layers.BackgroundLayer
+import org.maplibre.compose.layers.CircleLayer
 import org.maplibre.compose.layers.FillLayer
 import org.maplibre.compose.layers.RasterLayer
 import org.maplibre.compose.mlnffi.FfiTestPlatform
@@ -66,6 +66,7 @@ import org.maplibre.compose.mlnffi.setFfiTestMapContent
 import org.maplibre.compose.overlay.MapOverlay
 import org.maplibre.compose.overlay.include
 import org.maplibre.compose.sources.GeoJsonData
+import org.maplibre.compose.sources.GeoJsonOptions
 import org.maplibre.compose.sources.RasterSource
 import org.maplibre.compose.sources.rememberGeoJsonSource
 import org.maplibre.compose.style.BaseStyle
@@ -404,16 +405,16 @@ class MlnFfiMapCompositionTest {
   fun a_later_revision_supersedes_reconciliation_failure_before_the_surface_is_revealed() =
     runFfiComposeUiTest {
       val runtime = createMapRuntime(runtimeOptions)
-      var invalidAnchor by mutableStateOf(true)
+      // Synchronous GeoJSON parsing rejects malformed data inside the revision itself.
+      var malformedData by mutableStateOf(true)
       val state =
         runtime.createMapState(initialBaseStyle = BaseStyle.Empty) {
-          if (invalidAnchor) {
-            Anchor.Below("missing-base-layer") {
-              BackgroundLayer(id = "application-background", color = const(Color.Red))
-            }
-          } else {
-            BackgroundLayer(id = "application-background", color = const(Color.Blue))
-          }
+          val points =
+            rememberGeoJsonSource(
+              data = GeoJsonData.JsonString(if (malformedData) "{" else EMPTY_FEATURE_COLLECTION),
+              options = GeoJsonOptions(synchronousUpdate = true),
+            )
+          CircleLayer(id = "application-circles", source = points, color = const(Color.Red))
         }
 
       setFfiTestMapContent(runtimeOptions) { MaplibreMap(state = state) }
@@ -426,12 +427,12 @@ class MlnFfiMapCompositionTest {
       )
       onNodeWithContentDescription("Map").assertExists("a map without a style has no semantics")
 
-      invalidAnchor = false
+      malformedData = false
       waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) {
         state.style.loadState == StyleLoadState.Ready
       }
       val session = requireNotNull(state.currentMapAttachment).adapter as MlnFfiMapSession
-      assertTrue("application-background" in session.currentStyleLayerIds())
+      assertTrue("application-circles" in session.currentStyleLayerIds())
       assertTrue(onAllNodesWithTag(MAP_LOAD_PLACEHOLDER_TAG).fetchSemanticsNodes().isEmpty())
 
       runtime.close()
@@ -811,6 +812,8 @@ class MlnFfiMapCompositionTest {
       BaseStyle.Json(
         """{"version":8,"sources":{},"layers":[{"id":"replacement-style","type":"background"}]}"""
       )
+
+    const val EMPTY_FEATURE_COLLECTION = """{"type":"FeatureCollection","features":[]}"""
 
     const val RENDER_TIMEOUT_MILLIS = 30_000L
 

--- a/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MlnFfiStyleSwitchTest.kt
+++ b/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MlnFfiStyleSwitchTest.kt
@@ -53,7 +53,17 @@ class MlnFfiStyleSwitchTest {
   }
 
   @Test
-  fun rotating_the_base_style_with_content_composed_over_it() = runFfiComposeUiTest {
+  fun rotating_the_base_style_with_content_composed_over_it() =
+    // A different base-style anchor per style, so the anchor changes in the same recomposition as
+    // the style itself.
+    rotateStyles { it.anchor }
+
+  @Test
+  fun one_predicate_anchor_lands_below_the_labels_of_every_style() =
+    // The label layers have different IDs per style, so one anchor has to resolve against each.
+    rotateStyles { Anchor.Below { layer -> layer.type == "symbol" } }
+
+  private fun rotateStyles(anchorFor: (DemoStyle) -> Anchor) = runFfiComposeUiTest {
     val runtime = createMapRuntime(runtimeOptions)
     var style by mutableStateOf(STYLES[0])
     var extraLayer by mutableStateOf(false)
@@ -62,12 +72,10 @@ class MlnFfiStyleSwitchTest {
         val points = rememberGeoJsonSource(data = GeoJsonData.Features(pointAt(longitude = 0.0)))
         // Two layers on one source at different anchors, so the re-add order matters.
         CircleLayer(id = "user-circles", source = points, color = const(Color.Red))
-        // A different base-style anchor per style, so the anchor changes in the same
-        // recomposition as the style itself.
-        Anchor.At(style.anchor) {
+        Anchor.At(anchorFor(style)) {
           FillLayer(id = "user-fill", source = points, color = const(Color.Blue))
-          // Comes and goes across the rotation, covering removal of a layer that was added while
-          // its anchor was unresolvable.
+          // Comes and goes across the rotation, covering removal of a layer that was added against
+          // a different base style.
           if (extraLayer) {
             FillLayer(id = "user-extra", source = points, color = const(Color.Green))
           }
@@ -256,6 +264,9 @@ class MlnFfiStyleSwitchTest {
     const val B_STYLE_URL = "held://style-b"
     const val C_STYLE_URL = "held://style-c"
 
+    const val EMPTY_SOURCE_JSON =
+      """{"type":"geojson","data":{"type":"FeatureCollection","features":[]}}"""
+
     const val STYLE_C_JSON =
       """{"version":8,"sources":{},"layers":[{"id":"base-c","type":"background"}]}"""
 
@@ -310,9 +321,9 @@ class MlnFfiStyleSwitchTest {
           base =
             BaseStyle.Json(
               """
-              {"version":8,"sources":{},"layers":[
+              {"version":8,"sources":{"empty":$EMPTY_SOURCE_JSON},"layers":[
                 {"id":"bg-a","type":"background","paint":{"background-color":"#eee"}},
-                {"id":"labels-a","type":"background","paint":{"background-color":"#e0e0e0"}}
+                {"id":"labels-a","type":"symbol","source":"empty"}
               ]}
               """
             ),
@@ -323,9 +334,9 @@ class MlnFfiStyleSwitchTest {
           base =
             BaseStyle.Json(
               """
-              {"version":8,"sources":{},"layers":[
+              {"version":8,"sources":{"empty":$EMPTY_SOURCE_JSON},"layers":[
                 {"id":"bg-b","type":"background","paint":{"background-color":"#ddd"}},
-                {"id":"labels-b","type":"background","paint":{"background-color":"#cccccc"}}
+                {"id":"labels-b","type":"symbol","source":"empty"}
               ]}
               """
             ),

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/Anchor.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/Anchor.kt
@@ -11,17 +11,8 @@ internal val LocalAnchor: ProvidableCompositionLocal<Anchor> = compositionLocalO
 
 /**
  * Declares where layers from the style content are placed in the layer stack of the loaded base
- * style.
- *
- * [Top] places layers over every layer and [Bottom] places them under every layer. [Above] and
- * [Below] place layers next to the base-style layers that a predicate selects: [Below] lands
- * directly under the lowest matching layer, and [Above] lands directly over the highest matching
- * layer. When no layer matches, [Below] places the layers at the top of the stack and [Above]
- * places them at the bottom.
- *
- * Only the layers of the loaded base style are candidates. A layer declared in the style content is
- * never matched, so an anchor cannot refer to layers of another anchor. Layers that resolve to the
- * same position keep their order from the style content.
+ * style: [Top], [Bottom], [Above], or [Below]. Layers that resolve to the same position keep their
+ * order from the style content.
  *
  * See [Anchor.Companion] for the composable functions that apply an anchor to a block of layers.
  */
@@ -41,13 +32,9 @@ public sealed interface Anchor {
 
   /**
    * Layers are placed directly over the highest base-style layer that [predicate] accepts, or at
-   * the bottom of the stack when it accepts none. See [Anchor.Companion.Above] to use this in the
-   * style content.
-   *
-   * Every time the style content is applied to the loaded style, the predicate is called with a
-   * [LayerHandle] for one base-style layer at a time, from the top of the stack down, until it
-   * accepts one. The handles are read-only: a property setter throws
-   * [StyleHandleException][org.maplibre.compose.style.StyleHandleException].
+   * the bottom of the stack when it accepts none. Layers declared in the style content are not
+   * candidates, and the [LayerHandle] passed to the predicate is read-only. See
+   * [Anchor.Companion.Above] to use this in the style content.
    */
   public class Above private constructor(private val selector: LayerSelector) : Anchor {
     public constructor(predicate: (LayerHandle) -> Boolean) : this(LayerSelector(predicate))
@@ -67,13 +54,9 @@ public sealed interface Anchor {
 
   /**
    * Layers are placed directly under the lowest base-style layer that [predicate] accepts, or at
-   * the top of the stack when it accepts none. See [Anchor.Companion.Below] to use this in the
-   * style content.
-   *
-   * Every time the style content is applied to the loaded style, the predicate is called with a
-   * [LayerHandle] for one base-style layer at a time, from the bottom of the stack up, until it
-   * accepts one. The handles are read-only: a property setter throws
-   * [StyleHandleException][org.maplibre.compose.style.StyleHandleException].
+   * the top of the stack when it accepts none. Layers declared in the style content are not
+   * candidates, and the [LayerHandle] passed to the predicate is read-only. See
+   * [Anchor.Companion.Below] to use this in the style content.
    */
   public class Below private constructor(private val selector: LayerSelector) : Anchor {
     public constructor(predicate: (LayerHandle) -> Boolean) : this(LayerSelector(predicate))
@@ -113,8 +96,7 @@ public sealed interface Anchor {
 
     /**
      * The layers specified in [block] are placed directly over the highest base-style layer that
-     * [predicate] accepts, or at the bottom of the stack when it accepts none. See [Anchor.Above]
-     * for how the predicate is evaluated.
+     * [predicate] accepts, or at the bottom of the stack when it accepts none. See [Anchor.Above].
      */
     @Composable
     @MaplibreComposable
@@ -132,8 +114,7 @@ public sealed interface Anchor {
 
     /**
      * The layers specified in [block] are placed directly under the lowest base-style layer that
-     * [predicate] accepts, or at the top of the stack when it accepts none. See [Anchor.Below] for
-     * how the predicate is evaluated.
+     * [predicate] accepts, or at the top of the stack when it accepts none. See [Anchor.Below].
      */
     @Composable
     @MaplibreComposable

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/Anchor.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/Anchor.kt
@@ -44,9 +44,9 @@ public sealed interface Anchor {
    * the bottom of the stack when it accepts none. See [Anchor.Companion.Above] to use this in the
    * style content.
    *
-   * The predicate is called with a [LayerHandle] for each base-style layer, from the bottom of the
-   * stack to the top, every time the style content is applied to the loaded style. The handles are
-   * read-only: a property setter throws
+   * Every time the style content is applied to the loaded style, the predicate is called with a
+   * [LayerHandle] for one base-style layer at a time, from the top of the stack down, until it
+   * accepts one. The handles are read-only: a property setter throws
    * [StyleHandleException][org.maplibre.compose.style.StyleHandleException].
    */
   public class Above private constructor(private val selector: LayerSelector) : Anchor {
@@ -70,9 +70,9 @@ public sealed interface Anchor {
    * the top of the stack when it accepts none. See [Anchor.Companion.Below] to use this in the
    * style content.
    *
-   * The predicate is called with a [LayerHandle] for each base-style layer, from the bottom of the
-   * stack to the top, every time the style content is applied to the loaded style. The handles are
-   * read-only: a property setter throws
+   * Every time the style content is applied to the loaded style, the predicate is called with a
+   * [LayerHandle] for one base-style layer at a time, from the bottom of the stack up, until it
+   * accepts one. The handles are read-only: a property setter throws
    * [StyleHandleException][org.maplibre.compose.style.StyleHandleException].
    */
   public class Below private constructor(private val selector: LayerSelector) : Anchor {

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/Anchor.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/Anchor.kt
@@ -10,59 +10,101 @@ import org.maplibre.compose.util.MaplibreComposable
 internal val LocalAnchor: ProvidableCompositionLocal<Anchor> = compositionLocalOf { Anchor.Top }
 
 /**
- * Declares where the layers should be anchored, i.e. positioned in the list of layers in the map
+ * Declares where layers from the style content are placed in the layer stack of the loaded base
  * style.
  *
- * This allows for layers declared in Compose to be inserted at any location of the layers defined
- * in the base style JSON rather than exclusively on top of these.
+ * [Top] places layers over every layer and [Bottom] places them under every layer. [Above] and
+ * [Below] place layers next to the base-style layers that a predicate selects: [Below] lands
+ * directly under the lowest matching layer, and [Above] lands directly over the highest matching
+ * layer. When no layer matches, [Below] places the layers at the top of the stack and [Above]
+ * places them at the bottom.
  *
- * **Note:** This mechanism can only be used to anchor layers at `layerId`s from the *base map
- * style* loaded by [MapStyleState.baseStyle][org.maplibre.compose.map.MapStyleState.baseStyle].
- * Anchoring layers defined in the composition to other layers defined in the composition is not
- * possible.
+ * Only the layers of the loaded base style are candidates. A layer declared in the style content is
+ * never matched, so an anchor cannot refer to layers of another anchor. Layers that resolve to the
+ * same position keep their order from the style content.
  *
- * See [Anchor.Companion] for [Composable] functions to use in the layers composition.
+ * See [Anchor.Companion] for the composable functions that apply an anchor to a block of layers.
  */
 @Immutable
 public sealed interface Anchor {
   /**
-   * Layer(s) are anchored at the top, i.e. in front of all other layers. See [Anchor.Companion.Top]
-   * to use this in the layers composition.
+   * Layers are placed over every other layer. See [Anchor.Companion.Top] to use this in the style
+   * content.
    */
   public data object Top : Anchor
 
   /**
-   * Layer(s) are anchored at the bottom, i.e. in behind of all other layers. See
-   * [Anchor.Companion.Bottom] to use this in the layers composition.
+   * Layers are placed under every other layer. See [Anchor.Companion.Bottom] to use this in the
+   * style content.
    */
   public data object Bottom : Anchor
 
   /**
-   * Layer(s) are anchored above the layer (i.e. in front of it) with the given [layerId] from the
-   * base map style. See [Anchor.Companion.Above] to use this in the layers composition.
+   * Layers are placed directly over the highest base-style layer that [predicate] accepts, or at
+   * the bottom of the stack when it accepts none. See [Anchor.Companion.Above] to use this in the
+   * style content.
+   *
+   * The predicate is called with a [LayerHandle] for each base-style layer, from the bottom of the
+   * stack to the top, every time the style content is applied to the loaded style. The handles are
+   * read-only: a property setter throws
+   * [StyleHandleException][org.maplibre.compose.style.StyleHandleException].
    */
-  public data class Above(val layerId: String) : Anchor
+  public class Above private constructor(private val selector: LayerSelector) : Anchor {
+    public constructor(predicate: (LayerHandle) -> Boolean) : this(LayerSelector(predicate))
+
+    /** Anchors over the base-style layer with the given [layerId]. */
+    public constructor(layerId: String) : this(LayerSelector(layerId))
+
+    public val predicate: (LayerHandle) -> Boolean
+      get() = selector.predicate
+
+    override fun equals(other: Any?): Boolean = other is Above && selector == other.selector
+
+    override fun hashCode(): Int = selector.hashCode()
+
+    override fun toString(): String = "Above($selector)"
+  }
 
   /**
-   * Layer(s) are anchored below the layer (i.e. behind it) with the given [layerId] from the base
-   * map style. See [Anchor.Companion.Below] to use this in the layers composition.
+   * Layers are placed directly under the lowest base-style layer that [predicate] accepts, or at
+   * the top of the stack when it accepts none. See [Anchor.Companion.Below] to use this in the
+   * style content.
+   *
+   * The predicate is called with a [LayerHandle] for each base-style layer, from the bottom of the
+   * stack to the top, every time the style content is applied to the loaded style. The handles are
+   * read-only: a property setter throws
+   * [StyleHandleException][org.maplibre.compose.style.StyleHandleException].
    */
-  public data class Below(val layerId: String) : Anchor
+  public class Below private constructor(private val selector: LayerSelector) : Anchor {
+    public constructor(predicate: (LayerHandle) -> Boolean) : this(LayerSelector(predicate))
+
+    /** Anchors under the base-style layer with the given [layerId]. */
+    public constructor(layerId: String) : this(LayerSelector(layerId))
+
+    public val predicate: (LayerHandle) -> Boolean
+      get() = selector.predicate
+
+    override fun equals(other: Any?): Boolean = other is Below && selector == other.selector
+
+    override fun hashCode(): Int = selector.hashCode()
+
+    override fun toString(): String = "Below($selector)"
+  }
 
   public companion object {
-    /** The layers specified in [block] are put at the top, i.e. in front of all other layers. */
+    /** The layers specified in [block] are placed over every other layer. */
     @Composable
     @MaplibreComposable
     public fun Top(block: @Composable () -> Unit): Unit = At(Top, block)
 
-    /** The layers specified in [block] are put at the bottom, i.e. behind of all other layers. */
+    /** The layers specified in [block] are placed under every other layer. */
     @Composable
     @MaplibreComposable
     public fun Bottom(block: @Composable () -> Unit): Unit = At(Bottom, block)
 
     /**
-     * The layers specified in [block] are put above the layer (i.e. in front of it) with the given
-     * [layerId] from the base map style.
+     * The layers specified in [block] are placed directly over the base-style layer with the given
+     * [layerId], or at the bottom of the stack when the base style has no such layer.
      */
     @Composable
     @MaplibreComposable
@@ -70,19 +112,53 @@ public sealed interface Anchor {
       At(Above(layerId), block)
 
     /**
-     * The layers specified in [block] are put below the layer (i.e. behind it) with the given
-     * [layerId] from the base map style.
+     * The layers specified in [block] are placed directly over the highest base-style layer that
+     * [predicate] accepts, or at the bottom of the stack when it accepts none. See [Anchor.Above]
+     * for how the predicate is evaluated.
+     */
+    @Composable
+    @MaplibreComposable
+    public fun Above(predicate: (LayerHandle) -> Boolean, block: @Composable () -> Unit): Unit =
+      At(Above(predicate), block)
+
+    /**
+     * The layers specified in [block] are placed directly under the base-style layer with the given
+     * [layerId], or at the top of the stack when the base style has no such layer.
      */
     @Composable
     @MaplibreComposable
     public fun Below(layerId: String, block: @Composable () -> Unit): Unit =
       At(Below(layerId), block)
 
-    /** The layers specified in [block] are put at the given [Anchor]. */
+    /**
+     * The layers specified in [block] are placed directly under the lowest base-style layer that
+     * [predicate] accepts, or at the top of the stack when it accepts none. See [Anchor.Below] for
+     * how the predicate is evaluated.
+     */
+    @Composable
+    @MaplibreComposable
+    public fun Below(predicate: (LayerHandle) -> Boolean, block: @Composable () -> Unit): Unit =
+      At(Below(predicate), block)
+
+    /** The layers specified in [block] are placed at the given [Anchor]. */
     @Composable
     @MaplibreComposable
     public fun At(anchor: Anchor, block: @Composable () -> Unit) {
       CompositionLocalProvider(LocalAnchor provides anchor) { block() }
     }
   }
+}
+
+/** The ID form compares by ID; the predicate form compares by reference. */
+private class LayerSelector(val predicate: (LayerHandle) -> Boolean, val layerId: String? = null) {
+  constructor(layerId: String) : this({ it.id == layerId }, layerId)
+
+  override fun equals(other: Any?): Boolean =
+    other is LayerSelector &&
+      layerId == other.layerId &&
+      (layerId != null || predicate == other.predicate)
+
+  override fun hashCode(): Int = layerId?.hashCode() ?: predicate.hashCode()
+
+  override fun toString(): String = if (layerId != null) "layerId=$layerId" else "predicate"
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/Anchor.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/Anchor.kt
@@ -33,8 +33,9 @@ public sealed interface Anchor {
   /**
    * Layers are placed directly over the highest base-style layer that [predicate] accepts, or at
    * the bottom of the stack when it accepts none. Layers declared in the style content are not
-   * candidates, and the [LayerHandle] passed to the predicate is read-only. See
-   * [Anchor.Companion.Above] to use this in the style content.
+   * candidates, and the [LayerHandle] passed to the predicate is read-only. The predicate runs
+   * outside composition, so snapshot state it reads is not observed; read state in composition and
+   * capture the values. See [Anchor.Companion.Above] to use this in the style content.
    */
   public class Above private constructor(private val selector: LayerSelector) : Anchor {
     public constructor(predicate: (LayerHandle) -> Boolean) : this(LayerSelector(predicate))
@@ -55,8 +56,9 @@ public sealed interface Anchor {
   /**
    * Layers are placed directly under the lowest base-style layer that [predicate] accepts, or at
    * the top of the stack when it accepts none. Layers declared in the style content are not
-   * candidates, and the [LayerHandle] passed to the predicate is read-only. See
-   * [Anchor.Companion.Below] to use this in the style content.
+   * candidates, and the [LayerHandle] passed to the predicate is read-only. The predicate runs
+   * outside composition, so snapshot state it reads is not observed; read state in composition and
+   * capture the values. See [Anchor.Companion.Below] to use this in the style content.
    */
   public class Below private constructor(private val selector: LayerSelector) : Anchor {
     public constructor(predicate: (LayerHandle) -> Boolean) : this(LayerSelector(predicate))

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/LayerHandle.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/LayerHandle.kt
@@ -19,7 +19,8 @@ import org.maplibre.compose.style.toTransitionOptions
  * Provides property access to a layer for one loaded base-style generation.
  *
  * Style content owns all properties of declared layers. Their properties can be read, but setter
- * calls and [clearFilter] throw [StyleHandleException]. Base-style layers also permit writes.
+ * calls and [clearFilter] throw [StyleHandleException]. Base-style layers also permit writes,
+ * except through the handles that an [Anchor] predicate receives, which are read-only.
  */
 public class LayerHandle
 internal constructor(

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/LayerHandle.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/LayerHandle.kt
@@ -99,9 +99,7 @@ internal constructor(
 
   private fun requireCurrent() {
     style.requireCurrent(identity)
-    check(isCurrentResource()) { "Layer '$id' is no longer owned by this handle" }
-    val currentType = style.getLayer(id)?.definition()?.type
-    check(currentType == type) { "Layer '$id' is no longer the $type layer owned by this handle" }
+    check(isCurrentResource()) { "Layer '$id' is no longer the $type layer owned by this handle" }
   }
 
   private fun <T> operation(action: () -> T): T = operations.run {
@@ -122,12 +120,22 @@ internal constructor(
   }
 }
 
+/**
+ * A handle for the style state, which outlives revisions. Each operation re-reads the layer's type
+ * from the engine, so a layer that another writer replaced under the same ID is refused.
+ */
 internal fun StyleBinding.layerHandle(
   id: String,
   isCurrentResource: () -> Boolean,
   operations: StyleHandleOperationGuard,
 ): LayerHandle? {
   requireCurrent()
-  val layer = getLayer(id) ?: return null
-  return LayerHandle(id, layer.definition().type, this, isCurrentResource, operations)
+  val type = getLayer(id)?.definition()?.type ?: return null
+  return LayerHandle(
+    id = id,
+    type = type,
+    style = this,
+    isCurrentResource = { isCurrentResource() && getLayer(id)?.definition()?.type == type },
+    operations = operations,
+  )
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/LayerNode.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/LayerNode.kt
@@ -30,11 +30,14 @@ internal fun <T : Layer> LayerNode(
   val anchor = LocalAnchor.current
   val node = LocalStyleNode.current
 
-  key(factory, anchor, recreateKey) {
+  // The anchor is not part of the node's identity: a predicate anchor built from a fresh lambda on
+  // each recomposition must update the node in place, not recreate it and its click registration.
+  key(factory, recreateKey) {
     ComposeNode<LayerNode<T>, MapNodeApplier>(
       factory = { LayerNode(layer = factory(), anchor = anchor) },
       update = {
         update()
+        set(anchor) { this.anchor = it }
         set(onClick) { this.onClick = it }
         set(onLongClick) { this.onLongClick = it }
         set(onDoubleClick) { this.onDoubleClick = it }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/LayerNode.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/LayerNode.kt
@@ -6,7 +6,7 @@ import org.maplibre.compose.layers.Anchor
 import org.maplibre.compose.layers.FeaturesClickHandler
 import org.maplibre.compose.layers.Layer
 
-internal class LayerNode<T : Layer>(val layer: T, val anchor: Anchor) : MapNode {
+internal class LayerNode<T : Layer>(val layer: T, var anchor: Anchor) : MapNode {
   internal var onClick: FeaturesClickHandler? = null
 
   internal var onLongClick: FeaturesClickHandler? = null

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleBinding.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleBinding.kt
@@ -76,6 +76,14 @@ internal interface StyleBinding {
   fun layerIds(): List<String>
 
   /**
+   * Every layer's style-spec type keyed by ID, in stack order from bottom to top. The default reads
+   * each layer separately; an engine with per-call overhead overrides this to read them in one
+   * pass.
+   */
+  fun layerTypes(): Map<String, String> =
+    layerIds().mapNotNull { id -> getLayer(id)?.definition()?.type?.let { id to it } }.toMap()
+
+  /**
    * Adds a complete layer object directly below [beforeLayerId], or on top when that is empty.
    *
    * @return false if the style has unloaded, in which case nothing was added.

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleBinding.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleBinding.kt
@@ -76,9 +76,9 @@ internal interface StyleBinding {
   fun layerIds(): List<String>
 
   /**
-   * Every layer's style-spec type keyed by ID, in stack order from bottom to top. The default reads
-   * each layer separately; an engine with per-call overhead overrides this to read them in one
-   * pass.
+   * Every layer's style-spec type keyed by ID, in stack order from bottom to top. A layer the
+   * engine adds for its own use is omitted, as [getLayer] omits it. The default reads each layer
+   * separately; an engine with per-call overhead overrides this to read them in one pass.
    */
   fun layerTypes(): Map<String, String> =
     layerIds().mapNotNull { id -> getLayer(id)?.definition()?.type?.let { id to it } }.toMap()

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleReconciler.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleReconciler.kt
@@ -46,7 +46,7 @@ internal class StyleReconciler {
       sources.mapNotNullTo(mutableSetOf()) { (id, applied) ->
         desiredSources[id]?.takeIf { !applied.definition.canUpdateTo(it) }?.let { id }
       }
-    val placements = hashMapOf<Anchor, String>()
+    val placements = hashMapOf<Anchor, Placement>()
     val placedLayers =
       revision.layers.map { desired ->
         PlacedLayer(
@@ -158,19 +158,22 @@ internal class StyleReconciler {
         .map { (id, type) -> predicateLayerHandle(style, id, type) }
         .also { baseLayers = it }
 
-  /**
-   * Resolves [anchor] to the ID of the base-style layer that its layers sit directly below, or to
-   * an empty string for the top of the stack.
-   */
-  private fun placement(style: StyleBinding, anchor: Anchor): String =
+  /** Resolves [anchor] against the base-style layers of the bound generation. */
+  private fun placement(style: StyleBinding, anchor: Anchor): Placement =
     when (anchor) {
-      is Anchor.Top -> ""
-      is Anchor.Bottom -> baseLayers(style).firstOrNull()?.id.orEmpty()
-      is Anchor.Below -> baseLayers(style).firstOrNull { anchor.predicate(it) }?.id.orEmpty()
+      is Anchor.Top -> Placement.Top
+      is Anchor.Bottom -> Placement.Bottom
+      is Anchor.Below ->
+        baseLayers(style).firstOrNull { anchor.predicate(it) }?.let { Placement.Below(it.id) }
+          ?: Placement.Top
       is Anchor.Above -> {
         val base = baseLayers(style)
         val highest = base.indexOfLast { anchor.predicate(it) }
-        base.getOrNull(if (highest < 0) 0 else highest + 1)?.id.orEmpty()
+        when {
+          highest < 0 -> Placement.Bottom
+          highest == base.lastIndex -> Placement.Top
+          else -> Placement.Below(base[highest + 1].id)
+        }
       }
     }
 
@@ -226,18 +229,30 @@ internal class StyleReconciler {
 
   private fun shouldMoveLayer(
     ids: List<String>,
-    placement: String,
+    placement: Placement,
     previousId: String?,
     id: String,
     nextDesiredId: String?,
   ): Boolean {
     if (previousId != null) return ids.idAbove(previousId) != id
     if (nextDesiredId != null) return ids.idAbove(id) != nextDesiredId
-    return placement != id && ids.idAbove(id) != placement
+    val before = beforeLayerId(ids, placement, null)
+    return before != id && ids.idAbove(id) != before
   }
 
-  private fun beforeLayerId(ids: List<String>, placement: String, previousId: String?): String =
-    if (previousId != null) ids.idAbove(previousId) else placement
+  /**
+   * The ID a layer at [placement] is inserted below, or an empty string for the top of the stack.
+   * [Placement.Bottom] reads the tracked order at insertion time, so it sits under the engine's own
+   * layers as well as the base style's.
+   */
+  private fun beforeLayerId(ids: List<String>, placement: Placement, previousId: String?): String {
+    if (previousId != null) return ids.idAbove(previousId)
+    return when (placement) {
+      Placement.Top -> ""
+      Placement.Bottom -> ids.firstOrNull().orEmpty()
+      is Placement.Below -> placement.layerId
+    }
+  }
 
   private fun List<String>.idAbove(id: String): String {
     val index = indexOf(id)
@@ -252,19 +267,34 @@ internal class StyleReconciler {
 
   private class AppliedLayer(
     var definition: LayerDefinition,
-    val placement: String,
+    val placement: Placement,
     val installation: LayerInstallation,
   )
 
-  private class PlacedLayer(desired: DesiredStyleLayer, val placement: String) {
+  private class PlacedLayer(desired: DesiredStyleLayer, val placement: Placement) {
     val definition: LayerDefinition = desired.definition
+  }
+
+  /**
+   * An anchor resolved against one base-style generation. Layers with equal placements form one
+   * group in style-content order, so two anchors that resolve to the same position never move each
+   * other's layers.
+   */
+  private sealed interface Placement {
+    data object Top : Placement
+
+    data object Bottom : Placement
+
+    /** Directly under the base-style layer [layerId]. */
+    data class Below(val layerId: String) : Placement
   }
 }
 
 /**
  * A handle for an anchor predicate. The reconciler holds the style while a predicate runs, so
  * operations run inline; a write from a predicate would mutate the base style mid-revision, so
- * writes are refused.
+ * writes are refused. Base layers do not change within a generation, so [type] is trusted for the
+ * handle's life and a property read costs one engine read.
  */
 private fun predicateLayerHandle(style: StyleBinding, id: String, type: String): LayerHandle {
   val identity = style.identity.layers.get(id)

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleReconciler.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleReconciler.kt
@@ -1,6 +1,7 @@
 package org.maplibre.compose.style
 
 import org.maplibre.compose.layers.Anchor
+import org.maplibre.compose.layers.LayerHandle
 
 /** Reconciles complete desired revisions into one loaded base-style generation. */
 internal class StyleReconciler {
@@ -15,6 +16,12 @@ internal class StyleReconciler {
    * re-read only when it may have drifted: after a binding change or a failed revision.
    */
   private var knownLayerIds: MutableList<String>? = null
+
+  /**
+   * The base-style layers of the bound generation, bottom to top, as anchor predicates see them.
+   * Base layers do not change within one generation, so they are read once per binding.
+   */
+  private var baseLayers: List<LayerHandle>? = null
 
   suspend fun apply(style: StyleBinding, revision: DesiredStyleRevision): StyleResourceChanges {
     style.requireCurrent()
@@ -39,19 +46,27 @@ internal class StyleReconciler {
       sources.mapNotNullTo(mutableSetOf()) { (id, applied) ->
         desiredSources[id]?.takeIf { !applied.definition.canUpdateTo(it) }?.let { id }
       }
-    val desiredLayers = revision.layers.associateBy { it.definition.id }
+    val placements = hashMapOf<Anchor, String>()
+    val placedLayers =
+      revision.layers.map { desired ->
+        PlacedLayer(
+          desired,
+          placements.getOrPut(desired.anchor) { placement(style, desired.anchor) },
+        )
+      }
+    val desiredLayers = placedLayers.associateBy { it.definition.id }
 
     layers.values.toList().forEach { applied ->
       val desired = desiredLayers[applied.definition.id]
       if (
         desired == null ||
-          desired.anchor != applied.anchor ||
+          desired.placement != applied.placement ||
           desired.definition.type != applied.definition.type ||
           desired.definition.sourceId != applied.definition.sourceId ||
           desired.definition.value["source-layer"] != applied.definition.value["source-layer"] ||
           desired.definition.sourceId in replacedSourceIds
       ) {
-        removeLayer(style, applied, changes)
+        removeLayer(applied, changes)
       }
     }
 
@@ -75,20 +90,20 @@ internal class StyleReconciler {
 
     syncImages(style, revision.images)
 
-    revision.layers
-      .groupByTo(linkedMapOf()) { it.anchor }
-      .forEach { (anchor, group) ->
+    placedLayers
+      .groupByTo(linkedMapOf()) { it.placement }
+      .forEach { (placement, group) ->
         var previousId: String? = null
         group.forEachIndexed { index, desired ->
           val id = desired.definition.id
           val nextDesiredId = group.getOrNull(index + 1)?.definition?.id
           var applied = layers[id]
           if (applied == null) {
-            val before = beforeLayerId(layerIds(style), anchor, previousId)
+            val before = beforeLayerId(layerIds(style), placement, previousId)
             applied =
               AppliedLayer(
                 definition = desired.definition,
-                anchor = anchor,
+                placement = placement,
                 installation =
                   LayerInstallation(
                     style,
@@ -103,8 +118,8 @@ internal class StyleReconciler {
           } else {
             applied.installation.update(desired.definition, revision.animatorDurationScale)
             applied.definition = desired.definition
-            if (shouldMoveLayer(layerIds(style), anchor, previousId, id, nextDesiredId)) {
-              val before = beforeLayerId(layerIds(style), anchor, previousId)
+            if (shouldMoveLayer(layerIds(style), placement, previousId, id, nextDesiredId)) {
+              val before = beforeLayerId(layerIds(style), placement, previousId)
               if (before != id) {
                 layerOrderChanged = true
                 applied.installation.move(before)
@@ -129,10 +144,35 @@ internal class StyleReconciler {
     layers.clear()
     images.clear()
     knownLayerIds = null
+    baseLayers = null
   }
 
   private fun layerIds(style: StyleBinding): MutableList<String> =
     knownLayerIds ?: style.layerIds().toMutableList().also { knownLayerIds = it }
+
+  private fun baseLayers(style: StyleBinding): List<LayerHandle> =
+    baseLayers
+      ?: style
+        .layerTypes()
+        .filterKeys { it !in layers }
+        .map { (id, type) -> predicateLayerHandle(style, id, type) }
+        .also { baseLayers = it }
+
+  /**
+   * Resolves [anchor] to the ID of the base-style layer that its layers sit directly below, or to
+   * an empty string for the top of the stack.
+   */
+  private fun placement(style: StyleBinding, anchor: Anchor): String =
+    when (anchor) {
+      is Anchor.Top -> ""
+      is Anchor.Bottom -> baseLayers(style).firstOrNull()?.id.orEmpty()
+      is Anchor.Below -> baseLayers(style).firstOrNull { anchor.predicate(it) }?.id.orEmpty()
+      is Anchor.Above -> {
+        val base = baseLayers(style)
+        val highest = base.indexOfLast { anchor.predicate(it) }
+        base.getOrNull(if (highest < 0) 0 else highest + 1)?.id.orEmpty()
+      }
+    }
 
   /** Places [id] directly below [beforeLayerId], or on top when that is empty. */
   private fun MutableList<String>.insertBelow(id: String, beforeLayerId: String) {
@@ -140,7 +180,7 @@ internal class StyleReconciler {
       add(id)
     } else {
       val index = indexOf(beforeLayerId)
-      require(index >= 0) { "Layer ID '$beforeLayerId' not found in style" }
+      check(index >= 0) { "Layer ID '$beforeLayerId' not found in style" }
       add(index, id)
     }
   }
@@ -160,11 +200,7 @@ internal class StyleReconciler {
     sources.remove(applied.definition.id)
   }
 
-  private fun removeLayer(
-    style: StyleBinding,
-    applied: AppliedLayer,
-    changes: StyleResourceChanges,
-  ) {
+  private fun removeLayer(applied: AppliedLayer, changes: StyleResourceChanges) {
     changes.layers.add(applied.definition.id)
     applied.installation.remove()
     knownLayerIds?.remove(applied.definition.id)
@@ -190,36 +226,22 @@ internal class StyleReconciler {
 
   private fun shouldMoveLayer(
     ids: List<String>,
-    anchor: Anchor,
+    placement: String,
     previousId: String?,
     id: String,
     nextDesiredId: String?,
   ): Boolean {
     if (previousId != null) return ids.idAbove(previousId) != id
-    if (nextDesiredId != null) return ids.positionBefore(id) != nextDesiredId
-    val before = beforeLayerId(ids, anchor, previousId = null)
-    return before != id && ids.positionBefore(id) != before
+    if (nextDesiredId != null) return ids.idAbove(id) != nextDesiredId
+    return placement != id && ids.idAbove(id) != placement
   }
 
-  private fun beforeLayerId(ids: List<String>, anchor: Anchor, previousId: String?): String {
-    if (previousId != null) return ids.idAbove(previousId)
-    return when (anchor) {
-      is Anchor.Top -> ""
-      is Anchor.Bottom -> ids.firstOrNull().orEmpty()
-      is Anchor.Above -> ids.idAbove(anchor.layerId)
-      is Anchor.Below -> anchor.layerId
-    }
-  }
+  private fun beforeLayerId(ids: List<String>, placement: String, previousId: String?): String =
+    if (previousId != null) ids.idAbove(previousId) else placement
 
   private fun List<String>.idAbove(id: String): String {
     val index = indexOf(id)
-    require(index >= 0) { "Layer ID '$id' not found in base style" }
-    return getOrNull(index + 1).orEmpty()
-  }
-
-  private fun List<String>.positionBefore(id: String): String {
-    val index = indexOf(id)
-    require(index >= 0) { "Layer ID '$id' not found in style" }
+    check(index >= 0) { "Layer ID '$id' not found in style" }
     return getOrNull(index + 1).orEmpty()
   }
 
@@ -230,8 +252,38 @@ internal class StyleReconciler {
 
   private class AppliedLayer(
     var definition: LayerDefinition,
-    val anchor: Anchor,
+    val placement: String,
     val installation: LayerInstallation,
+  )
+
+  private class PlacedLayer(desired: DesiredStyleLayer, val placement: String) {
+    val definition: LayerDefinition = desired.definition
+  }
+}
+
+/**
+ * A handle for an anchor predicate. The reconciler holds the style while a predicate runs, so
+ * operations run inline; a write from a predicate would mutate the base style mid-revision, so
+ * writes are refused.
+ */
+private fun predicateLayerHandle(style: StyleBinding, id: String, type: String): LayerHandle {
+  val identity = style.identity.layers.get(id)
+  return LayerHandle(
+    id = id,
+    type = type,
+    style = style,
+    isCurrentResource = { style.identity.layers.isCurrent(id, identity) },
+    operations =
+      object : StyleHandleOperationGuard {
+        override fun <T> run(action: () -> T): T = action()
+
+        override fun requireSourceWritable(id: String) = refuseWrite(id)
+
+        override fun requireLayerWritable(id: String) = refuseWrite(id)
+
+        private fun refuseWrite(id: String): Nothing =
+          throw StyleHandleException("Layer '$id' is read-only in an anchor predicate")
+      },
   )
 }
 

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
@@ -943,8 +943,7 @@ class MapPresentationTest {
     val original = DesiredStyleLayer(layer.definition(), Anchor.Top, null, null)
     fixture.state.desiredStyleRevision =
       DesiredStyleRevision(emptyList(), listOf(original), emptyList())
-    // A base layer separates Top from Bottom; without one they resolve to the same position.
-    val binding = RecordingStyleBinding(layers = listOf(BackgroundLayer("base")))
+    val binding = RecordingStyleBinding()
     val reconciler = StyleReconciler()
     reconciler.apply(binding, fixture.state.desiredStyleRevision)
     fixture.state.durableStyleCallbacks().onStyleChanged(fixture.adapter, binding)

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
@@ -943,7 +943,8 @@ class MapPresentationTest {
     val original = DesiredStyleLayer(layer.definition(), Anchor.Top, null, null)
     fixture.state.desiredStyleRevision =
       DesiredStyleRevision(emptyList(), listOf(original), emptyList())
-    val binding = RecordingStyleBinding()
+    // A base layer separates Top from Bottom; without one they resolve to the same position.
+    val binding = RecordingStyleBinding(layers = listOf(BackgroundLayer("base")))
     val reconciler = StyleReconciler()
     reconciler.apply(binding, fixture.state.desiredStyleRevision)
     fixture.state.durableStyleCallbacks().onStyleChanged(fixture.adapter, binding)

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/style/StyleCompositionOrderTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/style/StyleCompositionOrderTest.kt
@@ -2,10 +2,17 @@ package org.maplibre.compose.style
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
 import org.maplibre.compose.layers.Anchor
 import org.maplibre.compose.layers.BackgroundLayer
+import org.maplibre.compose.layers.Layer
 import org.maplibre.compose.layers.RasterLayer
+import org.maplibre.compose.layers.UnknownLayer
 import org.maplibre.compose.sources.RasterSource
 
 class StyleCompositionOrderTest {
@@ -40,6 +47,10 @@ class StyleCompositionOrderTest {
         Anchor.Bottom,
         Anchor.Above("water"),
         Anchor.Below("roads"),
+        Anchor.Above { it.type == "symbol" },
+        Anchor.Below { it.type == "symbol" },
+        Anchor.Below("missing"),
+        Anchor.Above("missing"),
       )
     for (anchor in anchors) {
       val source =
@@ -59,7 +70,13 @@ class StyleCompositionOrderTest {
       val style =
         RecordingStyleBinding(
           layers =
-            listOf(BackgroundLayer("water"), BackgroundLayer("park"), BackgroundLayer("roads"))
+            listOf(
+              BackgroundLayer("water"),
+              symbolLayer("water-labels"),
+              BackgroundLayer("park"),
+              BackgroundLayer("roads"),
+              symbolLayer("road-labels"),
+            )
         )
       val reconciler = StyleReconciler()
 
@@ -89,4 +106,161 @@ class StyleCompositionOrderTest {
 
     assertEquals(listOf("water", "hillshade"), style.layerIds())
   }
+
+  @Test
+  fun a_predicate_lands_below_its_lowest_match_and_above_its_highest_match() = runTest {
+    val style = RecordingStyleBinding(layers = labelledBase())
+    val below = Anchor.Below { it.type == "symbol" }
+    val above = Anchor.Above { it.type == "symbol" }
+
+    StyleReconciler()
+      .apply(style, revision(background("under") to below, background("over") to above))
+
+    assertEquals(
+      listOf("bg", "under", "water-labels", "water", "road-labels", "over", "top"),
+      style.layerIds(),
+    )
+  }
+
+  @Test
+  fun a_predicate_can_read_a_layer_property() = runTest {
+    val base =
+      listOf(
+        BackgroundLayer("bg"),
+        UnknownLayer("hidden", layerJson("hidden", "symbol", visibility = "none")),
+        symbolLayer("shown"),
+      )
+    val style = RecordingStyleBinding(layers = base)
+    val belowShown = Anchor.Below {
+      it.type == "symbol" && it.getProperty("visibility")?.jsonPrimitive?.content != "none"
+    }
+
+    StyleReconciler().apply(style, revision(background("under") to belowShown))
+
+    assertEquals(listOf("bg", "hidden", "under", "shown"), style.layerIds())
+  }
+
+  @Test
+  fun a_predicate_with_no_match_lands_at_the_end_of_its_scan() = runTest {
+    val style = RecordingStyleBinding(layers = labelledBase())
+    val below = Anchor.Below { it.type == "hillshade" }
+    val above = Anchor.Above { it.type == "hillshade" }
+
+    StyleReconciler()
+      .apply(style, revision(background("under") to below, background("over") to above))
+
+    assertEquals(
+      listOf("over", "bg", "water-labels", "water", "road-labels", "top", "under"),
+      style.layerIds(),
+    )
+  }
+
+  @Test
+  fun a_missing_layer_id_lands_at_the_end_of_its_scan() = runTest {
+    val style = RecordingStyleBinding(layers = labelledBase())
+
+    StyleReconciler()
+      .apply(
+        style,
+        revision(
+          background("under") to Anchor.Below("missing"),
+          background("over") to Anchor.Above("missing"),
+        ),
+      )
+
+    assertEquals(
+      listOf("over", "bg", "water-labels", "water", "road-labels", "top", "under"),
+      style.layerIds(),
+    )
+  }
+
+  @Test
+  fun composition_owned_layers_are_never_matched() = runTest {
+    val style = RecordingStyleBinding(layers = listOf(BackgroundLayer("bg"), symbolLayer("labels")))
+    val reconciler = StyleReconciler()
+    reconciler.apply(style, revision(symbolLayer("composed-labels") to Anchor.Top))
+
+    reconciler.apply(
+      style,
+      revision(
+        symbolLayer("composed-labels") to Anchor.Top,
+        background("by-id") to Anchor.Above("composed-labels"),
+        background("by-type") to Anchor.Above { it.type == "symbol" },
+        background("by-earlier-type") to Anchor.Above { it.type == "background" && it.id != "bg" },
+      ),
+    )
+
+    assertEquals(
+      listOf("by-id", "by-earlier-type", "bg", "labels", "composed-labels", "by-type"),
+      style.layerIds(),
+    )
+  }
+
+  @Test
+  fun a_second_apply_with_fresh_predicates_changes_nothing() = runTest {
+    val backing = RecordingStyleBinding(layers = labelledBase())
+    val mutations = mutableListOf<String>()
+    val style =
+      object : StyleBinding by backing {
+        override fun addLayer(layer: JsonObject, beforeLayerId: String): Boolean {
+          mutations += "add"
+          return backing.addLayer(layer, beforeLayerId)
+        }
+
+        override fun removeLayer(layerId: String) {
+          mutations += "remove"
+          backing.removeLayer(layerId)
+        }
+
+        override fun moveLayer(layerId: String, beforeLayerId: String) {
+          mutations += "move"
+          backing.moveLayer(layerId, beforeLayerId)
+        }
+      }
+    val reconciler = StyleReconciler()
+    fun revisionWithFreshPredicates() =
+      revision(
+        background("under") to Anchor.Below { it.type == "symbol" },
+        background("over") to Anchor.Above { it.type == "symbol" },
+        background("also-under") to Anchor.Below { it.type == "symbol" },
+        background("nowhere") to Anchor.Above { it.type == "hillshade" },
+      )
+
+    reconciler.apply(style, revisionWithFreshPredicates())
+    val afterFirst = backing.layerIds()
+    mutations.clear()
+    val changes = reconciler.apply(style, revisionWithFreshPredicates())
+
+    assertEquals(emptyList(), mutations)
+    assertEquals(afterFirst, backing.layerIds())
+    assertNull(changes.layerOrder)
+  }
+
+  private fun labelledBase(): List<Layer> =
+    listOf(
+      BackgroundLayer("bg"),
+      symbolLayer("water-labels"),
+      BackgroundLayer("water"),
+      symbolLayer("road-labels"),
+      BackgroundLayer("top"),
+    )
+
+  private fun revision(vararg layers: Pair<Layer, Anchor>) =
+    DesiredStyleRevision(
+      sources = emptyList(),
+      layers =
+        layers.map { (layer, anchor) -> DesiredStyleLayer(layer.definition(), anchor, null, null) },
+      images = emptyList(),
+    )
+
+  private fun background(id: String): Layer = BackgroundLayer(id)
+
+  private fun symbolLayer(id: String): Layer = UnknownLayer(id, layerJson(id, "symbol"))
+
+  private fun layerJson(id: String, type: String, visibility: String? = null): JsonObject =
+    buildJsonObject {
+      put("id", id)
+      put("type", type)
+      visibility?.let { put("layout", buildJsonObject { put("visibility", it) }) }
+    }
 }

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/style/StyleCompositionOrderTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/style/StyleCompositionOrderTest.kt
@@ -174,6 +174,49 @@ class StyleCompositionOrderTest {
     )
   }
 
+  /**
+   * MapLibre GL JS has no layers of its own, so an empty base style has nothing between the top and
+   * the bottom of the stack. The two must stay apart, and a scan with no match must reach its end.
+   */
+  @Test
+  fun top_and_bottom_stay_distinct_on_an_empty_base() = runTest {
+    val style = RecordingStyleBinding()
+    val reconciler = StyleReconciler()
+    fun revision() =
+      revision(
+        background("front") to Anchor.Top,
+        background("back") to Anchor.Bottom,
+        background("over-nothing") to Anchor.Above { it.type == "symbol" },
+        background("under-nothing") to Anchor.Below { it.type == "symbol" },
+      )
+
+    reconciler.apply(style, revision())
+    assertEquals(listOf("back", "over-nothing", "front", "under-nothing"), style.layerIds())
+
+    val changes = reconciler.apply(style, revision())
+    assertEquals(listOf("back", "over-nothing", "front", "under-nothing"), style.layerIds())
+    assertNull(changes.layerOrder)
+  }
+
+  /** The engine's own layers, such as MapLibre Native's annotation layer, sit above the base. */
+  @Test
+  fun bottom_lands_under_a_layer_that_is_not_a_base_layer() = runTest {
+    val style = RecordingStyleBinding(layers = listOf(BackgroundLayer("engine-owned")))
+    val base =
+      object : StyleBinding by style {
+        override fun layerTypes(): Map<String, String> = emptyMap()
+      }
+    val reconciler = StyleReconciler()
+    val revision = revision(background("front") to Anchor.Top, background("back") to Anchor.Bottom)
+
+    reconciler.apply(base, revision)
+    assertEquals(listOf("back", "engine-owned", "front"), style.layerIds())
+
+    val changes = reconciler.apply(base, revision)
+    assertEquals(listOf("back", "engine-owned", "front"), style.layerIds())
+    assertNull(changes.layerOrder)
+  }
+
   @Test
   fun composition_owned_layers_are_never_matched() = runTest {
     val style = RecordingStyleBinding(layers = listOf(BackgroundLayer("bg"), symbolLayer("labels")))

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/JsMapView.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/JsMapView.kt
@@ -58,7 +58,8 @@ internal actual fun ComposableMapView(
   val currentOnReset = rememberUpdatedState(onReset)
 
   // Must run in the apply phase, not from a coroutine: the unload has to precede the content
-  // subcomposition inserting layers, or a style switch crashes on anchor validation (see #269).
+  // subcomposition inserting layers, or a style switch inserts them against the base style being
+  // replaced (see #269).
   SideEffect { session.setBaseStyle(style) }
   if (session.hasUsableViewport) {
     SideEffect {

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/style/GlJsStyleBinding.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/style/GlJsStyleBinding.kt
@@ -198,6 +198,11 @@ internal class GlJsStyleBinding(
     return map.getLayersOrder().toList()
   }
 
+  override fun layerTypes(): Map<String, String> {
+    requireLoaded()
+    return map.getLayersOrder().mapNotNull { id -> map.getLayer(id)?.let { id to it.type } }.toMap()
+  }
+
   private fun reconstructSource(id: String): Source =
     UnknownSource(
       id,

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/layers/AnchorPlacementTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/layers/AnchorPlacementTest.kt
@@ -1,0 +1,65 @@
+package org.maplibre.compose.layers
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+import org.maplibre.compose.style.BaseStyle
+import org.maplibre.compose.style.RecordingStyleBinding
+import org.maplibre.compose.testing.MapTestResult
+import org.maplibre.compose.testing.composeStyle
+import org.maplibre.compose.testing.createMapFixture
+import org.maplibre.compose.testing.declare
+import org.maplibre.compose.testing.runMapTest
+
+class AnchorPlacementTest {
+
+  /**
+   * An empty base style leaves each engine with only its own layers: none on MapLibre GL JS, the
+   * annotation layer on MapLibre Native. Neither may separate the top from the bottom, or be
+   * offered to a predicate.
+   */
+  @Test
+  fun anchors_resolve_against_base_layers_only_on_an_empty_base(): MapTestResult = runMapTest {
+    createMapFixture().use { fixture ->
+      fixture.loadStyle(BaseStyle.Empty)
+      fixture.declare {
+        BackgroundLayer("front", visible = true)
+        Anchor.Bottom { BackgroundLayer("back", visible = true) }
+        Anchor.Above({ it.type == "symbol" }) { BackgroundLayer("over-symbols", visible = true) }
+      }
+
+      val declared = setOf("front", "back", "over-symbols")
+      assertEquals(
+        listOf("back", "over-symbols", "front"),
+        assertNotNull(fixture.style).layerIds().filter { it in declared },
+      )
+      assertEquals(declared, fixture.state.style.layers.map { it.id }.toSet())
+    }
+  }
+
+  /** A capturing lambda built outside a composable is a new instance on every read. */
+  private fun anchorBelow(type: String): Anchor = Anchor.Below { it.type == type }
+
+  @Test
+  fun a_fresh_predicate_on_each_recomposition_keeps_the_layer_node(): MapTestResult = runMapTest {
+    var generation by mutableStateOf(0)
+    val registrations = mutableListOf<Any?>()
+
+    composeStyle(
+      RecordingStyleBinding(),
+      thenChange = { generation++ },
+      onRevision = { revision -> revision.layers.forEach { registrations += it.registration } },
+    ) {
+      generation
+      Anchor.At(anchorBelow("symbol")) { BackgroundLayer("under", visible = true) }
+    }
+
+    assertTrue(registrations.size >= 2, "the change did not republish: $registrations")
+    registrations.forEach { assertSame(registrations.first(), it) }
+  }
+}

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/style/DeclaredStyleOwnershipTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/style/DeclaredStyleOwnershipTest.kt
@@ -1,10 +1,7 @@
 package org.maplibre.compose.style
 
-import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.ImageBitmap
-import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.DpRect
-import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -17,19 +14,16 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import org.maplibre.compose.layers.CircleLayer
 import org.maplibre.compose.layers.RasterLayer
-import org.maplibre.compose.map.DefaultStyleCompositionEvaluator
-import org.maplibre.compose.map.SnapshotStyleOwnership
 import org.maplibre.compose.sources.GeoJsonData
 import org.maplibre.compose.sources.GeoJsonOptions
 import org.maplibre.compose.sources.GeoJsonSource
 import org.maplibre.compose.sources.ImageSource
 import org.maplibre.compose.sources.rememberGeoJsonSource
 import org.maplibre.compose.sources.rememberImageSource
-import org.maplibre.compose.testing.MapFixture
 import org.maplibre.compose.testing.MapTestResult
 import org.maplibre.compose.testing.createMapFixture
+import org.maplibre.compose.testing.declare
 import org.maplibre.compose.testing.runMapTest
-import org.maplibre.compose.util.MaplibreComposable
 import org.maplibre.compose.util.PositionQuad
 import org.maplibre.spatialk.geojson.Geometry
 import org.maplibre.spatialk.geojson.Point
@@ -108,22 +102,6 @@ class DeclaredStyleOwnershipTest {
       assertFailsWith<StyleHandleException> { handle.setImage(bitmap) }
       assertFailsWith<StyleHandleException> { handle.setUri("https://example.invalid/image.png") }
     }
-  }
-
-  /** Evaluate real composables, then publish and reconcile through the map's production paths. */
-  private suspend fun MapFixture.declare(content: @Composable @MaplibreComposable () -> Unit) {
-    awaitMapReady()
-    val revision =
-      DefaultStyleCompositionEvaluator.evaluate(
-        content,
-        checkNotNull(style),
-        checkNotNull(session.getViewport()),
-        Density(1f),
-        LayoutDirection.Ltr,
-        SnapshotStyleOwnership.Empty,
-      )
-    state.beginStyleRevision(session, revision)
-    state.updateStyleResources(session, session.reconcileStyleRevision(revision))
   }
 
   private companion object {

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/testing/MapFixture.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/testing/MapFixture.kt
@@ -1,5 +1,8 @@
 package org.maplibre.compose.testing
 
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
 import kotlin.math.abs
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
@@ -8,13 +11,16 @@ import kotlin.time.TimeSource
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import org.maplibre.compose.camera.internal.CameraInputTarget
+import org.maplibre.compose.map.DefaultStyleCompositionEvaluator
 import org.maplibre.compose.map.MapAdapter
 import org.maplibre.compose.map.MapAttachment
 import org.maplibre.compose.map.MapEvent
 import org.maplibre.compose.map.MapExtent
 import org.maplibre.compose.map.MapState
+import org.maplibre.compose.map.SnapshotStyleOwnership
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.compose.style.StyleBinding
+import org.maplibre.compose.util.MaplibreComposable
 
 /**
  * A real map session on whichever MapLibre this platform uses, driven frame by frame by the test.
@@ -118,6 +124,22 @@ internal suspend fun MapFixture.pumpUntilPixel(
 }
 
 internal expect fun createMapFixture(extent: MapExtent = MapFixture.DEFAULT_EXTENT): MapFixture
+
+/** Evaluates real composables, then publishes and reconciles through the map's production paths. */
+internal suspend fun MapFixture.declare(content: @Composable @MaplibreComposable () -> Unit) {
+  awaitMapReady()
+  val revision =
+    DefaultStyleCompositionEvaluator.evaluate(
+      content,
+      checkNotNull(style),
+      checkNotNull(session.getViewport()),
+      Density(1f),
+      LayoutDirection.Ltr,
+      SnapshotStyleOwnership.Empty,
+    )
+  state.beginStyleRevision(session, revision)
+  state.updateStyleResources(session, session.reconcileStyleRevision(revision))
+}
 
 internal enum class MapLibreFlavor {
   NATIVE,

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/testing/StyleComposition.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/testing/StyleComposition.kt
@@ -23,11 +23,12 @@ import org.maplibre.compose.util.MaplibreComposable
 /**
  * Composes [content] once against [style] and applies the revision it publishes, then returns
  * [style] with everything the composition installed. With [thenChange], runs it, recomposes, and
- * applies the revision that follows.
+ * applies the revision that follows. [onRevision] sees each revision the composition publishes.
  */
 internal suspend fun composeStyle(
   style: RecordingStyleBinding = RecordingStyleBinding(),
   thenChange: (() -> Unit)? = null,
+  onRevision: (DesiredStyleRevision) -> Unit = {},
   content: @Composable @MaplibreComposable () -> Unit,
 ): RecordingStyleBinding {
   val frameClock = BroadcastFrameClock()
@@ -42,7 +43,14 @@ internal suspend fun composeStyle(
             LocalDensity provides Density(1f),
             LocalLayoutDirection provides LayoutDirection.Ltr,
           ) {
-            StyleContent(rootNode, publish = { revision = it }, content = content)
+            StyleContent(
+              rootNode,
+              publish = {
+                revision = it
+                onRevision(it)
+              },
+              content = content,
+            )
           }
         }
         val reconciler = StyleReconciler()

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -1068,7 +1068,7 @@ internal class MlnFfiMapSession(
     requestedStyle = style
     val trackerRequest = styleLoadTracker.request()
     // Disposes the composition holding the old style's sources and layers, which would otherwise
-    // fail anchor validation against the base layers being replaced.
+    // be validated against the base layers being replaced.
     val lifecycleRequest = lifecycleEngineIdentity?.let {
       lifecycleCallbacks.beginStyleRequest(it, this)
     }

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapView.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapView.kt
@@ -137,7 +137,8 @@ internal fun MlnFfiMapView(
   val currentOnReset = rememberUpdatedState(onReset)
 
   // Must run in the apply phase, not from a coroutine: the unload has to precede the content
-  // subcomposition inserting layers, or a style switch fails anchor validation (see #269).
+  // subcomposition inserting layers, or a style switch inserts them against the base style being
+  // replaced (see #269).
   SideEffect { session.setBaseStyle(style) }
   SideEffect {
     if (session.beginPresentationAttachment() && session.isPresentationPublished) {

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/style/MlnFfiStyleBinding.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/style/MlnFfiStyleBinding.kt
@@ -183,6 +183,11 @@ internal open class MlnFfiStyleBinding(
 
   override fun layerIds(): List<String> = readMap { it.styleLayerIds() }.orEmpty()
 
+  override fun layerTypes(): Map<String, String> = readMap { map ->
+    map.styleLayerIds().mapNotNull { id -> map.styleLayerType(id)?.let { id to it } }.toMap()
+  }
+    .orEmpty()
+
   private fun isStyleSource(map: MapHandle, id: String): Boolean =
     map.styleSourceExists(id) && map.styleSourceType(id) != SourceType.ANNOTATIONS
 

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/style/MlnFfiStyleBinding.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/style/MlnFfiStyleBinding.kt
@@ -178,18 +178,32 @@ internal open class MlnFfiStyleBinding(
     .orEmpty()
 
   override fun getLayer(id: String): Layer? = readMap { map ->
-    if (!map.styleLayerExists(id)) null else reconstructLayer(map, id)
+    if (!isStyleLayer(map, id)) null else reconstructLayer(map, id)
   }
 
+  /** The full engine order, annotation layer included: insertions and moves are relative to it. */
   override fun layerIds(): List<String> = readMap { it.styleLayerIds() }.orEmpty()
 
   override fun layerTypes(): Map<String, String> = readMap { map ->
-    map.styleLayerIds().mapNotNull { id -> map.styleLayerType(id)?.let { id to it } }.toMap()
+    map
+      .styleLayerIds()
+      .filter { isStyleLayer(map, it) }
+      .mapNotNull { id -> map.styleLayerType(id)?.let { id to it } }
+      .toMap()
   }
     .orEmpty()
 
   private fun isStyleSource(map: MapHandle, id: String): Boolean =
     map.styleSourceExists(id) && map.styleSourceType(id) != SourceType.ANNOTATIONS
+
+  /** MapLibre Native appends a layer that draws from its annotation source to every style. */
+  private fun isStyleLayer(map: MapHandle, id: String): Boolean {
+    if (!map.styleLayerExists(id)) return false
+    val sourceId = map.layerSourceId(id)
+    return sourceId.isEmpty() ||
+      !map.styleSourceExists(sourceId) ||
+      map.styleSourceType(sourceId) != SourceType.ANNOTATIONS
+  }
 
   private fun reconstructSource(map: MapHandle, id: String): Source =
     UnknownSource(id, sourceDefinition(map, id))


### PR DESCRIPTION
## Description

`Anchor.Above` and `Anchor.Below` now take a predicate over the base style's `LayerHandle`s: `Below` lands under the lowest match and `Above` over the highest, and with no match `Below` falls back to the top of the stack and `Above` to the bottom, so a missing layer ID no longer fails a revision. The reconciler resolves every anchor to a placement (top, bottom, or below one base layer) before it groups and diffs layers, so a fresh lambda on each recomposition never removes, re-adds, or moves a layer, and MapLibre Native's annotation layer is neither offered to predicates nor reported as a style layer. The `layerId` forms remain as sugar, and the transit and data demos anchor their layers below `symbol` layers.

Stacked on #1332. Closes #958.

## Validation

- `mise run check`: passed
- `mise run test:desktop`: 835 tests, 0 failures, 7 skipped (pre-existing skips)
- `caffeinate mise run test:js`: 532 tests, 0 failures
- `mise run build:docs`: built; the later KDoc and doc trims only remove text, verified by `mise run check`, a JVM compile, and the docs CI job
- The new `AnchorPlacementTest` (live, both engines) fails on native without the annotation-layer filter and fails on both engines without the layer-node key change; verified by reverting each temporarily.

## AI assistance

Claude Fable 5.1 via Claude Code (workflow-driven implementation), pending author review.

