### PR TITLE
Prevent tilt from interrupting pinch and rotation

### DIFF
--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/TransformRecognitionPolicy.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/TransformRecognitionPolicy.kt
@@ -96,6 +96,8 @@ internal class TransformRecognitionPolicy(
       motion.displacement.y != 0f &&
         shove != null &&
         !shoving &&
+        !rotating &&
+        !zooming &&
         GestureMath.shouldStartShove(
           (motion.displacement.y / density.density).toDouble(),
           current.horizontalAngle,
@@ -115,7 +117,7 @@ internal class TransformRecognitionPolicy(
       rotationOrigin = current
     }
 
-    // Rotation wins simultaneous recognition; tilt takes over only when neither starts.
+    // Rotation wins simultaneous recognition; tilt can take over pan, but not rotation or zoom.
     // Each first delta excludes the recognition threshold to avoid a visible camera jump.
     if (startRotate) {
       cancels += CameraComponent.Zoom

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/interaction/internal/PointerPairGestureTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/interaction/internal/PointerPairGestureTest.kt
@@ -259,6 +259,36 @@ class PointerPairGestureTest {
   }
 
   @Test
+  fun vertical_drift_during_rotation_does_not_start_tilt() {
+    val input = PairInput(MapInteractions.Standard)
+    fun move(at: Long, degrees: Double, vertical: Float) {
+      val angle = degrees * PI / 180.0
+      val radius = Offset(80f * cos(angle).toFloat(), 80f * sin(angle).toFloat())
+      val center = Offset(0f, vertical)
+      input.move(at, center - radius, center + radius)
+    }
+    move(20, 16.0, 0f)
+    assertTrue(input.target.rotateCalls.any { it.bearingDelta != 0.0 })
+    val rotations = input.target.rotateCalls.size
+    move(40, 18.0, 24f)
+    move(60, 20.0, 32f)
+    assertTrue(input.target.rotateCalls.size > rotations, "rotation stopped during vertical drift")
+    assertTrue(input.target.rotateCalls.all { it.pitchDelta == 0.0 }, "rotation became tilt")
+  }
+
+  @Test
+  fun vertical_drift_during_pinch_does_not_start_tilt() {
+    val input = PairInput(MapInteractions.Standard)
+    input.move(20, Offset(-100f, 0f), Offset(100f, 0f))
+    assertTrue(input.target.scaleCalls.isNotEmpty())
+    val scales = input.target.scaleCalls.size
+    input.move(40, Offset(-120f, 24f), Offset(120f, 24f))
+    input.move(60, Offset(-140f, 32f), Offset(140f, 32f))
+    assertTrue(input.target.scaleCalls.size > scales, "pinch stopped during vertical drift")
+    assertTrue(input.target.rotateCalls.isEmpty(), "horizontal pinch became tilt")
+  }
+
+  @Test
   fun a_small_sideways_shift_at_the_end_of_a_pinch_does_not_start_rotation() {
     val input = PairInput(MapInteractions.Standard)
     for ((index, span) in listOf(150f, 120f, 90f, 60f).withIndex()) {


### PR DESCRIPTION
## Description

Prevent two-finger tilt from taking over an active pinch or rotation when the fingers drift vertically. Tilt can still take over an initial pan, preserving normal two-finger tilt gestures.

Resolves #1334.

## Validation

- Both new regression tests fail before the fix and pass afterward.
- `mise run test:android` passed.
- The existing pan-to-tilt Compose input test passed on desktop.
- `mise run check` passed.
- Physical touch input was not tested locally.

## AI assistance

GPT-6 in Codex implemented the fix and regression tests and drafted this description.
