### PR TITLE
Improve shove recognition and pinch release momentum

### DIFF
--- a/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/interaction/internal/TransformInputTest.kt
+++ b/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/interaction/internal/TransformInputTest.kt
@@ -378,7 +378,7 @@ class TransformInputTest {
   }
 
   @Test
-  fun a_new_pan_preserves_the_previous_pinchs_zoom_momentum() {
+  fun a_continued_pan_settles_with_the_previous_pinch_momentum() {
     fixture.runRecognitionTest { target ->
       val map = mapNode()
       map.performTouchInput {
@@ -390,7 +390,7 @@ class TransformInputTest {
           move(delayMillis = 16)
         }
         up(0)
-        repeat(5) {
+        repeat(12) {
           updatePointerBy(1, Offset(80f, 0f))
           move(delayMillis = 16)
         }
@@ -400,17 +400,39 @@ class TransformInputTest {
       val moves = target.moveCalls.size
       val scales = target.scaleCalls.size
       assertTrue(scales > 0)
-      map.performTouchInput { up(1) }
-      waitForIdle()
-      assertTrue(target.scaleCalls.size > scales, "new pan discarded zoom momentum")
-      assertTrue(target.moveCalls.size > moves, "continued pan lost its own momentum")
+      mainClock.autoAdvance = false
+      try {
+        map.performTouchInput { up(1) }
+        mainClock.advanceTimeBy(160)
+        waitForIdle()
+        val partialPan = target.moveCalls.drop(moves).sumOf { it.x.toDouble() }
+        val partialZoom = target.scaleCalls.drop(scales).sumOf { ln(it.scale) }
+        mainClock.advanceTimeBy(600)
+        waitForIdle()
+        val totalPan = target.moveCalls.drop(moves).sumOf { it.x.toDouble() }
+        val totalZoom = target.scaleCalls.drop(scales).sumOf { ln(it.scale) }
+        assertTrue(partialPan > 0.0 && partialPan < totalPan, "continued pan lost momentum")
+        assertTrue(partialZoom > 0.0 && partialZoom < totalZoom, "new pan discarded zoom momentum")
+        assertEquals(partialZoom / totalZoom, partialPan / totalPan, 1e-5)
+      } finally {
+        mainClock.autoAdvance = true
+      }
       assertEquals(1, target.endedCount)
     }
   }
 
   @Test
-  fun a_finger_departing_a_pinch_does_not_become_a_pan_fling() {
-    fixture.runRecognitionTest { target ->
+  fun a_finger_departing_a_pinch_does_not_become_a_pan_fling() =
+    checkDepartingPinchFinger(zoomMomentum = true)
+
+  @Test
+  fun a_finger_departing_a_pinch_cannot_fling_when_zoom_momentum_is_disabled() =
+    checkDepartingPinchFinger(zoomMomentum = false)
+
+  private fun checkDepartingPinchFinger(zoomMomentum: Boolean) {
+    fixture.runRecognitionTest(
+      options = MapInteractions { camera { zoom { momentum { enabled = zoomMomentum } } } }
+    ) { target ->
       val map = mapNode()
       map.performTouchInput {
         down(0, center - Offset(80f, 0f))
@@ -424,6 +446,10 @@ class TransformInputTest {
         // A fast departing finger crosses slop during the interval between lifts.
         updatePointerBy(1, Offset(160f, 0f))
         move(delayMillis = 8)
+        repeat(3) {
+          updatePointerBy(1, Offset(24f, 0f))
+          move(delayMillis = 8)
+        }
       }
       waitForIdle()
       val moves = target.moveCalls.size
@@ -435,7 +461,8 @@ class TransformInputTest {
       }
       waitForIdle()
       assertEquals(moves, target.moveCalls.size, "departing finger became a pan fling")
-      assertTrue(target.scaleCalls.size > scales, "pinch momentum was discarded")
+      if (zoomMomentum) assertTrue(target.scaleCalls.size > scales, "pinch momentum was discarded")
+      else assertEquals(scales, target.scaleCalls.size)
     }
   }
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/GestureMath.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/GestureMath.kt
@@ -1,5 +1,6 @@
 package org.maplibre.compose.interaction.internal
 
+import androidx.compose.ui.geometry.Offset
 import kotlin.math.PI
 import kotlin.math.abs
 import kotlin.math.ceil
@@ -25,7 +26,7 @@ internal object GestureMath {
   const val ROTATE_START_DEGREES = 3.0
   // MapLibre GL JS uses 25 logical pixels of arc travel to reject pinch-induced angle noise.
   const val ROTATE_START_WHILE_ZOOMING_ARC_DP = 25.0
-  const val SHOVE_MAX_FINGER_ANGLE_DEGREES = 20.0
+  const val SHOVE_MAX_FINGER_ANGLE_DEGREES = 45.0
   const val PRESSURE_RATIO_THRESHOLD = 0.67f
 
   /** 6 mm at 160 dpi: 6 / 25.4 * 160. */
@@ -90,11 +91,15 @@ internal object GestureMath {
   }
 
   fun shouldStartShove(
-    verticalDisplacementDp: Double,
+    firstDisplacementDp: Offset,
+    secondDisplacementDp: Offset,
     fingerAngleFromHorizontalDegrees: Double,
     startSlopDp: Double = SHOVE_START_DP,
   ): Boolean =
-    abs(verticalDisplacementDp) >= startSlopDp &&
+    abs((firstDisplacementDp.y + secondDisplacementDp.y) / 2) >= startSlopDp &&
+      abs(firstDisplacementDp.y) > abs(firstDisplacementDp.x) &&
+      abs(secondDisplacementDp.y) > abs(secondDisplacementDp.x) &&
+      (firstDisplacementDp.y > 0) == (secondDisplacementDp.y > 0) &&
       abs(fingerAngleFromHorizontalDegrees) <= SHOVE_MAX_FINGER_ANGLE_DEGREES
 
   /** Rejects a sudden pressure drop, which is usually a finger lift. */

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/GestureVelocityTracker.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/GestureVelocityTracker.kt
@@ -14,13 +14,13 @@ internal class GestureVelocityTracker(private val maximumVelocity: Float = Float
 
   fun resetTracking() = samples.clear()
 
-  fun addPointerInputChange(change: PointerInputChange) {
+  fun addPointerInputChange(change: PointerInputChange, notBefore: Long = Long.MIN_VALUE) {
     // A newly selected contact may carry history from its previous gesture.
-    val lastTime = samples.lastOrNull()?.time
+    val historyStart = maxOf(notBefore, samples.lastOrNull()?.time ?: Long.MIN_VALUE)
     change.historical.forEach {
-      if (lastTime == null || it.uptimeMillis >= lastTime) addPosition(it.uptimeMillis, it.position)
+      if (it.uptimeMillis >= historyStart) addPosition(it.uptimeMillis, it.position)
     }
-    addPosition(change.uptimeMillis, change.position)
+    if (change.uptimeMillis >= notBefore) addPosition(change.uptimeMillis, change.position)
   }
 
   fun addPosition(time: Long, position: Offset) {

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/PointerContinuation.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/PointerContinuation.kt
@@ -1,0 +1,34 @@
+package org.maplibre.compose.interaction.internal
+
+import androidx.compose.ui.unit.DpOffset
+
+/** Pending momentum, merged by component and settled once when every contact has lifted. */
+internal data class PointerContinuation(
+  val pan: GestureMath.Fling? = null,
+  val scale: GestureMath.ScaleVelocity? = null,
+  val rotation: GestureMath.RotationVelocity? = null,
+  val tilt: GestureMath.TiltVelocity? = null,
+  val scaleAnchor: DpOffset? = null,
+  val rotationAnchor: DpOffset? = null,
+) {
+  fun settled(): PointerContinuation =
+    if (scale != null) copy(pan = pan?.settleWith(scale.duration)) else this
+
+  fun without(component: CameraComponent): PointerContinuation =
+    when (component) {
+      CameraComponent.Pan -> copy(pan = null)
+      CameraComponent.Zoom -> copy(scale = null)
+      CameraComponent.Rotate -> copy(rotation = null)
+      CameraComponent.Tilt -> copy(tilt = null)
+    }
+
+  fun withPrevious(previous: PointerContinuation?): PointerContinuation =
+    copy(
+      pan = pan ?: previous?.pan,
+      scale = scale ?: previous?.scale,
+      rotation = rotation ?: previous?.rotation,
+      tilt = tilt ?: previous?.tilt,
+      scaleAnchor = if (scale != null) scaleAnchor else previous?.scaleAnchor,
+      rotationAnchor = if (rotation != null) rotationAnchor else previous?.rotationAnchor,
+    )
+}

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/PointerDragVelocity.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/PointerDragVelocity.kt
@@ -1,0 +1,38 @@
+package org.maplibre.compose.interaction.internal
+
+import androidx.compose.ui.input.pointer.PointerInputChange
+import androidx.compose.ui.unit.Velocity
+
+/** Separates direct dragging from the motion eligible to produce release momentum. */
+internal class PointerDragVelocity(maximumVelocity: Float) {
+  private val tracker = GestureVelocityTracker(maximumVelocity)
+  private var notBefore = Long.MIN_VALUE
+
+  fun begin(change: PointerInputChange, afterContactChange: Boolean = false) {
+    resetTracking()
+    if (afterContactChange) notBefore = change.uptimeMillis + CONTACT_RELEASE_MILLIS
+    addPointerInputChange(change)
+  }
+
+  fun recognize(change: PointerInputChange) {
+    tracker.resetTracking()
+    if (change.uptimeMillis >= notBefore) tracker.addPosition(change.uptimeMillis, change.position)
+  }
+
+  fun addPointerInputChange(change: PointerInputChange) {
+    // Historical samples must obey the same eligibility boundary as current samples.
+    tracker.addPointerInputChange(change, notBefore)
+  }
+
+  fun calculateVelocity(): Velocity = tracker.calculateVelocity()
+
+  fun resetTracking() {
+    tracker.resetTracking()
+    notBefore = Long.MIN_VALUE
+  }
+
+  private companion object {
+    // Brief movement between finger lifts belongs to releasing the old contact group.
+    const val CONTACT_RELEASE_MILLIS = 100L
+  }
+}

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/PointerGesture.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/PointerGesture.kt
@@ -75,12 +75,12 @@ internal class PointerGesture(
   private var lastSingle: PointerInputChange? = null
   private var singleDragOrigin: Offset? = null
   private var dragRecognition: PointerDrag? = null
-  private val singleVelocity = GestureVelocityTracker(maximumFlingVelocity)
+  private val singleVelocity = PointerDragVelocity(maximumFlingVelocity)
 
   private var pair: PointerPairGesture? = null
   private val contactOrder = mutableListOf<PointerId>()
   private var twoFingerTap: TwoFingerTapCandidate? = null
-  private var deferredTwoFingerVelocity: PairContinuation? = null
+  private var pendingContinuation: PointerContinuation? = null
 
   /** Null once the press is no longer a candidate click. Physical pixels, as Compose reports. */
   private var clickOrigin: Offset? = null
@@ -144,15 +144,15 @@ internal class PointerGesture(
       pair != null ||
       twoFingerTap != null ||
       clickOrigin != null ||
-      deferredTwoFingerVelocity != null
+      pendingContinuation != null
 
   private fun onSingle(event: PointerEvent, change: PointerInputChange) {
     if (pair != null) {
       // Keep the remaining finger usable, but start its drag from the current position.
       // Reusing the pair origin would make the map jump when either finger lifts.
       val completed = pair
-      deferredTwoFingerVelocity =
-        completed?.end()?.withPrevious(deferredTwoFingerVelocity) ?: deferredTwoFingerVelocity
+      pendingContinuation =
+        completed?.end()?.withPrevious(pendingContinuation) ?: pendingContinuation
       pair = null
       if (gestureToken?.acceptsCommands == false) {
         retainCameraAuthority()
@@ -169,8 +169,7 @@ internal class PointerGesture(
       dragRecognition = selectedDrag?.let {
         PointerDrag(change, maxOf(touchSlopPx, dragSlop(it, mouse = false)))
       }
-      singleVelocity.resetTracking()
-      singleVelocity.addPosition(change.uptimeMillis, change.position)
+      singleVelocity.begin(change, afterContactChange = true)
       return
     }
 
@@ -222,9 +221,8 @@ internal class PointerGesture(
 
     quickZoomOriginY = change.position.y
     quickZoomAppliedDelta = 0.0
-    singleVelocity.resetTracking()
-    singleVelocity.addPointerInputChange(change)
-    deferredTwoFingerVelocity = null
+    singleVelocity.begin(change)
+    pendingContinuation = null
 
     cancelCameraSession()
     acceptPress()
@@ -343,8 +341,7 @@ internal class PointerGesture(
         dragRecognition = next?.let { dragRecognizer(change, it) }
         dragSample = sample
         singleDragOrigin = change.position
-        singleVelocity.resetTracking()
-        singleVelocity.addPointerInputChange(change)
+        singleVelocity.begin(change)
         clickOrigin = null
         cancelLongClick()
         return
@@ -367,19 +364,19 @@ internal class PointerGesture(
       clickOrigin = null
       twoFingerTap = null
       // A replacement only takes over the camera components it controls.
-      deferredTwoFingerVelocity = deferredTwoFingerVelocity?.let {
+      pendingContinuation = pendingContinuation?.let {
         when (binding) {
-          SelectedDrag.TapDrag -> it.copy(scale = null)
-          SelectedDrag.Pan -> it.copy(pan = null)
-          SelectedDrag.RotateTilt -> it.copy(rotation = null, tilt = null)
+          SelectedDrag.TapDrag -> it.without(CameraComponent.Zoom)
+          SelectedDrag.Pan -> it.without(CameraComponent.Pan)
+          SelectedDrag.RotateTilt ->
+            it.without(CameraComponent.Rotate).without(CameraComponent.Tilt)
           SelectedDrag.FitBounds -> null
         }
       }
       if (gestureInProgress) {
         // A departing transform contact can cross slop at high speed. Estimate a new drag's
         // momentum from movement after recognition, not from that transition.
-        singleVelocity.resetTracking()
-        singleVelocity.addPosition(change.uptimeMillis, change.position)
+        singleVelocity.recognize(change)
       }
       beginGesture()
       when (binding) {
@@ -492,8 +489,7 @@ internal class PointerGesture(
     }
 
     if (previous != null) {
-      deferredTwoFingerVelocity =
-        previous.end()?.withPrevious(deferredTwoFingerVelocity) ?: deferredTwoFingerVelocity
+      pendingContinuation = previous.end()?.withPrevious(pendingContinuation) ?: pendingContinuation
       pair = null
       twoFingerTap = null
       if (gestureToken?.acceptsCommands == false) {
@@ -545,7 +541,7 @@ internal class PointerGesture(
         begin = { beginGesture() },
         onRecognized = { component ->
           twoFingerTap = null
-          deferredTwoFingerVelocity = deferredTwoFingerVelocity?.without(component)
+          pendingContinuation = pendingContinuation?.without(component)
         },
         retainAuthority = ::retainCameraAuthority,
         maximumFlingVelocity = maximumFlingVelocity,
@@ -590,17 +586,18 @@ internal class PointerGesture(
     cancelLongClick()
     val completed = pair
     val pairContinuation =
-      completed?.end()?.withPrevious(deferredTwoFingerVelocity) ?: deferredTwoFingerVelocity
+      completed?.end()?.withPrevious(pendingContinuation) ?: pendingContinuation
     pair = null
     if (gestureToken?.acceptsCommands == false) {
       retainCameraAuthority()
       return
     }
 
-    finishSingleVelocity(completedDrag)
-    pairContinuation?.let(::finishPairVelocity)
+    val continuation =
+      singleContinuation(completedDrag)?.withPrevious(pairContinuation) ?: pairContinuation
+    continuation?.settled()?.let(::animateContinuation)
 
-    deferredTwoFingerVelocity = null
+    pendingContinuation = null
     lastSingle = null
     singleDragOrigin = null
     dragRecognition = null
@@ -705,33 +702,33 @@ internal class PointerGesture(
   private fun clickMovementSlopPx(): Float =
     if (pressedType == PointerType.Mouse) clickSlopPx else panSlopPx
 
-  private fun finishSingleVelocity(binding: SelectedDrag?) {
-    if (binding == null || !gestureInProgress) return
+  private fun singleContinuation(binding: SelectedDrag?): PointerContinuation? {
+    if (binding == null || !gestureInProgress) return null
     val velocity = singleVelocity.calculateVelocity()
-    when (binding) {
+    return when (binding) {
       SelectedDrag.Pan -> {
-        val tuning = options.camera.settings.pan.momentum.takeIf { it.enabled } ?: return
+        val tuning = options.camera.settings.pan.momentum.takeIf { it.enabled } ?: return null
         val fling =
           GestureMath.fling(
             (velocity.x / density.density).toDouble(),
             (velocity.y / density.density).toDouble(),
             tuning,
-          ) ?: return
-        animateFling(fling)
+          ) ?: return null
+        PointerContinuation(pan = fling)
       }
       SelectedDrag.RotateTilt -> {
-        if (!options.camera.settings.tilt.enabled) return
-        val tuning = options.camera.settings.tilt.momentum.takeIf { it.enabled } ?: return
+        if (!options.camera.settings.tilt.enabled) return null
+        val tuning = options.camera.settings.tilt.momentum.takeIf { it.enabled } ?: return null
         val response =
           GestureMath.tiltVelocity(
             velocity.y / density.density * options.bindings.drag.rotateTilt.pitchDegreesPerDp,
             tuning,
-          ) ?: return
-        animateTiltVelocity(response)
+          ) ?: return null
+        PointerContinuation(tilt = response)
       }
-      SelectedDrag.FitBounds -> Unit
+      SelectedDrag.FitBounds -> null
       SelectedDrag.TapDrag -> {
-        val tuning = options.camera.settings.zoom.momentum.takeIf { it.enabled } ?: return
+        val tuning = options.camera.settings.zoom.momentum.takeIf { it.enabled } ?: return null
         val direction =
           if (options.bindings.tapDrag.direction == QuickZoomDirection.DownZoomsIn) 1 else -1
         val velocityResponse =
@@ -742,16 +739,16 @@ internal class PointerGesture(
               options.bindings.tapDrag.zoomLevelsPerViewport * direction,
             ),
             tuning,
-          ) ?: return
-        animateScaleVelocity(
-          velocityResponse,
-          dragSample?.let { options.bindings.tapDrag.anchor.location(it) },
+          ) ?: return null
+        PointerContinuation(
+          scale = velocityResponse,
+          scaleAnchor = dragSample?.let { options.bindings.tapDrag.anchor.location(it) },
         )
       }
     }
   }
 
-  private fun finishPairVelocity(velocity: PairContinuation) {
+  private fun animateContinuation(velocity: PointerContinuation) {
     velocity.pan?.let(::animateFling)
     velocity.scale?.let { animateScaleVelocity(it, velocity.scaleAnchor) }
     velocity.rotation?.let { animateRotationVelocity(it, velocity.rotationAnchor) }
@@ -877,7 +874,7 @@ internal class PointerGesture(
     pair?.cancel()
     cancelLongClick()
     longClickHandled = false
-    deferredTwoFingerVelocity = null
+    pendingContinuation = null
     pairing.discard(emitClick = false)
     pressRole = TapPairing.Press.First
     lastSingle = null

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/PointerPairGesture.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/PointerPairGesture.kt
@@ -128,13 +128,13 @@ internal class PointerPairGesture(
 
   fun cancel() = recognition.cancel()
 
-  fun end(): PairContinuation? {
+  fun end(): PointerContinuation? {
     val continuation = if (token?.acceptsCommands == true) continuation() else null
     recognition.cancel()
     return continuation
   }
 
-  private fun continuation(): PairContinuation? {
+  private fun continuation(): PointerContinuation? {
     val velocity = recognition.velocity()
     val panVelocity = velocity.centroid
 
@@ -185,8 +185,8 @@ internal class PointerPairGesture(
         }
 
     if (panFling == null && scale == null && rotation == null && tilt == null) return null
-    return PairContinuation(
-      if (scale != null) panFling?.settleWith(scale.duration) else panFling,
+    return PointerContinuation(
+      panFling,
       scale,
       rotation,
       tilt,
@@ -194,31 +194,4 @@ internal class PointerPairGesture(
       centroid.takeIf { settings.rotate.anchor == GestureAnchor.Input },
     )
   }
-}
-
-internal data class PairContinuation(
-  val pan: GestureMath.Fling?,
-  val scale: GestureMath.ScaleVelocity?,
-  val rotation: GestureMath.RotationVelocity?,
-  val tilt: GestureMath.TiltVelocity?,
-  val scaleAnchor: DpOffset?,
-  val rotationAnchor: DpOffset?,
-) {
-  fun without(component: CameraComponent): PairContinuation =
-    when (component) {
-      CameraComponent.Pan -> copy(pan = null)
-      CameraComponent.Zoom -> copy(scale = null)
-      CameraComponent.Rotate -> copy(rotation = null)
-      CameraComponent.Tilt -> copy(tilt = null)
-    }
-
-  fun withPrevious(previous: PairContinuation?): PairContinuation =
-    copy(
-      pan = pan ?: previous?.pan,
-      scale = scale ?: previous?.scale,
-      rotation = rotation ?: previous?.rotation,
-      tilt = tilt ?: previous?.tilt,
-      scaleAnchor = if (scale != null) scaleAnchor else previous?.scaleAnchor,
-      rotationAnchor = if (rotation != null) rotationAnchor else previous?.rotationAnchor,
-    )
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/TransformRecognitionPolicy.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/TransformRecognitionPolicy.kt
@@ -93,13 +93,13 @@ internal class TransformRecognitionPolicy(
     if (rotationBlockedByZoom) startRotate = false
 
     val startShove =
-      motion.displacement.y != 0f &&
-        shove != null &&
+      shove != null &&
         !shoving &&
         !rotating &&
         !zooming &&
         GestureMath.shouldStartShove(
-          (motion.displacement.y / density.density).toDouble(),
+          (current.first - motion.origin.first) / density.density,
+          (current.second - motion.origin.second) / density.density,
           current.horizontalAngle,
           shove.startSlop.value.toDouble(),
         )
@@ -117,9 +117,15 @@ internal class TransformRecognitionPolicy(
       rotationOrigin = current
     }
 
-    // Rotation wins simultaneous recognition; tilt can take over pan, but not rotation or zoom.
+    // Tilt wins simultaneous recognition, but cannot interrupt established rotation or zoom.
     // Each first delta excludes the recognition threshold to avoid a visible camera jump.
-    if (startRotate) {
+    if (startShove) {
+      cancels += CameraComponent.Pan
+      vertical =
+        motion.displacement.y -
+          sign(motion.displacement.y) * checkNotNull(shove).startSlop.value * density.density
+      starts += CameraComponent.Tilt
+    } else if (startRotate) {
       cancels += CameraComponent.Zoom
       rotationSpan = current.distance
       rotation = rotationFromStart - sign(rotationFromStart) * rotationThreshold
@@ -128,12 +134,6 @@ internal class TransformRecognitionPolicy(
       val baseline = if (rotating) rotationSpan else motion.origin.distance
       scale = current.distance / (baseline + sign(scaleSpan) * scaleThreshold * density.density / 2)
       starts += CameraComponent.Zoom
-    } else if (startShove) {
-      cancels += listOf(CameraComponent.Pan, CameraComponent.Zoom, CameraComponent.Rotate)
-      vertical =
-        motion.displacement.y -
-          sign(motion.displacement.y) * checkNotNull(shove).startSlop.value * density.density
-      starts += CameraComponent.Tilt
     }
 
     // Pan can accompany scale and rotation. Two-finger tilt owns the pair exclusively.

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/interaction/internal/GestureMathTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/interaction/internal/GestureMathTest.kt
@@ -1,8 +1,10 @@
 package org.maplibre.compose.interaction.internal
 
+import androidx.compose.ui.geometry.Offset
 import kotlin.math.abs
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -10,6 +12,30 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 
 class GestureMathTest {
+  @Test
+  fun shove_accepts_staggered_fingers_moving_up_or_down() {
+    for (direction in listOf(-1f, 1f)) {
+      assertTrue(
+        GestureMath.shouldStartShove(
+          Offset(4f, 20f) * direction,
+          Offset(2f, 24f) * direction,
+          45.0,
+        )
+      )
+    }
+    assertFalse(GestureMath.shouldStartShove(Offset(0f, 24f), Offset(0f, 24f), 46.0))
+    assertFalse(GestureMath.shouldStartShove(Offset(0f, 15f), Offset(0f, 15f), 30.0))
+  }
+
+  @Test
+  fun shove_requires_both_fingers_to_move_predominantly_vertically_in_the_same_direction() {
+    val vertical = Offset(0f, 40f)
+    for (other in listOf(Offset.Zero, Offset(0f, -4f), Offset(24f, 20f), Offset(20f, 20f))) {
+      assertFalse(GestureMath.shouldStartShove(vertical, other, 0.0), "accepted $other")
+      assertFalse(GestureMath.shouldStartShove(other, vertical, 0.0), "accepted $other")
+    }
+  }
+
   @Test
   fun pinch_preserves_direction_and_reverses_with_the_finger_motion() {
     assertEquals(1.0, GestureMath.pinchScale(1.0))

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/interaction/internal/PointerDragVelocityTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/interaction/internal/PointerDragVelocityTest.kt
@@ -1,0 +1,68 @@
+package org.maplibre.compose.interaction.internal
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.HistoricalChange
+import androidx.compose.ui.input.pointer.PointerId
+import androidx.compose.ui.input.pointer.PointerInputChange
+import androidx.compose.ui.unit.Velocity
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class PointerDragVelocityTest {
+  @Test
+  fun departing_motion_cannot_fling_regardless_of_event_rate() {
+    for (interval in listOf(4L, 8L, 16L)) {
+      val tracker = PointerDragVelocity(Float.MAX_VALUE)
+      tracker.begin(sample(0, 0f), afterContactChange = true)
+      tracker.recognize(sample(interval, 100f))
+      for (time in interval..96L step interval) {
+        tracker.addPointerInputChange(sample(time, time * 10f))
+      }
+      assertEquals(Velocity.Zero, tracker.calculateVelocity(), "interval $interval")
+    }
+  }
+
+  @Test
+  fun continued_drag_uses_only_motion_after_the_contact_release_interval() {
+    val tracker = PointerDragVelocity(Float.MAX_VALUE)
+    tracker.begin(sample(0, 0f), afterContactChange = true)
+    tracker.recognize(sample(8, 100f))
+    val clean = GestureVelocityTracker()
+    for (time in listOf(100L, 116L, 132L, 148L)) {
+      val position = (time - 100) * 0.5f
+      tracker.addPointerInputChange(
+        sample(time, position)
+          .copy(
+            pressure = 1f,
+            historical = listOf(HistoricalChange(96, Offset(-1000f, 0f))),
+          )
+      )
+      clean.addPosition(time, Offset(position, 0f))
+    }
+    assertTrue(clean.calculateVelocity().x > 0f)
+    assertEquals(clean.calculateVelocity(), tracker.calculateVelocity())
+  }
+
+  @Test
+  fun a_fresh_press_has_no_contact_release_delay() {
+    val tracker = PointerDragVelocity(Float.MAX_VALUE)
+    tracker.begin(sample(0, 0f), afterContactChange = true)
+    tracker.begin(sample(20, 0f))
+    tracker.addPointerInputChange(sample(36, 10f))
+    tracker.addPointerInputChange(sample(52, 20f))
+    assertTrue(tracker.calculateVelocity().x > 0f)
+  }
+
+  private fun sample(time: Long, x: Float) =
+    PointerInputChange(
+      id = PointerId(1),
+      uptimeMillis = time,
+      position = Offset(x, 0f),
+      pressed = true,
+      previousUptimeMillis = time,
+      previousPosition = Offset(x, 0f),
+      previousPressed = true,
+      isInitiallyConsumed = false,
+    )
+}

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/interaction/internal/PointerPairGestureTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/interaction/internal/PointerPairGestureTest.kt
@@ -252,7 +252,7 @@ class PointerPairGestureTest {
         val step = index + 1
         input.move(step * 16L, Offset(-80f + step * 8f, 0f), Offset(80f + step * 56f, 0f))
       }
-      val release = assertNotNull(input.pair.end())
+      val release = assertNotNull(input.pair.end()).settled()
       val pan = assertNotNull(release.pan)
       if (zoomMomentum) {
         val scale = assertNotNull(release.scale)
@@ -291,6 +291,44 @@ class PointerPairGestureTest {
     assertTrue(first.zoomDelta > 0.0)
     assertEquals(first.zoomDelta, second.zoomDelta, 1e-6)
     assertEquals(first.duration, second.duration)
+  }
+
+  @Test
+  fun staggered_fingers_can_shove_with_small_sideways_motion() {
+    val radius = Offset(80f, 60f)
+    val input = PairInput(MapInteractions.Standard, radius = radius)
+    input.move(20, -radius + Offset(2f, 12f), radius + Offset(2f, 12f))
+    assertTrue(input.target.rotateCalls.isEmpty(), "tilt started below slop")
+    input.move(40, -radius + Offset(4f, 24f), radius + Offset(4f, 24f))
+    assertTrue(input.target.rotateCalls.any { it.pitchDelta != 0.0 }, "staggered shove rejected")
+    assertTrue(input.target.rotateCalls.all { it.bearingDelta == 0.0 })
+    assertTrue(input.target.scaleCalls.isEmpty())
+    val pans = input.target.moveCalls.size
+    input.move(60, -radius + Offset(6f, 36f), radius + Offset(6f, 36f))
+    assertEquals(pans, input.target.moveCalls.size, "shove continued panning")
+  }
+
+  @Test
+  fun shove_wins_when_rotation_first_qualifies_on_the_same_event() {
+    val input = PairInput(MapInteractions.Standard)
+    val angle = 16.0 * PI / 180.0
+    val radius = Offset(80f * cos(angle).toFloat(), 80f * sin(angle).toFloat())
+    val center = Offset(0f, 40f)
+    input.move(20, center - radius, center + radius)
+    assertTrue(input.target.rotateCalls.any { it.pitchDelta != 0.0 }, "rotation won over shove")
+    assertTrue(input.target.rotateCalls.all { it.bearingDelta == 0.0 })
+    assertTrue(input.target.scaleCalls.isEmpty())
+    assertTrue(input.target.moveCalls.isEmpty())
+  }
+
+  @Test
+  fun shove_wins_when_pinch_first_qualifies_on_the_same_event() {
+    val input = PairInput(MapInteractions.Standard)
+    input.move(20, Offset(-100f, 40f), Offset(100f, 40f))
+    assertTrue(input.target.rotateCalls.any { it.pitchDelta != 0.0 }, "pinch won over shove")
+    assertTrue(input.target.rotateCalls.all { it.bearingDelta == 0.0 })
+    assertTrue(input.target.scaleCalls.isEmpty())
+    assertTrue(input.target.moveCalls.isEmpty())
   }
 
   @Test
@@ -383,12 +421,13 @@ class PointerPairGestureTest {
     initial: MapInteractions,
     private val secondType: PointerType = PointerType.Touch,
     center: Offset = Offset.Zero,
+    radius: Offset = Offset(80f, 0f),
   ) {
     val options = initial
 
     val target = map.target
     private var time = 0L
-    private var positions = listOf(center + Offset(-80f, 0f), center + Offset(80f, 0f))
+    private var positions = listOf(center - radius, center + radius)
     private val token = run {
       map.state.gestureAuthority.updateConfiguration(options.camera)
       target.onGestureStarted()


### PR DESCRIPTION
## Description

Make two-finger tilt easier to start: allow finger alignment within 45° of horizontal, require both fingers to move predominantly vertically in the same direction, and give tilt priority when it first qualifies alongside pinch or rotation. Established pinch and rotation remain protected from tilt takeover.

Prevent brief movement between finger lifts from causing an accidental pan fling after a pinch. Direct dragging remains immediate, but a dedicated drag velocity tracker excludes the first 100 ms after the pair loses a finger from new fling estimates, including historical input samples.

Single- and two-finger gestures now produce a shared release plan. Merge momentum by camera component and synchronize pan with any pending zoom momentum once, at final release, so a deliberate continued pan cannot bypass pinch settling.

## Validation

- Android host suite and desktop interaction tests passed.
- Static checks passed.
- Built, installed, and launched on an iPhone 16 Pro; the contributor confirmed the gesture behavior before the final cleanup.
- Regression coverage includes staggered shove alignment, initial gesture priority, active pinch/rotation protection, multi-sample finger departure with zoom momentum enabled or disabled, event-rate and historical-sample handling, and deliberate continued pan/zoom settlement.
- Browser and Android device behavior will receive CI coverage; they were not manually tested locally.

## AI assistance

OpenAI Codex (GPT-6) assisted with implementation, tests, cleanup, and this description. The contributor directed the design and tested the behavior on their iPhone.
