### PR TITLE
Fix benchmark scenario selection crash

### DIFF
--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/benchmark/BenchmarkMap.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/benchmark/BenchmarkMap.kt
@@ -10,7 +10,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
@@ -209,15 +208,13 @@ internal fun BenchmarkMap(state: DemoAppState, viewportInsets: MapViewportInsets
         drawTrail(mapState, session)
       }
   ) {
-    key(scenario.id) {
-      MaplibreMap(
-        state = mapState,
-        cameraPadding = viewportInsets.asPaddingValues(),
-        renderOptions = RenderOptions.Standard,
-        interactions = scenario.interactions,
-        contentWindowInsets = viewportInsets.asWindowInsets(),
-      ) {}
-    }
+    MaplibreMap(
+      state = mapState,
+      cameraPadding = viewportInsets.asPaddingValues(),
+      renderOptions = RenderOptions.Standard,
+      interactions = scenario.interactions,
+      contentWindowInsets = viewportInsets.asWindowInsets(),
+    ) {}
 
     Box(Modifier.fillMaxSize().padding(viewportInsets.asPaddingValues())) {
       Column(


### PR DESCRIPTION
## Description

Selecting a different benchmark scenario could crash with “The map state already has a presentation”. The scenario key recreated `MaplibreMap` while retaining its `MapState`, so the replacement view tried to attach before the previous view was disposed.

Remove the scenario key so the map view stays attached while its camera, content, and interactions update.

## Validation

- Reproduced the crash by selecting Fly-around on Android API 36, then verified navigation to Fly-around and back to Zoom pump after the fix.
- `mise run check` passed; the final commit also passed the formatting hook.
- Final `:demo-app:common:compileAndroidMain` passed.
- Other platforms were not tested locally.

## AI assistance

GPT-6 through Codex assisted with diagnosis, implementation, validation, and this description.
