### PR TITLE
Fix dragging lag in the editable markers demo

### DIFF
--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/EditableMarkersDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/EditableMarkersDemo.kt
@@ -84,6 +84,7 @@ import org.maplibre.compose.layers.SymbolLayer
 import org.maplibre.compose.map.MapState
 import org.maplibre.compose.overlay.MapOverlayScope
 import org.maplibre.compose.sources.GeoJsonData
+import org.maplibre.compose.sources.GeoJsonOptions
 import org.maplibre.compose.sources.rememberGeoJsonSource
 import org.maplibre.compose.style.TransitionOptions
 import org.maplibre.spatialk.geojson.Feature
@@ -309,7 +310,8 @@ object EditableMarkersDemo : Demo {
         val colors = markerColorScheme(marker.color)
         val source =
           rememberGeoJsonSource(
-            GeoJsonData.Features(Feature(geometry = Point(marker.position), properties = null))
+            GeoJsonData.Features(Feature(geometry = Point(marker.position), properties = null)),
+            options = GeoJsonOptions(synchronousUpdate = true),
           )
 
         // A soft shadow makes the lift during hover and drag visible against the map.


### PR DESCRIPTION
## Description

Enable synchronous GeoJSON updates for each single-point source in the editable markers demo. This fixes visibly lagging markers during dragging on iPhone, even when the map renders at 120 fps.

## Validation

- Built and installed the Debug app on an iPhone 16 Pro; manual testing confirmed smooth dragging with this change alone.
- `mise run check`.
- `mise exec -- ./gradlew :demo-app:common:compileKotlinJvm`.

## AI assistance

OpenAI GPT-6 through Codex assisted with investigation, the change, validation, and PR preparation.
