### PR TITLE
Bump MapLibre GL JS from 6.6.0 to 6.9.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,12 +47,12 @@ ktor = "3.5.2"
 lifecycleRuntimeCompose = "2.11.0"
 lwjgl = "3.4.2"
 materialKolor = "5.0.1"
-maplibre-js = "6.6.0"
+maplibre-js = "6.9.0"
 maplibre-nativeFfi = "0.202609.1"
 # The style-spec release the parity catalog reads; ci/style_spec_parity.py
 # fetches v8.json at this tag. Follow the maplibre-gl release's own
 # @maplibre/maplibre-gl-style-spec dependency when bumping maplibre-js.
-maplibre-styleSpec = "26.3.0"
+maplibre-styleSpec = "26.4.2"
 mobilityData = "0.4.0"
 playServices-location = "21.4.0"
 spatialk = "0.7.0"

--- a/kotlin-js-store/yarn.lock
+++ b/kotlin-js-store/yarn.lock
@@ -159,10 +159,10 @@
   dependencies:
     kdbush "^4.1.0"
 
-"@maplibre/maplibre-gl-style-spec@^26.3.0":
-  version "26.4.1"
-  resolved "https://registry.yarnpkg.com/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-26.4.1.tgz#e9cf3ed8f33b7f57c730f550375cb7ff115c1a93"
-  integrity sha512-I/qcIKVFHFSg1Meu/eqHrkSTjIez0gCsSaK56TNPutM3TkE61aSq6F1cZ4Kg4KiNs3cpViLtubDjfyRcQCdEJQ==
+"@maplibre/maplibre-gl-style-spec@^26.4.2":
+  version "26.4.2"
+  resolved "https://registry.yarnpkg.com/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-26.4.2.tgz#874e702d95982a0b9f88a77c872814a07846dfe7"
+  integrity sha512-6J0vZqMZvRAJKtdWJdDGHEh1YJ2ZHG08/GOur8gCArYhO8ZkM//OXqtI2AAEz4jc2G+Wq4MfcePg8qNK5TZ4Kg==
   dependencies:
     "@mapbox/jsonlint-lines-primitives" "^2.0.3"
     "@mapbox/unitbezier" "^1.0.0"
@@ -171,10 +171,10 @@
     quickselect "^3.0.0"
     tinyqueue "^3.0.0"
 
-"@maplibre/mlt@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@maplibre/mlt/-/mlt-1.2.0.tgz#fe13acd002b926c9eb683394be83c3fe5ef5c135"
-  integrity sha512-g45M8gEI4sMO3X9ib4K7n3ZKFf0qQOL+NMkHCnEK51lOrYFHiEssOuZncx1+miIgi1IEE2NcbRMcq8RBkL+QHA==
+"@maplibre/mlt@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@maplibre/mlt/-/mlt-1.2.1.tgz#806cf5209178072a15e98b12e397ce9d723636ef"
+  integrity sha512-5n5dgolE2EYxwCKgx8vlwURCB8A+kyfJJyThlYimjlGgOcOe2Bhw9VxxnnHC91OC9PgHg+nVdgVPTYPkIo62vg==
   dependencies:
     "@mapbox/point-geometry" "^1.1.0"
 
@@ -807,6 +807,13 @@ batch@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/batch/-/batch-0.6.1.tgz#dc34314f4e679318093fc760272525f94bf25c16"
   integrity sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==
+
+bidi-js@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/bidi-js/-/bidi-js-1.1.0.tgz#c92efafe3fce3b9fdd30ba67bdddf0dd4d424af7"
+  integrity sha512-fX1Onk0tdVPC7obPWB5EbJ1z7NVhLq4m2xZLq2YXBkxzMXIGRpNMU88n0EPgWseKl12J7zXs7qrDxPK4sRs2fg==
+  dependencies:
+    require-from-string "^2.0.2"
 
 binary-extensions@^2.0.0:
   version "2.3.0"
@@ -2106,20 +2113,21 @@ lru-cache@^10.2.0:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.4.3.tgz#410fc8a17b70e598013df257c2446b7f3383f119"
   integrity sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==
 
-maplibre-gl@6.6.0:
-  version "6.6.0"
-  resolved "https://registry.yarnpkg.com/maplibre-gl/-/maplibre-gl-6.6.0.tgz#e845757656b3a768d31fc38eceaa1120ba483f19"
-  integrity sha512-EQql6eZYPhbHvJpqY4AwoiuLkUfXFRBHk67S8mDtzNo1F/jAo7xAxunIzO7gJ1vwTcPMgrK9b64dqKHvnkTlDQ==
+maplibre-gl@6.9.0:
+  version "6.9.0"
+  resolved "https://registry.yarnpkg.com/maplibre-gl/-/maplibre-gl-6.9.0.tgz#120b878c94204791ed459094ea327a59b467a880"
+  integrity sha512-vFMwMK0Zs+NM/rOMSdtu8bO30DIexhBEVi5KC6f70/XtI+L/K2wC3LsDCAXFZ4s8ik5gAuDugfCNbpllpdJ9bA==
   dependencies:
     "@mapbox/point-geometry" "^1.1.0"
     "@mapbox/tiny-sdf" "^2.2.0"
     "@mapbox/unitbezier" "^1.0.0"
     "@mapbox/vector-tile" "^3.0.0"
     "@maplibre/geojson-vt" "^6.1.1"
-    "@maplibre/maplibre-gl-style-spec" "^26.3.0"
-    "@maplibre/mlt" "^1.2.0"
+    "@maplibre/maplibre-gl-style-spec" "^26.4.2"
+    "@maplibre/mlt" "^1.2.1"
     "@maplibre/vt-pbf" "^4.3.2"
     "@types/geojson" "^7946.0.16"
+    bidi-js "^1.1.0"
     earcut "^3.2.3"
     gl-matrix "^3.4.4"
     kdbush "^4.1.0"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

The browser engine was three minor releases behind current MapLibre GL JS (6.6.0 vs 6.9.0, published 2026-09-09). This pins `maplibre-js` to 6.9.0 and `maplibre-styleSpec` to 26.4.2, the style-spec release that 6.9.0 depends on.

The hand-written `external` declarations still match the 6.9.0 `.d.ts`. The runtime shims still hold:

- `Map` still calls `canvas.getContext` once, synchronously, while constructing
- `BindFramebuffer.set` is unchanged
- `triggerRepaint()` is still the only `browser.frame` caller
- `remove()` still reaches the context only through `WEBGL_lose_context`
- style-diff `setTransition` is still a no-op; `getTransition()` still reads `stylesheet.transition`

6.7–6.9 add engine behavior we get without a public API change: built-in complex-script and RTL shaping (the RTL plugin is deprecated upstream), SDF fill-pattern rendering, `getStyleUrl()`, and a thrown `GPUInitializationError` when WebGL2 cannot be created. Style-spec parity is already complete at these pins. The new `$root` `font-faces` property (with `setFontFaces` / `getFontFaces`) is a public API, and `sargunv/register-font-files` is already implementing it.

## Validation

- Compared declared members in `GlJsModule.kt` / `GlJsTypes.kt` with the 6.9.0 `maplibre-gl.d.ts`
- Diffed `src/ui/map.ts`, `src/webgl/value.ts`, and `src/style/style.ts` against 6.6.0
- `mise run style-spec:parity -- --check` against style spec 26.4.2: complete at the pinned engines
- `mise run test:js`: 596 tests, 0 failures
- `./gradlew :demo-app:common:compileKotlinJs`: success
- `mise run check`: success

Not run: desktop, Android, or iOS suites. This change is the JS pin, yarn lock, and style-spec catalog version.

## AI assistance

Cursor Cloud Agent (Grok 4.6).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6a387f25-a184-48a4-a1c6-d4c9308088b3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6a387f25-a184-48a4-a1c6-d4c9308088b3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

