### PR TITLE
Fix gestures from unknown pointer tools

### DIFF
--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/ClickEvent.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/ClickEvent.kt
@@ -17,6 +17,7 @@ public class ClickEvent internal constructor(sample: GesturePointerSample) {
   public val screenOffset: DpOffset = sample.screenOffset
   /** Geographic position in the pointed-to world copy; longitude may fall outside ±180°. */
   public val position: Position? = sample.position
+  /** Android accessibility gestures may report [PointerType.Unknown]. */
   public val pointerTypes: Set<PointerType> = sample.pointerTypes.toSet()
   public val buttons: Set<PointerButton> = sample.buttons.toSet()
   public val modifierKeys: Set<KeyModifier> = sample.modifierKeys.toSet()

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/InteractionBindings.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/InteractionBindings.kt
@@ -81,6 +81,7 @@ public class DragFitBoundsBuilder internal constructor(from: DragFitBoundsSettin
 @MapInteractionDsl
 public class DragBindingBuilder internal constructor(from: DragBinding) {
   public var enabled: Boolean = from.enabled
+  /** Android accessibility gestures may report [PointerType.Unknown]. */
   public var pointerTypes: Set<PointerType>? = from.pointerTypes
   private var rows = from.mappings
   private val panBuilder = DragPanBuilder(from.pan)
@@ -118,6 +119,7 @@ public class DragBindingBuilder internal constructor(from: DragBinding) {
 @MapInteractionDsl
 public class TransformPanBuilder internal constructor(from: TransformPanBinding) {
   public var enabled: Boolean = from.enabled
+  /** Android accessibility gestures may report [PointerType.Unknown]. */
   public var pointerTypes: Set<PointerType>? = from.pointerTypes
   public var modifiers: ModifierMatch? = from.modifiers
   /** Recognition distance for touch pairs. Host-recognized pans have already passed host slop. */
@@ -137,6 +139,7 @@ public class TransformPanBuilder internal constructor(from: TransformPanBinding)
 @MapInteractionDsl
 public class TransformZoomBuilder internal constructor(from: TransformZoomBinding) {
   public var enabled: Boolean = from.enabled
+  /** Android accessibility gestures may report [PointerType.Unknown]. */
   public var pointerTypes: Set<PointerType>? = from.pointerTypes
   public var modifiers: ModifierMatch? = from.modifiers
   public var startSpanSlop: Dp = from.startSpanSlop
@@ -160,6 +163,7 @@ public class TransformZoomBuilder internal constructor(from: TransformZoomBindin
 @MapInteractionDsl
 public class TransformRotateBuilder internal constructor(from: TransformRotateBinding) {
   public var enabled: Boolean = from.enabled
+  /** Android accessibility gestures may report [PointerType.Unknown]. */
   public var pointerTypes: Set<PointerType>? = from.pointerTypes
   public var modifiers: ModifierMatch? = from.modifiers
   public var startAngle: Double = from.startAngle
@@ -185,6 +189,7 @@ public class TransformRotateBuilder internal constructor(from: TransformRotateBi
 @MapInteractionDsl
 public class TransformTiltBuilder internal constructor(from: TransformTiltBinding) {
   public var enabled: Boolean = from.enabled
+  /** Android accessibility gestures may report [PointerType.Unknown]. */
   public var pointerTypes: Set<PointerType>? = from.pointerTypes
   public var modifiers: ModifierMatch? = from.modifiers
   public var startSlop: Dp = from.startSlop
@@ -206,6 +211,7 @@ public class TransformTiltBuilder internal constructor(from: TransformTiltBindin
 @MapInteractionDsl
 public class TapDragBuilder internal constructor(from: TapDragBinding) {
   public var enabled: Boolean = from.enabled
+  /** Android accessibility gestures may report [PointerType.Unknown]. */
   public var pointerTypes: Set<PointerType>? = from.pointerTypes
   public var modifiers: ModifierMatch? = from.modifiers
   public var startSlop: Dp = from.startSlop
@@ -263,6 +269,7 @@ public class TransformBuilder internal constructor(from: TransformBinding) {
 @MapInteractionDsl
 public class ScrollBindingBuilder internal constructor(from: ScrollBinding) {
   public var enabled: Boolean = from.enabled
+  /** Android accessibility gestures may report [PointerType.Unknown]. */
   public var pointerTypes: Set<PointerType>? = from.pointerTypes
   private var rows = from.mappings
 
@@ -295,6 +302,7 @@ public class ScrollBindingBuilder internal constructor(from: ScrollBinding) {
 @MapInteractionDsl
 public class TapBindingBuilder internal constructor(from: TapBinding) {
   public var enabled: Boolean = from.enabled
+  /** Android accessibility gestures may report [PointerType.Unknown]. */
   public var pointerTypes: Set<PointerType>? = from.pointerTypes
   private var rows = from.mappings
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/PointerMatching.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/PointerMatching.kt
@@ -24,7 +24,10 @@ internal data class PointerPattern(
           contact &&
           types.isNotEmpty() &&
           types.all {
-            it == PointerType.Touch || it == PointerType.Stylus || it == PointerType.Eraser
+            it == PointerType.Touch ||
+              it == PointerType.Stylus ||
+              it == PointerType.Eraser ||
+              it == PointerType.Unknown
           })) &&
       (modifiers?.matches(modifierKeys) != false)
 }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/ResolvedBindings.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/interaction/internal/ResolvedBindings.kt
@@ -84,7 +84,7 @@ internal data class TransformTiltBinding(
 internal data class TapDragBinding(
   val enabled: Boolean = true,
   val pointerTypes: Set<PointerType>? =
-    setOf(PointerType.Touch, PointerType.Stylus, PointerType.Eraser),
+    setOf(PointerType.Touch, PointerType.Stylus, PointerType.Eraser, PointerType.Unknown),
   val modifiers: ModifierMatch? = null,
   val startSlop: Dp = 7.dp,
   val anchor: GestureAnchor = GestureAnchor.CameraCenter,
@@ -147,7 +147,8 @@ internal data class InteractionBindings(
   companion object {
     fun standard(): InteractionBindings {
       val mouse = setOf(PointerType.Mouse)
-      val touch = setOf(PointerType.Touch, PointerType.Stylus, PointerType.Eraser)
+      val touch =
+        setOf(PointerType.Touch, PointerType.Stylus, PointerType.Eraser, PointerType.Unknown)
       return InteractionBindings(
         drag =
           DragBinding(

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/interaction/internal/InputConfigurationTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/interaction/internal/InputConfigurationTest.kt
@@ -26,6 +26,22 @@ class MapInteractionsTest {
   ) = GesturePointerSample(0, DpOffset.Zero, null, setOf(type), buttons, modifiers)
 
   @Test
+  fun unknown_contact_supports_standard_touch_gestures() {
+    val standard = InputConfiguration.Standard
+    val contact = sample(type = PointerType.Unknown, buttons = emptySet())
+    assertEquals(
+      DragResponse.Pan,
+      standard.bindings.drag.select(contact, standard.camera.settings),
+    )
+    for (family in
+      listOf(TapFamily.Tap, TapFamily.DoubleTap, TapFamily.LongPress, TapFamily.TwoFingerTap)) {
+      assertTrue(family.matches(standard, contact), "$family should accept unknown contact")
+    }
+    assertTrue(standard.bindings.tapDrag.matches(contact))
+    assertFalse(TapFamily.SecondaryClick.matches(standard, contact))
+  }
+
+  @Test
   fun camera_policy_and_terminal_none_share_ordered_routing() {
     val standard = InputConfiguration.Standard
     val ctrlShift = sample(modifiers = setOf(KeyModifier.Ctrl, KeyModifier.Shift))

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/interaction/internal/InputMatchingTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/interaction/internal/InputMatchingTest.kt
@@ -40,6 +40,7 @@ class InputMatchingTest {
       )
     )
     assertFalse(filter.matches(setOf(PointerType.Mouse), emptySet(), emptySet(), contact = true))
+    assertFalse(filter.matches(setOf(PointerType.Unknown), emptySet(), emptySet(), contact = true))
     assertTrue(
       PointerPattern(button = null)
         .matches(setOf(PointerType.Unknown), emptySet(), emptySet(), contact = true)
@@ -47,8 +48,9 @@ class InputMatchingTest {
   }
 
   @Test
-  fun touch_and_stylus_match_logical_primary_but_scroll_requires_physical_buttons() {
-    for (type in listOf(PointerType.Touch, PointerType.Stylus, PointerType.Eraser)) {
+  fun non_mouse_contact_matches_logical_primary_but_scroll_requires_physical_buttons() {
+    for (type in
+      listOf(PointerType.Touch, PointerType.Stylus, PointerType.Eraser, PointerType.Unknown)) {
       assertTrue(
         PointerPattern(button = PointerButton.Primary)
           .matches(setOf(type), emptySet(), emptySet(), contact = true)


### PR DESCRIPTION
## Description

Treat pressed `PointerType.Unknown` input as primary touch and include it in the default long-press and quick-zoom filters. Android accessibility gestures can report this type, which prevented Quick Cursor swipes from panning the map. Preserve the reported type for explicit filters and callbacks, and document it on `pointerTypes`.

Fixes #1385.

## Validation

- `mise run test:android` passed, including regression coverage for unknown contact and explicit type filters.
- `mise run fix` and formatting checks passed.
- Built and installed the demo on a Samsung SM-F966U1 running Android 16; the contributor confirmed Quick Cursor works.

## AI assistance

OpenAI Codex (GPT-6) assisted with investigation, implementation, tests, KDoc, and this PR description.
