### PR TITLE
Make style mutation capabilities explicit

### DIFF
--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoAppState.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoAppState.kt
@@ -2,7 +2,6 @@ package org.maplibre.compose.demoapp
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
@@ -156,13 +155,12 @@ fun rememberDemoAppState(): DemoAppState {
   val mapState =
     rememberMapState(
       runtime = mapRuntime,
-      initialBaseStyle = appliedStyle.base,
+      baseStyle = appliedStyle.base,
       initialCameraPosition = StartPosition,
     ) {
       mapConfiguration.selectedDemo?.let { demo -> key(demo) { demo.MapContent() } }
       DemoLocationMapContent(location, locationState)
     }
-  SideEffect { mapState.style.baseStyle = appliedStyle.base }
   val frameRateState = remember { FrameRateState() }
   return remember {
     DemoAppState(mapRuntime, mapState, settings, location, frameRateState, mapConfiguration)

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/benchmark/BenchmarkMap.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/benchmark/BenchmarkMap.kt
@@ -10,7 +10,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.withFrameNanos
@@ -67,12 +66,11 @@ internal fun BenchmarkMap(state: DemoAppState, viewportInsets: MapViewportInsets
   val mapState =
     rememberMapState(
       runtime = state.mapRuntime,
-      initialBaseStyle = scenario.style.base,
+      baseStyle = scenario.style.base,
       initialCameraPosition = scenario.camera,
     ) {
       scenario.MapContent(session)
     }
-  SideEffect { mapState.style.baseStyle = scenario.style.base }
   val mapLoaded = remember(scenario.id) { CompletableDeferred<Unit>() }
   LaunchedEffect(mapState.style.loadState, mapLoaded) {
     when (val load = mapState.style.loadState) {

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/MagnifyingLensDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/MagnifyingLensDemo.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableDoubleStateOf
 import androidx.compose.runtime.mutableFloatStateOf
@@ -97,9 +96,7 @@ object MagnifyingLensDemo : Demo {
   @Composable
   override fun MapOverlayScope.Overlay(state: DemoAppState) {
     val appliedStyle = state.appliedStyle
-    val lensState =
-      rememberMapState(runtime = state.mapRuntime, initialBaseStyle = appliedStyle.base)
-    SideEffect { lensState.style.baseStyle = appliedStyle.base }
+    val lensState = rememberMapState(runtime = state.mapRuntime, baseStyle = appliedStyle.base)
     val density = LocalDensity.current
     val layoutDirection = LocalLayoutDirection.current
     val lensSizePx = with(density) { lensSize.dp.toPx() }

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/MapSnapshotterDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/MapSnapshotterDemo.kt
@@ -101,7 +101,7 @@ object MapSnapshotterDemo : Demo {
     val snapshotter =
       remember(state.mapRuntime, appliedBaseStyle) {
         state.mapRuntime.createSnapshotter(
-          initialBaseStyle = appliedBaseStyle,
+          baseStyle = appliedBaseStyle,
           content = { SnapshotMarker() },
         )
       }

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Composition.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Composition.kt
@@ -15,7 +15,7 @@ fun Composition() {
   val state =
     rememberMapState(
       runtime = runtime,
-      initialBaseStyle = BaseStyle.Uri("https://tiles.openfreemap.org/styles/liberty"),
+      baseStyle = BaseStyle.Uri("https://tiles.openfreemap.org/styles/liberty"),
     ) {
       // Sources and layers declared here are added to the base style.
     }

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Layers.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Layers.kt
@@ -34,9 +34,7 @@ import org.maplibre.spatialk.geojson.toJson
 fun Layers() {
   // #region simple
   val baseState =
-    rememberMapState(
-      initialBaseStyle = BaseStyle.Uri("https://tiles.openfreemap.org/styles/liberty")
-    ) {
+    rememberMapState(baseStyle = BaseStyle.Uri("https://tiles.openfreemap.org/styles/liberty")) {
       getBaseSource<VectorTileSource>(id = "openmaptiles")?.let { tiles ->
         CircleLayer(id = "example", source = tiles, sourceLayer = "poi")
       }

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Snapshotter.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Snapshotter.kt
@@ -23,7 +23,7 @@ suspend fun captureCurrentMap(
 ): ImageBitmap {
   val snapshotter =
     runtime.createSnapshotter(
-      initialBaseStyle = mapState.style.baseStyle,
+      baseStyle = mapState.style.baseStyle,
       content = content,
     )
   return try {

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Styling.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Styling.kt
@@ -4,7 +4,6 @@ package org.maplibre.compose.docsnippets
 
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.SideEffect
 import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.maplibre.compose.demoapp.generated.Res
 import org.maplibre.compose.map.MaplibreMap
@@ -16,22 +15,19 @@ import org.maplibre.compose.style.BaseStyle
 fun Styling() {
   // #region simple
   val simple =
-    rememberMapState(
-      initialBaseStyle = BaseStyle.Uri("https://tiles.openfreemap.org/styles/liberty")
-    )
+    rememberMapState(baseStyle = BaseStyle.Uri("https://tiles.openfreemap.org/styles/liberty"))
   MaplibreMap(state = simple)
   // #endregion simple
 
   // #region dynamic
   val variant = if (isSystemInDarkTheme()) "dark" else "light"
   val baseStyle = BaseStyle.Uri("https://api.protomaps.com/styles/v4/$variant/en.json?key=MY_KEY")
-  val dynamic = rememberMapState(initialBaseStyle = baseStyle)
-  SideEffect { dynamic.style.baseStyle = baseStyle }
+  val dynamic = rememberMapState(baseStyle = baseStyle)
   MaplibreMap(state = dynamic)
   // #endregion dynamic
 
   // #region local
-  val local = rememberMapState(initialBaseStyle = BaseStyle.Uri(Res.getUri("files/style.json")))
+  val local = rememberMapState(baseStyle = BaseStyle.Uri(Res.getUri("files/style.json")))
   MaplibreMap(state = local)
   // #endregion local
 }

--- a/docs/src/content/docs/composition.mdx
+++ b/docs/src/content/docs/composition.mdx
@@ -27,9 +27,8 @@ The library manages the sources and layers in the style block. It
 does not modify the rest of the base style. To change a base style layer, use
 the `asMutable` view of its <Api of="LayerHandle" /> from `mapState.style.layers`.
 
-Changing `baseStyle` reloads the remembered map's style while keeping the same
-map state. Maps and snapshotters created through `MapRuntime` instead accept an
-`initialBaseStyle`; their `style.asMutable` view permits later base-style commands.
+Maps and snapshotters created through `MapRuntime` accept `initialBaseStyle`.
+Use `style.asMutable` to change their base style after creation.
 
 Composition owns the definitions and lifetimes of declared sources, layers, and
 images. Their handles expose reads and runtime operations; `asMutable` is null.

--- a/docs/src/content/docs/composition.mdx
+++ b/docs/src/content/docs/composition.mdx
@@ -16,7 +16,7 @@ viewport, projection, and feature-query operations while the map is attached.
 
 ## The style is base plus content
 
-A MapLibre style is a document with sources and layers. The `initialBaseStyle`
+A MapLibre style is a document with sources and layers. The `baseStyle`
 parameter loads that document without modification. The trailing
 <Api of="rememberMapState" /> block declares your sources, layers, and their
 positions in the layer stack.
@@ -25,13 +25,15 @@ positions in the layer stack.
 
 The library manages the sources and layers in the style block. It
 does not modify the rest of the base style. To change a base style layer, use
-its <Api of="LayerHandle" /> from `mapState.style.layers`.
+the `asMutable` view of its <Api of="LayerHandle" /> from `mapState.style.layers`.
 
-`initialBaseStyle` seeds the map once. Changing that input does not reload the
-remembered map; assign `mapState.style.baseStyle` to switch styles.
+Changing `baseStyle` reloads the remembered map's style while keeping the same
+map state. Maps and snapshotters created through `MapRuntime` instead accept an
+`initialBaseStyle`; their `style.asMutable` view permits later base-style commands.
 
 Composition owns the definitions and lifetimes of declared sources, layers, and
-images. Handles reject definition writes and removal commands for those resources.
+images. Their handles expose reads and runtime operations; `asMutable` is null.
+For other resources, `asMutable` provides definition writes and `remove()`.
 Use `mapState.style.sources[source]` to obtain a declared source's typed handle for
 feature state, cluster queries, and invalidation. These runtime operations do not
 change its declared definition. Handles belong to one loaded style generation;
@@ -56,7 +58,7 @@ current state, and let the runtime reconcile it.
 
 ## Style switches re-apply your content
 
-When you assign `mapState.style.baseStyle`, the map loads the new style and evaluates
+When you change `baseStyle`, the map loads the new style and evaluates
 the style block against it. Each evaluation declares your
 sources and layers against the new style. They persist across the switch
 without extra code. An `Anchor` is resolved against the new style's layers.

--- a/docs/src/content/docs/composition.mdx
+++ b/docs/src/content/docs/composition.mdx
@@ -27,9 +27,6 @@ The library manages the sources and layers in the style block. It
 does not modify the rest of the base style. To change a base style layer, use
 the `asMutable` view of its <Api of="LayerHandle" /> from `mapState.style.layers`.
 
-Maps and snapshotters created through `MapRuntime` accept `initialBaseStyle`.
-Use `style.asMutable` to change their base style after creation.
-
 Composition owns the definitions and lifetimes of declared sources, layers, and
 images. Their handles expose reads and runtime operations; `asMutable` is null.
 For other resources, `asMutable` provides definition writes and `remove()`.

--- a/docs/src/content/docs/styling.mdx
+++ b/docs/src/content/docs/styling.mdx
@@ -27,8 +27,8 @@ Create a <Api of="MapState" /> with the style URI as its initial
 
 ## Switch styles at runtime
 
-Assign `mapState.style.baseStyle` to switch styles. To follow Compose state such
-as the system theme, assign it in a `SideEffect`:
+Pass the current style to `rememberMapState` to follow Compose state such as
+the system theme:
 
 <Code code={region(styling, "dynamic")} lang="kotlin" title="App.kt" />
 

--- a/lib/maplibre-compose/src/androidDeviceTest/kotlin/org/maplibre/compose/camera/AndroidMapStateRecreationTest.kt
+++ b/lib/maplibre-compose/src/androidDeviceTest/kotlin/org/maplibre/compose/camera/AndroidMapStateRecreationTest.kt
@@ -122,7 +122,7 @@ class MapStateRecreationActivity : ComponentActivity() {
     setContent {
       val firstRuntime: MapRuntime = DefaultMapRuntime.instance
       val secondRuntime: MapRuntime = DefaultMapRuntime.instance
-      val state = rememberMapState(firstRuntime, initialBaseStyle = BaseStyle.Empty)
+      val state = rememberMapState(firstRuntime, baseStyle = BaseStyle.Empty)
       SideEffect {
         mapState = state
         defaultRuntimeIsShared = firstRuntime === secondRuntime

--- a/lib/maplibre-compose/src/androidDeviceTest/kotlin/org/maplibre/compose/map/AndroidExplicitRuntimeTest.kt
+++ b/lib/maplibre-compose/src/androidDeviceTest/kotlin/org/maplibre/compose/map/AndroidExplicitRuntimeTest.kt
@@ -20,7 +20,7 @@ class AndroidExplicitRuntimeTest {
       createMapRuntime(
         MapRuntimeOptions(cacheFile = Path(cacheDirectory.resolve("cache.db").absolutePath))
       )
-    val state = runtime.createMapState(initialBaseStyle = BaseStyle.Empty)
+    val state = runtime.createMapState(baseStyle = BaseStyle.Empty)
 
     try {
       assertSame(context.applicationContext, AndroidMlnFfiPlatform.applicationContext)

--- a/lib/maplibre-compose/src/androidDeviceTest/kotlin/org/maplibre/compose/mlnffi/AndroidSurfaceReplacementTest.kt
+++ b/lib/maplibre-compose/src/androidDeviceTest/kotlin/org/maplibre/compose/mlnffi/AndroidSurfaceReplacementTest.kt
@@ -248,7 +248,7 @@ private fun TestMap(
   onPresentation: () -> Unit,
   onFrame: () -> Unit,
 ) {
-  val state = rememberMapState(initialBaseStyle = SOLID_STYLE)
+  val state = rememberMapState(baseStyle = SOLID_STYLE)
   LaunchedEffect(state) {
     onState(state)
     snapshotFlow { state.currentMapAttachment }.first { it != null }

--- a/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/layers/LayerClickOrderTest.kt
+++ b/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/layers/LayerClickOrderTest.kt
@@ -136,7 +136,7 @@ class LayerClickOrderTest {
       mapState =
         rememberMapState(
           initialCameraPosition = CameraPosition(target = Position(0.0, 0.0), zoom = START_ZOOM),
-          initialBaseStyle = BaseStyle.Empty,
+          baseStyle = BaseStyle.Empty,
         ) {
           val source = rememberGeoJsonSource(data = GeoJsonData.JsonString(WORLD_POLYGON))
 

--- a/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MlnFfiMapCompositionTest.kt
+++ b/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MlnFfiMapCompositionTest.kt
@@ -461,11 +461,11 @@ class MlnFfiMapCompositionTest {
 
     assertTrue(!firstAttachment.isValid)
     assertEquals(StyleLoadState.Ready, state.style.loadState)
-    state.style.baseStyle = BaseStyle.Json("{")
+    state.style.asMutable!!.baseStyle = BaseStyle.Json("{")
     waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) {
       state.currentMapAttachment == null && state.style.loadState is StyleLoadState.Failed
     }
-    state.style.baseStyle = RETAINED_STYLE
+    state.style.asMutable!!.baseStyle = RETAINED_STYLE
     assertEquals(StyleLoadState.Loading, state.style.loadState)
 
     presented = true
@@ -560,7 +560,7 @@ class MlnFfiMapCompositionTest {
     assertTrue(session.canPresentFrames)
     assertTrue(onAllNodesWithTag(MAP_LOAD_PLACEHOLDER_TAG).fetchSemanticsNodes().isEmpty())
 
-    runOnUiThread { state.style.baseStyle = second }
+    runOnUiThread { state.style.asMutable!!.baseStyle = second }
     waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) { state.style.baseStyle == second }
     assertTrue(
       session.canPresentFrames,
@@ -591,7 +591,7 @@ class MlnFfiMapCompositionTest {
     val session = requireNotNull(state.currentMapAttachment).adapter as MlnFfiMapSession
     assertTrue(session.canPresentFrames)
 
-    runOnUiThread { state.style.baseStyle = BaseStyle.Json("{") }
+    runOnUiThread { state.style.asMutable!!.baseStyle = BaseStyle.Json("{") }
     waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) {
       state.style.loadState is StyleLoadState.Failed
     }
@@ -835,7 +835,7 @@ private fun TestMap(
   val state =
     rememberMapState(
       initialCameraPosition = initialCameraPosition,
-      initialBaseStyle = baseStyle,
+      baseStyle = baseStyle,
     ) {
       content()
     }

--- a/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MlnFfiMapCompositionTest.kt
+++ b/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MlnFfiMapCompositionTest.kt
@@ -97,8 +97,7 @@ class MlnFfiMapCompositionTest {
     runFfiComposeUiTest {
       val runtime = createMapRuntime(runtimeOptions)
       val start = CameraPosition(target = Position(0.0, 0.0), zoom = 12.0, tilt = 60.0)
-      val state =
-        runtime.createMapState(initialBaseStyle = BaseStyle.Empty, initialCameraPosition = start)
+      val state = runtime.createMapState(baseStyle = BaseStyle.Empty, cameraPosition = start)
       var configuration by mutableStateOf(MapInteractions.None)
       var density = 1f
       try {
@@ -178,7 +177,7 @@ class MlnFfiMapCompositionTest {
   @Test
   fun map_state_renders_a_base_style_and_publishes_one_presentation() = runFfiComposeUiTest {
     val runtime = createMapRuntime(runtimeOptions)
-    val state = runtime.createMapState(initialBaseStyle = BaseStyle.Empty)
+    val state = runtime.createMapState(baseStyle = BaseStyle.Empty)
 
     setFfiTestMapContent(runtimeOptions) { MaplibreMap(state = state) }
     waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) {
@@ -200,7 +199,7 @@ class MlnFfiMapCompositionTest {
   @Test
   fun focus_modifiers_on_the_map_modifier_reach_the_input_node() = runFfiComposeUiTest {
     val runtime = createMapRuntime(runtimeOptions)
-    val state = runtime.createMapState(initialBaseStyle = BaseStyle.Empty)
+    val state = runtime.createMapState(baseStyle = BaseStyle.Empty)
     val focusRequester = FocusRequester()
     val hasFocus = AtomicBoolean(false)
 
@@ -232,8 +231,8 @@ class MlnFfiMapCompositionTest {
     val runtime = createMapRuntime(runtimeOptions)
     val state =
       runtime.createMapState(
-        initialCameraPosition = CameraPosition(zoom = 1.0),
-        initialBaseStyle = BaseStyle.Empty,
+        cameraPosition = CameraPosition(zoom = 1.0),
+        baseStyle = BaseStyle.Empty,
       )
     var constraints by mutableStateOf(CameraConstraints())
 
@@ -275,8 +274,8 @@ class MlnFfiMapCompositionTest {
         onDispose {}
       }
     }
-    val first = runtime.createMapState(initialBaseStyle = BaseStyle.Empty, content = content)
-    val second = runtime.createMapState(initialBaseStyle = BaseStyle.Empty, content = content)
+    val first = runtime.createMapState(baseStyle = BaseStyle.Empty, content = content)
+    val second = runtime.createMapState(baseStyle = BaseStyle.Empty, content = content)
 
     setFfiTestMapContent(runtimeOptions, presentationCount = 2) {
       if (showFirst) {
@@ -334,7 +333,7 @@ class MlnFfiMapCompositionTest {
           onDispose {}
         }
       }
-      val state = runtime.createMapState(initialBaseStyle = BaseStyle.Empty, content = content)
+      val state = runtime.createMapState(baseStyle = BaseStyle.Empty, content = content)
 
       setFfiTestMapContent(runtimeOptions) { MaplibreMap(state = state) }
       waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) {
@@ -361,7 +360,7 @@ class MlnFfiMapCompositionTest {
       var presented by mutableStateOf(true)
       var latest by mutableStateOf(false)
       val state =
-        runtime.createMapState(initialBaseStyle = BaseStyle.Empty) {
+        runtime.createMapState(baseStyle = BaseStyle.Empty) {
           BackgroundLayer(
             id = if (latest) "latest-background" else "initial-background",
             color = const(if (latest) Color.Blue else Color.Red),
@@ -408,7 +407,7 @@ class MlnFfiMapCompositionTest {
       // Synchronous GeoJSON parsing rejects malformed data inside the revision itself.
       var malformedData by mutableStateOf(true)
       val state =
-        runtime.createMapState(initialBaseStyle = BaseStyle.Empty) {
+        runtime.createMapState(baseStyle = BaseStyle.Empty) {
           val points =
             rememberGeoJsonSource(
               data = GeoJsonData.JsonString(if (malformedData) "{" else EMPTY_FEATURE_COLLECTION),
@@ -443,8 +442,7 @@ class MlnFfiMapCompositionTest {
   fun a_map_state_retains_its_native_map_between_presentations() = runFfiComposeUiTest {
     val runtime = createMapRuntime(runtimeOptions)
     val camera = CameraPosition(target = Position(longitude = 11.0, latitude = 47.0), zoom = 6.0)
-    val state =
-      runtime.createMapState(initialCameraPosition = camera, initialBaseStyle = BaseStyle.Empty)
+    val state = runtime.createMapState(cameraPosition = camera, baseStyle = BaseStyle.Empty)
     var presented by mutableStateOf(true)
 
     setFfiTestMapContent(runtimeOptions, presentationCount = 2) {
@@ -491,8 +489,8 @@ class MlnFfiMapCompositionTest {
         CameraPosition(target = Position(longitude = -122.4, latitude = 37.8), zoom = 10.0)
       val state =
         runtime.createMapState(
-          initialCameraPosition = camera,
-          initialBaseStyle = REPLACEMENT_STYLE,
+          cameraPosition = camera,
+          baseStyle = REPLACEMENT_STYLE,
         )
       var presented by mutableStateOf(true)
       var scaleFactor by mutableStateOf(1f)
@@ -550,7 +548,7 @@ class MlnFfiMapCompositionTest {
       BaseStyle.Json("""{"version":8,"sources":{},"layers":[{"id":"bg-a","type":"background"}]}""")
     val second =
       BaseStyle.Json("""{"version":8,"sources":{},"layers":[{"id":"bg-b","type":"background"}]}""")
-    val state = runtime.createMapState(initialBaseStyle = first)
+    val state = runtime.createMapState(baseStyle = first)
 
     setFfiTestMapContent(runtimeOptions) { MaplibreMap(state = state) }
     waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) {
@@ -582,7 +580,7 @@ class MlnFfiMapCompositionTest {
   @Test
   fun a_failed_replacement_style_hides_the_native_map() = runFfiComposeUiTest {
     val runtime = createMapRuntime(runtimeOptions)
-    val state = runtime.createMapState(initialBaseStyle = BaseStyle.Empty)
+    val state = runtime.createMapState(baseStyle = BaseStyle.Empty)
 
     setFfiTestMapContent(runtimeOptions) { MaplibreMap(state = state) }
     waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) {

--- a/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MlnFfiStyleSwitchTest.kt
+++ b/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MlnFfiStyleSwitchTest.kt
@@ -68,7 +68,7 @@ class MlnFfiStyleSwitchTest {
     var style by mutableStateOf(STYLES[0])
     var extraLayer by mutableStateOf(false)
     val state =
-      runtime.createMapState(initialBaseStyle = STYLES[0].base) {
+      runtime.createMapState(baseStyle = STYLES[0].base) {
         val points = rememberGeoJsonSource(data = GeoJsonData.Features(pointAt(longitude = 0.0)))
         // Two layers on one source at different anchors, so the re-add order matters.
         CircleLayer(id = "user-circles", source = points, color = const(Color.Red))
@@ -120,7 +120,7 @@ class MlnFfiStyleSwitchTest {
     var style by mutableStateOf(SLOT_STYLES[0])
     var sourceLayer by mutableStateOf("places")
     val state =
-      runtime.createMapState(initialBaseStyle = SLOT_STYLES[0]) {
+      runtime.createMapState(baseStyle = SLOT_STYLES[0]) {
         val points = rememberGeoJsonSource(data = GeoJsonData.Features(pointAt(longitude = 0.0)))
         Anchor.Below("base-slot") {
           FillLayer(
@@ -186,7 +186,7 @@ class MlnFfiStyleSwitchTest {
       )
     var showLatestLayer by mutableStateOf(false)
     val state =
-      runtime.createMapState(initialBaseStyle = INITIAL_STYLE) {
+      runtime.createMapState(baseStyle = INITIAL_STYLE) {
         if (showLatestLayer) {
           Anchor.Below("base-c") {
             BackgroundLayer(id = "user-latest", color = const(Color.Blue))

--- a/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MlnFfiStyleSwitchTest.kt
+++ b/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/map/MlnFfiStyleSwitchTest.kt
@@ -99,7 +99,7 @@ class MlnFfiStyleSwitchTest {
       runOnUiThread {
         style = STYLES[(round + 1) % STYLES.size]
         extraLayer = !extraLayer
-        state.style.baseStyle = style.base
+        state.style.asMutable!!.baseStyle = style.base
       }
       waitUntil(timeoutMillis = SETTLE_TIMEOUT_MILLIS) {
         state.style.loadState == StyleLoadState.Ready && session.loadedStyleIdentity != identity
@@ -148,7 +148,7 @@ class MlnFfiStyleSwitchTest {
     runOnUiThread {
       style = SLOT_STYLES[1]
       sourceLayer = "roads"
-      state.style.baseStyle = style
+      state.style.asMutable!!.baseStyle = style
     }
     waitUntil(timeoutMillis = SETTLE_TIMEOUT_MILLIS) {
       state.style.loadState == StyleLoadState.Ready
@@ -204,7 +204,7 @@ class MlnFfiStyleSwitchTest {
     val session = requireNotNull(state.currentMapAttachment).adapter as MlnFfiMapSession
 
     runOnUiThread {
-      state.style.baseStyle = BaseStyle.Uri(B_STYLE_URL)
+      state.style.asMutable!!.baseStyle = BaseStyle.Uri(B_STYLE_URL)
     }
     waitUntil(timeoutMillis = SETTLE_TIMEOUT_MILLIS) {
       styleBStarted.count == 0L
@@ -212,7 +212,7 @@ class MlnFfiStyleSwitchTest {
 
     runOnUiThread {
       showLatestLayer = true
-      state.style.baseStyle = BaseStyle.Uri(C_STYLE_URL)
+      state.style.asMutable!!.baseStyle = BaseStyle.Uri(C_STYLE_URL)
     }
 
     waitUntil(timeoutMillis = SETTLE_TIMEOUT_MILLIS) {

--- a/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/sources/GeoJsonPreparationThreadTest.kt
+++ b/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/sources/GeoJsonPreparationThreadTest.kt
@@ -66,7 +66,8 @@ class GeoJsonPreparationThreadTest {
               GeoJsonSource("points", GeoJsonData.JsonString(EMPTY), options)
             )
           )
-        val updateFailure = assertFailsWith<StyleHandleException> { handle.setData(data) }
+        val updateFailure =
+          assertFailsWith<StyleHandleException> { handle.asMutable!!.setData(data) }
         assertSame(failure, updateFailure.cause?.cause)
         (fixture.style as MlnFfiStyleBinding).awaitGeoJsonUpdates()
         fixture.settle()
@@ -105,7 +106,7 @@ class GeoJsonPreparationThreadTest {
             )
           )
         )
-      if (!initial) handle.setData(data)
+      if (!initial) handle.asMutable!!.setData(data)
 
       assertEquals(0L, serialized.count, "submission returned before serialization")
       assertEquals(emptyList(), fixture.errors)
@@ -147,7 +148,7 @@ class GeoJsonPreparationThreadTest {
           )
         if (!initial) {
           binding.awaitGeoJsonUpdates()
-          handle.setData(data)
+          handle.asMutable!!.setData(data)
         }
         assertTrue(entered.await(5, TimeUnit.SECONDS), "worker did not begin serialization")
         // Preparation is still blocked, but an owner-thread round trip must finish.

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/LayerHandle.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/LayerHandle.kt
@@ -1,75 +1,24 @@
 package org.maplibre.compose.layers
 
 import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonNull
-import org.maplibre.compose.style.CLEARED_TRANSITION
-import org.maplibre.compose.style.LayerPropertyKind
-import org.maplibre.compose.style.LayerPropertyWrite
-import org.maplibre.compose.style.LayerSummary
-import org.maplibre.compose.style.StyleBinding
 import org.maplibre.compose.style.StyleHandleException
-import org.maplibre.compose.style.StyleHandleOperationGuard
-import org.maplibre.compose.style.StyleIdentity
-import org.maplibre.compose.style.TRANSITION_SUFFIX
 import org.maplibre.compose.style.TransitionOptions
-import org.maplibre.compose.style.scaledBy
-import org.maplibre.compose.style.toTransitionJson
-import org.maplibre.compose.style.toTransitionOptions
 
-/**
- * Provides property access to a layer for one loaded base-style generation.
- *
- * A setter does not wait for the engine to apply the write. A value the engine rejects is logged,
- * and the layer keeps its previous value.
- *
- * Style content owns all properties of declared layers. Their properties can be read, but setter
- * calls and [clearFilter] throw [StyleHandleException]. Base-style layers also permit writes,
- * except through the handles that an [Anchor] predicate receives, which are read-only.
- */
-public class LayerHandle
-internal constructor(
-  public val id: String,
-  public val type: String,
-  /** The ID of the source the layer draws from, or null for a layer without one. */
-  public val source: String?,
-  /** The source layer the layer draws from, or null when the layer names none. */
-  public val sourceLayer: String?,
-  private val style: StyleBinding,
-  private val isCurrentResource: () -> Boolean,
-  private val operations: StyleHandleOperationGuard,
-) {
-  private val identity: StyleIdentity = style.identity
+/** Reads a layer in one loaded style generation. Handles expire on removal or replacement. */
+public sealed interface LayerHandle {
+  public val id: String
+  public val type: String
+  /** The source ID, or null for a layer without one. */
+  public val source: String?
+  /** The source layer, or null when none is specified. */
+  public val sourceLayer: String?
+  /**
+   * Definition writes, or null for a declared layer or a handle supplied to an anchor predicate.
+   */
+  public val asMutable: MutableLayerHandle?
 
   /** Returns the current value of [name], or null when the layer has no value for that property. */
-  public suspend fun getProperty(name: String): JsonElement? {
-    return suspendingOperation { style.layerProperty(id, name) }
-  }
-
-  /** Sets the layout property [name] for this loaded style. */
-  public fun setLayoutProperty(name: String, value: JsonElement) {
-    setProperty(name, value, LayerPropertyKind.LAYOUT)
-  }
-
-  /** Sets the paint property [name] for this loaded style. */
-  public fun setPaintProperty(name: String, value: JsonElement) {
-    setProperty(name, value, LayerPropertyKind.PAINT)
-  }
-
-  /**
-   * Sets the transition of the paint property [property], named without the `-transition` suffix. A
-   * null [options] returns the property to the style's global transition. The reset is written at
-   * once, as the spec's empty transition object; a layer composable drops the key from its layer
-   * definition instead, with the same result.
-   *
-   * On Android, the system animator duration scale multiplies the timing that reaches the engine. A
-   * scale of zero applies the property change instantly.
-   */
-  public fun setPaintTransition(property: String, options: TransitionOptions?) {
-    setPaintProperty(
-      property + TRANSITION_SUFFIX,
-      options?.scaledBy(style.animatorDurationScale)?.toTransitionJson() ?: CLEARED_TRANSITION,
-    )
-  }
+  public suspend fun getProperty(name: String): JsonElement?
 
   /**
    * Returns the transition of the paint property [property], named without the `-transition`
@@ -83,8 +32,30 @@ internal constructor(
    * The reported timing is the engine's: a transition that the library wrote is under the animator
    * duration scale of the time it was written.
    */
-  public suspend fun getPaintTransition(property: String): TransitionOptions? =
-    getProperty(property + TRANSITION_SUFFIX)?.toTransitionOptions()
+  public suspend fun getPaintTransition(property: String): TransitionOptions?
+}
+
+/**
+ * Definition writes for a layer that composition does not own. Writes do not wait for the engine;
+ * rejected values are logged and retain the previous value. The view expires with its read handle.
+ */
+public sealed interface MutableLayerHandle : LayerHandle {
+  /** Sets the layout property [name] for this loaded style. */
+  public fun setLayoutProperty(name: String, value: JsonElement): Unit
+
+  /** Sets the paint property [name] for this loaded style. */
+  public fun setPaintProperty(name: String, value: JsonElement): Unit
+
+  /**
+   * Sets the transition of the paint property [property], named without the `-transition` suffix. A
+   * null [options] returns the property to the style's global transition. The reset is written at
+   * once, as the spec's empty transition object; a layer composable drops the key from its layer
+   * definition instead, with the same result.
+   *
+   * On Android, the system animator duration scale multiplies the timing that reaches the engine. A
+   * scale of zero applies the property change instantly.
+   */
+  public fun setPaintTransition(property: String, options: TransitionOptions?): Unit
 
   /**
    * Sets the top-level property [name], such as `minzoom`, for this loaded style.
@@ -92,69 +63,8 @@ internal constructor(
    * @throws StyleHandleException if [name] is `source` or `source-layer`: [source] and
    *   [sourceLayer] are fixed for the layer's generation.
    */
-  public fun setRootProperty(name: String, value: JsonElement) {
-    if (name in FIXED_ROOT_PROPERTIES) {
-      throw StyleHandleException("'$name' is fixed for the generation of $type layer '$id'")
-    }
-    setProperty(name, value, LayerPropertyKind.ROOT)
-  }
+  public fun setRootProperty(name: String, value: JsonElement): Unit
 
   /** Removes the layer filter for this loaded style. */
-  public fun clearFilter() {
-    setProperty("filter", JsonNull, LayerPropertyKind.ROOT)
-  }
-
-  /**
-   * Posts one write through the batched path, so the engine's rejection is logged the way a
-   * rejected composed property is, and the caller does not wait for the engine.
-   */
-  private fun setProperty(name: String, value: JsonElement, kind: LayerPropertyKind) {
-    operation {
-      operations.requireLayerWritable(id)
-      style.setLayerProperties(listOf(LayerPropertyWrite(id, type, name, value, kind)))
-    }
-  }
-
-  private fun requireCurrent() {
-    style.requireCurrent(identity)
-    check(isCurrentResource()) { "Layer '$id' is no longer the $type layer owned by this handle" }
-  }
-
-  private fun <T> operation(action: () -> T): T = operations.run {
-    requireCurrent()
-    action()
-  }
-
-  private suspend fun <T> suspendingOperation(action: suspend () -> T): T {
-    operation {}
-    val result = action()
-    operation {}
-    return result
-  }
-
-  private companion object {
-    val FIXED_ROOT_PROPERTIES = setOf("source", "source-layer")
-  }
-}
-
-/**
- * A handle for the style state, which outlives revisions. A layer replaced under the same ID takes
- * a new identity, so [isCurrentResource] refuses the handle of the replaced one.
- */
-internal fun StyleBinding.layerHandle(
-  id: String,
-  summary: LayerSummary,
-  isCurrentResource: () -> Boolean,
-  operations: StyleHandleOperationGuard,
-): LayerHandle {
-  requireCurrent()
-  return LayerHandle(
-    id = id,
-    type = summary.type,
-    source = summary.source,
-    sourceLayer = summary.sourceLayer,
-    style = this,
-    isCurrentResource = isCurrentResource,
-    operations = operations,
-  )
+  public fun clearFilter(): Unit
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/LayerHandleImpl.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/LayerHandleImpl.kt
@@ -1,0 +1,131 @@
+package org.maplibre.compose.layers
+
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import org.maplibre.compose.style.CLEARED_TRANSITION
+import org.maplibre.compose.style.LayerPropertyKind
+import org.maplibre.compose.style.LayerPropertyWrite
+import org.maplibre.compose.style.LayerSummary
+import org.maplibre.compose.style.StyleBinding
+import org.maplibre.compose.style.StyleHandleException
+import org.maplibre.compose.style.StyleHandleOperationGuard
+import org.maplibre.compose.style.StyleIdentity
+import org.maplibre.compose.style.TRANSITION_SUFFIX
+import org.maplibre.compose.style.TransitionOptions
+import org.maplibre.compose.style.scaledBy
+import org.maplibre.compose.style.toTransitionJson
+import org.maplibre.compose.style.toTransitionOptions
+
+internal class LayerHandleImpl
+internal constructor(
+  override val id: String,
+  override val type: String,
+  override val source: String?,
+  override val sourceLayer: String?,
+  private val style: StyleBinding,
+  private val isCurrentResource: () -> Boolean,
+  private val operations: StyleHandleOperationGuard,
+) : LayerHandle {
+  private val identity: StyleIdentity = style.identity
+
+  override suspend fun getProperty(name: String): JsonElement? {
+    return suspendingOperation { style.layerProperty(id, name) }
+  }
+
+  internal fun setLayoutProperty(name: String, value: JsonElement) {
+    setProperty(name, value, LayerPropertyKind.LAYOUT)
+  }
+
+  internal fun setPaintProperty(name: String, value: JsonElement) {
+    setProperty(name, value, LayerPropertyKind.PAINT)
+  }
+
+  internal fun setPaintTransition(property: String, options: TransitionOptions?) {
+    setPaintProperty(
+      property + TRANSITION_SUFFIX,
+      options?.scaledBy(style.animatorDurationScale)?.toTransitionJson() ?: CLEARED_TRANSITION,
+    )
+  }
+
+  override suspend fun getPaintTransition(property: String): TransitionOptions? =
+    getProperty(property + TRANSITION_SUFFIX)?.toTransitionOptions()
+
+  internal fun setRootProperty(name: String, value: JsonElement) {
+    if (name in FIXED_ROOT_PROPERTIES) {
+      throw StyleHandleException("'$name' is fixed for the generation of $type layer '$id'")
+    }
+    setProperty(name, value, LayerPropertyKind.ROOT)
+  }
+
+  internal fun clearFilter() {
+    setProperty("filter", JsonNull, LayerPropertyKind.ROOT)
+  }
+
+  private fun setProperty(name: String, value: JsonElement, kind: LayerPropertyKind) {
+    operation {
+      operations.requireLayerWritable(id)
+      style.setLayerProperties(listOf(LayerPropertyWrite(id, type, name, value, kind)))
+    }
+  }
+
+  override val asMutable: MutableLayerHandle?
+    get() = operation {
+      if (operations.isLayerWritable(id)) MutableLayerHandleImpl(this) else null
+    }
+
+  private fun requireCurrent() {
+    style.requireCurrent(identity)
+    check(isCurrentResource()) { "Layer '$id' is no longer the $type layer owned by this handle" }
+  }
+
+  private fun <T> operation(action: () -> T): T = operations.run {
+    requireCurrent()
+    action()
+  }
+
+  private suspend fun <T> suspendingOperation(action: suspend () -> T): T {
+    operation {}
+    val result = action()
+    operation {}
+    return result
+  }
+
+  private companion object {
+    val FIXED_ROOT_PROPERTIES = setOf("source", "source-layer")
+  }
+}
+
+internal fun StyleBinding.layerHandle(
+  id: String,
+  summary: LayerSummary,
+  isCurrentResource: () -> Boolean,
+  operations: StyleHandleOperationGuard,
+): LayerHandle {
+  requireCurrent()
+  return LayerHandleImpl(
+    id = id,
+    type = summary.type,
+    source = summary.source,
+    sourceLayer = summary.sourceLayer,
+    style = this,
+    isCurrentResource = isCurrentResource,
+    operations = operations,
+  )
+}
+
+private class MutableLayerHandleImpl(private val layer: LayerHandleImpl) :
+  MutableLayerHandle, LayerHandle by layer {
+  override fun setLayoutProperty(name: String, value: JsonElement) =
+    layer.setLayoutProperty(name, value)
+
+  override fun setPaintProperty(name: String, value: JsonElement) =
+    layer.setPaintProperty(name, value)
+
+  override fun setRootProperty(name: String, value: JsonElement) =
+    layer.setRootProperty(name, value)
+
+  override fun setPaintTransition(property: String, options: TransitionOptions?) =
+    layer.setPaintTransition(property, options)
+
+  override fun clearFilter() = layer.clearFilter()
+}

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
@@ -116,27 +116,27 @@ public interface MapRuntime {
   public val offlineManager: OfflineManager
 
   /**
-   * Creates a logical map with [initialBaseStyle] and the sources, layers, and images that
-   * [content] declares. The caller must close the result.
+   * Creates a logical map with [baseStyle] and the sources, layers, and images that [content]
+   * declares. The caller must close the result.
    *
    * [content] reads the returned state through [LocalMapState] and its viewport through
    * [LocalViewport].
    */
   public fun createMapState(
-    initialBaseStyle: BaseStyle,
-    initialCameraPosition: CameraPosition = CameraPosition(),
+    baseStyle: BaseStyle,
+    cameraPosition: CameraPosition = CameraPosition(),
     content: @Composable @MaplibreComposable () -> Unit = {},
   ): MapState
 
   /**
-   * Creates an independent non-UI map with [initialBaseStyle] and the sources, layers, and images
-   * that [content] declares, for image capture. The caller must close the result.
+   * Creates an independent non-UI map with [baseStyle] and the sources, layers, and images that
+   * [content] declares, for image capture. The caller must close the result.
    *
    * [content] reads the viewport of each capture request through [LocalViewport]. It has no
    * [MapState], so [LocalMapState] is null.
    */
   public fun createSnapshotter(
-    initialBaseStyle: BaseStyle,
+    baseStyle: BaseStyle,
     content: @Composable @MaplibreComposable () -> Unit = {},
   ): MapSnapshotter
 
@@ -206,15 +206,14 @@ internal interface MapStyleStateOwner {
 }
 
 /** Desired and applied style state for one logical map or snapshotter. */
-public class MapStyleState internal constructor(initialBaseStyle: BaseStyle) {
+public class MapStyleState internal constructor(baseStyle: BaseStyle) {
   private var owner: MapStyleStateOwner? = null
   private val loadedStyle = AtomicReference<StyleBinding?>(null)
   private var sourcesState: Map<String, SourceHandle> by
     mutableStateOf(emptyMap(), referentialEqualityPolicy())
   private var layersState: Map<String, LayerHandle> by
     mutableStateOf(emptyMap(), referentialEqualityPolicy())
-  private var baseStyleState: BaseStyle by
-    mutableStateOf(initialBaseStyle, structuralEqualityPolicy())
+  private var baseStyleState: BaseStyle by mutableStateOf(baseStyle, structuralEqualityPolicy())
 
   internal var baseStyleDeclared: Boolean = false
 
@@ -659,8 +658,8 @@ private class MapAttachmentChangedException :
 public class MapState
 internal constructor(
   internal val runtime: RuntimeImplementation,
-  initialCameraPosition: CameraPosition,
-  initialBaseStyle: BaseStyle,
+  cameraPosition: CameraPosition,
+  baseStyle: BaseStyle,
   content: @Composable @MaplibreComposable () -> Unit,
 ) {
   internal val styleContent: @Composable @MaplibreComposable () -> Unit = {
@@ -693,12 +692,12 @@ internal constructor(
     )
   private var closedState: Boolean by mutableStateOf(false)
   private var cameraPositionState: CameraPosition by
-    mutableStateOf(initialCameraPosition, structuralEqualityPolicy())
+    mutableStateOf(cameraPosition, structuralEqualityPolicy())
 
   internal var desiredStyleRevision: DesiredStyleRevision = DesiredStyleRevision.Empty
 
   public val style: MapStyleState =
-    MapStyleState(initialBaseStyle).also {
+    MapStyleState(baseStyle).also {
       it.attach(
         object : MapStyleStateOwner {
           override fun setBaseStyle(value: BaseStyle) = this@MapState.setBaseStyle(value)
@@ -1811,8 +1810,8 @@ public fun rememberMapState(
     rememberSaveable(runtime, saver = mapStateSaver(runtime, baseStyle, stableContent)) {
       runtime
         .createMapState(
-          initialBaseStyle = baseStyle,
-          initialCameraPosition = initialCameraPosition,
+          baseStyle = baseStyle,
+          cameraPosition = initialCameraPosition,
           content = stableContent,
         )
         .also { it.style.baseStyleDeclared = true }
@@ -1824,7 +1823,7 @@ public fun rememberMapState(
 
 private fun mapStateSaver(
   runtime: MapRuntime,
-  initialBaseStyle: BaseStyle,
+  baseStyle: BaseStyle,
   content: @Composable @MaplibreComposable () -> Unit,
 ): Saver<MapState, List<Double>> =
   Saver(
@@ -1837,8 +1836,8 @@ private fun mapStateSaver(
       require(values.size == 5) { "A saved camera position must contain five values" }
       runtime
         .createMapState(
-          initialBaseStyle = initialBaseStyle,
-          initialCameraPosition =
+          baseStyle = baseStyle,
+          cameraPosition =
             CameraPosition(
               bearing = values[0],
               target = Position(longitude = values[1], latitude = values[2]),
@@ -1875,20 +1874,20 @@ internal class RuntimeImplementation(
   private var closedState: Boolean by mutableStateOf(false)
 
   final override fun createMapState(
-    initialBaseStyle: BaseStyle,
-    initialCameraPosition: CameraPosition,
+    baseStyle: BaseStyle,
+    cameraPosition: CameraPosition,
     content: @Composable @MaplibreComposable () -> Unit,
   ): MapState = lock.withLock {
     requireOpenLocked()
-    MapState(this, initialCameraPosition, initialBaseStyle, content).also(children::add)
+    MapState(this, cameraPosition, baseStyle, content).also(children::add)
   }
 
   final override fun createSnapshotter(
-    initialBaseStyle: BaseStyle,
+    baseStyle: BaseStyle,
     content: @Composable @MaplibreComposable () -> Unit,
   ): MapSnapshotter = lock.withLock {
     requireOpenLocked()
-    MapSnapshotterImplementation(this, initialBaseStyle, content).also(snapshotters::add)
+    MapSnapshotterImplementation(this, baseStyle, content).also(snapshotters::add)
   }
 
   private fun requireOpen() {

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
@@ -1253,6 +1253,7 @@ internal constructor(
       if (binding.imageExists(id) == true) {
         throw StyleHandleException("Image ID '$id' already exists in style")
       }
+      binding.identity.images.remove(id)
       binding.addImage(id, image, sdf, stretch)
       val handle = lifecycle.serialized {
         requireStyleHandleLocked(binding)

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -176,17 +177,28 @@ internal interface MapStyleStateOwner {
 
   fun desiredSourceDefinition(id: String): org.maplibre.compose.style.SourceDefinition?
 
+  fun isSourceWritable(id: String): Boolean
+
+  fun isLayerWritable(id: String): Boolean
+
+  fun isImageWritable(id: String): Boolean
+
   fun requireSourceWritable(id: String)
 
   fun requireLayerWritable(id: String)
 
   fun addStyleSource(source: Source): SourceHandle
 
-  fun removeStyleSource(id: String): Boolean
+  fun removeStyleSource(id: String, expectedStyle: StyleBinding, identity: Any): Boolean
 
-  fun addStyleImage(id: String, image: ImageBitmap, sdf: Boolean, stretch: ImageStretch?)
+  fun addStyleImage(
+    id: String,
+    image: ImageBitmap,
+    sdf: Boolean,
+    stretch: ImageStretch?,
+  ): StyleImageHandle
 
-  fun removeStyleImage(id: String): Boolean
+  fun removeStyleImage(id: String, expectedStyle: StyleBinding, identity: Any): Boolean
 
   fun readyLoadedStyle(): StyleBinding?
 
@@ -204,14 +216,19 @@ public class MapStyleState internal constructor(initialBaseStyle: BaseStyle) {
   private var baseStyleState: BaseStyle by
     mutableStateOf(initialBaseStyle, structuralEqualityPolicy())
 
-  /**
-   * The current base style. Assigning a new value loads it and replaces generation-bound resources.
-   */
-  public var baseStyle: BaseStyle
+  internal var baseStyleDeclared: Boolean = false
+
+  /** The desired base style. A change replaces generation-bound resources. */
+  public val baseStyle: BaseStyle
     get() = baseStyleState
-    set(value) {
-      owner?.setBaseStyle(value) ?: setBaseStyleState(value)
-    }
+
+  /** Base-style commands, or null when [rememberMapState] owns the base style. */
+  public val asMutable: MutableMapStyleState?
+    get() = if (baseStyleDeclared) null else MutableMapStyleState(this)
+
+  internal fun updateBaseStyle(value: BaseStyle) {
+    owner?.setBaseStyle(value) ?: setBaseStyleState(value)
+  }
 
   public var loadState: StyleLoadState by mutableStateOf(StyleLoadState.Pending)
     internal set
@@ -310,7 +327,7 @@ public class MapStyleState internal constructor(initialBaseStyle: BaseStyle) {
     return layersState[id]
   }
 
-  private fun readyLoadedStyle(): StyleBinding? {
+  internal fun readyLoadedStyle(): StyleBinding? {
     if (loadState != StyleLoadState.Ready) return null
     // With an owner attached, its serialized check is the only authority: a plain fallback to the
     // stored reference could return a binding the owner has already moved to Loading.
@@ -420,10 +437,17 @@ public class MapStyleState internal constructor(initialBaseStyle: BaseStyle) {
   internal fun layerHandles(): Map<String, LayerHandle> =
     if (readyLoadedStyle() == null) emptyMap() else layersState
 
-  private fun operationGuard(style: StyleBinding): StyleHandleOperationGuard =
+  internal fun operationGuard(style: StyleBinding): StyleHandleOperationGuard =
     object : StyleHandleOperationGuard {
       override fun <T> run(action: () -> T): T =
         owner?.runStyleHandleOperation(style, action) ?: action()
+
+      override fun isSourceWritable(id: String): Boolean = owner?.isSourceWritable(id) == true
+
+      override fun isLayerWritable(id: String): Boolean = owner?.isLayerWritable(id) == true
+
+      override fun removeSource(id: String, identity: Any): Boolean =
+        requireOwner().removeStyleSource(id, style, identity)
 
       override fun requireSourceWritable(id: String) {
         owner?.requireSourceWritable(id)
@@ -682,6 +706,18 @@ internal constructor(
           override fun desiredSourceDefinition(id: String) =
             this@MapState.desiredSourceDefinition(id)
 
+          override fun isSourceWritable(id: String): Boolean = lifecycle.serialized {
+            desiredStyleRevision.sources.none { it.id == id }
+          }
+
+          override fun isLayerWritable(id: String): Boolean = lifecycle.serialized {
+            desiredStyleRevision.layers.none { it.definition.id == id }
+          }
+
+          override fun isImageWritable(id: String): Boolean = lifecycle.serialized {
+            desiredStyleRevision.images.none { it.id == id }
+          }
+
           override fun requireSourceWritable(id: String) = lifecycle.serialized {
             requireNoDesiredSource(id)
           }
@@ -694,7 +730,8 @@ internal constructor(
 
           override fun addStyleSource(source: Source) = this@MapState.addStyleSource(source)
 
-          override fun removeStyleSource(id: String) = this@MapState.removeStyleSource(id)
+          override fun removeStyleSource(id: String, expectedStyle: StyleBinding, identity: Any) =
+            this@MapState.removeStyleSource(id, expectedStyle, identity)
 
           override fun addStyleImage(
             id: String,
@@ -703,7 +740,8 @@ internal constructor(
             stretch: ImageStretch?,
           ) = this@MapState.addStyleImage(id, image, sdf, stretch)
 
-          override fun removeStyleImage(id: String) = this@MapState.removeStyleImage(id)
+          override fun removeStyleImage(id: String, expectedStyle: StyleBinding, identity: Any) =
+            this@MapState.removeStyleImage(id, expectedStyle, identity)
 
           override fun readyLoadedStyle() = this@MapState.readyLoadedStyle()
 
@@ -1160,10 +1198,14 @@ internal constructor(
     }
   }
 
-  internal fun removeStyleSource(id: String): Boolean {
+  internal fun removeStyleSource(id: String, expectedStyle: StyleBinding, identity: Any): Boolean {
     val reservation = StyleMutationReservation()
     val binding = lifecycle.serialized {
       requireOpenLocked()
+      requireStyleHandleLocked(expectedStyle)
+      check(expectedStyle.identity.sources.isCurrent(id, identity)) {
+        "Source '$id' has been removed or replaced"
+      }
       requireNoDesiredSource(id)
       requireNoActiveStyleMutation()
       checkNotNull(style.currentLoadedStyle()).also(::requireStyleHandleLocked).also {
@@ -1192,7 +1234,7 @@ internal constructor(
     image: ImageBitmap,
     sdf: Boolean,
     stretch: ImageStretch?,
-  ) {
+  ): StyleImageHandle {
     val record = ImperativeImageRecord(fromResolver = false)
     val reservation = StyleMutationReservation()
     val binding = lifecycle.serialized {
@@ -1213,8 +1255,12 @@ internal constructor(
         throw StyleHandleException("Image ID '$id' already exists in style")
       }
       binding.addImage(id, image, sdf, stretch)
-      lifecycle.serialized { requireStyleHandleLocked(binding) }
+      val handle = lifecycle.serialized {
+        requireStyleHandleLocked(binding)
+        StyleImageHandleImpl(id, style, binding)
+      }
       committed = true
+      return handle
     } catch (error: StyleMutationException) {
       throw StyleHandleException("Could not add image '$id': ${error.message}", error)
     } finally {
@@ -1336,6 +1382,8 @@ internal constructor(
     var committed = false
     try {
       if (binding.imageExists(imageId) == true) return
+      // An engine eviction ends the previous image identity, even when its ID is reused.
+      binding.identity.images.remove(imageId)
       binding.addImage(imageId, resolved.image, resolved.sdf, resolved.stretch)
       committed = lifecycle.serialized {
         !lifecycle.isClosed && style.isCurrentLoadedStyle(binding)
@@ -1366,10 +1414,14 @@ internal constructor(
     missingImageResolutions.clear()
   }
 
-  internal fun removeStyleImage(id: String): Boolean {
+  internal fun removeStyleImage(id: String, expectedStyle: StyleBinding, identity: Any): Boolean {
     val reservation = StyleMutationReservation()
     val binding = lifecycle.serialized {
       requireOpenLocked()
+      requireStyleHandleLocked(expectedStyle)
+      check(expectedStyle.identity.images.isCurrent(id, identity)) {
+        "Image '$id' has been removed or replaced"
+      }
       requireNoDesiredImage(id)
       requireNoActiveStyleMutation()
       checkNotNull(style.currentLoadedStyle()).also(::requireStyleHandleLocked).also {
@@ -1382,6 +1434,7 @@ internal constructor(
       lifecycle.serialized {
         requireStyleHandleLocked(binding)
         imperativeImages.remove(id)
+        binding.identity.images.remove(id)
       }
       return true
     } catch (error: StyleMutationException) {
@@ -1737,10 +1790,10 @@ internal class MapPresentationOwnerToken
 /**
  * Remembers a logical map and closes it when this call leaves composition.
  *
- * [initialBaseStyle] and [initialCameraPosition] seed the map. Changes to these inputs do not
- * update it; use [MapStyleState.baseStyle] and [MapState.setCameraPosition]. Changes to [content]
- * update the declared resources. Restoration creates a new map with the saved camera position and
- * the current [initialBaseStyle].
+ * [baseStyle] owns the map's base style and updates it on recomposition. Its
+ * [MapStyleState.asMutable] is null. [initialCameraPosition] only seeds the camera; use
+ * [MapState.setCameraPosition] to move it. Changes to [content] update the declared resources.
+ * Restoration creates a new map with the saved camera position and the current [baseStyle].
  *
  * [content] declares the map's sources, layers, and images. It reads the returned state through
  * [LocalMapState] and its viewport through [LocalViewport].
@@ -1748,20 +1801,23 @@ internal class MapPresentationOwnerToken
 @Composable
 public fun rememberMapState(
   runtime: MapRuntime = DefaultMapRuntime.instance,
-  initialBaseStyle: BaseStyle = BaseStyle.Demo,
+  baseStyle: BaseStyle = BaseStyle.Demo,
   initialCameraPosition: CameraPosition = CameraPosition(),
   content: @Composable @MaplibreComposable () -> Unit = {},
 ): MapState {
   val currentContent by rememberUpdatedState(content)
   val stableContent = remember<@Composable @MaplibreComposable () -> Unit> { { currentContent() } }
   val state =
-    rememberSaveable(runtime, saver = mapStateSaver(runtime, initialBaseStyle, stableContent)) {
-      runtime.createMapState(
-        initialBaseStyle = initialBaseStyle,
-        initialCameraPosition = initialCameraPosition,
-        content = stableContent,
-      )
+    rememberSaveable(runtime, saver = mapStateSaver(runtime, baseStyle, stableContent)) {
+      runtime
+        .createMapState(
+          initialBaseStyle = baseStyle,
+          initialCameraPosition = initialCameraPosition,
+          content = stableContent,
+        )
+        .also { it.style.baseStyleDeclared = true }
     }
+  SideEffect { state.style.updateBaseStyle(baseStyle) }
   DisposableEffect(state) { onDispose { state.close() } }
   return state
 }
@@ -1779,17 +1835,19 @@ private fun mapStateSaver(
     },
     restore = { values ->
       require(values.size == 5) { "A saved camera position must contain five values" }
-      runtime.createMapState(
-        initialBaseStyle = initialBaseStyle,
-        initialCameraPosition =
-          CameraPosition(
-            bearing = values[0],
-            target = Position(longitude = values[1], latitude = values[2]),
-            tilt = values[3],
-            zoom = values[4],
-          ),
-        content = content,
-      )
+      runtime
+        .createMapState(
+          initialBaseStyle = initialBaseStyle,
+          initialCameraPosition =
+            CameraPosition(
+              bearing = values[0],
+              target = Position(longitude = values[1], latitude = values[2]),
+              tilt = values[3],
+              zoom = values[4],
+            ),
+          content = content,
+        )
+        .also { it.style.baseStyleDeclared = true }
     },
   )
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapSnapshotter.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapSnapshotter.kt
@@ -246,6 +246,18 @@ internal class MapSnapshotterImplementation(
           override fun desiredSourceDefinition(id: String) =
             this@MapSnapshotterImplementation.desiredSourceDefinition(id)
 
+          override fun isSourceWritable(id: String): Boolean = lock.withLock {
+            desiredRevision.sources.none { it.id == id }
+          }
+
+          override fun isLayerWritable(id: String): Boolean = lock.withLock {
+            desiredRevision.layers.none { it.definition.id == id }
+          }
+
+          override fun isImageWritable(id: String): Boolean = lock.withLock {
+            desiredRevision.images.none { it.id == id }
+          }
+
           override fun requireSourceWritable(id: String) = lock.withLock {
             requireNoDesiredSource(id)
           }
@@ -259,8 +271,8 @@ internal class MapSnapshotterImplementation(
           override fun addStyleSource(source: Source) =
             this@MapSnapshotterImplementation.addStyleSource(source)
 
-          override fun removeStyleSource(id: String) =
-            this@MapSnapshotterImplementation.removeStyleSource(id)
+          override fun removeStyleSource(id: String, expectedStyle: StyleBinding, identity: Any) =
+            this@MapSnapshotterImplementation.removeStyleSource(id, expectedStyle, identity)
 
           override fun addStyleImage(
             id: String,
@@ -269,8 +281,8 @@ internal class MapSnapshotterImplementation(
             stretch: ImageStretch?,
           ) = this@MapSnapshotterImplementation.addStyleImage(id, image, sdf, stretch)
 
-          override fun removeStyleImage(id: String) =
-            this@MapSnapshotterImplementation.removeStyleImage(id)
+          override fun removeStyleImage(id: String, expectedStyle: StyleBinding, identity: Any) =
+            this@MapSnapshotterImplementation.removeStyleImage(id, expectedStyle, identity)
 
           override fun readyLoadedStyle() = this@MapSnapshotterImplementation.readyLoadedStyle()
 
@@ -540,10 +552,14 @@ internal class MapSnapshotterImplementation(
     }
   }
 
-  internal fun removeStyleSource(id: String): Boolean {
+  internal fun removeStyleSource(id: String, expectedStyle: StyleBinding, identity: Any): Boolean {
     val reservation = StyleMutationReservation()
     val binding = lock.withLock {
       requireOpenLocked()
+      requireStyleHandleLocked(expectedStyle)
+      check(expectedStyle.identity.sources.isCurrent(id, identity)) {
+        "Source '$id' has been removed or replaced"
+      }
       requireNoDesiredSource(id)
       requireNoActiveStyleOperation()
       checkNotNull(style.currentLoadedStyle()).also(::requireStyleHandleLocked).also {
@@ -572,7 +588,7 @@ internal class MapSnapshotterImplementation(
     image: ImageBitmap,
     sdf: Boolean,
     stretch: ImageStretch?,
-  ) {
+  ): StyleImageHandle {
     val record = ImperativeImageRecord()
     val reservation = StyleMutationReservation()
     val binding = lock.withLock {
@@ -593,8 +609,12 @@ internal class MapSnapshotterImplementation(
         throw StyleHandleException("Image ID '$id' already exists in style")
       }
       binding.addImage(id, image, sdf, stretch)
-      lock.withLock { requireStyleHandleLocked(binding) }
+      val handle = lock.withLock {
+        requireStyleHandleLocked(binding)
+        StyleImageHandleImpl(id, style, binding)
+      }
       committed = true
+      return handle
     } catch (error: StyleMutationException) {
       throw StyleHandleException("Could not add image '$id': ${error.message}", error)
     } finally {
@@ -605,10 +625,14 @@ internal class MapSnapshotterImplementation(
     }
   }
 
-  internal fun removeStyleImage(id: String): Boolean {
+  internal fun removeStyleImage(id: String, expectedStyle: StyleBinding, identity: Any): Boolean {
     val reservation = StyleMutationReservation()
     val binding = lock.withLock {
       requireOpenLocked()
+      requireStyleHandleLocked(expectedStyle)
+      check(expectedStyle.identity.images.isCurrent(id, identity)) {
+        "Image '$id' has been removed or replaced"
+      }
       requireNoDesiredImage(id)
       requireNoActiveStyleOperation()
       checkNotNull(style.currentLoadedStyle()).also(::requireStyleHandleLocked).also {
@@ -621,6 +645,7 @@ internal class MapSnapshotterImplementation(
       lock.withLock {
         requireStyleHandleLocked(binding)
         imperativeImages.remove(id)
+        binding.identity.images.remove(id)
       }
       return true
     } catch (error: StyleMutationException) {

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapSnapshotter.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapSnapshotter.kt
@@ -214,7 +214,7 @@ public interface MapSnapshotter {
 
 internal class MapSnapshotterImplementation(
   private val runtime: RuntimeImplementation,
-  initialBaseStyle: BaseStyle,
+  baseStyle: BaseStyle,
   private val styleContent: @Composable @MaplibreComposable () -> Unit,
 ) : MapSnapshotter {
   private val lock = reentrantLock()
@@ -237,7 +237,7 @@ internal class MapSnapshotterImplementation(
   private var desiredRevision = DesiredStyleRevision.Empty
 
   override val style: MapStyleState =
-    MapStyleState(initialBaseStyle).also {
+    MapStyleState(baseStyle).also {
       it.attach(
         object : MapStyleStateOwner {
           override fun setBaseStyle(value: BaseStyle) =

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapSnapshotter.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapSnapshotter.kt
@@ -608,6 +608,7 @@ internal class MapSnapshotterImplementation(
       if (binding.imageExists(id) == true) {
         throw StyleHandleException("Image ID '$id' already exists in style")
       }
+      binding.identity.images.remove(id)
       binding.addImage(id, image, sdf, stretch)
       val handle = lock.withLock {
         requireStyleHandleLocked(binding)

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapStyleResources.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapStyleResources.kt
@@ -12,6 +12,9 @@ import org.maplibre.compose.sources.GeoJsonSource
 import org.maplibre.compose.sources.GeoJsonSourceHandle
 import org.maplibre.compose.sources.ImageSource
 import org.maplibre.compose.sources.ImageSourceHandle
+import org.maplibre.compose.sources.MutableGeoJsonSourceHandle
+import org.maplibre.compose.sources.MutableImageSourceHandle
+import org.maplibre.compose.sources.MutableSourceHandle
 import org.maplibre.compose.sources.RasterDemTileSource
 import org.maplibre.compose.sources.RasterDemTileSourceHandle
 import org.maplibre.compose.sources.RasterTileSource
@@ -69,10 +72,16 @@ public class StyleSources internal constructor(private val style: MapStyleState)
     get(source.id) as? CustomVectorTileSourceHandle
 
   /** Adds [source] to the current loaded-style generation and returns its handle. */
-  public fun add(source: Source): SourceHandle = style.requireOwner().addStyleSource(source)
+  public fun add(source: Source): MutableSourceHandle =
+    checkNotNull(style.requireOwner().addStyleSource(source).asMutable)
 
-  /** Removes [id] from the current loaded-style generation and reports whether it existed. */
-  public fun remove(id: String): Boolean = style.requireOwner().removeStyleSource(id)
+  /** Adds a GeoJSON source and returns definition writes and removal for its generation. */
+  public fun add(source: GeoJsonSource): MutableGeoJsonSourceHandle =
+    checkNotNull((style.requireOwner().addStyleSource(source) as GeoJsonSourceHandle).asMutable)
+
+  /** Adds an image source and returns definition writes and removal for its generation. */
+  public fun add(source: ImageSource): MutableImageSourceHandle =
+    checkNotNull((style.requireOwner().addStyleSource(source) as ImageSourceHandle).asMutable)
 
   /** Iterates over the current loaded sources in engine style order. */
   override fun iterator(): Iterator<SourceHandle> = style.sourceHandles().values.iterator()
@@ -98,12 +107,18 @@ public class StyleImages internal constructor(private val style: MapStyleState) 
     image: ImageBitmap,
     sdf: Boolean = false,
     stretch: ImageStretch? = null,
-  ) {
-    style.requireOwner().addStyleImage(id, image, sdf, stretch)
+  ): MutableStyleImageHandle {
+    return checkNotNull(style.requireOwner().addStyleImage(id, image, sdf, stretch).asMutable)
   }
 
-  /** Removes [id] and reports whether it existed. */
-  public fun remove(id: String): Boolean = style.requireOwner().removeStyleImage(id)
+  /** Returns the image in the current loaded style, or null when absent or unavailable. */
+  public operator fun get(id: String): StyleImageHandle? {
+    val binding = style.readyLoadedStyle() ?: return null
+    return style.operationGuard(binding).run {
+      if (binding.imageExists(id) != true) return@run null
+      StyleImageHandleImpl(id, style, binding)
+    }
+  }
 }
 
 /**

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MutableMapStyleState.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MutableMapStyleState.kt
@@ -1,0 +1,17 @@
+package org.maplibre.compose.map
+
+import org.maplibre.compose.style.BaseStyle
+import org.maplibre.compose.style.StyleHandleException
+
+/** Base-style commands for a map or snapshotter created outside [rememberMapState]. */
+public class MutableMapStyleState internal constructor(private val style: MapStyleState) {
+  /** Loads a new base style and replaces the current generation's resources. */
+  public var baseStyle: BaseStyle
+    get() = style.baseStyle
+    set(value) {
+      if (style.baseStyleDeclared) {
+        throw StyleHandleException("The base style is declared by rememberMapState")
+      }
+      style.updateBaseStyle(value)
+    }
+}

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/StyleImageHandle.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/StyleImageHandle.kt
@@ -1,0 +1,51 @@
+package org.maplibre.compose.map
+
+import org.maplibre.compose.style.StyleBinding
+import org.maplibre.compose.style.StyleHandleException
+
+/** A style image in one loaded style generation. */
+public sealed interface StyleImageHandle {
+  public val id: String
+  /** Removal access, or null when composition owns this image. */
+  public val asMutable: MutableStyleImageHandle?
+}
+
+/** Permission to remove a style image. */
+public sealed interface MutableStyleImageHandle : StyleImageHandle {
+  /** Removes this image. Fails if this handle has expired. */
+  public fun remove(): Boolean
+}
+
+internal class StyleImageHandleImpl(
+  override val id: String,
+  private val style: MapStyleState,
+  private val binding: StyleBinding,
+) : StyleImageHandle {
+  private val identity = binding.identity.images.get(id)
+
+  override val asMutable: MutableStyleImageHandle?
+    get() = operation {
+      if (style.requireOwner().isImageWritable(id)) MutableStyleImageHandleImpl(this) else null
+    }
+
+  fun remove(): Boolean = operation {
+    if (!style.requireOwner().isImageWritable(id)) {
+      throw StyleHandleException("Image ID '$id' is declared by the style content")
+    }
+    style.requireOwner().removeStyleImage(id, binding, identity)
+  }
+
+  private fun <T> operation(action: () -> T): T =
+    style.operationGuard(binding).run {
+      binding.requireCurrent()
+      check(binding.identity.images.isCurrent(id, identity)) {
+        "Image '$id' has been removed or replaced"
+      }
+      action()
+    }
+}
+
+private class MutableStyleImageHandleImpl(private val image: StyleImageHandleImpl) :
+  MutableStyleImageHandle, StyleImageHandle by image {
+  override fun remove(): Boolean = image.remove()
+}

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/sources/GeoJsonSource.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/sources/GeoJsonSource.kt
@@ -130,10 +130,10 @@ public sealed interface GeoJsonData {
  * @param lineMetrics Whether to calculate line distance metrics. This is required for
  *   [LineLayer][org.maplibre.compose.layers.LineLayer]s that specify a `gradient`.
  * @param synchronousUpdate Whether native engines serialize, parse, index, and install inline data
- *   on the map's owner thread before source creation or [GeoJsonSourceHandle.setData] returns.
- *   Requested tiles are also generated during the update pass. This blocks the caller and can
- *   reduce frame rate; it does not wait for rendering. URL loading remains asynchronous. Android,
- *   iOS, and desktop honor this option. The browser ignores it.
+ *   on the map's owner thread before source creation or [MutableGeoJsonSourceHandle.setData]
+ *   returns. Requested tiles are also generated during the update pass. This blocks the caller and
+ *   can reduce frame rate; it does not wait for rendering. URL loading remains asynchronous.
+ *   Android, iOS, and desktop honor this option. The browser ignores it.
  */
 @Immutable
 public data class GeoJsonOptions(

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/sources/SourceHandle.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/sources/SourceHandle.kt
@@ -2,16 +2,10 @@ package org.maplibre.compose.sources
 
 import androidx.compose.ui.graphics.ImageBitmap
 import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.JsonPrimitive
 import org.maplibre.compose.expressions.ast.Expression
 import org.maplibre.compose.expressions.dsl.const
 import org.maplibre.compose.expressions.value.BooleanValue
-import org.maplibre.compose.style.SourceDefinition
-import org.maplibre.compose.style.StyleBinding
 import org.maplibre.compose.style.StyleHandleException
-import org.maplibre.compose.style.StyleHandleOperationGuard
-import org.maplibre.compose.style.StyleIdentity
-import org.maplibre.compose.style.StyleMutationException
 import org.maplibre.compose.util.PositionQuad
 import org.maplibre.spatialk.geojson.BoundingBox
 import org.maplibre.spatialk.geojson.Feature
@@ -19,95 +13,68 @@ import org.maplibre.spatialk.geojson.FeatureCollection
 import org.maplibre.spatialk.geojson.Geometry
 
 /**
- * Provides access to a source for one loaded base-style generation.
- *
- * A feature-state write does not wait for the engine to apply it. A state the engine rejects is
- * logged, and the feature keeps its previous state.
- *
- * Style content owns the definitions of declared sources: attempts to replace their data, image,
- * URI, or bounds throw [StyleHandleException]. Feature state, queries, and invalidation remain
- * available. Base-style sources and sources added through
- * [org.maplibre.compose.map.StyleSources.add] also permit definition writes.
+ * Access to a source in one loaded style generation. Feature state and invalidation remain
+ * available when composition owns the source definition. Handles expire on removal, replacement, or
+ * a base-style reload. A feature-state write does not wait for the engine; rejected writes are
+ * logged and retain the previous state.
  */
-public sealed class SourceHandle
-protected constructor(
-  public val id: String,
+public sealed interface SourceHandle {
+  public val id: String
   /**
-   * The source attribution when this handle was created. A source whose attribution arrives later,
-   * such as from a TileJSON document, is published again as a new handle.
+   * Attribution captured when this handle was published. Attribution loaded later from TileJSON is
+   * published as a new handle.
    */
-  public val attributionHtml: String,
-  internal val style: StyleBinding,
-  private val expectedKind: String?,
-  private val currentKind: () -> String?,
-  private val operations: StyleHandleOperationGuard,
-) {
-  private val identity: StyleIdentity = style.identity
-
-  private fun requireCurrent() {
-    style.requireCurrent(identity)
-    val actualKind = currentKind()
-    check(actualKind != null && (expectedKind == null || actualKind == expectedKind)) {
-      "Source '$id' is no longer the $expectedKind source owned by this handle"
-    }
-  }
-
-  protected fun writeFeatureState(sourceLayerId: String?, featureId: String, state: JsonObject) {
-    operation { style.setFeatureState(id, sourceLayerId, featureId, state) }
-  }
-
-  protected suspend fun readFeatureState(sourceLayerId: String?, featureId: String): JsonObject {
-    return suspendingOperation { style.featureState(id, sourceLayerId, featureId) }
-  }
-
-  protected fun clearFeatureState(
-    sourceLayerId: String?,
-    featureId: String,
-    stateKey: String?,
-  ) {
-    operation { style.removeFeatureState(id, sourceLayerId, featureId, stateKey) }
-  }
-
-  protected fun clearFeatureStates(sourceLayerId: String?) {
-    operation { style.resetFeatureStates(id, sourceLayerId) }
-  }
-
-  internal fun <T> operation(action: () -> T): T = operations.run {
-    requireCurrent()
-    action()
-  }
-
-  protected fun definitionOperation(action: () -> Unit): Unit = operation {
-    operations.requireSourceWritable(id)
-    action()
-  }
-
-  protected suspend fun <T> suspendingOperation(action: suspend () -> T): T {
-    operation {}
-    val result = action()
-    operation {}
-    return result
-  }
+  public val attributionHtml: String
+  /**
+   * Mutation access to this source, or null when composition owns its definition. Access fails when
+   * this handle has expired. The view retains this handle's identity and grants no ownership.
+   */
+  public val asMutable: MutableSourceHandle?
 }
 
-/** Provides imperative access to a GeoJSON source for one loaded base-style generation. */
-public class GeoJsonSourceHandle
-internal constructor(
-  id: String,
-  attributionHtml: String,
-  style: StyleBinding,
-  private val options: GeoJsonOptions,
-  currentKind: () -> String?,
-  operations: StyleHandleOperationGuard,
-) :
-  SourceHandle(
-    id,
-    attributionHtml,
-    style,
-    expectedKind = "geojson",
-    currentKind = currentKind,
-    operations = operations,
-  ) {
+/** Permission to remove a source in its loaded style generation. */
+public sealed interface MutableSourceHandle : SourceHandle {
+  /** Removes this source. Fails if the handle expired or a layer still references the source. */
+  public fun remove(): Boolean
+}
+
+/** Access to a GeoJSON source in one loaded style generation. */
+public sealed interface GeoJsonSourceHandle : SourceHandle {
+  override val asMutable: MutableGeoJsonSourceHandle?
+
+  /** Returns true if [feature] represents a cluster created by this source. */
+  public fun isCluster(feature: Feature<*, JsonObject?>): Boolean
+
+  /** Returns the cluster expansion zoom for [feature], or zero if [feature] is not a cluster. */
+  public suspend fun getClusterExpansionZoom(feature: Feature<*, JsonObject?>): Double
+
+  /** Returns the cluster children for [feature], or an empty collection for a non-cluster. */
+  public suspend fun getClusterChildren(
+    feature: Feature<*, JsonObject?>
+  ): FeatureCollection<Geometry, JsonObject?>
+
+  /** Returns the cluster leaves for [feature], or an empty collection for a non-cluster. */
+  public suspend fun getClusterLeaves(
+    feature: Feature<*, JsonObject?>,
+    limit: Long,
+    offset: Long,
+  ): FeatureCollection<Geometry, JsonObject?>
+
+  /** Merges [state] into the runtime state of the feature identified by [featureId]. */
+  public fun setFeatureState(featureId: String, state: JsonObject): Unit
+
+  /** Returns the runtime state of the feature identified by [featureId]. */
+  public suspend fun getFeatureState(featureId: String): JsonObject
+
+  /** Removes [stateKey], or every state key when [stateKey] is null. */
+  public fun removeFeatureState(featureId: String, stateKey: String? = null): Unit
+
+  /** Removes runtime state from every feature in this source. */
+  public fun resetFeatureStates(): Unit
+}
+
+/** Definition writes and removal for a GeoJSON source. */
+public sealed interface MutableGeoJsonSourceHandle : GeoJsonSourceHandle, MutableSourceHandle {
   /**
    * Submits [data] to replace the source data for this loaded style.
    *
@@ -128,79 +95,11 @@ internal constructor(
    * @throws StyleHandleException if style content declares this source, or submission or
    *   synchronous preparation or installation fails.
    */
-  public fun setData(data: GeoJsonData) {
-    definitionOperation {
-      mutate("set data") { style.submitGeoJsonData(id, data, options) }
-    }
-  }
-
-  /** Returns true if [feature] represents a cluster created by this source. */
-  public fun isCluster(feature: Feature<*, JsonObject?>): Boolean =
-    CLUSTER_ID_PROPERTY in feature.properties.orEmpty()
-
-  /** Returns the cluster expansion zoom for [feature], or zero if [feature] is not a cluster. */
-  public suspend fun getClusterExpansionZoom(feature: Feature<*, JsonObject?>): Double =
-    suspendingOperation {
-      style.clusterExpansionZoom(id, feature) ?: 0.0
-    }
-
-  /** Returns the cluster children for [feature], or an empty collection for a non-cluster. */
-  public suspend fun getClusterChildren(
-    feature: Feature<*, JsonObject?>
-  ): FeatureCollection<Geometry, JsonObject?> = suspendingOperation {
-    style.clusterChildren(id, feature) ?: FeatureCollection(emptyList())
-  }
-
-  /** Returns the cluster leaves for [feature], or an empty collection for a non-cluster. */
-  public suspend fun getClusterLeaves(
-    feature: Feature<*, JsonObject?>,
-    limit: Long,
-    offset: Long,
-  ): FeatureCollection<Geometry, JsonObject?> = suspendingOperation {
-    style.clusterLeaves(id, feature, limit, offset) ?: FeatureCollection(emptyList())
-  }
-
-  /** Merges [state] into the runtime state of the feature identified by [featureId]. */
-  public fun setFeatureState(featureId: String, state: JsonObject) {
-    writeFeatureState(sourceLayerId = null, featureId, state)
-  }
-
-  /** Returns the runtime state of the feature identified by [featureId]. */
-  public suspend fun getFeatureState(featureId: String): JsonObject =
-    readFeatureState(sourceLayerId = null, featureId)
-
-  /** Removes [stateKey], or every state key when [stateKey] is null. */
-  public fun removeFeatureState(featureId: String, stateKey: String? = null) {
-    clearFeatureState(sourceLayerId = null, featureId, stateKey)
-  }
-
-  /** Removes runtime state from every feature in this source. */
-  public fun resetFeatureStates() {
-    clearFeatureStates(sourceLayerId = null)
-  }
-
-  private inline fun mutate(operation: String, action: () -> Unit) {
-    try {
-      action()
-    } catch (error: StyleMutationException) {
-      throw StyleHandleException(
-        "Could not $operation on GeoJSON source '$id': ${error.message}",
-        error,
-      )
-    }
-  }
+  public fun setData(data: GeoJsonData): Unit
 }
 
-/** Provides imperative access to a vector source for one loaded base-style generation. */
-public open class VectorTileSourceHandle
-internal constructor(
-  id: String,
-  attributionHtml: String,
-  style: StyleBinding,
-  expectedKind: String = "vector",
-  currentKind: () -> String?,
-  operations: StyleHandleOperationGuard,
-) : SourceHandle(id, attributionHtml, style, expectedKind, currentKind, operations) {
+/** Access to a vector tile source in one loaded style generation. */
+public sealed interface VectorTileSourceHandle : SourceHandle {
   /**
    * Returns loaded features from [sourceLayerIds] that match [predicate]. The result is empty
    * before the map has rendered.
@@ -208,200 +107,71 @@ internal constructor(
   public suspend fun querySourceFeatures(
     sourceLayerIds: Set<String>,
     predicate: Expression<BooleanValue> = const(true),
-  ): List<Feature<Geometry, JsonObject?>> {
-    return suspendingOperation {
-      style.querySourceFeatures(id, sourceLayerIds, predicate.toFilterJson())
-    }
-  }
+  ): List<Feature<Geometry, JsonObject?>>
 
   /** Merges [state] into the runtime state of one feature. */
-  public fun setFeatureState(sourceLayerId: String, featureId: String, state: JsonObject) {
-    writeFeatureState(sourceLayerId, featureId, state)
-  }
+  public fun setFeatureState(sourceLayerId: String, featureId: String, state: JsonObject): Unit
 
   /** Returns the runtime state of one feature. */
-  public suspend fun getFeatureState(sourceLayerId: String, featureId: String): JsonObject =
-    readFeatureState(sourceLayerId, featureId)
+  public suspend fun getFeatureState(sourceLayerId: String, featureId: String): JsonObject
 
   /** Removes [stateKey], or every state key when [stateKey] is null. */
   public fun removeFeatureState(
     sourceLayerId: String,
     featureId: String,
     stateKey: String? = null,
-  ) {
-    clearFeatureState(sourceLayerId, featureId, stateKey)
-  }
+  ): Unit
 
   /** Removes runtime state from every feature in [sourceLayerId]. */
-  public fun resetFeatureStates(sourceLayerId: String) {
-    clearFeatureStates(sourceLayerId)
-  }
+  public fun resetFeatureStates(sourceLayerId: String): Unit
 }
 
-/** Provides imperative access to an application-supplied vector source. */
-public class CustomVectorTileSourceHandle
-internal constructor(
-  id: String,
-  attributionHtml: String,
-  style: StyleBinding,
-  currentKind: () -> String?,
-  operations: StyleHandleOperationGuard,
-) :
-  VectorTileSourceHandle(
-    id,
-    attributionHtml,
-    style,
-    expectedKind = "custom-vector",
-    currentKind = currentKind,
-    operations = operations,
-  ) {
+/** Access to a custom vector tile source in one loaded style generation. */
+public sealed interface CustomVectorTileSourceHandle : VectorTileSourceHandle {
   /** Requests new data for [tile]. */
-  public fun invalidateTile(tile: TileCoordinate) {
-    operation { style.invalidateCustomVectorSourceTile(id, tile) }
-  }
+  public fun invalidateTile(tile: TileCoordinate): Unit
 }
 
-/** Provides imperative access to an application-supplied geometry source. */
-public class CustomGeometrySourceHandle
-internal constructor(
-  id: String,
-  attributionHtml: String,
-  style: StyleBinding,
-  currentKind: () -> String?,
-  operations: StyleHandleOperationGuard,
-) : SourceHandle(id, attributionHtml, style, "custom-geometry", currentKind, operations) {
+/** Access to a custom geometry source in one loaded style generation. */
+public sealed interface CustomGeometrySourceHandle : SourceHandle {
   /** Requests new features for tiles that intersect [bounds]. */
-  public fun invalidateBounds(bounds: BoundingBox) {
-    operation { style.invalidateCustomGeometrySourceBounds(id, bounds) }
-  }
+  public fun invalidateBounds(bounds: BoundingBox): Unit
 
   /** Requests new features for [tile]. */
-  public fun invalidateTile(tile: TileCoordinate) {
-    operation { style.invalidateCustomGeometrySourceTile(id, tile) }
-  }
+  public fun invalidateTile(tile: TileCoordinate): Unit
 }
 
-/** Provides imperative access to an image source for one loaded base-style generation. */
-public class ImageSourceHandle
-internal constructor(
-  id: String,
-  attributionHtml: String,
-  style: StyleBinding,
-  currentKind: () -> String?,
-  operations: StyleHandleOperationGuard,
-) : SourceHandle(id, attributionHtml, style, "image", currentKind, operations) {
+/** Access to an image source in one loaded style generation. */
+public sealed interface ImageSourceHandle : SourceHandle {
+  override val asMutable: MutableImageSourceHandle?
+}
+
+/** Definition writes and removal for an image source. */
+public sealed interface MutableImageSourceHandle : ImageSourceHandle, MutableSourceHandle {
   /**
    * Updates the geographic corners of the image.
    *
    * @throws StyleHandleException if style content declares this source.
    */
-  public fun setBounds(bounds: PositionQuad) {
-    definitionOperation {
-      style.setImageSourceCoordinates(
-        id,
-        listOf(bounds.topLeft, bounds.topRight, bounds.bottomRight, bounds.bottomLeft),
-      )
-    }
-  }
+  public fun setBounds(bounds: PositionQuad): Unit
 
   /**
    * Replaces the source image with [image].
    *
    * @throws StyleHandleException if style content declares this source.
    */
-  public fun setImage(image: ImageBitmap) {
-    definitionOperation { style.setImageSourceImage(id, image) }
-  }
+  public fun setImage(image: ImageBitmap): Unit
 
   /**
    * Replaces the source image URI with [uri].
    *
    * @throws StyleHandleException if style content declares this source.
    */
-  public fun setUri(uri: String) {
-    definitionOperation { style.setImageSourceUrl(id, uri) }
-  }
+  public fun setUri(uri: String): Unit
 }
 
-/** Provides imperative access to a raster source for one loaded base-style generation. */
-public class RasterTileSourceHandle
-internal constructor(
-  id: String,
-  attributionHtml: String,
-  style: StyleBinding,
-  currentKind: () -> String?,
-  operations: StyleHandleOperationGuard,
-) : SourceHandle(id, attributionHtml, style, "raster", currentKind, operations)
+/** Access to a raster tile source in one loaded style generation. */
+public sealed interface RasterTileSourceHandle : SourceHandle {}
 
-/** Provides imperative access to a raster DEM source for one loaded base-style generation. */
-public class RasterDemTileSourceHandle
-internal constructor(
-  id: String,
-  attributionHtml: String,
-  style: StyleBinding,
-  currentKind: () -> String?,
-  operations: StyleHandleOperationGuard,
-) : SourceHandle(id, attributionHtml, style, "raster-dem", currentKind, operations)
-
-internal fun StyleBinding.sourceHandle(
-  id: String,
-  definition: SourceDefinition?,
-  currentDefinition: () -> SourceDefinition?,
-  isCurrentResource: () -> Boolean,
-  operations: StyleHandleOperationGuard,
-): SourceHandle? {
-  requireCurrent()
-  if (sourceExists(id) != true) return null
-  val source = getSource(id)
-  val kind = sourceKind(definition, source) ?: return null
-  val attribution = source?.attributionHtml.orEmpty()
-  val composed = definition != null
-  // The identity check covers replacement under the same ID, so the kind check needs no engine
-  // read: a composed source's kind follows its desired definition, and any other source keeps the
-  // kind it was created with.
-  val currentKind = currentKind@{
-    if (!isCurrentResource()) return@currentKind null
-    if (!composed) return@currentKind kind
-    currentDefinition()?.let { sourceKind(it, null) ?: kind }
-  }
-  return when (kind) {
-    "geojson" ->
-      GeoJsonSourceHandle(
-        id,
-        attribution,
-        this,
-        (definition as? SourceDefinition.GeoJson)?.options ?: GeoJsonOptions(),
-        currentKind,
-        operations,
-      )
-    "custom-vector" -> CustomVectorTileSourceHandle(id, attribution, this, currentKind, operations)
-    "custom-geometry" -> CustomGeometrySourceHandle(id, attribution, this, currentKind, operations)
-    "image" -> ImageSourceHandle(id, attribution, this, currentKind, operations)
-    "raster" -> RasterTileSourceHandle(id, attribution, this, currentKind, operations)
-    "raster-dem" -> RasterDemTileSourceHandle(id, attribution, this, currentKind, operations)
-    "vector" ->
-      VectorTileSourceHandle(
-        id,
-        attribution,
-        this,
-        currentKind = currentKind,
-        operations = operations,
-      )
-    else -> null
-  }
-}
-
-/**
- * The style-spec type of a source, from its definition when the definition states one and from the
- * engine's [source] otherwise. Null when neither does.
- */
-private fun sourceKind(definition: SourceDefinition?, source: Source?): String? =
-  when (definition) {
-    is SourceDefinition.CustomGeometry -> "custom-geometry"
-    is SourceDefinition.CustomVector -> "custom-vector"
-    is SourceDefinition.GeoJson -> "geojson"
-    is SourceDefinition.Image -> "image"
-    is SourceDefinition.RasterDem -> "raster-dem"
-    is SourceDefinition.Json -> (definition.value["type"] as? JsonPrimitive)?.content
-    null -> (source?.toJson()?.get("type") as? JsonPrimitive)?.content
-  }
+/** Access to a raster DEM tile source in one loaded style generation. */
+public sealed interface RasterDemTileSourceHandle : SourceHandle {}

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/sources/SourceHandleImpl.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/sources/SourceHandleImpl.kt
@@ -1,0 +1,425 @@
+package org.maplibre.compose.sources
+
+import androidx.compose.ui.graphics.ImageBitmap
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import org.maplibre.compose.expressions.ast.Expression
+import org.maplibre.compose.expressions.value.BooleanValue
+import org.maplibre.compose.style.SourceDefinition
+import org.maplibre.compose.style.StyleBinding
+import org.maplibre.compose.style.StyleHandleException
+import org.maplibre.compose.style.StyleHandleOperationGuard
+import org.maplibre.compose.style.StyleIdentity
+import org.maplibre.compose.style.StyleMutationException
+import org.maplibre.compose.util.PositionQuad
+import org.maplibre.spatialk.geojson.BoundingBox
+import org.maplibre.spatialk.geojson.Feature
+import org.maplibre.spatialk.geojson.FeatureCollection
+import org.maplibre.spatialk.geojson.Geometry
+
+internal sealed class SourceHandleImpl
+protected constructor(
+  final override val id: String,
+  final override val attributionHtml: String,
+  internal val style: StyleBinding,
+  private val expectedKind: String?,
+  private val currentKind: () -> String?,
+  private val operations: StyleHandleOperationGuard,
+) : SourceHandle {
+  private val identity: StyleIdentity = style.identity
+  private val resourceIdentity = style.identity.sources.get(id)
+
+  override val asMutable: MutableSourceHandle?
+    get() = operation {
+      if (operations.isSourceWritable(id)) mutableView() else null
+    }
+
+  private fun mutableView(): MutableSourceHandle =
+    when (this) {
+      is GeoJsonSourceHandleImpl -> MutableGeoJsonSourceHandleImpl(this)
+      is ImageSourceHandleImpl -> MutableImageSourceHandleImpl(this)
+      is CustomVectorTileSourceHandleImpl -> MutableCustomVectorTileSourceHandleImpl(this)
+      is CustomGeometrySourceHandleImpl -> MutableCustomGeometrySourceHandleImpl(this)
+      is VectorTileSourceHandleImpl -> MutableVectorTileSourceHandleImpl(this)
+      is RasterTileSourceHandleImpl -> MutableRasterTileSourceHandleImpl(this)
+      is RasterDemTileSourceHandleImpl -> MutableRasterDemTileSourceHandleImpl(this)
+    }
+
+  internal fun remove(): Boolean = operation {
+    operations.requireSourceWritable(id)
+    operations.removeSource(id, resourceIdentity)
+  }
+
+  private fun requireCurrent() {
+    style.requireCurrent(identity)
+    val actualKind = currentKind()
+    check(actualKind != null && (expectedKind == null || actualKind == expectedKind)) {
+      "Source '$id' is no longer the $expectedKind source owned by this handle"
+    }
+  }
+
+  protected fun writeFeatureState(sourceLayerId: String?, featureId: String, state: JsonObject) {
+    operation { style.setFeatureState(id, sourceLayerId, featureId, state) }
+  }
+
+  protected suspend fun readFeatureState(sourceLayerId: String?, featureId: String): JsonObject {
+    return suspendingOperation { style.featureState(id, sourceLayerId, featureId) }
+  }
+
+  protected fun clearFeatureState(
+    sourceLayerId: String?,
+    featureId: String,
+    stateKey: String?,
+  ) {
+    operation { style.removeFeatureState(id, sourceLayerId, featureId, stateKey) }
+  }
+
+  protected fun clearFeatureStates(sourceLayerId: String?) {
+    operation { style.resetFeatureStates(id, sourceLayerId) }
+  }
+
+  internal fun <T> operation(action: () -> T): T = operations.run {
+    requireCurrent()
+    action()
+  }
+
+  internal fun definitionOperation(action: () -> Unit): Unit = operation {
+    operations.requireSourceWritable(id)
+    action()
+  }
+
+  protected suspend fun <T> suspendingOperation(action: suspend () -> T): T {
+    operation {}
+    val result = action()
+    operation {}
+    return result
+  }
+}
+
+internal class GeoJsonSourceHandleImpl
+internal constructor(
+  id: String,
+  attributionHtml: String,
+  style: StyleBinding,
+  private val options: GeoJsonOptions,
+  currentKind: () -> String?,
+  operations: StyleHandleOperationGuard,
+) :
+  SourceHandleImpl(
+    id,
+    attributionHtml,
+    style,
+    expectedKind = "geojson",
+    currentKind = currentKind,
+    operations = operations,
+  ),
+  GeoJsonSourceHandle {
+  override val asMutable: MutableGeoJsonSourceHandle?
+    get() = super.asMutable as? MutableGeoJsonSourceHandle
+
+  internal fun setData(data: GeoJsonData) {
+    definitionOperation {
+      mutate("set data") { style.submitGeoJsonData(id, data, options) }
+    }
+  }
+
+  override fun isCluster(feature: Feature<*, JsonObject?>): Boolean =
+    CLUSTER_ID_PROPERTY in feature.properties.orEmpty()
+
+  override suspend fun getClusterExpansionZoom(feature: Feature<*, JsonObject?>): Double =
+    suspendingOperation {
+      style.clusterExpansionZoom(id, feature) ?: 0.0
+    }
+
+  override suspend fun getClusterChildren(
+    feature: Feature<*, JsonObject?>
+  ): FeatureCollection<Geometry, JsonObject?> = suspendingOperation {
+    style.clusterChildren(id, feature) ?: FeatureCollection(emptyList())
+  }
+
+  override suspend fun getClusterLeaves(
+    feature: Feature<*, JsonObject?>,
+    limit: Long,
+    offset: Long,
+  ): FeatureCollection<Geometry, JsonObject?> = suspendingOperation {
+    style.clusterLeaves(id, feature, limit, offset) ?: FeatureCollection(emptyList())
+  }
+
+  override fun setFeatureState(featureId: String, state: JsonObject) {
+    writeFeatureState(sourceLayerId = null, featureId, state)
+  }
+
+  override suspend fun getFeatureState(featureId: String): JsonObject =
+    readFeatureState(sourceLayerId = null, featureId)
+
+  override fun removeFeatureState(featureId: String, stateKey: String?) {
+    clearFeatureState(sourceLayerId = null, featureId, stateKey)
+  }
+
+  override fun resetFeatureStates() {
+    clearFeatureStates(sourceLayerId = null)
+  }
+
+  private inline fun mutate(operation: String, action: () -> Unit) {
+    try {
+      action()
+    } catch (error: StyleMutationException) {
+      throw StyleHandleException(
+        "Could not $operation on GeoJSON source '$id': ${error.message}",
+        error,
+      )
+    }
+  }
+}
+
+internal open class VectorTileSourceHandleImpl
+internal constructor(
+  id: String,
+  attributionHtml: String,
+  style: StyleBinding,
+  expectedKind: String = "vector",
+  currentKind: () -> String?,
+  operations: StyleHandleOperationGuard,
+) :
+  SourceHandleImpl(id, attributionHtml, style, expectedKind, currentKind, operations),
+  VectorTileSourceHandle {
+  override suspend fun querySourceFeatures(
+    sourceLayerIds: Set<String>,
+    predicate: Expression<BooleanValue>,
+  ): List<Feature<Geometry, JsonObject?>> {
+    return suspendingOperation {
+      style.querySourceFeatures(id, sourceLayerIds, predicate.toFilterJson())
+    }
+  }
+
+  override fun setFeatureState(sourceLayerId: String, featureId: String, state: JsonObject) {
+    writeFeatureState(sourceLayerId, featureId, state)
+  }
+
+  override suspend fun getFeatureState(sourceLayerId: String, featureId: String): JsonObject =
+    readFeatureState(sourceLayerId, featureId)
+
+  override fun removeFeatureState(
+    sourceLayerId: String,
+    featureId: String,
+    stateKey: String?,
+  ) {
+    clearFeatureState(sourceLayerId, featureId, stateKey)
+  }
+
+  override fun resetFeatureStates(sourceLayerId: String) {
+    clearFeatureStates(sourceLayerId)
+  }
+}
+
+internal class CustomVectorTileSourceHandleImpl
+internal constructor(
+  id: String,
+  attributionHtml: String,
+  style: StyleBinding,
+  currentKind: () -> String?,
+  operations: StyleHandleOperationGuard,
+) :
+  VectorTileSourceHandleImpl(
+    id,
+    attributionHtml,
+    style,
+    expectedKind = "custom-vector",
+    currentKind = currentKind,
+    operations = operations,
+  ),
+  CustomVectorTileSourceHandle {
+  override fun invalidateTile(tile: TileCoordinate) {
+    operation { style.invalidateCustomVectorSourceTile(id, tile) }
+  }
+}
+
+internal class CustomGeometrySourceHandleImpl
+internal constructor(
+  id: String,
+  attributionHtml: String,
+  style: StyleBinding,
+  currentKind: () -> String?,
+  operations: StyleHandleOperationGuard,
+) :
+  SourceHandleImpl(id, attributionHtml, style, "custom-geometry", currentKind, operations),
+  CustomGeometrySourceHandle {
+  override fun invalidateBounds(bounds: BoundingBox) {
+    operation { style.invalidateCustomGeometrySourceBounds(id, bounds) }
+  }
+
+  override fun invalidateTile(tile: TileCoordinate) {
+    operation { style.invalidateCustomGeometrySourceTile(id, tile) }
+  }
+}
+
+internal class ImageSourceHandleImpl
+internal constructor(
+  id: String,
+  attributionHtml: String,
+  style: StyleBinding,
+  currentKind: () -> String?,
+  operations: StyleHandleOperationGuard,
+) :
+  SourceHandleImpl(id, attributionHtml, style, "image", currentKind, operations),
+  ImageSourceHandle {
+  override val asMutable: MutableImageSourceHandle?
+    get() = super.asMutable as? MutableImageSourceHandle
+
+  internal fun setBounds(bounds: PositionQuad) {
+    definitionOperation {
+      style.setImageSourceCoordinates(
+        id,
+        listOf(bounds.topLeft, bounds.topRight, bounds.bottomRight, bounds.bottomLeft),
+      )
+    }
+  }
+
+  internal fun setImage(image: ImageBitmap) {
+    definitionOperation { style.setImageSourceImage(id, image) }
+  }
+
+  internal fun setUri(uri: String) {
+    definitionOperation { style.setImageSourceUrl(id, uri) }
+  }
+}
+
+internal class RasterTileSourceHandleImpl
+internal constructor(
+  id: String,
+  attributionHtml: String,
+  style: StyleBinding,
+  currentKind: () -> String?,
+  operations: StyleHandleOperationGuard,
+) :
+  SourceHandleImpl(id, attributionHtml, style, "raster", currentKind, operations),
+  RasterTileSourceHandle
+
+internal class RasterDemTileSourceHandleImpl
+internal constructor(
+  id: String,
+  attributionHtml: String,
+  style: StyleBinding,
+  currentKind: () -> String?,
+  operations: StyleHandleOperationGuard,
+) :
+  SourceHandleImpl(id, attributionHtml, style, "raster-dem", currentKind, operations),
+  RasterDemTileSourceHandle
+
+internal fun StyleBinding.sourceHandle(
+  id: String,
+  definition: SourceDefinition?,
+  currentDefinition: () -> SourceDefinition?,
+  isCurrentResource: () -> Boolean,
+  operations: StyleHandleOperationGuard,
+): SourceHandle? {
+  requireCurrent()
+  if (sourceExists(id) != true) return null
+  val source = getSource(id)
+  val kind = sourceKind(definition, source) ?: return null
+  val attribution = source?.attributionHtml.orEmpty()
+  val composed = definition != null
+  // The identity check covers replacement under the same ID, so the kind check needs no engine
+  // read: a composed source's kind follows its desired definition, and any other source keeps the
+  // kind it was created with.
+  val currentKind = currentKind@{
+    if (!isCurrentResource()) return@currentKind null
+    if (!composed) return@currentKind kind
+    currentDefinition()?.let { sourceKind(it, null) ?: kind }
+  }
+  return when (kind) {
+    "geojson" ->
+      GeoJsonSourceHandleImpl(
+        id,
+        attribution,
+        this,
+        (definition as? SourceDefinition.GeoJson)?.options ?: GeoJsonOptions(),
+        currentKind,
+        operations,
+      )
+    "custom-vector" ->
+      CustomVectorTileSourceHandleImpl(id, attribution, this, currentKind, operations)
+    "custom-geometry" ->
+      CustomGeometrySourceHandleImpl(id, attribution, this, currentKind, operations)
+    "image" -> ImageSourceHandleImpl(id, attribution, this, currentKind, operations)
+    "raster" -> RasterTileSourceHandleImpl(id, attribution, this, currentKind, operations)
+    "raster-dem" -> RasterDemTileSourceHandleImpl(id, attribution, this, currentKind, operations)
+    "vector" ->
+      VectorTileSourceHandleImpl(
+        id,
+        attribution,
+        this,
+        currentKind = currentKind,
+        operations = operations,
+      )
+    else -> null
+  }
+}
+
+private fun sourceKind(definition: SourceDefinition?, source: Source?): String? =
+  when (definition) {
+    is SourceDefinition.CustomGeometry -> "custom-geometry"
+    is SourceDefinition.CustomVector -> "custom-vector"
+    is SourceDefinition.GeoJson -> "geojson"
+    is SourceDefinition.Image -> "image"
+    is SourceDefinition.RasterDem -> "raster-dem"
+    is SourceDefinition.Json -> (definition.value["type"] as? JsonPrimitive)?.content
+    null -> (source?.toJson()?.get("type") as? JsonPrimitive)?.content
+  }
+
+private class MutableGeoJsonSourceHandleImpl(val source: GeoJsonSourceHandleImpl) :
+  MutableGeoJsonSourceHandle, GeoJsonSourceHandle by source {
+  override fun setData(data: GeoJsonData) = source.setData(data)
+
+  override fun remove(): Boolean = source.remove()
+}
+
+private class MutableImageSourceHandleImpl(val source: ImageSourceHandleImpl) :
+  MutableImageSourceHandle, ImageSourceHandle by source {
+  override fun setBounds(bounds: PositionQuad) = source.setBounds(bounds)
+
+  override fun setImage(image: ImageBitmap) = source.setImage(image)
+
+  override fun setUri(uri: String) = source.setUri(uri)
+
+  override fun remove(): Boolean = source.remove()
+}
+
+private class MutableVectorTileSourceHandleImpl(val source: VectorTileSourceHandleImpl) :
+  MutableSourceHandle, VectorTileSourceHandle by source {
+  override fun remove(): Boolean = source.remove()
+}
+
+private class MutableCustomVectorTileSourceHandleImpl(
+  val source: CustomVectorTileSourceHandleImpl
+) : MutableSourceHandle, CustomVectorTileSourceHandle by source {
+  override fun remove(): Boolean = source.remove()
+}
+
+private class MutableCustomGeometrySourceHandleImpl(val source: CustomGeometrySourceHandleImpl) :
+  MutableSourceHandle, CustomGeometrySourceHandle by source {
+  override fun remove(): Boolean = source.remove()
+}
+
+private class MutableRasterTileSourceHandleImpl(val source: RasterTileSourceHandleImpl) :
+  MutableSourceHandle, RasterTileSourceHandle by source {
+  override fun remove(): Boolean = source.remove()
+}
+
+private class MutableRasterDemTileSourceHandleImpl(val source: RasterDemTileSourceHandleImpl) :
+  MutableSourceHandle, RasterDemTileSourceHandle by source {
+  override fun remove(): Boolean = source.remove()
+}
+
+internal val SourceHandle.implementation: SourceHandleImpl
+  get() =
+    when (this) {
+      is SourceHandleImpl -> this
+      is MutableGeoJsonSourceHandleImpl -> source
+      is MutableImageSourceHandleImpl -> source
+      is MutableVectorTileSourceHandleImpl -> source
+      is MutableCustomVectorTileSourceHandleImpl -> source
+      is MutableCustomGeometrySourceHandleImpl -> source
+      is MutableRasterTileSourceHandleImpl -> source
+      is MutableRasterDemTileSourceHandleImpl -> source
+    }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleHandleException.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleHandleException.kt
@@ -12,6 +12,12 @@ public class StyleHandleException(message: String, cause: Throwable? = null) :
 internal interface StyleHandleOperationGuard {
   fun <T> run(action: () -> T): T
 
+  fun isSourceWritable(id: String): Boolean
+
+  fun isLayerWritable(id: String): Boolean
+
+  fun removeSource(id: String, identity: Any): Boolean
+
   fun requireSourceWritable(id: String)
 
   fun requireLayerWritable(id: String)

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleIdentity.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleIdentity.kt
@@ -9,6 +9,7 @@ import kotlin.concurrent.atomics.ExperimentalAtomicApi
 internal class StyleIdentity private constructor() {
   val sources = ResourceIdentities()
   val layers = ResourceIdentities()
+  val images = ResourceIdentities()
 
   companion object {
     fun create(): StyleIdentity = StyleIdentity()

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleReconciler.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/StyleReconciler.kt
@@ -2,6 +2,7 @@ package org.maplibre.compose.style
 
 import org.maplibre.compose.layers.Anchor
 import org.maplibre.compose.layers.LayerHandle
+import org.maplibre.compose.layers.LayerHandleImpl
 
 /** Reconciles complete desired revisions into one loaded base-style generation. */
 internal class StyleReconciler {
@@ -216,6 +217,7 @@ internal class StyleReconciler {
       val next = desiredById[applied.id]
       if (next == null || next != applied) {
         style.removeImage(applied.id)
+        style.identity.images.remove(applied.id)
         images.remove(applied.id)
       }
     }
@@ -301,7 +303,7 @@ private fun predicateLayerHandle(
   summary: LayerSummary,
 ): LayerHandle {
   val identity = style.identity.layers.get(id)
-  return LayerHandle(
+  return LayerHandleImpl(
     id = id,
     type = summary.type,
     source = summary.source,
@@ -311,6 +313,12 @@ private fun predicateLayerHandle(
     operations =
       object : StyleHandleOperationGuard {
         override fun <T> run(action: () -> T): T = action()
+
+        override fun isSourceWritable(id: String): Boolean = false
+
+        override fun isLayerWritable(id: String): Boolean = false
+
+        override fun removeSource(id: String, identity: Any): Boolean = refuseWrite(id)
 
         override fun requireSourceWritable(id: String) = refuseWrite(id)
 

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
@@ -739,7 +739,7 @@ class MapPresentationTest {
       firstStyle.featureState("points", null, "7")["selected"]?.jsonPrimitive?.boolean,
     )
 
-    fixture.state.style.baseStyle = BaseStyle.Json("replacement")
+    fixture.state.style.asMutable!!.baseStyle = BaseStyle.Json("replacement")
     assertFailsWith<IllegalStateException> {
       handle.setFeatureState("7", buildJsonObject { put("stale", true) })
     }
@@ -818,7 +818,7 @@ class MapPresentationTest {
     fixture.state.durableStyleCallbacks().onStyleReady(fixture.adapter)
     val stale = assertIs<VectorTileSourceHandle>(fixture.state.style.sources["shared"])
 
-    assertTrue(fixture.state.style.sources.remove("shared"))
+    assertTrue(fixture.state.style.sources["shared"]!!.asMutable!!.remove())
     val replacement =
       fixture.state.style.sources.add(attributedVectorSource("shared", "replacement"))
 
@@ -931,7 +931,7 @@ class MapPresentationTest {
 
     val handle = assertIs<LayerHandle>(fixture.state.style.layers["background"])
     assertNull(fixture.state.style.layers["missing"])
-    handle.setPaintProperty("background-opacity", JsonPrimitive(0.5))
+    handle.asMutable!!.setPaintProperty("background-opacity", JsonPrimitive(0.5))
     assertEquals(JsonPrimitive(0.5), handle.getProperty("background-opacity"))
 
     loadedStyle.invalidate()
@@ -1016,7 +1016,7 @@ class MapPresentationTest {
     assertEquals(listOf("bottom", "top"), styleSources.map { it.id })
     assertEquals(listOf("bottom", "top"), styleLayers.map { it.id })
 
-    fixture.state.style.baseStyle = BaseStyle.Json("replacement")
+    fixture.state.style.asMutable!!.baseStyle = BaseStyle.Json("replacement")
     assertTrue(styleSources.none())
     assertTrue(styleLayers.none())
     fixture.close()
@@ -1036,17 +1036,21 @@ class MapPresentationTest {
     assertEquals("added", fixture.state.style.sources["added"]?.id)
     fixture.state.style.sources.add(blocked)
     assertFailsWith<StyleHandleException> { fixture.state.style.sources.add(added) }
-    assertFalse(fixture.state.style.sources.remove("missing"))
-    assertTrue(fixture.state.style.sources.remove("added"))
+    assertNull(fixture.state.style.sources["missing"])
+    assertTrue(firstHandle.remove())
     assertNull(fixture.state.style.sources["added"])
     val replacementHandle = fixture.state.style.sources.add(added)
+    assertFailsWith<IllegalStateException> { firstHandle.remove() }
+    assertTrue(binding.sourceExists("added") == true)
     assertFailsWith<IllegalStateException> {
       assertIs<VectorTileSourceHandle>(firstHandle).resetFeatureStates("layer")
     }
     assertEquals("added attribution", replacementHandle.attributionHtml)
-    assertTrue(fixture.state.style.sources.remove("added"))
+    assertTrue(fixture.state.style.sources["added"]!!.asMutable!!.remove())
 
-    assertFailsWith<StyleHandleException> { fixture.state.style.sources.remove("blocked") }
+    assertFailsWith<StyleHandleException> {
+      fixture.state.style.sources["blocked"]!!.asMutable!!.remove()
+    }
     assertTrue("blocked" in binding.sources)
     assertTrue(fixture.state.style.sources["blocked"] != null)
     fixture.close()
@@ -1060,12 +1064,17 @@ class MapPresentationTest {
     fixture.state.durableStyleCallbacks().onStyleChanged(fixture.adapter, binding)
     fixture.state.durableStyleCallbacks().onStyleReady(fixture.adapter)
 
-    fixture.state.style.images.add("marker", image)
+    val handle = fixture.state.style.images.add("marker", image)
     assertEquals(setOf("marker"), binding.imageIds)
     assertFailsWith<StyleHandleException> { fixture.state.style.images.add("marker", image) }
-    assertFalse(fixture.state.style.images.remove("missing"))
-    assertTrue(fixture.state.style.images.remove("marker"))
+    assertNull(fixture.state.style.images["missing"])
+    assertTrue(handle.remove())
     assertTrue(binding.imageIds.isEmpty())
+    val replacement = fixture.state.style.images.add("marker", image)
+    assertFailsWith<IllegalStateException> { handle.remove() }
+    assertEquals(setOf("marker"), binding.imageIds)
+    fixture.state.style.asMutable!!.baseStyle = BaseStyle.Empty
+    assertFailsWith<IllegalStateException> { replacement.remove() }
     fixture.close()
   }
 
@@ -1103,7 +1112,7 @@ class MapPresentationTest {
     )
 
     val handle = assertNotNull(fixture.state.style.layers["background"])
-    handle.setPaintTransition("background-color", options)
+    handle.asMutable!!.setPaintTransition("background-color", options)
     assertEquals(scaled, handle.getPaintTransition("background-color"))
     fixture.close()
   }
@@ -1134,7 +1143,7 @@ class MapPresentationTest {
     transition.set(options)
     assertEquals(options, transition.get())
 
-    fixture.state.style.baseStyle = BaseStyle.Json("replacement")
+    fixture.state.style.asMutable!!.baseStyle = BaseStyle.Json("replacement")
     assertNull(transition.get())
     assertNull(light.getProperty("color"))
     assertNull(sky.getProperty("sky-color"))
@@ -1176,11 +1185,17 @@ class MapPresentationTest {
     }
     fixture.state.durableStyleCallbacks().onStyleChanged(fixture.adapter, binding)
 
+    fixture.state.durableStyleCallbacks().onStyleReady(fixture.adapter)
+    var previous: MutableStyleImageHandle? = null
+
     repeat(3) { eviction ->
       assertNotNull(fixture.state.resolveMissingImage(fixture.adapter, "icon")).await()
       assertTrue(binding.imageExists("icon"), "image stayed absent after eviction $eviction")
       assertEquals(eviction + 1, calls)
-      // Native eviction removes the engine image without going through StyleImages.remove.
+      previous?.let { stale -> assertFailsWith<IllegalStateException> { stale.remove() } }
+      assertTrue(binding.imageExists("icon"))
+      previous = assertNotNull(fixture.state.style.images["icon"]?.asMutable)
+      // Native eviction removes the engine image without going through the image handle.
       binding.removeImage("icon")
     }
     fixture.close()
@@ -1392,6 +1407,47 @@ class MapPresentationTest {
   }
 
   @Test
+  fun retained_mutation_capabilities_cannot_write_a_new_declaration() = runTest {
+    val fixture = presentationFixture()
+    val source = attributedVectorSource("owned", "attribution")
+    val layer = BackgroundLayer("owned")
+    val image = FakeImageBitmap(1, 1)
+    val binding =
+      RecordingStyleBinding(
+        sources = listOf(source),
+        layers = listOf(layer),
+        images = listOf("owned" to image),
+      )
+    fixture.state.durableStyleCallbacks().onStyleChanged(fixture.adapter, binding)
+    fixture.state.durableStyleCallbacks().onStyleReady(fixture.adapter)
+    val sourceHandle = fixture.state.style.sources["owned"]!!
+    val layerHandle = fixture.state.style.layers["owned"]!!
+    val imageHandle = fixture.state.style.images["owned"]!!
+    val mutableSource = assertNotNull(sourceHandle.asMutable)
+    val mutableLayer = assertNotNull(layerHandle.asMutable)
+    val mutableImage = assertNotNull(imageHandle.asMutable)
+
+    fixture.state.desiredStyleRevision =
+      DesiredStyleRevision(
+        sources = listOf(source.definition()),
+        layers = listOf(DesiredStyleLayer(layer.definition(), Anchor.Top, null, null)),
+        images = listOf(StyleImageDefinition("owned", ImageSnapshot.capture(image), false, null)),
+      )
+
+    assertNull(sourceHandle.asMutable)
+    assertNull(layerHandle.asMutable)
+    assertNull(imageHandle.asMutable)
+    assertFailsWith<StyleHandleException> { mutableSource.remove() }
+    assertFailsWith<StyleHandleException> {
+      mutableLayer.setPaintProperty("background-opacity", JsonPrimitive(0.5))
+    }
+    assertFailsWith<StyleHandleException> { mutableImage.remove() }
+    assertTrue(binding.sourceExists("owned") == true)
+    assertTrue(binding.imageExists("owned") == true)
+    fixture.close()
+  }
+
+  @Test
   fun imperative_commands_cannot_mutate_composition_owned_resources() {
     val fixture = presentationFixture()
     val source = attributedVectorSource("owned", "owned attribution")
@@ -1414,8 +1470,8 @@ class MapPresentationTest {
     fixture.state.durableStyleCallbacks().onStyleChanged(fixture.adapter, binding)
     fixture.state.durableStyleCallbacks().onStyleReady(fixture.adapter)
 
-    assertFailsWith<StyleHandleException> { fixture.state.style.sources.remove("owned") }
-    assertFailsWith<StyleHandleException> { fixture.state.style.images.remove("owned") }
+    assertNull(fixture.state.style.sources["owned"]!!.asMutable)
+    assertNull(fixture.state.style.images["owned"]!!.asMutable)
     assertTrue(binding.sourceExists("owned") == true)
     assertTrue(binding.imageExists("owned") == true)
     fixture.close()
@@ -1444,7 +1500,7 @@ class MapPresentationTest {
     assertEquals(StyleLoadState.Ready, fixture.state.style.loadState)
     assertTrue(fixture.state.style.sources["shared"] != null)
 
-    assertTrue(fixture.state.style.sources.remove("shared"))
+    assertTrue(fixture.state.style.sources["shared"]!!.asMutable!!.remove())
     fixture.state.style.images.add("shared", image)
     assertFailsWith<StyleHandleException> {
       fixture.state.beginStyleRevision(
@@ -1547,7 +1603,7 @@ class MapPresentationTest {
     testScheduler.advanceUntilIdle()
 
     assertTrue(state.style.sources["retained"] != null)
-    assertTrue(state.style.sources.remove("retained"))
+    assertTrue(state.style.sources["retained"]!!.asMutable!!.remove())
 
     val replacement = RecordingStyleBinding()
     val replacementToken = state.reservePresentation()

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
@@ -1057,6 +1057,24 @@ class MapPresentationTest {
   }
 
   @Test
+  fun adding_an_image_after_engine_eviction_retires_the_base_image_handle() {
+    val fixture = presentationFixture()
+    val image = FakeImageBitmap(1, 1)
+    val binding = RecordingStyleBinding(images = listOf("marker" to image))
+    fixture.state.durableStyleCallbacks().onStyleChanged(fixture.adapter, binding)
+    fixture.state.durableStyleCallbacks().onStyleReady(fixture.adapter)
+    val old = assertNotNull(fixture.state.style.images["marker"]?.asMutable)
+
+    binding.removeImage("marker")
+    val replacement = fixture.state.style.images.add("marker", image)
+
+    assertFailsWith<IllegalStateException> { old.remove() }
+    assertTrue(binding.imageExists("marker"))
+    assertTrue(replacement.remove())
+    fixture.close()
+  }
+
+  @Test
   fun imperative_image_commands_add_remove_and_reject_duplicates() {
     val fixture = presentationFixture()
     val binding = RecordingStyleBinding()

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
@@ -1622,8 +1622,8 @@ class MapPresentationTest {
     val initialCamera = CameraPosition(target = Position(12.0, 34.0), zoom = 8.0)
     val state =
       runtime.createMapState(
-        initialBaseStyle = BaseStyle.Demo,
-        initialCameraPosition = initialCamera,
+        baseStyle = BaseStyle.Demo,
+        cameraPosition = initialCamera,
       )
     val token = state.reservePresentation()
     val adapter = PresentationTestAdapter { state.currentMapAttachment }

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapSnapshotterTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapSnapshotterTest.kt
@@ -6,6 +6,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
@@ -179,6 +180,30 @@ class MapSnapshotterTest {
       assertEquals(setOf("imperative"), binding.imageIds)
     }
 
+    close(snapshotter, runtime)
+  }
+
+  @Test
+  fun adding_an_image_after_engine_eviction_retires_the_snapshot_image_handle() = runTest {
+    val image = FakeImageBitmap(1, 1)
+    val binding = RecordingStyleBinding(images = listOf("marker" to image))
+    val runtime =
+      mapRuntimeForTest(
+        createSnapshotterAdapter = { FakeSnapshotterAdapter(prepare = { _, _ -> binding }) },
+        styleEvaluator =
+          StyleCompositionEvaluator { _, _, _, _, _, _ -> DesiredStyleRevision.Empty },
+      )
+    val snapshotter = runtime.createSnapshotter(BaseStyle.Empty)
+    withContext(Dispatchers.Unconfined) {
+      snapshotter.capture(MapSnapshotRequest(1, 1))
+      val old = assertNotNull(snapshotter.style.images["marker"]?.asMutable)
+      binding.removeImage("marker")
+      val replacement = snapshotter.style.images.add("marker", image)
+
+      assertFailsWith<IllegalStateException> { old.remove() }
+      assertTrue(binding.imageExists("marker"))
+      assertTrue(replacement.remove())
+    }
     close(snapshotter, runtime)
   }
 

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapSnapshotterTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapSnapshotterTest.kt
@@ -163,13 +163,20 @@ class MapSnapshotterTest {
 
     withContext(Dispatchers.Unconfined) {
       snapshotter.capture(MapSnapshotRequest(1, 1))
-      assertTrue(snapshotter.style.sources.add(source) is GeoJsonSourceHandle)
+      val sourceHandle = snapshotter.style.sources.add(source)
+      assertEquals("imperative", sourceHandle.id)
       assertTrue(snapshotter.style.sources["imperative"] is GeoJsonSourceHandle)
-      snapshotter.style.images.add("imperative", FakeImageBitmap(1, 1))
+      val imageHandle = snapshotter.style.images.add("imperative", FakeImageBitmap(1, 1))
       assertEquals(setOf("imperative"), binding.imageIds)
-      assertTrue(snapshotter.style.images.remove("imperative"))
-      assertTrue(snapshotter.style.sources.remove("imperative"))
+      assertTrue(imageHandle.remove())
+      assertTrue(sourceHandle.remove())
       assertTrue(snapshotter.style.sources.none())
+      snapshotter.style.sources.add(source)
+      snapshotter.style.images.add("imperative", FakeImageBitmap(1, 1))
+      assertFailsWith<IllegalStateException> { sourceHandle.remove() }
+      assertFailsWith<IllegalStateException> { imageHandle.remove() }
+      assertTrue(binding.sourceExists("imperative") == true)
+      assertEquals(setOf("imperative"), binding.imageIds)
     }
 
     close(snapshotter, runtime)
@@ -510,7 +517,7 @@ class MapSnapshotterTest {
     val staleResult = async { runCatching { snapshotter.capture(MapSnapshotRequest(1, 1)) } }
     prepareStarted.await()
 
-    snapshotter.style.baseStyle = replacementStyle
+    snapshotter.style.asMutable!!.baseStyle = replacementStyle
     releaseFailure.complete(Unit)
     assertTrue(staleResult.await().isFailure)
     assertEquals(StyleLoadState.Pending, snapshotter.style.loadState)

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/sources/SourceHandleReconstructionTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/sources/SourceHandleReconstructionTest.kt
@@ -39,6 +39,12 @@ class SourceHandleReconstructionTest {
   private object ImmediateOperations : StyleHandleOperationGuard {
     override fun <T> run(action: () -> T): T = action()
 
+    override fun isSourceWritable(id: String): Boolean = true
+
+    override fun isLayerWritable(id: String): Boolean = true
+
+    override fun removeSource(id: String, identity: Any): Boolean = error("Unused")
+
     override fun requireSourceWritable(id: String) {}
 
     override fun requireLayerWritable(id: String) {}

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/style/StyleCompositionOrderTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/style/StyleCompositionOrderTest.kt
@@ -134,6 +134,7 @@ class StyleCompositionOrderTest {
       )
     val style = RecordingStyleBinding(layers = base)
     val belowRoads = Anchor.Below {
+      assertNull(it.asMutable)
       it.type == "symbol" && it.source == "base" && it.sourceLayer == "road"
     }
 

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserMapLifecycleTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserMapLifecycleTest.kt
@@ -102,7 +102,7 @@ class BrowserMapLifecycleTest {
 
       val deferredStyle = installDeferredReplayStyle()
       try {
-        state.style.baseStyle = REPLAY_STYLE
+        state.style.asMutable!!.baseStyle = REPLAY_STYLE
         runOnIdle { presented.value = true }
         waitUntilMap("the replacement Web map to request its retained style") {
           state.currentMapAttachment != null && deferredStyle.isStyleRequested()

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserMapLifecycleTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserMapLifecycleTest.kt
@@ -73,8 +73,8 @@ class BrowserMapLifecycleTest {
         )
       val state =
         runtime.createMapState(
-          initialCameraPosition = initialCamera,
-          initialBaseStyle = STYLE_A,
+          cameraPosition = initialCamera,
+          baseStyle = STYLE_A,
         )
       val presented = mutableStateOf(true)
 

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserMapStyleStateTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserMapStyleStateTest.kt
@@ -157,7 +157,7 @@ class BrowserMapStyleStateTest {
       waitUntilMap("the Web map to detach") { state.currentMapAttachment == null }
       runOnIdle {
         useLatestRevision.value = true
-        state.style.baseStyle = STYLE_B
+        state.style.asMutable!!.baseStyle = STYLE_B
       }
 
       assertEquals(STYLE_B, state.style.baseStyle)
@@ -227,7 +227,7 @@ class BrowserMapStyleStateTest {
       assertNotNull(session.engineMapForTest())
       assertTrue(session.canPresentFrames)
 
-      runOnIdle { state.style.baseStyle = INVALID_STYLE }
+      runOnIdle { state.style.asMutable!!.baseStyle = INVALID_STYLE }
       waitUntilMap("the replacement style request to fail") {
         state.style.loadState is StyleLoadState.Failed
       }
@@ -280,7 +280,7 @@ class BrowserMapStyleStateTest {
         renderedLayerSets += ids.split(',').filter(String::isNotEmpty).toSet()
       }
     try {
-      runOnIdle { state.style.baseStyle = BaseStyle.Uri(DEFERRED_STYLE_URL) }
+      runOnIdle { state.style.asMutable!!.baseStyle = BaseStyle.Uri(DEFERRED_STYLE_URL) }
       waitUntilMap("MapLibre to request the replacement style") { deferredStyle.isRequested() }
       assertEquals(StyleLoadState.Loading, state.style.loadState)
       assertTrue(session.canPresentFrames, "the previous frame must remain visible during loading")
@@ -318,7 +318,7 @@ class BrowserMapStyleStateTest {
       var styleState: MapStyleState? = null
       var mapState: MapState? = null
       setBrowserMapContent {
-        val current = rememberMapState(initialBaseStyle = tileJsonStyle)
+        val current = rememberMapState(baseStyle = tileJsonStyle)
         mapState = current
         styleState = current.style
         MaplibreMap(state = current, modifier = Modifier)
@@ -352,7 +352,7 @@ class BrowserMapStyleStateTest {
         var mapState: MapState? = null
         setBrowserMapContent {
           val logicalMap =
-            rememberMapState(initialBaseStyle = BaseStyle.Empty) {
+            rememberMapState(baseStyle = BaseStyle.Empty) {
               if (showLateSource.value) {
                 RasterLayer(id = "late-layer", source = source, visible = true)
               }
@@ -393,7 +393,7 @@ class BrowserMapStyleStateTest {
     var mapState: MapState? = null
     setBrowserMapContent {
       val logicalMap =
-        rememberMapState(initialBaseStyle = current.value) {
+        rememberMapState(baseStyle = current.value) {
           identity = LocalStyleNode.current.style.identity
         }
       mapState = logicalMap
@@ -410,7 +410,7 @@ class BrowserMapStyleStateTest {
     )
 
     val observed = mutableListOf<List<String>>()
-    runOnIdle { checkNotNull(mapState).style.baseStyle = styleWith("second", "second-source") }
+    runOnIdle { current.value = styleWith("second", "second-source") }
     waitUntilMap("the second style's sources to be reported") {
       styleState?.sources?.map { it.attributionHtml }?.let { observed += it }
       mapState?.style?.loadState == StyleLoadState.Ready &&

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserMapStyleStateTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserMapStyleStateTest.kt
@@ -132,7 +132,7 @@ class BrowserMapStyleStateTest {
       val presented = mutableStateOf(true)
       val useLatestRevision = mutableStateOf(false)
       val state =
-        runtime.createMapState(initialBaseStyle = STYLE_A) {
+        runtime.createMapState(baseStyle = STYLE_A) {
           val suffix = if (useLatestRevision.value) "latest" else "initial"
           RasterLayer(
             id = "$suffix-overlay",
@@ -208,7 +208,7 @@ class BrowserMapStyleStateTest {
   fun a_web_presentation_waits_for_a_viewport_and_survives_style_failure(): Promise<*> =
     runBrowserMapTest {
       val runtime = createMapRuntime(MapRuntimeOptions())
-      val state = runtime.createMapState(initialBaseStyle = STYLE_A)
+      val state = runtime.createMapState(baseStyle = STYLE_A)
       val size = mutableStateOf(0.dp)
 
       setBrowserMapContent { MaplibreMap(state = state, modifier = Modifier.size(size.value)) }
@@ -245,7 +245,7 @@ class BrowserMapStyleStateTest {
     Promise<*> = runBrowserMapTest {
     val runtime = createMapRuntime(MapRuntimeOptions())
     val state =
-      runtime.createMapState(initialBaseStyle = STYLE_A) {
+      runtime.createMapState(baseStyle = STYLE_A) {
         BackgroundLayer(id = "application", color = const(Color.Red))
       }
 

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserStyleConformanceTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/gljs/BrowserStyleConformanceTest.kt
@@ -129,7 +129,7 @@ class BrowserStyleConformanceTest {
     onMapLoadFailed: (String?) -> Unit = {},
     content: @Composable @MaplibreComposable () -> Unit = {},
   ) {
-    val state = rememberMapState(initialBaseStyle = baseStyle, content = content)
+    val state = rememberMapState(baseStyle = baseStyle, content = content)
     val loadState = state.style.loadState
     LaunchedEffect(loadState) {
       if (loadState is StyleLoadState.Failed) onMapLoadFailed(loadState.reason)

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserCameraTransitionLifecycleTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserCameraTransitionLifecycleTest.kt
@@ -95,8 +95,7 @@ class BrowserCameraTransitionLifecycleTest {
   fun a_destroyed_web_map_cannot_move_the_logical_map_or_a_cached_presentation(): Promise<*> =
     runBrowserMapTest {
       val runtime = createMapRuntime(MapRuntimeOptions())
-      val state =
-        runtime.createMapState(initialCameraPosition = CURRENT_CAMERA, initialBaseStyle = STYLE)
+      val state = runtime.createMapState(cameraPosition = CURRENT_CAMERA, baseStyle = STYLE)
       val presented = mutableStateOf(true)
 
       setBrowserMapContent { if (presented.value) MaplibreMap(state = state) }

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserMapSnapshotterTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserMapSnapshotterTest.kt
@@ -328,7 +328,7 @@ class BrowserMapSnapshotterTest {
             snapshotTargets().isEmpty() && snapshotter.style.loadState == StyleLoadState.Pending
           }
         }
-        snapshotter.style.baseStyle = BASE_STYLE
+        snapshotter.style.asMutable!!.baseStyle = BASE_STYLE
         val image =
           snapshotter.capture(
             MapSnapshotRequest(

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserMapSnapshotterTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserMapSnapshotterTest.kt
@@ -92,7 +92,7 @@ class BrowserMapSnapshotterTest {
         POINT_STYLE()
       }
       val runtime = createMapRuntime(MapRuntimeOptions())
-      val state = runtime.createMapState(initialBaseStyle = BASE_STYLE, content = content)
+      val state = runtime.createMapState(baseStyle = BASE_STYLE, content = content)
       val snapshotter = runtime.createSnapshotter(BASE_STYLE, content)
       try {
         setBrowserMapContent(size = SIZE) { MaplibreMap(state = state) }

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserMapStateTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserMapStateTest.kt
@@ -50,7 +50,7 @@ class BrowserMapStateTest {
   fun map_state_renders_a_base_style_and_publishes_one_presentation(): Promise<*> =
     runBrowserMapTest {
       val runtime = createMapRuntime(MapRuntimeOptions())
-      val state = runtime.createMapState(initialBaseStyle = BaseStyle.Empty)
+      val state = runtime.createMapState(baseStyle = BaseStyle.Empty)
       val includeRival = mutableStateOf(false)
 
       setBrowserMapContent {

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserMapStateTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserMapStateTest.kt
@@ -30,7 +30,7 @@ class BrowserMapStateTest {
       firstRuntime = DefaultMapRuntime.instance
       secondRuntime = DefaultMapRuntime.instance
       if (includeState.value) {
-        val remembered = rememberMapState(firstRuntime, initialBaseStyle = BaseStyle.Empty)
+        val remembered = rememberMapState(firstRuntime, baseStyle = BaseStyle.Empty)
         SideEffect { state = remembered }
       }
     }

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/testing/GlJsMapFixture.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/testing/GlJsMapFixture.kt
@@ -34,8 +34,8 @@ internal class GlJsMapFixture(private val extent: MapExtent) : MapFixture {
   private val runtime = mapRuntimeForTest()
   override val state =
     runtime.createMapState(
-      initialCameraPosition = CameraPosition(zoom = 0.0),
-      initialBaseStyle = BaseStyle.Empty,
+      cameraPosition = CameraPosition(zoom = 0.0),
+      baseStyle = BaseStyle.Empty,
     )
   private val glJsSession = GlJsMapSession(state.lifecycle, recorder, MapLog, LayoutDirection.Ltr)
   private val token = state.reservePresentation()

--- a/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/map/DesktopPresentationHostLifetimeTest.kt
+++ b/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/map/DesktopPresentationHostLifetimeTest.kt
@@ -38,7 +38,7 @@ class DesktopPresentationHostLifetimeTest {
   fun replacing_a_compatible_presentation_host_keeps_the_runtime_logical_map_and_engine() =
     runFfiComposeUiTest {
       val runtime = createNativeMapRuntime(runtimeOptions)
-      val state = runtime.createMapState(initialBaseStyle = BaseStyle.Empty)
+      val state = runtime.createMapState(baseStyle = BaseStyle.Empty)
       var host by
         mutableStateOf(
           ContextlessPresentationHost("first", equalityKey = "same"),
@@ -73,7 +73,7 @@ class DesktopPresentationHostLifetimeTest {
   @Test
   fun inspection_mode_does_not_require_a_presentation_host() = runFfiComposeUiTest {
     val runtime = createNativeMapRuntime(runtimeOptions)
-    val state = runtime.createMapState(initialBaseStyle = BaseStyle.Empty)
+    val state = runtime.createMapState(baseStyle = BaseStyle.Empty)
 
     setContent {
       CompositionLocalProvider(LocalInspectionMode provides true) { MaplibreMap(state = state) }

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/layers/LayerHandlePropertyTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/layers/LayerHandlePropertyTest.kt
@@ -25,7 +25,7 @@ class LayerHandlePropertyTest {
       fixture.loadStyle(STYLE)
       val handle = assertNotNull(fixture.state.style.layers["background"])
 
-      handle.setPaintProperty("background-opacity", JsonPrimitive(0.25))
+      handle.asMutable!!.setPaintProperty("background-opacity", JsonPrimitive(0.25))
 
       assertEquals(JsonPrimitive(0.25), handle.getProperty("background-opacity"))
     }
@@ -42,14 +42,14 @@ class LayerHandlePropertyTest {
       val handle = assertNotNull(fixture.state.style.layers["background"])
       val timing = TransitionOptions(700.milliseconds, 50.milliseconds)
 
-      handle.setPaintTransition("background-color", timing)
+      handle.asMutable!!.setPaintTransition("background-color", timing)
 
       assertEquals(
         timing.scaledBy(systemAnimatorDurationScale()),
         handle.getPaintTransition("background-color"),
       )
 
-      handle.setPaintTransition("background-color", null)
+      handle.asMutable!!.setPaintTransition("background-color", null)
 
       assertNull(handle.getPaintTransition("background-color"))
     }
@@ -62,10 +62,10 @@ class LayerHandlePropertyTest {
       createMapFixture().use { fixture ->
         fixture.loadStyle(STYLE)
         val handle = assertNotNull(fixture.state.style.layers["background"])
-        handle.setPaintProperty("background-opacity", JsonPrimitive(0.25))
+        handle.asMutable!!.setPaintProperty("background-opacity", JsonPrimitive(0.25))
 
         captureWarnings { warnings ->
-          handle.setPaintProperty("background-opacity", JsonPrimitive("opaque"))
+          handle.asMutable!!.setPaintProperty("background-opacity", JsonPrimitive("opaque"))
 
           // The read is queued behind the write, so the warning has been logged once it answers.
           assertEquals(JsonPrimitive(0.25), handle.getProperty("background-opacity"))
@@ -95,18 +95,20 @@ class LayerHandlePropertyTest {
       assertEquals(JsonPrimitive(2.0), handle.getProperty("minzoom"))
       assertEquals(JsonPrimitive("points-source"), circle.getProperty("source"))
       assertEquals(JsonPrimitive("points-layer"), circle.getProperty("source-layer"))
-      handle.setRootProperty("minzoom", JsonPrimitive(3.0))
+      handle.asMutable!!.setRootProperty("minzoom", JsonPrimitive(3.0))
       assertEquals(JsonPrimitive(3.0), handle.getProperty("minzoom"))
 
       captureWarnings { warnings ->
-        handle.setRootProperty("minzoom", JsonPrimitive("4"))
+        handle.asMutable!!.setRootProperty("minzoom", JsonPrimitive("4"))
         assertEquals(JsonPrimitive(3.0), handle.getProperty("minzoom"))
         assertEquals(1, warnings.count { "'background'" in it }, "Warnings: $warnings")
       }
       assertFailsWith<StyleHandleException> {
-        circle.setRootProperty("source-layer", JsonPrimitive("replacement"))
+        circle.asMutable!!.setRootProperty("source-layer", JsonPrimitive("replacement"))
       }
-      assertFailsWith<StyleHandleException> { circle.setRootProperty("source", JsonPrimitive("x")) }
+      assertFailsWith<StyleHandleException> {
+        circle.asMutable!!.setRootProperty("source", JsonPrimitive("x"))
+      }
       assertEquals("points-layer", circle.sourceLayer)
       assertEquals(JsonPrimitive("points-layer"), circle.getProperty("source-layer"))
     }

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/MapStateEventsTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/MapStateEventsTest.kt
@@ -29,7 +29,7 @@ class MapStateEventsTest {
             async(start = CoroutineStart.UNDISPATCHED) {
               fixture.state.events.first { it is MapEvent.FrameRendered }
             }
-          fixture.state.style.baseStyle = EVENT_TEST_STYLE
+          fixture.state.style.asMutable!!.baseStyle = EVENT_TEST_STYLE
 
           assertEquals(MapEvent.StyleLoaded, styleLoaded.await())
           frameRendered.await()

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/MissingImageResolverTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/MissingImageResolverTest.kt
@@ -3,8 +3,8 @@ package org.maplibre.compose.map
 import androidx.compose.ui.graphics.ImageBitmap
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CompletableDeferred
@@ -41,7 +41,7 @@ class MissingImageResolverTest {
 
       assertEquals(listOf(MISSING_ICON_ID), requests.toList(), "the resolver ran more than once")
       assertTrue(
-        fixture.state.style.images.remove(MISSING_ICON_ID),
+        fixture.state.style.images[MISSING_ICON_ID]!!.asMutable!!.remove(),
         "the resolved image did not reach the style",
       )
     }
@@ -97,7 +97,7 @@ class MissingImageResolverTest {
 
       assertEquals(listOf(MISSING_ICON_ID, MISSING_ICON_ID), requests.toList())
       assertTrue(
-        fixture.state.style.images.remove(MISSING_ICON_ID),
+        fixture.state.style.images[MISSING_ICON_ID]!!.asMutable!!.remove(),
         "the resolved image did not reach the reloaded style",
       )
     }
@@ -118,8 +118,8 @@ class MissingImageResolverTest {
         declined.size == 1
       }
       fixture.settle()
-      assertFalse(
-        fixture.state.style.images.remove(MISSING_ICON_ID),
+      assertNull(
+        fixture.state.style.images[MISSING_ICON_ID],
         "a declined image reached the style",
       )
 
@@ -138,7 +138,7 @@ class MissingImageResolverTest {
       assertEquals(listOf(MISSING_ICON_ID), supplied.toList())
       assertEquals(listOf(MISSING_ICON_ID), declined.toList(), "the replaced resolver ran again")
       assertTrue(
-        fixture.state.style.images.remove(MISSING_ICON_ID),
+        fixture.state.style.images[MISSING_ICON_ID]!!.asMutable!!.remove(),
         "the resolved image did not reach the style",
       )
     }

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/RememberMapStyleTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/RememberMapStyleTest.kt
@@ -6,26 +6,27 @@ import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.v2.runComposeUiTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.assertSame
 import org.maplibre.compose.style.BaseStyle
 
 @OptIn(ExperimentalTestApi::class)
 class RememberMapStyleTest {
   @Test
-  fun recomposition_does_not_overwrite_a_base_style_command() = runComposeUiTest {
+  fun recomposition_updates_the_owned_base_style_without_replacing_the_map() = runComposeUiTest {
     val runtime = mapRuntimeForTest()
     val seed = mutableStateOf<BaseStyle>(BaseStyle.Empty)
     lateinit var state: MapState
     setContent {
-      val remembered = rememberMapState(runtime, initialBaseStyle = seed.value)
+      val remembered = rememberMapState(runtime, baseStyle = seed.value)
       SideEffect { state = remembered }
     }
     waitForIdle()
     val original = state
     val replacement = BaseStyle.Json("""{"version":8,"sources":{},"layers":[]}""")
     runOnIdle {
-      state.style.baseStyle = replacement
-      seed.value = BaseStyle.Demo
+      assertNull(state.style.asMutable)
+      seed.value = replacement
     }
     runOnIdle {
       assertSame(original, state)

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/overlay/MapOverlayTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/overlay/MapOverlayTest.kt
@@ -25,7 +25,7 @@ import org.maplibre.spatialk.geojson.Position
 class MapOverlayTest {
   @Test
   fun overlay_composes_before_the_map_attaches() = runComposeUiTest {
-    val mapState = mapRuntimeForTest().createMapState(initialBaseStyle = BaseStyle.Empty)
+    val mapState = mapRuntimeForTest().createMapState(baseStyle = BaseStyle.Empty)
     setContent {
       MapOverlayHost(
         overlay = {
@@ -46,7 +46,7 @@ class MapOverlayTest {
 
   @Test
   fun removing_a_placed_towards_child_resets_its_state() = runComposeUiTest {
-    val mapState = mapRuntimeForTest().createMapState(initialBaseStyle = BaseStyle.Empty)
+    val mapState = mapRuntimeForTest().createMapState(baseStyle = BaseStyle.Empty)
     val state = PlacedTowardsState()
     var show by mutableStateOf(true)
     setContent {

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/overlay/ZoomButtonsTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/overlay/ZoomButtonsTest.kt
@@ -23,7 +23,7 @@ import org.maplibre.compose.style.BaseStyle
 class ZoomButtonsTest {
   @Test
   fun zoom_buttons_compose_before_the_map_attaches_and_report_clicks() = runComposeUiTest {
-    val mapState = mapRuntimeForTest().createMapState(initialBaseStyle = BaseStyle.Empty)
+    val mapState = mapRuntimeForTest().createMapState(baseStyle = BaseStyle.Empty)
     var zoomInClicks = 0
     var zoomOutClicks = 0
     setContent {
@@ -53,7 +53,7 @@ class ZoomButtonsTest {
 
   @Test
   fun full_overlay_draws_zoom_buttons() = runComposeUiTest {
-    val mapState = mapRuntimeForTest().createMapState(initialBaseStyle = BaseStyle.Empty)
+    val mapState = mapRuntimeForTest().createMapState(baseStyle = BaseStyle.Empty)
     setContent {
       MapOverlayHost(
         overlay = { include(MapOverlay.Full) },

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/style/DeclaredStyleOwnershipTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/style/DeclaredStyleOwnershipTest.kt
@@ -7,6 +7,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
@@ -33,55 +34,45 @@ import org.maplibre.spatialk.geojson.dsl.buildFeatureCollection
 
 class DeclaredStyleOwnershipTest {
   @Test
-  fun declared_sources_allow_feature_state_and_clusters_but_reject_definition_writes():
-    MapTestResult = runMapTest {
-    createMapFixture().use { fixture ->
-      fixture.loadStyle(BaseStyle.Empty)
-      lateinit var source: GeoJsonSource
-      fixture.declare {
-        source = rememberGeoJsonSource(DATA, GeoJsonOptions(cluster = true))
-        CircleLayer("points", source, visible = true)
-      }
-      val handle = assertNotNull(fixture.state.style.sources[source])
-      val selected = buildJsonObject { put("selected", true) }
-      handle.setFeatureState("0", selected)
-      assertEquals(selected, handle.getFeatureState("0"))
-      handle.removeFeatureState("0", "selected")
-      assertEquals(JsonObject(emptyMap()), handle.getFeatureState("0"))
-      handle.setFeatureState("0", selected)
-      handle.resetFeatureStates()
-      assertEquals(JsonObject(emptyMap()), handle.getFeatureState("0"))
-      assertFailsWith<StyleHandleException> { handle.setData(EMPTY_DATA) }
-      assertFailsWith<StyleHandleException> { fixture.state.style.sources.remove(handle.id) }
+  fun declared_sources_allow_runtime_operations_without_mutation_capabilities(): MapTestResult =
+    runMapTest {
+      createMapFixture().use { fixture ->
+        fixture.loadStyle(BaseStyle.Empty)
+        lateinit var source: GeoJsonSource
+        fixture.declare {
+          source = rememberGeoJsonSource(DATA, GeoJsonOptions(cluster = true))
+          CircleLayer("points", source, visible = true)
+        }
+        val handle = assertNotNull(fixture.state.style.sources[source])
+        val selected = buildJsonObject { put("selected", true) }
+        handle.setFeatureState("0", selected)
+        assertEquals(selected, handle.getFeatureState("0"))
+        handle.removeFeatureState("0", "selected")
+        assertEquals(JsonObject(emptyMap()), handle.getFeatureState("0"))
+        handle.setFeatureState("0", selected)
+        handle.resetFeatureStates()
+        assertEquals(JsonObject(emptyMap()), handle.getFeatureState("0"))
+        assertNull(handle.asMutable)
+        val layer = assertNotNull(fixture.state.style.layers["points"])
+        assertEquals(JsonPrimitive("circle"), layer.getProperty("type"))
+        assertNull(layer.asMutable)
 
-      val layer = assertNotNull(fixture.state.style.layers["points"])
-      assertEquals(JsonPrimitive("circle"), layer.getProperty("type"))
-      assertFailsWith<StyleHandleException> {
-        layer.setPaintProperty("circle-radius", JsonPrimitive(20))
-      }
-      assertFailsWith<StyleHandleException> {
-        layer.setLayoutProperty("visibility", JsonPrimitive("none"))
-      }
-      assertFailsWith<StyleHandleException> { layer.setRootProperty("minzoom", JsonPrimitive(2)) }
-      assertFailsWith<StyleHandleException> { layer.clearFilter() }
-      assertFailsWith<StyleHandleException> { layer.setPaintTransition("circle-radius", null) }
+        val area = DpRect(0.dp, 0.dp, 512.dp, 512.dp)
+        fixture.pumpUntil("the declared source's cluster") {
+          fixture.state.queryRenderedFeatures(area).any(handle::isCluster)
+        }
+        val cluster = fixture.state.queryRenderedFeatures(area).first(handle::isCluster)
+        assertTrue(handle.getClusterExpansionZoom(cluster) > 0.0)
+        assertTrue(handle.getClusterChildren(cluster).features.isNotEmpty())
+        assertEquals(3, handle.getClusterLeaves(cluster, 10, 0).features.size)
 
-      val area = DpRect(0.dp, 0.dp, 512.dp, 512.dp)
-      fixture.pumpUntil("the declared source's cluster") {
-        fixture.state.queryRenderedFeatures(area).any(handle::isCluster)
+        fixture.loadStyle(BaseStyle.Empty)
+        assertFailsWith<IllegalStateException> { handle.getFeatureState("0") }
       }
-      val cluster = fixture.state.queryRenderedFeatures(area).first(handle::isCluster)
-      assertTrue(handle.getClusterExpansionZoom(cluster) > 0.0)
-      assertTrue(handle.getClusterChildren(cluster).features.isNotEmpty())
-      assertEquals(3, handle.getClusterLeaves(cluster, 10, 0).features.size)
-
-      fixture.loadStyle(BaseStyle.Empty)
-      assertFailsWith<IllegalStateException> { handle.getFeatureState("0") }
     }
-  }
 
   @Test
-  fun declared_image_sources_reject_each_definition_write(): MapTestResult = runMapTest {
+  fun declared_image_sources_have_no_mutation_capability(): MapTestResult = runMapTest {
     createMapFixture().use { fixture ->
       fixture.loadStyle(BaseStyle.Empty)
       val bounds =
@@ -98,14 +89,11 @@ class DeclaredStyleOwnershipTest {
         RasterLayer("image", source, visible = true)
       }
       val handle = assertNotNull(fixture.state.style.sources[source])
-      assertFailsWith<StyleHandleException> { handle.setBounds(bounds) }
-      assertFailsWith<StyleHandleException> { handle.setImage(bitmap) }
-      assertFailsWith<StyleHandleException> { handle.setUri("https://example.invalid/image.png") }
+      assertNull(handle.asMutable)
     }
   }
 
   private companion object {
-    val EMPTY_DATA = GeoJsonData.JsonString("""{"type":"FeatureCollection","features":[]}""")
     val DATA =
       GeoJsonData.Features(
         buildFeatureCollection<Geometry, JsonObject?> {

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/style/LoadedStyleResourceMutationTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/style/LoadedStyleResourceMutationTest.kt
@@ -26,13 +26,15 @@ class LoadedStyleResourceMutationTest {
         )
 
       val handle = assertIs<GeoJsonSourceHandle>(fixture.state.style.sources.add(source))
-      handle.setData(GeoJsonData.JsonString("""{"type":"FeatureCollection","features":[]}"""))
+      handle.asMutable!!.setData(
+        GeoJsonData.JsonString("""{"type":"FeatureCollection","features":[]}""")
+      )
       assertIs<GeoJsonSourceHandle>(fixture.state.style.sources["imperative"])
       fixture.state.style.images.add("imperative", ImageBitmap(1, 1))
       fixture.settle()
 
-      assertTrue(fixture.state.style.images.remove("imperative"))
-      assertTrue(fixture.state.style.sources.remove("imperative"))
+      assertTrue(fixture.state.style.images["imperative"]!!.asMutable!!.remove())
+      assertTrue(fixture.state.style.sources["imperative"]!!.asMutable!!.remove())
       assertNull(fixture.state.style.sources["imperative"])
     }
   }

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/sources/SourceVolatility.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/sources/SourceVolatility.kt
@@ -11,10 +11,22 @@ import org.maplibre.compose.style.MlnFfiStyleBinding
  *
  * Like other handle operations, access fails after the source is removed or its style is replaced.
  */
-public var SourceHandle.isVolatile: Boolean
-  get() = operation {
-    checkNotNull((style as MlnFfiStyleBinding).readMap { it.styleSourceInfo(id)?.volatileSource })
+public val SourceHandle.isVolatile: Boolean
+  get() = implementation.operation {
+    checkNotNull(
+      (implementation.style as MlnFfiStyleBinding).readMap {
+        it.styleSourceInfo(id)?.volatileSource
+      }
+    )
   }
+
+/** Changes the source's native storage policy. See [SourceHandle.isVolatile]. */
+public var MutableSourceHandle.isVolatile: Boolean
+  get() = (this as SourceHandle).isVolatile
   set(value) {
-    operation { (style as MlnFfiStyleBinding).mutateMap { it.setStyleSourceVolatile(id, value) } }
+    implementation.definitionOperation {
+      (implementation.style as MlnFfiStyleBinding).mutateMap {
+        it.setStyleSourceVolatile(id, value)
+      }
+    }
   }

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/NativeMapSnapshotterTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/NativeMapSnapshotterTest.kt
@@ -118,8 +118,8 @@ class NativeMapSnapshotterTest {
             )
           snapshotter.capture(request)
 
-          snapshotter.style.baseStyle = ALTERNATE_STYLE
-          snapshotter.style.baseStyle = BASE_STYLE
+          snapshotter.style.asMutable!!.baseStyle = ALTERNATE_STYLE
+          snapshotter.style.asMutable!!.baseStyle = BASE_STYLE
           val captured = snapshotter.capture(request)
 
           assertEquals(GREEN, captured.readPixel(SIZE / 2, SIZE / 2))
@@ -148,7 +148,7 @@ class NativeMapSnapshotterTest {
         val rejected = runCatching { snapshotter.capture(MapSnapshotRequest(SIZE, SIZE)) }
         assertTrue(rejected.isFailure)
 
-        snapshotter.style.baseStyle = BASE_STYLE
+        snapshotter.style.asMutable!!.baseStyle = BASE_STYLE
         val captured = snapshotter.capture(MapSnapshotRequest(SIZE, SIZE))
 
         assertEquals(BACKGROUND, captured.readPixel(0, 0))
@@ -227,7 +227,7 @@ class NativeMapSnapshotterTest {
         assertEquals(GREEN, snapshotter.capture(request).readPixel(SIZE / 2, SIZE / 2))
 
         assertFailsWith<StyleHandleException> {
-          handle.setData(GeoJsonData.JsonString("{not json}"))
+          handle.asMutable!!.setData(GeoJsonData.JsonString("{not json}"))
         }
         val captured = snapshotter.capture(request)
 

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/PlatformMapAccessTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/PlatformMapAccessTest.kt
@@ -203,7 +203,7 @@ class PlatformMapAccessTest {
         closeResources = {},
         logger = null,
       )
-    val state = runtime.createMapState(initialBaseStyle = BaseStyle.Empty)
+    val state = runtime.createMapState(baseStyle = BaseStyle.Empty)
     try {
       block(state, runtime)
     } finally {

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/sources/GeoJsonSourceStyleReloadTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/sources/GeoJsonSourceStyleReloadTest.kt
@@ -27,7 +27,9 @@ class GeoJsonSourceStyleReloadTest {
       fixture.loadStyle(REPLACEMENT_STYLE)
 
       assertFailsWith<IllegalStateException> {
-        handle.setData(GeoJsonData.Features(FeatureCollection<Geometry, JsonObject?>(emptyList())))
+        handle.asMutable!!.setData(
+          GeoJsonData.Features(FeatureCollection<Geometry, JsonObject?>(emptyList()))
+        )
       }
     }
   }

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/sources/GeoJsonSourceUpdateTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/sources/GeoJsonSourceUpdateTest.kt
@@ -64,7 +64,7 @@ class GeoJsonSourceUpdateTest {
           fixture.readPixel(centerX, centerY).isNear(CIRCLE)
         }
 
-        sourceHandle.setData(GeoJsonData.Features(pointAt(FAR_AWAY)))
+        sourceHandle.asMutable!!.setData(GeoJsonData.Features(pointAt(FAR_AWAY)))
 
         // Real hosts draw only requested frames. No unconditional pump may mask a missing repaint.
         (fixture.style as MlnFfiStyleBinding).awaitGeoJsonUpdates()
@@ -86,7 +86,7 @@ class GeoJsonSourceUpdateTest {
       fixture.pumpUntil("the source to render above its minimum zoom") {
         fixture.readPixel(256, 256).isNear(CIRCLE)
       }
-      handle.setData(GeoJsonData.Features(pointAt(FAR_AWAY)))
+      handle.asMutable!!.setData(GeoJsonData.Features(pointAt(FAR_AWAY)))
       (fixture.style as MlnFfiStyleBinding).awaitGeoJsonUpdates()
       fixture.settle()
       assertTrue(fixture.readPixel(256, 256).isNear(BACKGROUND))
@@ -95,7 +95,7 @@ class GeoJsonSourceUpdateTest {
         fixture.readPixel(256, 256).isNear(BACKGROUND)
       }
 
-      handle.setData(GeoJsonData.Features(pointAt(ORIGIN)))
+      handle.asMutable!!.setData(GeoJsonData.Features(pointAt(ORIGIN)))
 
       (fixture.style as MlnFfiStyleBinding).awaitGeoJsonUpdates()
       fixture.settle()
@@ -131,7 +131,7 @@ class GeoJsonSourceUpdateTest {
             fixture.state.events.filterIsInstance<MapEvent.SourceDataFailed>().first()
           }
         // Submission succeeds; parsing fails later on the worker.
-        handle.setData(GeoJsonData.JsonString("{invalid GeoJSON}"))
+        handle.asMutable!!.setData(GeoJsonData.JsonString("{invalid GeoJSON}"))
         assertTrue(runCatching { binding.awaitGeoJsonUpdates() }.isFailure)
         val failure = withTimeout(5_000) { event.await() }
         assertEquals(SOURCE_ID, failure.sourceId)
@@ -139,7 +139,7 @@ class GeoJsonSourceUpdateTest {
       }
       assertTrue(fixture.readPixel(256, 256).isNear(CIRCLE))
 
-      handle.setData(GeoJsonData.Features(pointAt(FAR_AWAY)))
+      handle.asMutable!!.setData(GeoJsonData.Features(pointAt(FAR_AWAY)))
       binding.awaitGeoJsonUpdates()
       fixture.settle()
       assertTrue(fixture.readPixel(256, 256).isNear(BACKGROUND))
@@ -197,13 +197,13 @@ class GeoJsonSourceUpdateTest {
       }
 
       assertFailsWith<StyleHandleException> {
-        handle.setData(GeoJsonData.JsonString("{invalid GeoJSON}"))
+        handle.asMutable!!.setData(GeoJsonData.JsonString("{invalid GeoJSON}"))
       }
       fixture.settle()
       assertTrue(fixture.readPixel(256, 256).isNear(CIRCLE))
       assertEquals(emptyList(), fixture.engineEvents.filterIsInstance<MapEvent.SourceDataFailed>())
 
-      handle.setData(GeoJsonData.Features(pointAt(FAR_AWAY)))
+      handle.asMutable!!.setData(GeoJsonData.Features(pointAt(FAR_AWAY)))
       fixture.settle()
       assertTrue(fixture.readPixel(256, 256).isNear(BACKGROUND))
       assertEquals(emptyList(), fixture.engineEvents.filterIsInstance<MapEvent.SourceDataFailed>())

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/sources/SourceVolatilityTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/sources/SourceVolatilityTest.kt
@@ -24,14 +24,15 @@ class SourceVolatilityTest {
         fixture.state.style.sources.add(source)
         val handle = assertNotNull(fixture.state.style.sources[source.id])
         assertEquals(false, handle.isVolatile)
-        handle.isVolatile = true
+        val mutable = assertNotNull(handle.asMutable)
+        mutable.isVolatile = true
         // A separately acquired handle must see native state, rather than a handle-local copy.
         assertEquals(true, assertNotNull(fixture.state.style.sources[source.id]).isVolatile)
-        handle.isVolatile = false
+        mutable.isVolatile = false
         assertEquals(false, handle.isVolatile)
-        fixture.state.style.sources.remove(source.id)
+        fixture.state.style.sources[source.id]!!.asMutable!!.remove()
         assertFailsWith<IllegalStateException> { handle.isVolatile }
-        assertFailsWith<IllegalStateException> { handle.isVolatile = true }
+        assertFailsWith<IllegalStateException> { mutable.isVolatile = true }
       }
     }
 }


### PR DESCRIPTION
## Description

Source and layer handles exposed setters that compiled but threw when Compose owned the resource. Introduce nullable `asMutable` views so definition writes and source/image removal require explicit mutation capabilities. Feature-state setters and invalidation remain available on general handles. Retained capabilities still enforce ownership and resource identity, including images restored after engine eviction.

Make `rememberMapState(baseStyle = …)` reactive. Rename imperative factory inputs to `baseStyle` and `cameraPosition`. Maps and snapshotters created imperatively change the base style through `style.asMutable`. Update the demos, documentation, and callers for these breaking API changes.

## Validation

- `mise run test:desktop`
- `mise run test:js`
- `mise run test:android`
- `mise run check`
- `mise run build:docs`

Regression coverage includes Compose-owned resources, anchor predicates, retained capabilities after replacement or ownership changes, snapshotters, and reactive base-style updates. Android device and iOS suites were not run.

## AI assistance

Codex (GPT-6) assisted with implementation, tests, documentation, and PR drafting.

