### PR TITLE
Enable quick zoom for mouse by default

### DIFF
--- a/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/interaction/internal/ClickInputTest.kt
+++ b/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/interaction/internal/ClickInputTest.kt
@@ -395,6 +395,22 @@ class ClickInputTest {
   }
 
   @Test
+  fun mouse_quick_zoom_reports_its_first_click() = fixture.runRecognitionTest { target ->
+    mapNode().performMouseInput {
+      click(center)
+      advanceEventTime(SECOND_TAP_GAP_MILLIS)
+      press()
+      moveBy(Offset(0f, 100f))
+      release()
+    }
+    waitUntil(timeoutMillis = TIMEOUT) { target.scaleCalls.any { it.scale > 1.0 } }
+    mainClock.advanceTimeBy(1_000)
+    waitForIdle()
+    assertEquals(1, target.clicks, "a mouse quick zoom did not report exactly its first click")
+    assertEquals(0, target.moveCalls.size, "a mouse quick zoom panned")
+  }
+
+  @Test
   fun horizontal_motion_disqualifies_quick_zoom() = fixture.runRecognitionTest { target ->
     mapNode().performTouchInput {
       click(center)
@@ -407,6 +423,22 @@ class ClickInputTest {
     waitForIdle()
     assertEquals(0, target.scaleCalls.size, "a rejected quick zoom scaled")
     assertEquals(0, target.moveCalls.size, "the disqualifying move panned")
+  }
+
+  @Test
+  fun horizontal_mouse_motion_disqualifies_quick_zoom() = fixture.runRecognitionTest { target ->
+    mapNode().performMouseInput {
+      click(center)
+      advanceEventTime(SECOND_TAP_GAP_MILLIS)
+      press()
+      moveBy(Offset(100f, 0f))
+      release()
+    }
+    mainClock.advanceTimeBy(500)
+    waitForIdle()
+    assertEquals(0, target.scaleCalls.size, "a rejected mouse quick zoom scaled")
+    assertEquals(0, target.moveCalls.size, "the disqualifying move panned")
+    assertEquals(1, target.clicks, "a rejected mouse quick zoom did not report its first click")
   }
 
   @Test

--- a/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/interaction/internal/ClickInputTest.kt
+++ b/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/interaction/internal/ClickInputTest.kt
@@ -424,6 +424,13 @@ class ClickInputTest {
     waitForIdle()
     assertEquals(0, target.scaleCalls.size, "a rejected quick zoom scaled")
     assertEquals(0, target.moveCalls.size, "the disqualifying move panned")
+    mapNode().performTouchInput {
+      advanceEventTime(1_000)
+      click(center)
+    }
+    mainClock.advanceTimeBy(1_000)
+    waitForIdle()
+    assertEquals(1, target.clicks, "a later tap reported the rejected quick zoom's first tap")
   }
 
   @Test

--- a/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/interaction/internal/ClickInputTest.kt
+++ b/lib/maplibre-compose/src/androidJvmTest/kotlin/org/maplibre/compose/interaction/internal/ClickInputTest.kt
@@ -417,6 +417,7 @@ class ClickInputTest {
       advanceEventTime(SECOND_TAP_GAP_MILLIS)
       down(0, center)
       moveTo(0, center + Offset(100f, 0f), delayMillis = 50)
+      moveTo(0, center + Offset(100f, 100f), delayMillis = 50)
       up(0)
     }
     mainClock.advanceTimeBy(500)
@@ -432,6 +433,7 @@ class ClickInputTest {
       advanceEventTime(SECOND_TAP_GAP_MILLIS)
       press()
       moveBy(Offset(100f, 0f))
+      moveBy(Offset(0f, 100f))
       release()
     }
     mainClock.advanceTimeBy(500)

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/InteractionRouting.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/InteractionRouting.kt
@@ -32,7 +32,6 @@ internal fun TapBinding.matches(sample: GesturePointerSample): Boolean =
 internal fun TapDragBinding.matches(sample: GesturePointerSample): Boolean =
   eligible(enabled, pointerTypes, sample) &&
     (modifiers?.matches(sample.modifierKeys) != false) &&
-    PointerType.Mouse !in sample.pointerTypes &&
     PointerPattern(button = PointerButton.Primary).matches(sample)
 
 internal fun CameraSettings.permits(response: DragResponse): Boolean =

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/PointerDrag.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/PointerDrag.kt
@@ -17,6 +17,10 @@ internal class PointerDrag(
   var active = false
     private set
 
+  /** A vertical-only drag whose motion crossed the threshold sideways first. */
+  var rejected = false
+    private set
+
   data class Motion(
     val started: Boolean,
     val delta: Offset,
@@ -29,9 +33,14 @@ internal class PointerDrag(
     val delta = change.position - old.position
     if (delta == Offset.Zero) return null
     if (active) return Motion(false, delta)
+    if (rejected) return null
     val displacement = change.position - origin
     val beyond =
       if (verticalOnly) {
+        if (abs(displacement.x) >= slop && abs(displacement.x) > abs(displacement.y)) {
+          rejected = true
+          return null
+        }
         if (abs(displacement.y) < slop || displacement.y == 0f) return null
         Offset(0f, displacement.y - sign(displacement.y) * slop)
       } else {

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/PointerGesture.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/PointerGesture.kt
@@ -350,7 +350,14 @@ internal class PointerGesture(
     }
     val binding = selectedDrag ?: return
     if (delta == Offset.Zero) return
-    val motion = dragRecognition?.move(change) ?: return
+    val recognition = dragRecognition ?: return
+    val motion = recognition.move(change)
+    if (recognition.rejected) {
+      dragRecognition = null
+      selectedDrag = null
+      return
+    }
+    if (motion == null) return
 
     // The recognizer removes slop from the first delta; quick zoom must use that same origin.
     delta = motion.delta

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/PointerGesture.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/PointerGesture.kt
@@ -609,6 +609,8 @@ internal class PointerGesture(
     pressRole = TapPairing.Press.First
     twoFingerTap = null
     selectedDrag = null
+    // A paired press that ended without a click or drag claimed the first tap; drop it.
+    if (pairedSecondTap && origin == null) pairing.discard(emitClick = false)
 
     if (
       (!gestureInProgress &&

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/ResolvedBindings.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/ResolvedBindings.kt
@@ -83,8 +83,7 @@ internal data class TransformTiltBinding(
 
 internal data class TapDragBinding(
   val enabled: Boolean = true,
-  val pointerTypes: Set<PointerType>? =
-    setOf(PointerType.Touch, PointerType.Stylus, PointerType.Eraser, PointerType.Unknown),
+  val pointerTypes: Set<PointerType>? = null,
   val modifiers: ModifierMatch? = null,
   val startSlop: Dp = 7.dp,
   val anchor: GestureAnchor = GestureAnchor.CameraCenter,

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/ResolvedBindings.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/ResolvedBindings.kt
@@ -199,6 +199,8 @@ internal data class InteractionBindings(
                 .build()
           ),
         secondaryClick = TapBinding(pointerTypes = mouse),
+        // Modifier drags (box zoom, rotate/tilt) keep priority over a paired mouse press.
+        tapDrag = TapDragBinding(modifiers = ModifierMatch.Exactly()),
         longPress = TapBinding(pointerTypes = touch),
         twoFingerTap =
           TapBinding(

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/interaction/internal/InputConfigurationTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/interaction/internal/InputConfigurationTest.kt
@@ -128,14 +128,15 @@ class MapInteractionsTest {
   }
 
   @Test
-  fun tap_drag_admits_primary_mouse_like_touch() {
+  fun standard_tap_drag_yields_to_modifier_drags_and_secondary_button() {
     val standard = InputConfiguration.Standard
-    assertTrue(standard.bindings.tapDrag.matches(sample(PointerType.Mouse)))
-    assertTrue(standard.bindings.tapDrag.matches(sample(PointerType.Touch)))
-    assertFalse(
-      standard.bindings.tapDrag.matches(
-        sample(PointerType.Mouse, buttons = setOf(PointerButton.Secondary))
-      )
+    assertTrue(standard.bindings.tapDrag.matches(sample()))
+    assertFalse(standard.bindings.tapDrag.matches(sample(buttons = setOf(PointerButton.Secondary))))
+    val shifted = sample(modifiers = setOf(KeyModifier.Shift))
+    assertFalse(standard.bindings.tapDrag.matches(shifted))
+    assertEquals(
+      DragResponse.FitBounds,
+      standard.bindings.drag.select(shifted, standard.camera.settings),
     )
   }
 

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/interaction/internal/InputConfigurationTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/interaction/internal/InputConfigurationTest.kt
@@ -128,6 +128,18 @@ class MapInteractionsTest {
   }
 
   @Test
+  fun tap_drag_admits_primary_mouse_like_touch() {
+    val standard = InputConfiguration.Standard
+    assertTrue(standard.bindings.tapDrag.matches(sample(PointerType.Mouse)))
+    assertTrue(standard.bindings.tapDrag.matches(sample(PointerType.Touch)))
+    assertFalse(
+      standard.bindings.tapDrag.matches(
+        sample(PointerType.Mouse, buttons = setOf(PointerButton.Secondary))
+      )
+    )
+  }
+
+  @Test
   fun mappings_are_replaced_and_tuning_does_not_restore_them() {
     val cleared = InputConfiguration { bindings { doubleTap { mappings {} } } }
     val tuned = InputConfiguration(from = cleared) { bindings { doubleTap { zoomStep = 2.0 } } }


### PR DESCRIPTION
## Description

Quick zoom (double-click then drag vertically) now works with a mouse by default, matching Google Maps and other desktop map apps; the default tap-drag pointer filter and the hard mouse reject in `matches()` are gone. The standard binding requires no modifiers so Shift and Ctrl drags still select box zoom and rotate/tilt, and a paired drag that moves sideways past the threshold is rejected rather than starting quick zoom on later vertical motion. Mouse still reports the first click, as double-click does.

## Validation

`mise run check` and the jvm `ClickInputTest`, `MapInteractionsTest`, and `InputMatchingTest` suites pass; the horizontal-then-vertical tests fail without the `PointerDrag` rejection.

## AI assistance

Cursor (Grok agent) for the initial change; Claude Code (Fable 5.1) for the rebase, review fixes, and tests.
