### PR TITLE
Run JS tests in Playwright Firefox alongside Chromium

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,10 +38,9 @@ that matters to the change.
 tests out of `commonTest`, which Android host tests inherit. Android host and
 device tests live in `androidHostTest` and `androidDeviceTest` respectively.
 
-Browser tests run real maps in one Playwright Chromium. `mise run test:js`
-installs it, sets `CHROME_BIN`, and prints its version. The GitHub Ubuntu image
-also has Chrome, Firefox, and Edge; the suite does not launch them. Do not pass
-`--tests` to the browser suite; it silently runs no tests and reports success.
+Browser tests run real maps in Playwright Chromium and Firefox. Set `CHROME_BIN`
+and `FIREFOX_BIN` if Karma cannot find them. Do not pass `--tests` to the
+browser suite; it silently runs no tests and reports success.
 
 Android SDK lookup is `local.properties`, then `ANDROID_HOME`, then
 `ANDROID_SDK_ROOT`. `mise run android-sdk-packages` installs required packages.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,9 +38,10 @@ that matters to the change.
 tests out of `commonTest`, which Android host tests inherit. Android host and
 device tests live in `androidHostTest` and `androidDeviceTest` respectively.
 
-Browser tests run real maps in Chrome. Set `CHROME_BIN` if Karma cannot find it.
-Do not pass `--tests` to the browser suite; it silently runs no tests and
-reports success.
+Browser tests run real maps in one Playwright Chromium. `mise run test:js`
+installs it, sets `CHROME_BIN`, and prints its version. The GitHub Ubuntu image
+also has Chrome, Firefox, and Edge; the suite does not launch them. Do not pass
+`--tests` to the browser suite; it silently runs no tests and reports success.
 
 Android SDK lookup is `local.properties`, then `ANDROID_HOME`, then
 `ANDROID_SDK_ROOT`. `mise run android-sdk-packages` installs required packages.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,8 +178,21 @@ job ran:
 - `mise run test:android` — Android host (JVM) suite
 - `mise run test:android:device [api-level]` — instrumented suite
 - `mise run test:ios`
-- `mise run test:js`
+- `mise run test:js` — Kotlin/JS browser suite
 - `mise run test:desktop`
+
+`test:js` launches **one** browser: the Playwright Chromium that `deps:chromium`
+installs, via `CHROME_BIN`. The task prints that binary's version before Gradle
+starts. Karma would run every launcher listed in `config.browsers`, but
+`karma.config.d` replaces that list with a single headless Chromium that has a
+software WebGL context.
+
+The JS CI job uses `ubuntu-24.04`. That image also ships Google Chrome, Firefox,
+and Edge. The suite does not launch them. Safari is not on the Linux image, so
+WebKit is not in CI.
+
+A published browser version floor, including Firefox and Safari, is still open
+in [#1169](https://github.com/maplibre/maplibre-compose/issues/1169).
 
 The device suites bring their own device. `test:android:device` boots a headless
 emulator for the API level you name, and installs the emulator and system image

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,21 +178,8 @@ job ran:
 - `mise run test:android` — Android host (JVM) suite
 - `mise run test:android:device [api-level]` — instrumented suite
 - `mise run test:ios`
-- `mise run test:js` — Kotlin/JS browser suite
+- `mise run test:js`
 - `mise run test:desktop`
-
-`test:js` launches **one** browser: the Playwright Chromium that `deps:chromium`
-installs, via `CHROME_BIN`. The task prints that binary's version before Gradle
-starts. Karma would run every launcher listed in `config.browsers`, but
-`karma.config.d` replaces that list with a single headless Chromium that has a
-software WebGL context.
-
-The JS CI job uses `ubuntu-24.04`. That image also ships Google Chrome, Firefox,
-and Edge. The suite does not launch them. Safari is not on the Linux image, so
-WebKit is not in CI.
-
-A published browser version floor, including Firefox and Safari, is still open
-in [#1169](https://github.com/maplibre/maplibre-compose/issues/1169).
 
 The device suites bring their own device. `test:android:device` boots a headless
 emulator for the API level you name, and installs the emulator and system image

--- a/ci/jobs.json
+++ b/ci/jobs.json
@@ -1,7 +1,7 @@
 [
   { "job": "hygiene", "variant": "ubuntu", "tier": "draft" },
   { "job": "docs", "variant": "ubuntu", "tier": "draft" },
-  { "job": "js", "variant": "chromium", "tier": "draft" },
+  { "job": "js", "variant": "chromium-firefox", "tier": "draft" },
   { "job": "ios-device", "variant": "arm64", "tier": "draft" },
   { "job": "ios", "variant": "arm64", "tier": "ready" },
   {

--- a/ci/plan_test.py
+++ b/ci/plan_test.py
@@ -63,7 +63,7 @@ class CatalogTest(unittest.TestCase):
             {
                 "hygiene / ubuntu",
                 "docs / ubuntu",
-                "js / chromium",
+                "js / chromium-firefox",
                 "ios-device / arm64",
                 "android / 36",
                 "desktop / linux-x64",

--- a/kotlin-js-store/yarn.lock
+++ b/kotlin-js-store/yarn.lock
@@ -1831,6 +1831,11 @@ is-core-module@^2.16.0:
   dependencies:
     hasown "^2.0.2"
 
+is-docker@^2.0.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.2.1.tgz#33eeabe23cfe86f14bde4408a02c0cfb853acdaa"
+  integrity sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==
+
 is-docker@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-3.0.0.tgz#90093aa3106277d8a77a5910dbae71747e15a200"
@@ -1906,6 +1911,13 @@ is-unicode-supported@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz#3f26c76a809593b52bfa2ecb5710ed2779b522a7"
   integrity sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==
+
+is-wsl@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.2.0.tgz#74a4c76e77ca9fd3f932f290c17ea326cd157271"
+  integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
+  dependencies:
+    is-docker "^2.0.0"
 
 is-wsl@^3.1.0:
   version "3.1.0"
@@ -1987,6 +1999,14 @@ karma-chrome-launcher@3.2.0:
   integrity sha512-rE9RkUPI7I9mAxByQWkGJFXfFD6lE4gC5nPuZdobf/QdTEJI6EU4yIay/cfU/xV4ZxlM5JiTv7zWYgA64NpS5Q==
   dependencies:
     which "^1.2.1"
+
+karma-firefox-launcher@2.1.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/karma-firefox-launcher/-/karma-firefox-launcher-2.1.3.tgz#b278a4cbffa92ab81394b1a398813847b0624a85"
+  integrity sha512-LMM2bseebLbYjODBOVt7TCPP9OI2vZIXCavIXhkO9m+10Uj5l7u/SKoeRmYx8FYHTVGZSpk6peX+3BMHC1WwNw==
+  dependencies:
+    is-wsl "^2.2.0"
+    which "^3.0.0"
 
 karma-mocha@2.0.1:
   version "2.0.1"
@@ -3403,6 +3423,13 @@ which@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
+  dependencies:
+    isexe "^2.0.0"
+
+which@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/which/-/which-3.0.1.tgz#89f1cd0c23f629a8105ffe69b8172791c87b4be1"
+  integrity sha512-XA1b62dzQzLfaEOSQFTCOd5KFf/1VSzZo7/7TUjnya6u0vGGKzU96UQBZTAThCb2j4/xjBAyii1OhRLJEivHvg==
   dependencies:
     isexe "^2.0.0"
 

--- a/lib/location/build.gradle.kts
+++ b/lib/location/build.gradle.kts
@@ -24,6 +24,7 @@ kotlin {
 
   js {
     useEsModules()
+    // karma.config.d/ci.js replaces this list with one unsandboxed Chromium on Linux CI.
     browser { testTask { useKarma { useChromeHeadless() } } }
   }
 

--- a/lib/location/build.gradle.kts
+++ b/lib/location/build.gradle.kts
@@ -24,8 +24,14 @@ kotlin {
 
   js {
     useEsModules()
-    // karma.config.d/ci.js replaces this list with one unsandboxed Chromium on Linux CI.
-    browser { testTask { useKarma { useChromeHeadless() } } }
+    browser {
+      testTask {
+        useKarma {
+          useChromeHeadless()
+          useFirefoxHeadless()
+        }
+      }
+    }
   }
 
   applyDefaultHierarchyTemplate()

--- a/lib/location/karma.config.d/ci.js
+++ b/lib/location/karma.config.d/ci.js
@@ -1,12 +1,10 @@
 // The CI runner is an isolated VM, so its launcher disables Chromium's unavailable sandbox.
-// Replacing config.browsers here is why this module's JS tests still launch one Chromium
-// even if useKarma lists more names.
 if (process.env.CI && process.platform === "linux") {
-  config.customLaunchers = {
+  config.customLaunchers = Object.assign({}, config.customLaunchers, {
     ChromeHeadlessCI: {
       base: "ChromeHeadless",
       flags: ["--no-sandbox"],
     },
-  };
-  config.browsers = ["ChromeHeadlessCI"];
+  });
+  config.browsers = ["ChromeHeadlessCI", "FirefoxHeadless"];
 }

--- a/lib/location/karma.config.d/ci.js
+++ b/lib/location/karma.config.d/ci.js
@@ -6,5 +6,7 @@ if (process.env.CI && process.platform === "linux") {
       flags: ["--no-sandbox"],
     },
   });
-  config.browsers = ["ChromeHeadlessCI", "FirefoxHeadless"];
+  config.browsers = config.browsers.map((browser) =>
+    browser === "ChromeHeadless" ? "ChromeHeadlessCI" : browser,
+  );
 }

--- a/lib/location/karma.config.d/ci.js
+++ b/lib/location/karma.config.d/ci.js
@@ -1,4 +1,6 @@
 // The CI runner is an isolated VM, so its launcher disables Chromium's unavailable sandbox.
+// Replacing config.browsers here is why this module's JS tests still launch one Chromium
+// even if useKarma lists more names.
 if (process.env.CI && process.platform === "linux") {
   config.customLaunchers = {
     ChromeHeadlessCI: {

--- a/lib/maplibre-compose/build.gradle.kts
+++ b/lib/maplibre-compose/build.gradle.kts
@@ -44,8 +44,7 @@ kotlin {
       testTask {
         useKarma {
           useChromeHeadless()
-          // Headed: Firefox headless has no WebGL. test:js puts a display under Xvfb on Linux.
-          useFirefox()
+          useFirefoxHeadless()
         }
       }
     }

--- a/lib/maplibre-compose/build.gradle.kts
+++ b/lib/maplibre-compose/build.gradle.kts
@@ -39,7 +39,8 @@ kotlin {
     // (CMP-4906).
     binaries.executable()
     // The browser platform composites MapLibre GL JS into the Compose scene, so its tests need a
-    // real WebGL context; karma.config.d supplies the flags that give one to a headless browser.
+    // real WebGL context. karma.config.d replaces this Karma list with one headless Chromium
+    // that has those flags. Extra useKarma launchers do not run until that file lists them too.
     browser { testTask { useKarma { useChromeHeadless() } } }
   }
 

--- a/lib/maplibre-compose/build.gradle.kts
+++ b/lib/maplibre-compose/build.gradle.kts
@@ -39,9 +39,16 @@ kotlin {
     // (CMP-4906).
     binaries.executable()
     // The browser platform composites MapLibre GL JS into the Compose scene, so its tests need a
-    // real WebGL context. karma.config.d replaces this Karma list with one headless Chromium
-    // that has those flags. Extra useKarma launchers do not run until that file lists them too.
-    browser { testTask { useKarma { useChromeHeadless() } } }
+    // real WebGL context; karma.config.d supplies the launchers that give one to each browser.
+    browser {
+      testTask {
+        useKarma {
+          useChromeHeadless()
+          // Headed: Firefox headless has no WebGL. test:js puts a display under Xvfb on Linux.
+          useFirefox()
+        }
+      }
+    }
   }
 
   applyDefaultHierarchyTemplate()

--- a/lib/maplibre-compose/karma.config.d/webgl.js
+++ b/lib/maplibre-compose/karma.config.d/webgl.js
@@ -1,8 +1,5 @@
 // MapLibre GL JS refuses to start without a WebGL context, and a headless browser on a machine
 // with no GPU has none unless it is told to rasterize in software.
-//
-// Firefox headless also refuses WebGL (https://bugzil.la/1375585), so this launcher is headed and
-// test:js gives it a display with Xvfb on Linux.
 
 config.customLaunchers = Object.assign({}, config.customLaunchers, {
   ChromeHeadlessWebGL: {
@@ -15,7 +12,7 @@ config.customLaunchers = Object.assign({}, config.customLaunchers, {
     ],
   },
   FirefoxWebGL: {
-    base: "Firefox",
+    base: "FirefoxHeadless",
     prefs: {
       "webgl.force-enabled": true,
       "webgl.disabled": false,

--- a/lib/maplibre-compose/karma.config.d/webgl.js
+++ b/lib/maplibre-compose/karma.config.d/webgl.js
@@ -1,5 +1,8 @@
 // MapLibre GL JS refuses to start without a WebGL context, and a headless browser on a machine
 // with no GPU has none unless it is told to rasterize in software.
+//
+// This assignment is the suite's browser list. Gradle's useKarma block can name more
+// launchers, but Karma only runs the names left in config.browsers after these files merge.
 
 config.customLaunchers = {
   ChromeHeadlessWebGL: {

--- a/lib/maplibre-compose/karma.config.d/webgl.js
+++ b/lib/maplibre-compose/karma.config.d/webgl.js
@@ -11,13 +11,13 @@ config.customLaunchers = Object.assign({}, config.customLaunchers, {
       "--no-sandbox",
     ],
   },
+  // Headless Firefox on Linux has no WebGL, so Linux runs a headed Firefox on the Xvfb display that
+  // test:js provides.
   FirefoxWebGL: {
-    base: "FirefoxHeadless",
+    base: process.platform === "linux" ? "Firefox" : "FirefoxHeadless",
     prefs: {
       "webgl.force-enabled": true,
       "webgl.disabled": false,
-      "webgl.forbid-software": false,
-      "gfx.webrender.software": true,
     },
   },
 });

--- a/lib/maplibre-compose/karma.config.d/webgl.js
+++ b/lib/maplibre-compose/karma.config.d/webgl.js
@@ -16,6 +16,8 @@ config.customLaunchers = Object.assign({}, config.customLaunchers, {
     prefs: {
       "webgl.force-enabled": true,
       "webgl.disabled": false,
+      "webgl.forbid-software": false,
+      "gfx.webrender.software": true,
     },
   },
 });

--- a/lib/maplibre-compose/karma.config.d/webgl.js
+++ b/lib/maplibre-compose/karma.config.d/webgl.js
@@ -1,10 +1,10 @@
 // MapLibre GL JS refuses to start without a WebGL context, and a headless browser on a machine
 // with no GPU has none unless it is told to rasterize in software.
 //
-// This assignment is the suite's browser list. Gradle's useKarma block can name more
-// launchers, but Karma only runs the names left in config.browsers after these files merge.
+// Firefox headless also refuses WebGL (https://bugzil.la/1375585), so this launcher is headed and
+// test:js gives it a display with Xvfb on Linux.
 
-config.customLaunchers = {
+config.customLaunchers = Object.assign({}, config.customLaunchers, {
   ChromeHeadlessWebGL: {
     base: "ChromeHeadless",
     flags: [
@@ -14,5 +14,12 @@ config.customLaunchers = {
       "--no-sandbox",
     ],
   },
-};
-config.browsers = ["ChromeHeadlessWebGL"];
+  FirefoxWebGL: {
+    base: "Firefox",
+    prefs: {
+      "webgl.force-enabled": true,
+      "webgl.disabled": false,
+    },
+  },
+});
+config.browsers = ["ChromeHeadlessWebGL", "FirefoxWebGL"];

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/AntimeridianContractTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/AntimeridianContractTest.kt
@@ -123,6 +123,8 @@ class AntimeridianContractTest {
         it.pumpUntil("the style's features to become queryable") {
           it.state.queryRenderedFeatures(offset = DpOffset(800.dp, 256.dp)).isNotEmpty()
         }
+        // The wrapped world copy renders from its own tile, which can land after the first hit.
+        it.settle()
 
         val hits =
           it.state.queryRenderedFeatures(offset = DpOffset(800.dp, 256.dp)).mapNotNull { hit ->

--- a/mise.toml
+++ b/mise.toml
@@ -85,6 +85,7 @@ swiftformat = { version = "{{vars.swiftformat_version}}", backend = "github:nick
 [env]
 PLAYWRIGHT_BROWSERS_PATH = "{{ config_root }}/.cache/playwright"
 CHROME_BIN = { value = '''{{ exec(command="node -e \"console.log(require(process.argv[1]).chromium.executablePath())\" \"" ~ tools.playwright.path ~ "/node_modules/playwright\"") }}''', tools = true }
+FIREFOX_BIN = { value = '''{{ exec(command="node -e \"console.log(require(process.argv[1]).firefox.executablePath())\" \"" ~ tools.playwright.path ~ "/node_modules/playwright\"") }}''', tools = true }
 
 [hooks]
 postinstall = ["hk install --mise --quiet"]
@@ -100,6 +101,15 @@ run = "playwright install chromium --no-shell"
 
 [tasks."deps:chromium"]
 run = "mise deps install chromium"
+
+[deps.firefox]
+auto = false
+sources = ["mise.lock"]
+outputs = [".cache/playwright/firefox-*"]
+run = "playwright install firefox --no-shell"
+
+[tasks."deps:firefox"]
+run = "mise deps install firefox"
 
 [tasks.check]
 description = "Run every formatter and linter in report-only mode."
@@ -198,15 +208,21 @@ udid="$(.mise/bin/boot-ios-simulator)"
 '''
 
 [tasks."test:js"]
-depends = ["deps:chromium"]
+depends = ["deps:chromium", "deps:firefox"]
 description = "Run the Kotlin/JS browser test suite."
 run = '''
-# Playwright Chromium, not the Chrome/Firefox/Edge binaries on the host.
-# Karma runs every name in config.browsers; karma.config.d keeps that list at
-# one WebGL-capable headless Chromium.
 echo "JS tests launch ${CHROME_BIN:?}"
 "$CHROME_BIN" --version
-./gradlew jsBrowserTest
+echo "JS tests launch ${FIREFOX_BIN:?}"
+"$FIREFOX_BIN" --version
+# Firefox refuses WebGL in headless mode (bugzilla 1375585). Headed Firefox on
+# Xvfb still gets a software GL context; Chromium stays on its SwiftShader flags.
+if [[ "$(uname -s)" == Linux ]]; then
+  xvfb-run --auto-servernum --server-args="-screen 0 1280x1024x24" \
+    env LIBGL_ALWAYS_SOFTWARE=1 ./gradlew jsBrowserTest
+else
+  ./gradlew jsBrowserTest
+fi
 '''
 
 [tasks."test:desktop"]

--- a/mise.toml
+++ b/mise.toml
@@ -200,7 +200,14 @@ udid="$(.mise/bin/boot-ios-simulator)"
 [tasks."test:js"]
 depends = ["deps:chromium"]
 description = "Run the Kotlin/JS browser test suite."
-run = "./gradlew jsBrowserTest"
+run = '''
+# Playwright Chromium, not the Chrome/Firefox/Edge binaries on the host.
+# Karma runs every name in config.browsers; karma.config.d keeps that list at
+# one WebGL-capable headless Chromium.
+echo "JS tests launch ${CHROME_BIN:?}"
+"$CHROME_BIN" --version
+./gradlew jsBrowserTest
+'''
 
 [tasks."test:desktop"]
 description = "Run the desktop (JVM) test suite against a real Vulkan or Metal device."

--- a/mise.toml
+++ b/mise.toml
@@ -215,7 +215,12 @@ echo "JS tests launch ${CHROME_BIN:?}"
 "$CHROME_BIN" --version
 echo "JS tests launch ${FIREFOX_BIN:?}"
 "$FIREFOX_BIN" --version
-./gradlew jsBrowserTest
+if [[ "$(uname -s)" == Linux ]]; then
+  xvfb-run --auto-servernum --server-args="-screen 0 1280x1024x24" \
+    env LIBGL_ALWAYS_SOFTWARE=1 ./gradlew jsBrowserTest
+else
+  ./gradlew jsBrowserTest
+fi
 '''
 
 [tasks."test:desktop"]

--- a/mise.toml
+++ b/mise.toml
@@ -215,14 +215,7 @@ echo "JS tests launch ${CHROME_BIN:?}"
 "$CHROME_BIN" --version
 echo "JS tests launch ${FIREFOX_BIN:?}"
 "$FIREFOX_BIN" --version
-# Firefox refuses WebGL in headless mode (bugzilla 1375585). Headed Firefox on
-# Xvfb still gets a software GL context; Chromium stays on its SwiftShader flags.
-if [[ "$(uname -s)" == Linux ]]; then
-  xvfb-run --auto-servernum --server-args="-screen 0 1280x1024x24" \
-    env LIBGL_ALWAYS_SOFTWARE=1 ./gradlew jsBrowserTest
-else
-  ./gradlew jsBrowserTest
-fi
+./gradlew jsBrowserTest
 '''
 
 [tasks."test:desktop"]


### PR DESCRIPTION
Partial work on #1169. This adds Firefox coverage; WebKit and a published browser floor are not part of this PR.

## Description

`mise run test:js` installs Playwright Firefox alongside Chromium and runs both JS test suites in each browser. Firefox is headless except on Linux, where headless Firefox has no WebGL, so the task runs it headed under Xvfb. The JS CI variant is renamed from `chromium` to `chromium-firefox`, and the antimeridian query test now settles before reading both world copies, which Firefox on Linux otherwise raced.

## Validation

`mise run check`, `mise run ci:test-scripts`, and `mise run test:js` on macOS (631 cases each in ChromeHeadless 151 and Firefox 153, no Firefox window). The CI JS job passes the same suites on Linux under Xvfb.

## AI assistance

Cursor Grok 4.6 (Cloud Agent) for the initial draft; Claude Code (Fable 5.1) for the rebase, headless switch, and review fixes.
