### PR TITLE
Batch layer handle reads per loaded style generation

### DIFF
--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/LayerHandle.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/LayerHandle.kt
@@ -126,16 +126,16 @@ internal constructor(
  */
 internal fun StyleBinding.layerHandle(
   id: String,
+  type: String,
   isCurrentResource: () -> Boolean,
   operations: StyleHandleOperationGuard,
-): LayerHandle? {
+): LayerHandle {
   requireCurrent()
-  val type = getLayer(id)?.definition()?.type ?: return null
   return LayerHandle(
     id = id,
     type = type,
     style = this,
-    isCurrentResource = { isCurrentResource() && getLayer(id)?.definition()?.type == type },
+    isCurrentResource = { isCurrentResource() && layerType(id) == type },
     operations = operations,
   )
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
@@ -379,15 +379,23 @@ public class MapStyleState internal constructor(initialBaseStyle: BaseStyle) {
   }
 
   internal fun readLayers(current: StyleBinding): Map<String, LayerHandle> {
-    val ids = current.layerIds().toSet()
-    current.identity.layers.retain(ids)
-    return ids.mapNotNull { id -> layerHandle(current, id)?.let { id to it } }.toMap()
+    val types = current.layerTypes()
+    current.identity.layers.retain(types.keys)
+    return types.mapValues { (id, type) -> layerHandle(current, id, type) }
   }
 
-  internal fun layerHandle(current: StyleBinding, id: String): LayerHandle? {
+  /** Rereads the handles of [ids] in one engine round trip; a removed layer maps to null. */
+  internal fun readLayers(current: StyleBinding, ids: Set<String>): Map<String, LayerHandle?> {
+    if (ids.isEmpty()) return emptyMap()
+    val types = current.layerTypes()
+    return ids.associateWith { id -> types[id]?.let { layerHandle(current, id, it) } }
+  }
+
+  internal fun layerHandle(current: StyleBinding, id: String, type: String): LayerHandle {
     val identity = current.identity.layers.get(id)
     return current.layerHandle(
       id,
+      type,
       isCurrentResource = { current.identity.layers.isCurrent(id, identity) },
       operations = operationGuard(current),
     )
@@ -1037,9 +1045,7 @@ internal constructor(
       StyleResourceRead(binding, styleHandleEpoch, styleSourceChangeRevision)
     }
     changes.sources.forEach { refreshStyleSources(adapter, it) }
-    val layers = runCatching {
-      changes.layers.associateWith { style.layerHandle(read.binding, it) }
-    }
+    val layers = runCatching { style.readLayers(read.binding, changes.layers) }
     lifecycle.serialized {
       if (!isCurrentStyleResourceRead(adapter, read)) return
       changes.layerOrder?.let { style.updateLayers(layers.getOrThrow(), it) }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleBinding.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleBinding.kt
@@ -76,6 +76,13 @@ internal interface StyleBinding {
   fun layerIds(): List<String>
 
   /**
+   * One layer's style-spec type, or null when the style has no layer [id] or the engine added it
+   * for its own use, as [getLayer] omits it. The default reads the whole layer; an engine overrides
+   * this to read only the type.
+   */
+  fun layerType(id: String): String? = getLayer(id)?.definition()?.type
+
+  /**
    * Every layer's style-spec type keyed by ID, in stack order from bottom to top. A layer the
    * engine adds for its own use is omitted, as [getLayer] omits it. The default reads each layer
    * separately; an engine with per-call overhead overrides this to read them in one pass.

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
@@ -106,9 +106,9 @@ class MapPresentationTest {
             return backing.sourceIds()
           }
 
-          override fun layerIds(): List<String> {
+          override fun layerTypes(): Map<String, String> {
             resourceReads++
-            return backing.layerIds()
+            return backing.layerTypes()
           }
         }
       val reconciler = StyleReconciler()

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsTypes.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsTypes.kt
@@ -98,6 +98,9 @@ internal external interface StyleLayer {
   val sourceLayer: String?
   val minzoom: Double?
   val maxzoom: Double?
+
+  /** Serializes this one layer as its style-spec object. */
+  fun serialize(): LayerSpecification
 }
 
 internal external interface SourceHandle {

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/style/GlJsStyleBinding.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/style/GlJsStyleBinding.kt
@@ -31,6 +31,7 @@ import org.maplibre.compose.gljs.SkySpecification
 import org.maplibre.compose.gljs.SourceHandle
 import org.maplibre.compose.gljs.SourceSpecification
 import org.maplibre.compose.gljs.StyleImageMetadata
+import org.maplibre.compose.gljs.StyleLayer
 import org.maplibre.compose.gljs.StyleSetterOptions
 import org.maplibre.compose.gljs.TransitionSpecification
 import org.maplibre.compose.gljs.UpdateImageOptions
@@ -190,12 +191,17 @@ internal class GlJsStyleBinding(
 
   override fun getLayer(id: String): Layer? {
     requireLoaded()
-    return map.getLayer(id)?.let { reconstructLayer(id) }
+    return map.getLayer(id)?.let(::reconstructLayer)
   }
 
   override fun layerIds(): List<String> {
     requireLoaded()
     return map.getLayersOrder().toList()
+  }
+
+  override fun layerType(id: String): String? {
+    requireLoaded()
+    return map.getLayer(id)?.type
   }
 
   override fun layerTypes(): Map<String, String> {
@@ -214,14 +220,14 @@ internal class GlJsStyleBinding(
       },
     )
 
-  private fun reconstructLayer(id: String): Layer {
+  private fun reconstructLayer(layer: StyleLayer): Layer {
     val definition =
-      map.getStyle().layers.firstOrNull { it.id == id }?.toJsonElement() as? JsonObject
+      layer.serialize().toJsonElement() as? JsonObject
         ?: buildJsonObject {
-          put("id", id)
-          map.getLayer(id)?.let { put("type", it.type) }
+          put("id", layer.id)
+          put("type", layer.type)
         }
-    return UnknownLayer(id, definition)
+    return UnknownLayer(layer.id, definition)
   }
 
   override fun addSource(sourceId: String, source: JsonObject): Boolean {

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/style/StyleLayerTypesTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/style/StyleLayerTypesTest.kt
@@ -1,0 +1,49 @@
+package org.maplibre.compose.style
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import org.maplibre.compose.testing.MapTestResult
+import org.maplibre.compose.testing.createMapFixture
+import org.maplibre.compose.testing.runMapTest
+
+class StyleLayerTypesTest {
+  @Test
+  fun layer_types_report_every_layer_in_style_order(): MapTestResult = runMapTest {
+    createMapFixture().use { fixture ->
+      fixture.loadStyle(LAYERED_STYLE)
+      val style = assertNotNull(fixture.style)
+
+      val types = style.layerTypes()
+
+      // Native's own annotations layer is omitted, as getLayer omits it.
+      assertEquals(mapOf("backdrop" to "background", "lakes" to "fill"), types)
+      assertEquals(listOf("backdrop", "lakes"), types.keys.toList())
+      assertEquals("fill", style.layerType("lakes"))
+      assertNull(style.layerType("missing"))
+    }
+  }
+
+  private companion object {
+    val LAYERED_STYLE =
+      BaseStyle.Json(
+        """
+        {
+          "version": 8,
+          "sources": {
+            "water": {
+              "type": "geojson",
+              "data": { "type": "FeatureCollection", "features": [] }
+            }
+          },
+          "layers": [
+            { "id": "backdrop", "type": "background" },
+            { "id": "lakes", "type": "fill", "source": "water" }
+          ]
+        }
+        """
+          .trimIndent()
+      )
+  }
+}

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/style/MlnFfiStyleBinding.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/style/MlnFfiStyleBinding.kt
@@ -184,6 +184,10 @@ internal open class MlnFfiStyleBinding(
   /** The full engine order, annotation layer included: insertions and moves are relative to it. */
   override fun layerIds(): List<String> = readMap { it.styleLayerIds() }.orEmpty()
 
+  override fun layerType(id: String): String? = readMap { map ->
+    if (isStyleLayer(map, id)) map.styleLayerType(id) else null
+  }
+
   override fun layerTypes(): Map<String, String> = readMap { map ->
     map
       .styleLayerIds()

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/MlnFfiMapIdleTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/MlnFfiMapIdleTest.kt
@@ -39,8 +39,10 @@ class MlnFfiMapIdleTest {
       requireNotNull(fixture.style).also { style ->
         style.getSources()
         style.layerIds()
+        style.layerTypes()
         style.getSource("missing")
         style.getLayer("missing")
+        style.layerType("missing")
       }
 
       val drawn = fixture.renderOnDemand(IDLE_WINDOW)


### PR DESCRIPTION
## Description

Builds layer handles from one batched `layerTypes()` read per loaded style generation, for both the initial `readLayers` and the post-revision refresh, instead of one `getLayer(id)` per handle, and adds `layerType(id)` so the per-operation ownership check reads only the type. On the browser both are direct `map.getLayer(id)` lookups, and the remaining full-definition `getLayer` serializes only that layer instead of scanning `getStyle()`; on native the batched read is a single owner-thread round trip and the type check is a single string read. Handle behaviour is unchanged.

Closes #1342.

## Validation

- `mise run check`: passes.
- `mise run test:desktop`: passes, including the new `StyleLayerTypesTest` live test and the idle-frame test extended to the new reads.
- `caffeinate mise run test:js`: passes, including the same live test on the browser engine. Needed a larger Kotlin daemon heap locally because other builds shared the daemon; no repo config changed.
- `MapPresentationTest` now counts the batched read as the resource read that recovery must repeat.
- Not run: Android and iOS. The native change is shared Kotlin over existing FFI calls.

## AI assistance

Claude Fable 5.1 via Claude Code drafted the change, the tests, and this description.
