### PR TITLE
Update native FFI to 0.202609.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -48,7 +48,7 @@ lifecycleRuntimeCompose = "2.11.0"
 lwjgl = "3.4.2"
 materialKolor = "5.0.1"
 maplibre-js = "6.6.0"
-maplibre-nativeFfi = "0.202609.0"
+maplibre-nativeFfi = "0.202609.1"
 # The style-spec release the parity catalog reads; ci/style_spec_parity.py
 # fetches v8.json at this tag. Follow the maplibre-gl release's own
 # @maplibre/maplibre-gl-style-spec dependency when bumping maplibre-js.


### PR DESCRIPTION
## Description

Update `maplibre-native-ffi` to `0.202609.1`.

Key fixes in this release:
- **Synchronous GeoJSON symbol icons with text ([#699](https://github.com/maplibre/maplibre-native-ffi/pull/699)):** Carries a Native patch (`0009-synchronous-symbol-dependencies.patch`) that registers image dependencies before cached glyph notifications can synchronously finalize layout. This prevents symbol layer icons from disappearing across zoom changes when sources update synchronously and layers combine icons and text (as in the editable markers demo).
- **On-demand image retention under cache pressure ([#695](https://github.com/maplibre/maplibre-native-ffi/pull/695)):** Carries a Native patch (`0007-retain-active-on-demand-images.patch`) in `ImageManager` to keep active on-demand images registered during mixed present/missing requests, avoiding the eviction of in-use images under cache pressure.
- **Pitch bounds with padding on small viewports ([#696](https://github.com/maplibre/maplibre-native-ffi/pull/696)):** Carries a Native patch (`0008-padding-pitch-bounds.patch`) ensuring camera pitch bounds are preserved when padding is large relative to viewport height.
- **Orphaned runtime / thread recycling ([#692](https://github.com/maplibre/maplibre-native-ffi/pull/692)):** Process-unique thread tokens release an owner thread slot when a thread terminates with a live runtime, preventing thread ID recycling collisions.

## Validation

- `mise run check`
- `mise run style-spec:parity -- --check`
- `mise run test:desktop` (macOS ARM64, Metal)

## AI assistance

- **Tools:** Gemini via Antigravity
- **Context:** Dependency bump, upstream release change analysis, local check and test execution, and PR preparation.