### PR TITLE
Make CameraPosition serializable for view-model saved state

### DIFF
--- a/docs/src/content/docs/camera.mdx
+++ b/docs/src/content/docs/camera.mdx
@@ -28,11 +28,6 @@ Use <Api of="MapState.setCameraPosition" /> to move without an animation. The
 position is retained when the map is detached and restored when it is displayed
 again.
 
-When a view model owns the <Api of="MapState" />, persist
-<Api of="CameraPosition" /> with kotlinx.serialization.
-<Api of="rememberMapState" /> already saves the camera when composition owns
-the state.
-
 ## Fit a bounding box
 
 <Api of="MapState.animateCameraToBounds" /> fits a `BoundingBox` in the current

--- a/docs/src/content/docs/camera.mdx
+++ b/docs/src/content/docs/camera.mdx
@@ -28,6 +28,11 @@ Use <Api of="MapState.setCameraPosition" /> to move without an animation. The
 position is retained when the map is detached and restored when it is displayed
 again.
 
+When a view model owns the <Api of="MapState" />, persist
+<Api of="CameraPosition" /> with kotlinx.serialization.
+<Api of="rememberMapState" /> already saves the camera when composition owns
+the state.
+
 ## Fit a bounding box
 
 <Api of="MapState.animateCameraToBounds" /> fits a `BoundingBox` in the current

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/CameraPosition.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/CameraPosition.kt
@@ -7,11 +7,6 @@ import org.maplibre.spatialk.geojson.Position
 /**
  * Defines how the camera is oriented towards the map.
  *
- * The type is serializable with kotlinx.serialization so a view model can save and restore the
- * camera when it owns the [org.maplibre.compose.map.MapState].
- * [org.maplibre.compose.map.rememberMapState] already saves the camera when composition owns the
- * state.
- *
  * @param bearing Direction that the camera is pointing in, in degrees clockwise from north.
  * @param target Position that the camera points at.
  * @param tilt The camera angle, in degrees, from the nadir (directly down). A value in the range of

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/CameraPosition.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/CameraPosition.kt
@@ -1,10 +1,16 @@
 package org.maplibre.compose.camera
 
 import androidx.compose.runtime.Immutable
+import kotlinx.serialization.Serializable
 import org.maplibre.spatialk.geojson.Position
 
 /**
  * Defines how the camera is oriented towards the map.
+ *
+ * The type is serializable with kotlinx.serialization so a view model can save and restore the
+ * camera when it owns the [org.maplibre.compose.map.MapState].
+ * [org.maplibre.compose.map.rememberMapState] already saves the camera when composition owns the
+ * state.
  *
  * @param bearing Direction that the camera is pointing in, in degrees clockwise from north.
  * @param target Position that the camera points at.
@@ -13,6 +19,7 @@ import org.maplibre.spatialk.geojson.Position
  * @param zoom Zoom level at target. A value in the range of `[0 .. 25.5]`
  */
 @Immutable
+@Serializable
 public data class CameraPosition(
   public val bearing: Double = 0.0,
   public val target: Position = Position(0.0, 0.0),

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/camera/CameraPositionTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/camera/CameraPositionTest.kt
@@ -1,0 +1,31 @@
+package org.maplibre.compose.camera
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.maplibre.spatialk.geojson.Position
+
+class CameraPositionTest {
+  @Test
+  fun roundTripsCameraThroughJson() {
+    val expected =
+      CameraPosition(
+        bearing = 42.5,
+        target = Position(longitude = -122.675, latitude = 45.521, altitude = 12.0),
+        tilt = 30.0,
+        zoom = 13.0,
+      )
+
+    val encoded = Json.encodeToString(expected)
+
+    assertEquals(expected, Json.decodeFromString<CameraPosition>(encoded))
+  }
+
+  @Test
+  fun restoresOmittedFieldsToConstructorDefaults() {
+    val restored = Json.decodeFromString<CameraPosition>("{}")
+
+    assertEquals(CameraPosition(), restored)
+  }
+}


### PR DESCRIPTION
## Description

Make `CameraPosition` serializable with kotlinx.serialization so applications can persist camera state without a custom serializer. The serializer preserves target altitude and uses constructor defaults for omitted fields.

Closes #1389.

## Validation

The JSON round-trip and omitted-field tests passed in the existing CI suites. All draft and ready tier checks passed on the current head.

## AI assistance

Cursor Grok 4.6 drafted the implementation and tests. GPT-6 in Codex reviewed the change, review threads, and CI results and revised this description.
