### PR TITLE
Add deferred DP text offsets

### DIFF
--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/EditableMarkersDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/EditableMarkersDemo.kt
@@ -72,6 +72,7 @@ import org.maplibre.compose.demoapp.generated.delete_24px
 import org.maplibre.compose.expressions.dsl.const
 import org.maplibre.compose.expressions.dsl.image
 import org.maplibre.compose.expressions.dsl.offset
+import org.maplibre.compose.expressions.dsl.textOffset
 import org.maplibre.compose.expressions.value.IconPitchAlignment
 import org.maplibre.compose.expressions.value.IconRotationAlignment
 import org.maplibre.compose.expressions.value.SymbolAnchor
@@ -359,8 +360,7 @@ object EditableMarkersDemo : Demo {
           textFont = const(style.textFont),
           textSize = const(14.sp),
           textAnchor = const(SymbolAnchor.Top),
-          // Convert a fixed gap to sp so the offset does not grow with accessibility text size.
-          textOffset = with(LocalDensity.current) { offset(0.sp, 12.dp.toSp()) },
+          textOffset = textOffset(0.dp, 12.dp),
           textColor = const(theme.onSurface),
           textHaloColor = const(theme.surface),
           textHaloWidth = const(2.dp),

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/TransitNetworkDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/TransitNetworkDemo.kt
@@ -72,7 +72,7 @@ import org.maplibre.compose.expressions.dsl.const
 import org.maplibre.compose.expressions.dsl.convertToColor
 import org.maplibre.compose.expressions.dsl.eq
 import org.maplibre.compose.expressions.dsl.feature
-import org.maplibre.compose.expressions.dsl.offset
+import org.maplibre.compose.expressions.dsl.textOffset
 import org.maplibre.compose.expressions.value.SymbolAnchor
 import org.maplibre.compose.layers.Anchor
 import org.maplibre.compose.layers.CircleLayer
@@ -414,7 +414,7 @@ object TransitNetworkDemo : Demo {
       textHaloColor = const(Color.White),
       textHaloWidth = const(1.dp),
       textAnchor = const(SymbolAnchor.Top),
-      textOffset = offset(0.em, 0.4.em),
+      textOffset = textOffset(0.em, 0.4.em),
     )
   }
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/ast/DpTextOffsetCalculation.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/ast/DpTextOffsetCalculation.kt
@@ -1,0 +1,17 @@
+package org.maplibre.compose.expressions.ast
+
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.isSpecified
+import org.maplibre.compose.expressions.value.TextUnitOffsetValue
+
+internal data class DpTextOffsetCalculation(val x: Dp, val y: Dp) :
+  Expression<TextUnitOffsetValue> {
+  init {
+    require(x.isSpecified && y.isSpecified) { "DP text offset must be specified" }
+  }
+
+  override fun compile(context: ExpressionContext): CompiledExpression<TextUnitOffsetValue> =
+    scaledTextOffset(x.value, y.value, context.dpScale).compile(context).cast()
+
+  override fun visit(block: (Expression<*>) -> Unit): Unit = block(this)
+}

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/ast/ExpressionContext.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/ast/ExpressionContext.kt
@@ -14,6 +14,10 @@ public interface ExpressionContext {
   /** The scale factor to convert SPs to the desired unit */
   public val spScale: Expression<FloatValue>
 
+  /** The scale factor to convert DP text offsets to the desired text unit. */
+  public val dpScale: Expression<FloatValue>
+    get() = error("DP text offsets are not allowed in this context")
+
   /** @return the resolved identifier for the [bitmap]. */
   public fun resolveBitmap(bitmap: BitmapLiteral): String
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/ast/TextUnitOffsetCalculation.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/ast/TextUnitOffsetCalculation.kt
@@ -6,6 +6,8 @@ import androidx.compose.ui.unit.isSpecified
 import org.maplibre.compose.expressions.dsl.interpolate
 import org.maplibre.compose.expressions.dsl.linear
 import org.maplibre.compose.expressions.dsl.offset
+import org.maplibre.compose.expressions.value.FloatOffsetValue
+import org.maplibre.compose.expressions.value.FloatValue
 import org.maplibre.compose.expressions.value.TextUnitOffsetValue
 
 /**
@@ -22,18 +24,7 @@ public data class TextUnitOffsetCalculation private constructor(val x: TextUnit,
         else -> error("Unrecognized TextUnitType: ${x.type}")
       }
 
-    // Interpolation clamps above this scale.
-    val maxScale = 1000f
-
-    return interpolate(
-        type = linear(),
-        input = scale,
-        0f to offset(0f, 0f),
-        1f to offset(x.value, y.value),
-        maxScale to offset(x.value * maxScale, y.value * maxScale),
-      )
-      .compile(context)
-      .cast()
+    return scaledTextOffset(x.value, y.value, scale).compile(context).cast()
   }
 
   override fun visit(block: (Expression<*>) -> Unit): Unit = block(this)
@@ -45,4 +36,21 @@ public data class TextUnitOffsetCalculation private constructor(val x: TextUnit,
       return TextUnitOffsetCalculation(x, y)
     }
   }
+}
+
+internal fun scaledTextOffset(
+  x: Float,
+  y: Float,
+  scale: Expression<FloatValue>,
+): Expression<FloatOffsetValue> {
+  // Interpolation scales both components because style expressions cannot multiply vectors.
+  // Keep the same upper bound as the SP/EM offset conversion.
+  val maxScale = 1000f
+  return interpolate(
+    type = linear(),
+    input = scale,
+    0f to offset(0f, 0f),
+    1f to offset(x, y),
+    maxScale to offset(x * maxScale, y * maxScale),
+  )
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/dsl/literals.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/dsl/literals.kt
@@ -131,14 +131,6 @@ public fun offset(x: Float, y: Float): OffsetLiteral = OffsetLiteral.of(Offset(x
 public fun offset(x: Dp, y: Dp): DpOffsetLiteral = DpOffsetLiteral.of(DpOffset(x, y))
 
 /**
- * Creates a literal expression for a 2D [TextUnit] offset.
- *
- * Both [x] and [y] must have the same [TextUnitType].
- */
-public fun offset(x: TextUnit, y: TextUnit): Expression<TextUnitOffsetValue> =
-  TextUnitOffsetCalculation.of(x, y)
-
-/**
  * Creates a text offset with a fixed DP distance, independent of font scale and label size.
  *
  * As with SP offsets, the layer's text size must not use zoom interpolation.
@@ -152,9 +144,9 @@ public fun textOffset(x: Dp, y: Dp): Expression<TextUnitOffsetValue> = DpTextOff
  * Creates a text offset in SP or EM. Both components must have the same [TextUnitType].
  *
  * SP offsets scale with accessibility text size; EM offsets also scale with the label's text size.
- * Equivalent to [offset] with [TextUnit] arguments.
  */
-public fun textOffset(x: TextUnit, y: TextUnit): Expression<TextUnitOffsetValue> = offset(x, y)
+public fun textOffset(x: TextUnit, y: TextUnit): Expression<TextUnitOffsetValue> =
+  TextUnitOffsetCalculation.of(x, y)
 
 /** Creates a literal expression for a [DpPadding] value. */
 public fun padding(left: Dp, top: Dp, right: Dp, bottom: Dp): Expression<DpPaddingValue> =

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/dsl/literals.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/dsl/literals.kt
@@ -139,11 +139,9 @@ public fun offset(x: TextUnit, y: TextUnit): Expression<TextUnitOffsetValue> =
   TextUnitOffsetCalculation.of(x, y)
 
 /**
- * Creates a text offset with a fixed DP distance, independent of accessibility text size.
+ * Creates a text offset with a fixed DP distance, independent of font scale and label size.
  *
- * The consuming symbol layer converts the offset to EM using its text size and local font scale.
- * The expression can be created outside composition and reused at different font scales. As with SP
- * offsets, the layer's text size must not use zoom interpolation.
+ * As with SP offsets, the layer's text size must not use zoom interpolation.
  *
  * Use the [TextUnit] overload for offsets that scale with accessibility text size (SP) or the
  * label's text size (EM).

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/dsl/literals.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/dsl/literals.kt
@@ -13,6 +13,7 @@ import org.maplibre.compose.expressions.ast.ColorLiteral
 import org.maplibre.compose.expressions.ast.DpLiteral
 import org.maplibre.compose.expressions.ast.DpOffsetLiteral
 import org.maplibre.compose.expressions.ast.DpPaddingLiteral
+import org.maplibre.compose.expressions.ast.DpTextOffsetCalculation
 import org.maplibre.compose.expressions.ast.EnumLiteral
 import org.maplibre.compose.expressions.ast.Expression
 import org.maplibre.compose.expressions.ast.FloatLiteral
@@ -136,6 +137,26 @@ public fun offset(x: Dp, y: Dp): DpOffsetLiteral = DpOffsetLiteral.of(DpOffset(x
  */
 public fun offset(x: TextUnit, y: TextUnit): Expression<TextUnitOffsetValue> =
   TextUnitOffsetCalculation.of(x, y)
+
+/**
+ * Creates a text offset with a fixed DP distance, independent of accessibility text size.
+ *
+ * The consuming symbol layer converts the offset to EM using its text size and local font scale.
+ * The expression can be created outside composition and reused at different font scales. As with SP
+ * offsets, the layer's text size must not use zoom interpolation.
+ *
+ * Use the [TextUnit] overload for offsets that scale with accessibility text size (SP) or the
+ * label's text size (EM).
+ */
+public fun textOffset(x: Dp, y: Dp): Expression<TextUnitOffsetValue> = DpTextOffsetCalculation(x, y)
+
+/**
+ * Creates a text offset in SP or EM. Both components must have the same [TextUnitType].
+ *
+ * SP offsets scale with accessibility text size; EM offsets also scale with the label's text size.
+ * Equivalent to [offset] with [TextUnit] arguments.
+ */
+public fun textOffset(x: TextUnit, y: TextUnit): Expression<TextUnitOffsetValue> = offset(x, y)
 
 /** Creates a literal expression for a [DpPadding] value. */
 public fun padding(left: Dp, top: Dp, right: Dp, bottom: Dp): Expression<DpPaddingValue> =

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/LayerPropertyCompiler.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/LayerPropertyCompiler.kt
@@ -14,6 +14,7 @@ import org.maplibre.compose.expressions.ast.Expression
 import org.maplibre.compose.expressions.ast.ExpressionContext
 import org.maplibre.compose.expressions.ast.PainterLiteral
 import org.maplibre.compose.expressions.dsl.const
+import org.maplibre.compose.expressions.dsl.div
 import org.maplibre.compose.expressions.value.ExpressionValue
 import org.maplibre.compose.expressions.value.FloatValue
 import org.maplibre.compose.style.ImageManager
@@ -58,6 +59,12 @@ internal class LayerPropertyCompiler(
               else -> error("mixing SP and EM units is not supported in most expressions")
             }
         }
+
+      // Use the same linear font scale as SymbolLayer's rendered text size.
+      override val dpScale: Expression<FloatValue>
+        get() =
+          (this@LayerPropertyCompiler.spScale
+            ?: error("DP text offsets require a text-unit compiler")) / const(density.fontScale)
 
       override fun resolveBitmap(bitmap: BitmapLiteral): String {
         return styleNode.imageManager.acquireBitmap(bitmap.key())

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/SymbolLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/SymbolLayer.kt
@@ -13,7 +13,7 @@ import org.maplibre.compose.expressions.ast.Expression
 import org.maplibre.compose.expressions.dsl.const
 import org.maplibre.compose.expressions.dsl.div
 import org.maplibre.compose.expressions.dsl.nil
-import org.maplibre.compose.expressions.dsl.offset
+import org.maplibre.compose.expressions.dsl.textOffset
 import org.maplibre.compose.expressions.value.BooleanValue
 import org.maplibre.compose.expressions.value.ColorValue
 import org.maplibre.compose.expressions.value.DpOffsetValue
@@ -550,7 +550,7 @@ public fun SymbolLayer(
 
   // text anchoring
   textAnchor: Expression<SymbolAnchor> = const(SymbolAnchor.Center),
-  textOffset: Expression<TextUnitOffsetValue> = offset(0f.em, 0f.em),
+  textOffset: Expression<TextUnitOffsetValue> = textOffset(0f.em, 0f.em),
   textVariableAnchor: Expression<ListValue<SymbolAnchor>> = nil(),
   textRadialOffset: Expression<TextUnitValue> = const(0f.em),
   textVariableAnchorOffset: Expression<TextVariableAnchorOffsetValue> = nil(),

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/SymbolLayer.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/SymbolLayer.kt
@@ -289,9 +289,9 @@ private fun rememberEmCompiler(textSize: Expression<TextUnitValue>): LayerProper
  *   Ignored if [textField] is not specified.
  *
  *   **Important:** If using zoom interpolation for text size, then all other properties defined in
- *   text units (like [textLetterSpacing], [textOffset], etc) MUST be defined in EM units, not SP
- *   units. This is a limitation of the MapLibre expression parser. If text size does not use zoom
- *   interpolation, then those other properties can be defined in either unit.
+ *   text units (like [textLetterSpacing], [textOffset], etc) MUST be defined in EM units, not SP or
+ *   DP units. This is a limitation of the MapLibre expression parser. If text size does not use
+ *   zoom interpolation, then those other properties can use their supported units.
  *
  * @param textTransform Specifies how to capitalize text. The expression may use feature properties.
  * @param textLetterSpacing Text tracking amount. The expression may use feature properties.
@@ -358,6 +358,10 @@ private fun rememberEmCompiler(textSize: Expression<TextUnitValue>): LayerProper
  *   and down, while negative values indicate left and up. If used with [textVariableAnchor], input
  *   values will be taken as absolute values. Offsets along the x- and y-axis will be applied
  *   automatically based on the anchor position. The expression may use feature properties.
+ *
+ *   Use [org.maplibre.compose.expressions.dsl.textOffset] with DP arguments for a fixed distance,
+ *   or SP/EM arguments for a distance that scales with text. See [textSize] for the zoom
+ *   restriction.
  *
  *   Overridden by [textRadialOffset].
  *

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/expressions/dsl/TextOffsetTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/expressions/dsl/TextOffsetTest.kt
@@ -5,15 +5,12 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
 import kotlin.test.Test
-import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import org.maplibre.compose.expressions.ast.ExpressionContext
 
 class TextOffsetTest {
   @Test
-  fun text_unit_overloads_keep_existing_offset_semantics() {
-    assertEquals(offset(1.sp, (-2).sp), textOffset(1.sp, (-2).sp))
-    assertEquals(offset(1.em, (-2).em), textOffset(1.em, (-2).em))
+  fun text_offsets_require_matching_units() {
     assertFailsWith<IllegalArgumentException> { textOffset(1.sp, 1.em) }
   }
 

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/expressions/dsl/TextOffsetTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/expressions/dsl/TextOffsetTest.kt
@@ -1,0 +1,28 @@
+package org.maplibre.compose.expressions.dsl
+
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import org.maplibre.compose.expressions.ast.ExpressionContext
+
+class TextOffsetTest {
+  @Test
+  fun text_unit_overloads_keep_existing_offset_semantics() {
+    assertEquals(offset(1.sp, (-2).sp), textOffset(1.sp, (-2).sp))
+    assertEquals(offset(1.em, (-2).em), textOffset(1.em, (-2).em))
+    assertFailsWith<IllegalArgumentException> { textOffset(1.sp, 1.em) }
+  }
+
+  @Test
+  fun dp_offsets_require_specified_values_and_a_text_compilation_context() {
+    assertFailsWith<IllegalArgumentException> { textOffset(Dp.Unspecified, 1.dp) }
+    assertFailsWith<IllegalArgumentException> { textOffset(1.dp, Dp.Unspecified) }
+    assertFailsWith<IllegalStateException> {
+      textOffset(0.dp, 12.dp).compile(ExpressionContext.None)
+    }
+  }
+}

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/layers/SymbolLayerCompositionTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/layers/SymbolLayerCompositionTest.kt
@@ -1,13 +1,18 @@
 package org.maplibre.compose.layers
 
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.painter.ColorPainter
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -17,8 +22,15 @@ import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.double
 import kotlinx.serialization.json.doubleOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonPrimitive
+import org.maplibre.compose.expressions.dsl.const
 import org.maplibre.compose.expressions.dsl.image
+import org.maplibre.compose.expressions.dsl.offset
+import org.maplibre.compose.expressions.dsl.textOffset
 import org.maplibre.compose.expressions.dsl.textVariableAnchorOffset
 import org.maplibre.compose.expressions.value.SymbolAnchor
 import org.maplibre.compose.sources.GeoJsonData
@@ -53,6 +65,84 @@ class SymbolLayerCompositionTest {
       Json.parseToJsonElement("""["literal",["top",[0,1],"bottom",[0,-2]]]""").normalizeNumbers(),
       assertNotNull(layout["text-variable-anchor-offset"]).normalizeNumbers(),
     )
+  }
+
+  @Test
+  fun dp_text_offsets_stay_fixed_when_font_scale_and_text_size_change() = runTest {
+    val source =
+      GeoJsonSource("features", GeoJsonData.Features(featureCollectionOf()), GeoJsonOptions())
+    val binding = RecordingStyleBinding()
+    val fontScale = mutableStateOf(1f)
+    val textSize = mutableStateOf(16.sp)
+    // Construct once, outside composition. Conversion must use the consuming layer's density.
+    val offsets =
+      mapOf(
+        "dp" to textOffset((-4).dp, 12.dp),
+        "sp" to textOffset((-4).sp, 12.sp),
+        "em" to textOffset((-4).em, 12.em),
+      )
+
+    fun checkOffsets() {
+      for (unit in offsets.keys) {
+        val layout = binding.getLayer(unit)!!.toJson()["layout"] as JsonObject
+        val renderedSize = layout.getValue("text-size").numberValue()
+        assertEquals(textSize.value.value * fontScale.value.toDouble(), renderedSize, 0.0001)
+        val offset = layout.getValue("text-offset").jsonArray
+        val scale = offset[2].numberValue()
+        val components = offset[6].jsonArray[1].jsonArray
+        val expectedScale =
+          when (unit) {
+            "dp" -> 1.0
+            "sp" -> fontScale.value.toDouble()
+            else -> renderedSize
+          }
+        for ((index, distance) in listOf(-4.0, 12.0).withIndex()) {
+          assertEquals(
+            distance * expectedScale,
+            components[index].numberValue() * scale * renderedSize,
+            0.0001,
+            unit,
+          )
+        }
+        // Ordinary DP offsets retain their original units.
+        assertEquals(
+          Json.parseToJsonElement("""["literal",[-4,12]]""").normalizeNumbers(),
+          layout.getValue("icon-offset").normalizeNumbers(),
+        )
+      }
+    }
+
+    composeStyle(
+      binding,
+      thenChange = {
+        checkOffsets()
+        fontScale.value = 2f
+        textSize.value = 24.sp
+      },
+    ) {
+      CompositionLocalProvider(LocalDensity provides Density(3f, fontScale.value)) {
+        for ((unit, value) in offsets) key(unit) {
+          SymbolLayer(
+            id = unit,
+            source = source,
+            textSize = const(textSize.value),
+            textOffset = value,
+            iconOffset = offset((-4).dp, 12.dp),
+          )
+        }
+      }
+    }
+    checkOffsets()
+  }
+
+  private fun JsonElement.numberValue(): Double {
+    if (this is JsonPrimitive) return double
+    val args = jsonArray
+    return when (args[0].jsonPrimitive.contentOrNull) {
+      "*" -> args[1].numberValue() * args[2].numberValue()
+      "/" -> args[1].numberValue() / args[2].numberValue()
+      else -> error("Unexpected numeric expression: $this")
+    }
   }
 
   @Test

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/layers/SymbolLayerCompositionTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/layers/SymbolLayerCompositionTest.kt
@@ -74,7 +74,7 @@ class SymbolLayerCompositionTest {
     val binding = RecordingStyleBinding()
     val fontScale = mutableStateOf(1f)
     val textSize = mutableStateOf(16.sp)
-    // Construct once, outside composition. Conversion must use the consuming layer's density.
+    // Reuse the same offsets as font scale and text size change.
     val offsets =
       mapOf(
         "dp" to textOffset((-4).dp, 12.dp),


### PR DESCRIPTION
## Description

Add `textOffset` constructors for fixed DP spacing and existing SP/EM spacing. DP offsets keep the label gap constant when accessibility font scale or label size changes. Like SP offsets, they cannot be combined with zoom-interpolated text size.

Remove `offset(TextUnit, TextUnit)`; callers use `textOffset` for both DP and SP/EM text offsets.

The editable markers demo now uses `textOffset(0.dp, 12.dp)` for its label gap.

Follow-up to #1350. Resolves #821.

## Validation

- `mise run check`
- `mise run style-spec:parity -- --check`
- `mise run test:js`
- `mise exec -- ./gradlew :lib:maplibre-compose:jvmTest`
- Library tests cover font-scale/text-size changes, DP/SP/EM behavior, unchanged icon offsets, and invalid inputs.
- Browser check of the updated demo's label scaling.

## AI assistance

Implemented with OpenAI Codex (GPT-6).

