### PR TITLE
Bound Android render-session recovery across successful frames

### DIFF
--- a/lib/maplibre-compose/src/androidDeviceTest/kotlin/org/maplibre/compose/mlnffi/AndroidRenderRecoveryTest.kt
+++ b/lib/maplibre-compose/src/androidDeviceTest/kotlin/org/maplibre/compose/mlnffi/AndroidRenderRecoveryTest.kt
@@ -1,0 +1,184 @@
+package org.maplibre.compose.mlnffi
+
+import android.graphics.PixelFormat
+import android.media.ImageReader
+import java.util.concurrent.FutureTask
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+import org.maplibre.compose.map.MapExtent
+
+class AndroidRenderRecoveryTest {
+  @Test
+  fun successful_frames_do_not_replenish_recovery_attempts() {
+    assertRecoveryLimit(MlnFfiFrameResult.RENDERED)
+  }
+
+  @Test
+  fun skipped_frames_do_not_replenish_recovery_attempts() {
+    assertRecoveryLimit(MlnFfiFrameResult.SKIPPED)
+  }
+
+  @Test
+  fun consecutive_failures_stop_after_three_rebuilds() {
+    withController { controller, renderer ->
+      controller.onRenderThread {
+        renderer.alwaysFail = true
+        controller.requestFrame()
+      }
+      renderer.awaitFrameOrFailure()
+      controller.onRenderThread {
+        assertEquals(4, renderer.frames)
+        assertEquals(4, renderer.attachments)
+        assertEquals(1, renderer.failures.size)
+      }
+    }
+  }
+
+  @Test
+  fun surface_recreation_does_not_replenish_recovery_attempts() {
+    assertRecoveryLimit(MlnFfiFrameResult.RENDERED, recreateSurface = true)
+  }
+
+  @Test
+  fun nonrecoverable_failure_is_terminal_without_rebuilding() {
+    withController { controller, renderer ->
+      val error = IllegalStateException("Unrecoverable test failure")
+      controller.onRenderThread { renderer.nextError = error }
+      draw(controller, renderer)
+      controller.onRenderThread {
+        assertEquals(1, renderer.attachments)
+        assertEquals(1, renderer.failures.size)
+        assertSame(error, renderer.failures.single().cause)
+      }
+    }
+  }
+
+  private fun assertRecoveryLimit(
+    result: MlnFfiFrameResult,
+    recreateSurface: Boolean = false,
+  ) {
+    withController { controller, renderer ->
+      controller.onRenderThread { renderer.result = result }
+      repeat(4) { attempt ->
+        controller.onRenderThread {
+          renderer.nextError = MlnFfiRecoverableFrameException("Test frame failure", null)
+        }
+        draw(controller, renderer)
+        controller.onRenderThread {
+          assertEquals(if (attempt == 3) 1 else 0, renderer.failures.size)
+          assertEquals(
+            1 + minOf(attempt + 1, 3) + if (recreateSurface) attempt else 0,
+            renderer.attachments,
+          )
+        }
+        if (recreateSurface && attempt < 3) {
+          controller.onRenderThread { controller.surfaceDestroyed() }
+          renderer.attachSurface(controller)
+          renderer.awaitFrameOrFailure()
+        }
+      }
+      val frames = controller.onRenderThread { renderer.frames }
+      val attachments = controller.onRenderThread { renderer.attachments }
+      val resizes = controller.onRenderThread { renderer.resizes }
+      controller.onRenderThread { controller.surfaceDestroyed() }
+      renderer.attachSurface(controller)
+      controller.surfaceChanged(16, 16, 1.0)
+      controller.setActive(false)
+      controller.setActive(true)
+      controller.onRenderThread { controller.requestFrame() }
+      controller.onRenderThread {
+        assertEquals(frames, renderer.frames)
+        assertEquals(attachments, renderer.attachments)
+        assertEquals(resizes, renderer.resizes)
+        assertEquals(1, renderer.failures.size)
+        assertEquals(1, renderer.closes)
+      }
+    }
+  }
+
+  private fun draw(controller: AndroidMlnFfiSurfaceController, renderer: ScriptedRenderer) {
+    controller.onRenderThread { controller.requestFrame() }
+    renderer.awaitFrameOrFailure()
+  }
+
+  private fun <T> AndroidMlnFfiSurfaceController.onRenderThread(action: () -> T): T {
+    val task = FutureTask(action)
+    assertTrue(enqueueRenderer { task.run() }, "The render thread rejected the test action")
+    return task.get(10, TimeUnit.SECONDS)
+  }
+
+  private fun withController(action: (AndroidMlnFfiSurfaceController, ScriptedRenderer) -> Unit) {
+    ImageReader.newInstance(32, 32, PixelFormat.RGBA_8888, 2).use { reader ->
+      val renderer = ScriptedRenderer(reader)
+      val controller =
+        AndroidMlnFfiSurfaceController(
+          renderer,
+          renderer.backend,
+          logger = null,
+          onFailure = {
+            renderer.failures.add(it)
+            renderer.completed.add(Unit)
+          },
+        )
+      try {
+        renderer.attachSurface(controller)
+        renderer.awaitFrameOrFailure()
+        controller.onRenderThread {
+          assertEquals(0, renderer.failures.size, "Surface initialization failed")
+          renderer.frames = 0
+        }
+        action(controller, renderer)
+      } finally {
+        controller.onRenderThread { controller.close() }
+      }
+    }
+  }
+
+  private class ScriptedRenderer(private val reader: ImageReader) : MlnFfiMapRenderer {
+    override val backend = MapRenderBackend.OPENGL
+    var nextError: Throwable? = null
+    var alwaysFail = false
+    var result = MlnFfiFrameResult.RENDERED
+    var frames = 0
+    var attachments = 0
+    var resizes = 0
+    var closes = 0
+    val failures = mutableListOf<Throwable>()
+    val completed = LinkedBlockingQueue<Unit>()
+
+    fun awaitFrameOrFailure() {
+      assertNotNull(completed.poll(10, TimeUnit.SECONDS), "No completed frame or terminal failure")
+    }
+
+    fun attachSurface(controller: AndroidMlnFfiSurfaceController) {
+      controller.surfaceCreated(reader.surface, 32, 32, 1.0)
+    }
+
+    override fun onSurfaceAvailable(session: MlnFfiMapHostSession) {
+      attachments++
+    }
+
+    override fun onSurfaceChanged(extent: MapExtent) {
+      resizes++
+    }
+
+    override fun render(frame: MlnFfiMapFrame): MlnFfiFrameResult {
+      frames++
+      val error = nextError
+      nextError = null
+      if (error != null) throw error
+      if (alwaysFail) throw MlnFfiRecoverableFrameException("Test frame failure", null)
+      completed.add(Unit)
+      return result
+    }
+
+    override fun close() {
+      closes++
+    }
+  }
+}

--- a/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/mlnffi/AndroidMlnFfiSurfaceController.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/mlnffi/AndroidMlnFfiSurfaceController.kt
@@ -44,7 +44,7 @@ internal class AndroidMlnFfiSurfaceController(
   private var active = true
   @Volatile private var closed = false
   private var terminalFailure = false
-  private var consecutiveFailures = 0
+  private var recoveryAttempts = 0
 
   /** Records [maximumFps] for the post delay. */
   fun setMaximumFps(maximumFps: Int?) {
@@ -68,7 +68,7 @@ internal class AndroidMlnFfiSurfaceController(
     scaleFactor: Double,
   ) {
     checkRenderThread()
-    if (closed) return
+    if (closed || terminalFailure) return
     surfaceDestroyedOnRenderThread()
     try {
       graphics = AndroidMapGraphicsContext.create(backend, surface)
@@ -89,7 +89,7 @@ internal class AndroidMlnFfiSurfaceController(
 
   private fun surfaceChangedOnRenderThread(width: Int, height: Int, scaleFactor: Double) {
     checkRenderThread()
-    if (graphics == null || closed) return
+    if (graphics == null || closed || terminalFailure) return
     val changed = MapExtent.fromPhysical(width, height, scaleFactor)
     if (changed == extent) return
     extent = changed
@@ -118,7 +118,6 @@ internal class AndroidMlnFfiSurfaceController(
       .onFailure { logger?.e(it) { "Failed to release the Android map graphics context" } }
     graphics = null
     extent = MapExtent.Empty
-    consecutiveFailures = 0
   }
 
   fun setActive(active: Boolean) {
@@ -157,7 +156,8 @@ internal class AndroidMlnFfiSurfaceController(
     framePosted = false
     val currentGraphics = graphics
     val currentExtent = extent
-    if (closed || !active || currentGraphics == null || currentExtent.isEmpty) return
+    if (closed || terminalFailure || !active || currentGraphics == null || currentExtent.isEmpty)
+      return
 
     val frameId = nextFrameId++
     val target = currentGraphics.target(currentExtent, generation)
@@ -166,21 +166,18 @@ internal class AndroidMlnFfiSurfaceController(
     val frameStartUptimeMs = SystemClock.uptimeMillis()
     try {
       if (renderer.render(frame) == MlnFfiFrameResult.RENDERED) {
-        consecutiveFailures = 0
         lastFrameStartUptimeMs = frameStartUptimeMs
       }
     } catch (error: Throwable) {
       if (error is VirtualMachineError) throw error
-      consecutiveFailures++
-      if (
-        error !is MlnFfiRecoverableFrameException || consecutiveFailures > MAX_RECOVERY_ATTEMPTS
-      ) {
+      if (error !is MlnFfiRecoverableFrameException || recoveryAttempts >= MAX_RECOVERY_ATTEMPTS) {
         fail("Android map frame $frameId could not recover", error)
         return
       }
+      recoveryAttempts++
       logger?.w(error) {
         "Android map frame $frameId failed; rebuilding the render session " +
-          "(attempt $consecutiveFailures of $MAX_RECOVERY_ATTEMPTS)"
+          "(attempt $recoveryAttempts of $MAX_RECOVERY_ATTEMPTS)"
       }
 
       // A lost context invalidates the session but not the Android surface or the map runtime.


### PR DESCRIPTION
## Description

Bound Android render-session recovery to three rebuilds over the controller's lifetime. Successful or skipped frames and surface recreation do not replenish the budget; the next recoverable failure is terminal. Late surface and frame callbacks cannot revive a failed controller. This also means isolated failures accumulate over a long-lived controller.

Fixes #1372.

## Validation

- Five Android controller regression tests passed on the API 36 emulator, including 10 consecutive suite runs (50 test executions).
- Tests cover successful and skipped frames between failures, consecutive failures, surface recreation, nonrecoverable errors, and callbacks after terminal failure. They use explicit completion signals and bounded render-thread waits with a scripted renderer and a real EGL surface.
- Temporarily restoring either the successful-frame reset or surface-destruction reset made the corresponding regression test fail. The restored fix passed all five tests again.
- `mise run check` passed. Physical-device Vulkan presentation was not tested.

## AI assistance

GPT-6 in Codex assisted with implementation, test audit, validation, and this description.
