### PR TITLE
Synchronize pan and pinch momentum settlement

### DIFF
--- a/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/interaction/internal/TransformInputTest.kt
+++ b/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/interaction/internal/TransformInputTest.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.performTrackpadInput
 import androidx.compose.ui.unit.dp
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
+import kotlin.math.ln
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -329,6 +330,51 @@ class TransformInputTest {
     waitForIdle()
     assertTrue(target.moveCalls.isEmpty(), "lifting the pinch started a pan")
     assertTrue(target.scaleCalls.size > scales, "pinch momentum was lost during release")
+  }
+
+  @Test
+  fun pan_and_pinch_release_follow_the_same_animation_progress() {
+    fixture.runRecognitionTest { target ->
+      val map = mapNode()
+      map.performTouchInput {
+        down(0, center - Offset(80f, 0f))
+        down(1, center + Offset(80f, 0f))
+        repeat(6) {
+          updatePointerBy(0, Offset(8f, 0f))
+          updatePointerBy(1, Offset(56f, 0f))
+          move(delayMillis = 16)
+        }
+      }
+      waitForIdle()
+      val moves = target.moveCalls.size
+      val scales = target.scaleCalls.size
+      mainClock.autoAdvance = false
+      try {
+        map.performTouchInput {
+          up(0)
+          up(1)
+        }
+        mainClock.advanceTimeBy(160)
+        waitForIdle()
+        val partialPan = target.moveCalls.drop(moves).sumOf { it.x.toDouble() }
+        val partialZoom = target.scaleCalls.drop(scales).sumOf { ln(it.scale) }
+        mainClock.advanceTimeBy(600)
+        waitForIdle()
+        val totalPan = target.moveCalls.drop(moves).sumOf { it.x.toDouble() }
+        val totalZoom = target.scaleCalls.drop(scales).sumOf { ln(it.scale) }
+        assertTrue(partialPan > 0.0 && partialPan < totalPan)
+        assertTrue(partialZoom > 0.0 && partialZoom < totalZoom)
+        assertEquals(partialZoom / totalZoom, partialPan / totalPan, 1e-5)
+        val completedMoves = target.moveCalls.size
+        val completedScales = target.scaleCalls.size
+        mainClock.advanceTimeBy(600)
+        waitForIdle()
+        assertEquals(completedMoves, target.moveCalls.size)
+        assertEquals(completedScales, target.scaleCalls.size)
+      } finally {
+        mainClock.autoAdvance = true
+      }
+    }
   }
 
   @Test

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/GestureMath.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/GestureMath.kt
@@ -101,7 +101,24 @@ internal object GestureMath {
   fun hasStablePressure(current: Float, previous: Float): Boolean =
     previous <= 0f || current / previous > PRESSURE_RATIO_THRESHOLD
 
-  data class Fling(val offsetXDp: Double, val offsetYDp: Double, val duration: Duration)
+  data class Fling(
+    val offsetXDp: Double,
+    val offsetYDp: Double,
+    val duration: Duration,
+    val decayPower: Int = 2,
+  ) {
+    fun settleWith(transformDuration: Duration): Fling {
+      // Preserve initial speed when changing decay curves, without increasing total travel.
+      val distanceScale =
+        minOf(1.0, transformDuration / duration * decayPower / TRANSFORM_DECAY_POWER)
+      return copy(
+        offsetXDp = offsetXDp * distanceScale,
+        offsetYDp = offsetYDp * distanceScale,
+        duration = transformDuration,
+        decayPower = TRANSFORM_DECAY_POWER,
+      )
+    }
+  }
 
   /**
    * Screen-space travel for a flick of this speed. Equal speeds produce equal offsets, whether or

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/PointerGesture.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/PointerGesture.kt
@@ -777,7 +777,7 @@ internal class PointerGesture(
   private fun animateFling(fling: GestureMath.Fling) {
     val token = gestureToken
     checkNotNull(cameraSession).scope.launch {
-      animateDecelerating(fling.duration, power = 2) { frameFraction ->
+      animateDecelerating(fling.duration, power = fling.decayPower) { frameFraction ->
         val deltaX = fling.offsetXDp * frameFraction
         val deltaY = fling.offsetYDp * frameFraction
         GestureMath.forEachScreenSpaceStep(deltaX, deltaY) { stepX, stepY ->

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/PointerPairGesture.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/PointerPairGesture.kt
@@ -186,7 +186,7 @@ internal class PointerPairGesture(
 
     if (panFling == null && scale == null && rotation == null && tilt == null) return null
     return PairContinuation(
-      panFling,
+      if (scale != null) panFling?.settleWith(scale.duration) else panFling,
       scale,
       rotation,
       tilt,

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/interaction/internal/GestureMathTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/interaction/internal/GestureMathTest.kt
@@ -41,6 +41,26 @@ class GestureMathTest {
   }
 
   @Test
+  fun synchronizing_pan_with_pinch_never_increases_travel_or_initial_speed() {
+    for (speed in listOf(250.0, 1000.0, 2000.0, 10000.0)) {
+      for (duration in listOf(100.milliseconds, 600.milliseconds)) {
+        val original = assertNotNull(GestureMath.fling(speed, -speed))
+        val combined = original.settleWith(duration)
+        assertEquals(duration, combined.duration)
+        assertEquals(GestureMath.TRANSFORM_DECAY_POWER, combined.decayPower)
+        assertTrue(combined.offsetXDp > 0.0)
+        assertTrue(combined.offsetXDp <= original.offsetXDp)
+        assertEquals(-combined.offsetXDp, combined.offsetYDp)
+        val originalSpeed =
+          original.offsetXDp * original.decayPower / original.duration.inWholeNanoseconds
+        val combinedSpeed =
+          combined.offsetXDp * combined.decayPower / combined.duration.inWholeNanoseconds
+        assertTrue(combinedSpeed <= originalSpeed + 1e-12)
+      }
+    }
+  }
+
+  @Test
   fun opposite_vertical_flings_are_equal_and_opposite() {
     val down = assertNotNull(GestureMath.fling(0.0, 1400.0))
     val up = assertNotNull(GestureMath.fling(0.0, -1400.0))

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/interaction/internal/PointerPairGestureTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/interaction/internal/PointerPairGestureTest.kt
@@ -18,6 +18,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
 import org.maplibre.compose.interaction.GestureAnchor
 import org.maplibre.compose.interaction.KeyModifier
 import org.maplibre.compose.interaction.MapInteractions
@@ -229,6 +230,40 @@ class PointerPairGestureTest {
     input.move(20, Offset(-50f, 0f), Offset(110f, 0f))
     input.move(40, Offset(-40f, 0f), Offset(120f, 0f))
     assertEquals(2, input.target.moveCalls.size)
+  }
+
+  @Test
+  fun pan_and_pinch_momentum_share_the_configured_zoom_duration_and_decay() {
+    for (zoomMomentum in listOf(true, false)) {
+      val input =
+        PairInput(
+          MapInteractions {
+            camera {
+              zoom {
+                momentum {
+                  enabled = zoomMomentum
+                  maximumDuration = 300.milliseconds
+                }
+              }
+            }
+          }
+        )
+      repeat(6) { index ->
+        val step = index + 1
+        input.move(step * 16L, Offset(-80f + step * 8f, 0f), Offset(80f + step * 56f, 0f))
+      }
+      val release = assertNotNull(input.pair.end())
+      val pan = assertNotNull(release.pan)
+      if (zoomMomentum) {
+        val scale = assertNotNull(release.scale)
+        assertEquals(300.milliseconds, scale.duration)
+        assertEquals(scale.duration, pan.duration)
+        assertEquals(GestureMath.TRANSFORM_DECAY_POWER, pan.decayPower)
+      } else {
+        assertNull(release.scale)
+        assertEquals(2, pan.decayPower)
+      }
+    }
   }
 
   @Test


### PR DESCRIPTION
## Description

Midpoint drift during a pinch can produce pan momentum that settles differently from the zoom. When both components have release momentum, use the pinch duration and decay curve for the pan, and rescale pan distance so neither total travel nor initial speed increases. Standalone pan momentum keeps its existing behavior.

## Validation

- `mise run test:android` passed, including regression coverage for momentum bounds and the configured pinch duration.
- Desktop `TransformInputTest` passed all 16 tests, including a combined release test comparing pan and zoom animation progress.
- `mise run check` and `git diff --check` passed.

Physical pinch feel has not been checked on a device.

## AI assistance

OpenAI Codex (GPT-6) assisted with implementation, regression tests, and the PR description.
