### PR TITLE
Avoid unnecessary viewport reads in LocationPuck

### DIFF
--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/location/LocationPuck.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/location/LocationPuck.kt
@@ -175,25 +175,24 @@ private fun LocationPuckContent(
   onClick: LocationClickHandler?,
   onLongClick: LocationClickHandler?,
 ) {
-  val viewport = LocalViewport.current
   val location = measurement?.location
   val bearing = measurement?.bearing
   val bearingAccuracy = measurement?.bearingAccuracy
   val bearingPainter = rememberBearingPainter(sizes, colors)
   val positionAccuracy = location?.horizontalAccuracy
+  val accuracyVisible = positionAccuracy != null && positionAccuracy > accuracyThreshold
+  val metersPerDp = if (accuracyVisible) LocalViewport.current?.metersPerDpAtTarget ?: 0.0 else 0.0
   val locationSource = rememberLocationSource(measurement, oldLocationThreshold)
   val isOldLocation = feature["isOldLocation"].asBoolean(const(false))
 
   CircleLayer(
     id = "$idPrefix-accuracy",
     source = locationSource,
-    visible = positionAccuracy != null && positionAccuracy > accuracyThreshold,
+    visible = accuracyVisible,
     radius =
       switch(
         condition(test = isOldLocation, output = const(0.dp)),
-        fallback =
-          (feature["accuracy"].asNumber() / const((viewport?.metersPerDpAtTarget ?: 0.0).toFloat()))
-            .dp,
+        fallback = (feature["accuracy"].asNumber() / const(metersPerDp.toFloat())).dp,
       ),
     color = const(colors.accuracyFillColor),
     strokeColor = const(colors.accuracyStrokeColor),

--- a/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/location/LocationPuckTest.kt
+++ b/lib/maplibre-compose/src/jvmTest/kotlin/org/maplibre/compose/location/LocationPuckTest.kt
@@ -1,10 +1,14 @@
 package org.maplibre.compose.location
 
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.Density
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -12,14 +16,84 @@ import kotlin.test.assertTrue
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.TestTimeSource
+import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import org.maplibre.compose.map.LocalViewport
+import org.maplibre.compose.map.MapSnapshotRequest
+import org.maplibre.compose.map.viewportFor
+import org.maplibre.compose.style.RecordingStyleBinding
+import org.maplibre.compose.style.StyleReconciler
+import org.maplibre.compose.style.rememberStyleComposition
 import org.maplibre.spatialk.geojson.Position
 import org.maplibre.spatialk.units.Bearing
 import org.maplibre.spatialk.units.extensions.degrees
+import org.maplibre.spatialk.units.extensions.meters
 
 @OptIn(ExperimentalTestApi::class)
 class LocationPuckTest {
+  @Test
+  fun onlyVisibleAccuracyCircleObservesViewport() = runComposeUiTest {
+    val style = RecordingStyleBinding()
+    val reconciler = StyleReconciler()
+    var location by mutableStateOf<LocationMeasurement?>(null)
+    var viewport by mutableStateOf(viewportFor(MapSnapshotRequest(100, 100)))
+    var viewportReads = 0
+    setContent {
+      val revision by
+        rememberStyleComposition(
+          maybeStyle = style,
+          content = {
+            CompositionLocalProvider(
+              LocalDensity provides Density(1f),
+              LocalViewport providesComputed { viewport.also { viewportReads++ } },
+            ) {
+              LocationPuck(idPrefix = "user", location = location)
+            }
+          },
+        )
+      LaunchedEffect(revision) { revision?.let { reconciler.apply(style, it) } }
+    }
+    fun accuracyRadius(): JsonElement =
+      style.layers.getValue("user-accuracy").getValue("paint").jsonObject.getValue("circle-radius")
+
+    waitForIdle()
+    assertEquals(0, viewportReads, "A puck without a fix must not observe the viewport")
+    runOnIdle {
+      location =
+        LocationMeasurement(
+          position = Position(13.0, 52.0),
+          horizontalAccuracy = 10.meters,
+          measuredAt = Clock.System.now(),
+        )
+      viewport = viewport.copy(metersPerDpAtTarget = 2.0)
+    }
+    waitForIdle()
+    assertEquals(0, viewportReads, "A hidden accuracy circle must not observe the viewport")
+
+    runOnIdle { location = location!!.copy(horizontalAccuracy = 100.meters) }
+    waitForIdle()
+    assertTrue(viewportReads > 0, "Showing the accuracy circle must start observing the viewport")
+    val firstRadius = accuracyRadius()
+    runOnIdle { viewport = viewport.copy(metersPerDpAtTarget = 4.0) }
+    waitForIdle()
+    assertTrue(firstRadius != accuracyRadius(), "A visible accuracy circle must track map scale")
+
+    runOnIdle { location = location!!.copy(horizontalAccuracy = 10.meters) }
+    waitForIdle()
+    val readsWhileHidden = viewportReads
+    runOnIdle { viewport = viewport.copy(metersPerDpAtTarget = 8.0) }
+    waitForIdle()
+    assertEquals(readsWhileHidden, viewportReads, "Hiding accuracy must stop viewport observation")
+    runOnIdle { location = location!!.copy(horizontalAccuracy = 100.meters) }
+    waitForIdle()
+    assertTrue(
+      viewportReads > readsWhileHidden,
+      "Showing accuracy must resume viewport observation",
+    )
+  }
+
   @Test
   fun locationFeatureExposesStaleness() {
     val location =


### PR DESCRIPTION
## Description

`LocationPuck` read `LocalViewport` even when its accuracy circle was hidden, so camera changes recomposed the puck's style layers with no visible benefit. Read the viewport only when the accuracy circle is visible, retaining scale updates while it is shown.

## Validation

- `mise run check` and `mise run test:desktop` passed.
- Added a composition regression test covering no location fix, hidden accuracy, visibility changes, and scale updates. Restoring the unconditional viewport read makes it fail.
- Android phone diagnostic: eight sidebar toggles over the settled 3D Manhattan view with Quick Cursor enabled produced 18 missed frame deadlines with this change, versus 57 before and 63 after restoring the previous build. These are short debug-build captures; remaining stutter is not resolved.
- Browser and iOS behavior were not tested locally.

## AI assistance

GPT-6 in Codex implemented the change and test, ran validation, and drafted this description.
