### PR TITLE
Support hardware-only painters in style images

### DIFF
--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/editablemarkers/MarkerRendering.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/editablemarkers/MarkerRendering.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.drawscope.DrawScope
-import androidx.compose.ui.graphics.drawscope.inset
+import androidx.compose.ui.graphics.drawscope.scale
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.unit.DpSize
@@ -159,7 +159,10 @@ internal fun rememberMarkerPainter(colors: ColorScheme): Painter {
 
       override fun DrawScope.onDraw() {
         with(silhouette) { draw(size, colorFilter = ColorFilter.tint(outline)) }
-        inset(horizontal = size.width * 0.055f, vertical = size.height * 0.045f) {
+        // Scale the canvas so both draws request the same vector size. With inset, VectorPainter
+        // rewrites its cached bitmap for the smaller draw before Android's recording canvas plays
+        // back the outline draw, corrupting the outline. Scaling avoids that cache mutation.
+        scale(scaleX = 0.89f, scaleY = 0.91f) {
           with(silhouette) { draw(size, colorFilter = ColorFilter.tint(colors.primary)) }
         }
         val center = Offset(size.width / 2f, size.height * 0.4f)

--- a/lib/maplibre-compose/src/androidDeviceTest/kotlin/org/maplibre/compose/style/RuntimeShaderPainterTest.kt
+++ b/lib/maplibre-compose/src/androidDeviceTest/kotlin/org/maplibre/compose/style/RuntimeShaderPainterTest.kt
@@ -8,9 +8,16 @@ import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.painter.Painter
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import org.junit.Assume.assumeTrue
 import org.maplibre.compose.expressions.dsl.image
 import org.maplibre.compose.layers.SymbolLayer
+import org.maplibre.compose.map.FakeSnapshotterAdapter
+import org.maplibre.compose.map.MapSnapshotRequest
+import org.maplibre.compose.map.mapRuntimeForTest
 import org.maplibre.compose.sources.GeoJsonData
 import org.maplibre.compose.sources.GeoJsonOptions
 import org.maplibre.compose.sources.GeoJsonSource
@@ -23,19 +30,13 @@ class RuntimeShaderPainterTest {
   fun shader_painter_reaches_style_as_readable_pixels() {
     assumeTrue("RuntimeShader requires API 33", Build.VERSION.SDK_INT >= 33)
     runGraphicsTest { graphics ->
-      val painter =
-        object : Painter() {
-          override val intrinsicSize = Size(4f, 4f)
-          private val brush =
-            ShaderBrush(RuntimeShader("half4 main(float2 p) { return half4(1, 0, 0, 1); }"))
-
-          override fun DrawScope.onDraw() = drawRect(brush)
-        }
+      val painter = shaderPainter()
       val source =
         GeoJsonSource("features", GeoJsonData.Features(featureCollectionOf()), GeoJsonOptions())
       var captured: ImageSnapshot? = null
       composeStyle(
         graphicsContext = graphics,
+        awaitRevision = { it.images.size == 1 },
         onRevision = { revision -> captured = revision.images.singleOrNull()?.image ?: captured },
       ) {
         SymbolLayer(id = "shader", source = source, iconImage = image(painter))
@@ -46,4 +47,48 @@ class RuntimeShaderPainterTest {
       assertEquals(List(16) { 0xffff0000.toInt() }, pixels.toList())
     }
   }
+
+  @Test
+  fun shader_painter_works_in_a_snapshot_without_a_ui_owner() {
+    assumeTrue("RuntimeShader requires API 33", Build.VERSION.SDK_INT >= 33)
+    runTest {
+      val adapter =
+        FakeSnapshotterAdapter(
+          capture = { _, revision ->
+            val captured = revision.images.single()
+            val layout = revision.layers.single().definition.value["layout"] as JsonObject
+            assertEquals(
+              JsonArray(listOf(JsonPrimitive("image"), JsonPrimitive(captured.id))),
+              layout["icon-image"],
+            )
+            captured.image.toImageBitmap()
+          }
+        )
+      val runtime = mapRuntimeForTest(createSnapshotterAdapter = { adapter })
+      val source =
+        GeoJsonSource("features", GeoJsonData.Features(featureCollectionOf()), GeoJsonOptions())
+      val painter = shaderPainter()
+      try {
+        val snapshotter =
+          runtime.createSnapshotter(BaseStyle.Empty) {
+            SymbolLayer(id = "shader", source = source, iconImage = image(painter))
+          }
+        val pixels = IntArray(16)
+        snapshotter.capture(MapSnapshotRequest(4, 4)).readPixels(pixels)
+        assertEquals(List(16) { 0xffff0000.toInt() }, pixels.toList())
+      } finally {
+        runtime.close()
+        runtime.awaitClosed()
+      }
+    }
+  }
+
+  private fun shaderPainter() =
+    object : Painter() {
+      override val intrinsicSize = Size(4f, 4f)
+      private val brush =
+        ShaderBrush(RuntimeShader("half4 main(float2 p) { return half4(1, 0, 0, 1); }"))
+
+      override fun DrawScope.onDraw() = drawRect(brush)
+    }
 }

--- a/lib/maplibre-compose/src/androidDeviceTest/kotlin/org/maplibre/compose/style/RuntimeShaderPainterTest.kt
+++ b/lib/maplibre-compose/src/androidDeviceTest/kotlin/org/maplibre/compose/style/RuntimeShaderPainterTest.kt
@@ -1,0 +1,49 @@
+package org.maplibre.compose.style
+
+import android.graphics.RuntimeShader
+import android.os.Build
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.ShaderBrush
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.painter.Painter
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import org.junit.Assume.assumeTrue
+import org.maplibre.compose.expressions.dsl.image
+import org.maplibre.compose.layers.SymbolLayer
+import org.maplibre.compose.sources.GeoJsonData
+import org.maplibre.compose.sources.GeoJsonOptions
+import org.maplibre.compose.sources.GeoJsonSource
+import org.maplibre.compose.testing.composeStyle
+import org.maplibre.compose.testing.runGraphicsTest
+import org.maplibre.spatialk.geojson.dsl.featureCollectionOf
+
+class RuntimeShaderPainterTest {
+  @Test
+  fun shader_painter_reaches_style_as_readable_pixels() {
+    assumeTrue("RuntimeShader requires API 33", Build.VERSION.SDK_INT >= 33)
+    runGraphicsTest { graphics ->
+      val painter =
+        object : Painter() {
+          override val intrinsicSize = Size(4f, 4f)
+          private val brush =
+            ShaderBrush(RuntimeShader("half4 main(float2 p) { return half4(1, 0, 0, 1); }"))
+
+          override fun DrawScope.onDraw() = drawRect(brush)
+        }
+      val source =
+        GeoJsonSource("features", GeoJsonData.Features(featureCollectionOf()), GeoJsonOptions())
+      var captured: ImageSnapshot? = null
+      composeStyle(
+        graphicsContext = graphics,
+        onRevision = { revision -> captured = revision.images.singleOrNull()?.image ?: captured },
+      ) {
+        SymbolLayer(id = "shader", source = source, iconImage = image(painter))
+      }
+      val bitmap = requireNotNull(captured).toImageBitmap()
+      val pixels = IntArray(16)
+      bitmap.readPixels(pixels)
+      assertEquals(List(16) { 0xffff0000.toInt() }, pixels.toList())
+    }
+  }
+}

--- a/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/map/SnapshotGraphicsContext.kt
+++ b/lib/maplibre-compose/src/androidMain/kotlin/org/maplibre/compose/map/SnapshotGraphicsContext.kt
@@ -1,0 +1,15 @@
+package org.maplibre.compose.map
+
+import android.widget.FrameLayout
+import androidx.compose.ui.graphics.GraphicsContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.maplibre.compose.mlnffi.AndroidMlnFfiPlatform
+
+internal actual suspend fun <T> withSnapshotGraphicsContext(
+  block: suspend (GraphicsContext) -> T
+): T =
+  withContext(Dispatchers.Main.immediate) {
+    val container = FrameLayout(AndroidMlnFfiPlatform.applicationContext)
+    block(GraphicsContext(container))
+  }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/dsl/image.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/expressions/dsl/image.kt
@@ -74,9 +74,10 @@ public fun image(
  * [FillExtrusionLayer][org.maplibre.compose.layers.FillExtrusionLayer],
  * [LineLayer][org.maplibre.compose.layers.LineLayer]) and as a section in the [format] expression.
  *
- * The [Painter] will be drawn to an [ImageBitmap] and registered with the style when it's
- * referenced by a layer, and unregistered from the style if it's no longer referenced by any layer.
- * An ID referencing the bitmap will be generated automatically and inserted into the expression.
+ * The [Painter] will be drawn asynchronously to an [ImageBitmap] and registered with the style when
+ * it's referenced by a layer, and unregistered from the style if it's no longer referenced by any
+ * layer. An ID referencing the bitmap will be generated automatically and inserted into the
+ * expression. A layer property containing a painter stays unset until its painters are ready.
  * Painters that draw identical pixels share one style image, so calling `painterResource` for the
  * same resource in several layers registers the image once.
  *

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/LayerPropertyCompiler.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/LayerPropertyCompiler.kt
@@ -1,17 +1,12 @@
 package org.maplibre.compose.layers
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.key
-import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.platform.LocalGraphicsContext
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.TextUnitType
-import kotlinx.coroutines.awaitCancellation
 import org.maplibre.compose.expressions.ast.BitmapLiteral
 import org.maplibre.compose.expressions.ast.CompiledExpression
 import org.maplibre.compose.expressions.ast.Expression
@@ -22,7 +17,6 @@ import org.maplibre.compose.expressions.dsl.const
 import org.maplibre.compose.expressions.dsl.div
 import org.maplibre.compose.expressions.value.ExpressionValue
 import org.maplibre.compose.expressions.value.FloatValue
-import org.maplibre.compose.style.ImageManager
 import org.maplibre.compose.style.LocalStyleNode
 import org.maplibre.compose.style.StyleNode
 
@@ -33,7 +27,20 @@ internal class LayerPropertyCompiler(
   private val emScale: Expression<FloatValue>? = null,
   private val spScale: Expression<FloatValue>? = null,
 ) {
-  private fun context(painters: Map<ImageManager.PainterKey, String> = emptyMap()) =
+  /**
+   * Compiles [expression]. A null [expression] compiles to a null literal, which leaves the
+   * property unset.
+   */
+  @Composable
+  operator fun <T : ExpressionValue?> invoke(expression: Expression<T>?): CompiledExpression<T> {
+    val expression = expression ?: NullLiteral.cast()
+    val images =
+      rememberLayerPropertyImages(expression, styleNode.imageManager, density, layoutDirection)
+        ?: return NullLiteral.cast()
+    return remember(this, expression, images) { expression.compile(context(images)) }
+  }
+
+  private fun context(images: LayerPropertyImages) =
     object : ExpressionContext {
       private var seenTextUnitType: TextUnitType? = null
 
@@ -71,79 +78,10 @@ internal class LayerPropertyCompiler(
           (this@LayerPropertyCompiler.spScale
             ?: error("DP text offsets require a text-unit compiler")) / const(density.fontScale)
 
-      override fun resolveBitmap(bitmap: BitmapLiteral): String {
-        return styleNode.imageManager.acquireBitmap(bitmap.key())
-      }
+      override fun resolveBitmap(bitmap: BitmapLiteral): String = images.resolve(bitmap)
 
-      override fun resolvePainter(painter: PainterLiteral): String {
-        return painters.getValue(painter.key(density, layoutDirection))
-      }
+      override fun resolvePainter(painter: PainterLiteral): String = images.resolve(painter)
     }
-
-  /**
-   * Compiles [expression]. A null [expression] compiles to a null literal, which leaves the
-   * property unset.
-   */
-  @Composable
-  operator fun <T : ExpressionValue?> invoke(expression: Expression<T>?): CompiledExpression<T> {
-    val expression = expression ?: NullLiteral.cast()
-    val painters =
-      remember(this, expression) {
-        buildSet {
-          expression.visit { if (it is PainterLiteral) add(it.key(density, layoutDirection)) }
-        }
-      }
-    // Expressions can be rebuilt each animation frame without changing their painters.
-    // Keep image references alive independently of expression compilation.
-    val resolvedPainters =
-      if (painters.isNotEmpty()) {
-        val graphicsContext = LocalGraphicsContext.current
-        key(styleNode, painters, graphicsContext) {
-          produceState<Map<ImageManager.PainterKey, String>?>(null) {
-              val acquired = mutableMapOf<ImageManager.PainterKey, String>()
-              try {
-                for (painter in painters) {
-                  acquired[painter] =
-                    styleNode.imageManager.acquirePainter(painter, graphicsContext)
-                }
-                value = acquired
-                awaitCancellation()
-              } finally {
-                acquired.keys.forEach(styleNode.imageManager::releasePainter)
-              }
-            }
-            .value
-        }
-      } else emptyMap()
-    if (resolvedPainters == null) return NullLiteral.cast()
-    DisposableEffect(this, expression, resolvedPainters) {
-      onDispose { releaseBitmaps(expression) }
-    }
-    return remember(this, expression, resolvedPainters) {
-      expression.compile(context(resolvedPainters))
-    }
-  }
-
-  private fun releaseBitmaps(expression: Expression<*>) {
-    expression.visit { if (it is BitmapLiteral) styleNode.imageManager.releaseBitmap(it.key()) }
-  }
-
-  private fun BitmapLiteral.key() = ImageManager.BitmapKey(value, sdf, stretch)
-
-  private fun PainterLiteral.key(
-    density: Density,
-    layoutDirection: LayoutDirection,
-  ): ImageManager.PainterKey =
-    ImageManager.PainterKey(
-      value,
-      density,
-      layoutDirection,
-      size,
-      sdf,
-      stretch,
-      alpha,
-      colorFilter,
-    )
 }
 
 @Composable

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/LayerPropertyCompiler.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/LayerPropertyCompiler.kt
@@ -2,12 +2,16 @@ package org.maplibre.compose.layers
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.key
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalGraphicsContext
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.TextUnitType
+import kotlinx.coroutines.awaitCancellation
 import org.maplibre.compose.expressions.ast.BitmapLiteral
 import org.maplibre.compose.expressions.ast.CompiledExpression
 import org.maplibre.compose.expressions.ast.Expression
@@ -29,7 +33,10 @@ internal class LayerPropertyCompiler(
   private val emScale: Expression<FloatValue>? = null,
   private val spScale: Expression<FloatValue>? = null,
 ) {
-  private val context =
+  private fun context(
+    painters: Map<ImageManager.PainterKey, String> = emptyMap(),
+    acquiredBitmaps: MutableList<ImageManager.BitmapKey>? = null,
+  ) =
     object : ExpressionContext {
       private var seenTextUnitType: TextUnitType? = null
 
@@ -68,15 +75,12 @@ internal class LayerPropertyCompiler(
             ?: error("DP text offsets require a text-unit compiler")) / const(density.fontScale)
 
       override fun resolveBitmap(bitmap: BitmapLiteral): String {
-        return styleNode.imageManager.acquireBitmap(bitmap.key())
+        val key = bitmap.key()
+        return styleNode.imageManager.acquireBitmap(key).also { acquiredBitmaps?.add(key) }
       }
 
       override fun resolvePainter(painter: PainterLiteral): String {
-        return styleNode.imageManager.acquirePainter(painter.key(density, layoutDirection))
-      }
-
-      fun reset() {
-        seenTextUnitType = null
+        return painters.getValue(painter.key(density, layoutDirection))
       }
     }
 
@@ -87,23 +91,38 @@ internal class LayerPropertyCompiler(
   @Composable
   operator fun <T : ExpressionValue?> invoke(expression: Expression<T>?): CompiledExpression<T> {
     val expression = expression ?: NullLiteral.cast()
-    DisposableEffect(this, expression) {
-      onDispose {
-        expression.visit {
-          when (it) {
-            is BitmapLiteral -> styleNode.imageManager.releaseBitmap(it.key())
-            is PainterLiteral ->
-              styleNode.imageManager.releasePainter(it.key(density, layoutDirection))
-
-            else -> {}
-          }
+    val painters =
+      remember(this, expression) {
+        buildSet {
+          expression.visit { if (it is PainterLiteral) add(it.key(density, layoutDirection)) }
         }
       }
+    if (painters.isNotEmpty()) {
+      val graphicsContext = LocalGraphicsContext.current
+      return key(this, expression, graphicsContext) {
+        produceState<CompiledExpression<T>>(NullLiteral.cast()) {
+            val acquired = mutableMapOf<ImageManager.PainterKey, String>()
+            val acquiredBitmaps = mutableListOf<ImageManager.BitmapKey>()
+            try {
+              for (painter in painters) {
+                acquired[painter] = styleNode.imageManager.acquirePainter(painter, graphicsContext)
+              }
+              value = expression.compile(context(acquired, acquiredBitmaps))
+              awaitCancellation()
+            } finally {
+              acquiredBitmaps.forEach(styleNode.imageManager::releaseBitmap)
+              acquired.keys.forEach(styleNode.imageManager::releasePainter)
+            }
+          }
+          .value
+      }
     }
-    return remember(this, expression) {
-      context.reset()
-      expression.compile(context)
-    }
+    DisposableEffect(this, expression) { onDispose { releaseBitmaps(expression) } }
+    return remember(this, expression) { expression.compile(context()) }
+  }
+
+  private fun releaseBitmaps(expression: Expression<*>) {
+    expression.visit { if (it is BitmapLiteral) styleNode.imageManager.releaseBitmap(it.key()) }
   }
 
   private fun BitmapLiteral.key() = ImageManager.BitmapKey(value, sdf, stretch)

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/LayerPropertyCompiler.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/LayerPropertyCompiler.kt
@@ -33,10 +33,7 @@ internal class LayerPropertyCompiler(
   private val emScale: Expression<FloatValue>? = null,
   private val spScale: Expression<FloatValue>? = null,
 ) {
-  private fun context(
-    painters: Map<ImageManager.PainterKey, String> = emptyMap(),
-    acquiredBitmaps: MutableList<ImageManager.BitmapKey>? = null,
-  ) =
+  private fun context(painters: Map<ImageManager.PainterKey, String> = emptyMap()) =
     object : ExpressionContext {
       private var seenTextUnitType: TextUnitType? = null
 
@@ -75,8 +72,7 @@ internal class LayerPropertyCompiler(
             ?: error("DP text offsets require a text-unit compiler")) / const(density.fontScale)
 
       override fun resolveBitmap(bitmap: BitmapLiteral): String {
-        val key = bitmap.key()
-        return styleNode.imageManager.acquireBitmap(key).also { acquiredBitmaps?.add(key) }
+        return styleNode.imageManager.acquireBitmap(bitmap.key())
       }
 
       override fun resolvePainter(painter: PainterLiteral): String {
@@ -97,28 +93,35 @@ internal class LayerPropertyCompiler(
           expression.visit { if (it is PainterLiteral) add(it.key(density, layoutDirection)) }
         }
       }
-    if (painters.isNotEmpty()) {
-      val graphicsContext = LocalGraphicsContext.current
-      return key(this, expression, graphicsContext) {
-        produceState<CompiledExpression<T>>(NullLiteral.cast()) {
-            val acquired = mutableMapOf<ImageManager.PainterKey, String>()
-            val acquiredBitmaps = mutableListOf<ImageManager.BitmapKey>()
-            try {
-              for (painter in painters) {
-                acquired[painter] = styleNode.imageManager.acquirePainter(painter, graphicsContext)
+    // Expressions can be rebuilt each animation frame without changing their painters.
+    // Keep image references alive independently of expression compilation.
+    val resolvedPainters =
+      if (painters.isNotEmpty()) {
+        val graphicsContext = LocalGraphicsContext.current
+        key(styleNode, painters, graphicsContext) {
+          produceState<Map<ImageManager.PainterKey, String>?>(null) {
+              val acquired = mutableMapOf<ImageManager.PainterKey, String>()
+              try {
+                for (painter in painters) {
+                  acquired[painter] =
+                    styleNode.imageManager.acquirePainter(painter, graphicsContext)
+                }
+                value = acquired
+                awaitCancellation()
+              } finally {
+                acquired.keys.forEach(styleNode.imageManager::releasePainter)
               }
-              value = expression.compile(context(acquired, acquiredBitmaps))
-              awaitCancellation()
-            } finally {
-              acquiredBitmaps.forEach(styleNode.imageManager::releaseBitmap)
-              acquired.keys.forEach(styleNode.imageManager::releasePainter)
             }
-          }
-          .value
-      }
+            .value
+        }
+      } else emptyMap()
+    if (resolvedPainters == null) return NullLiteral.cast()
+    DisposableEffect(this, expression, resolvedPainters) {
+      onDispose { releaseBitmaps(expression) }
     }
-    DisposableEffect(this, expression) { onDispose { releaseBitmaps(expression) } }
-    return remember(this, expression) { expression.compile(context()) }
+    return remember(this, expression, resolvedPainters) {
+      expression.compile(context(resolvedPainters))
+    }
   }
 
   private fun releaseBitmaps(expression: Expression<*>) {

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/LayerPropertyImages.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/LayerPropertyImages.kt
@@ -50,7 +50,15 @@ internal fun rememberLayerPropertyImages(
       bitmaps to painters
     }
   // Expressions can change every animation frame while their image inputs stay the same.
-  val painters = rememberPainterImages(manager, painterKeys) ?: return null
+  val painters = rememberPainterImages(manager, painterKeys)
+  if (painters == null) {
+    // Snapshot evaluators must wait until the property has compiled with its resolved image IDs.
+    DisposableEffect(manager) {
+      manager.beginImagePreparation()
+      onDispose { manager.endImagePreparation() }
+    }
+    return null
+  }
   val bitmaps = remember(manager, bitmapKeys) { bitmapKeys.associateWith(manager::acquireBitmap) }
   DisposableEffect(manager, bitmaps) {
     onDispose { bitmaps.keys.forEach(manager::releaseBitmap) }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/LayerPropertyImages.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/layers/LayerPropertyImages.kt
@@ -1,0 +1,92 @@
+package org.maplibre.compose.layers
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalGraphicsContext
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
+import kotlinx.coroutines.awaitCancellation
+import org.maplibre.compose.expressions.ast.BitmapLiteral
+import org.maplibre.compose.expressions.ast.Expression
+import org.maplibre.compose.expressions.ast.PainterLiteral
+import org.maplibre.compose.style.ImageManager
+import org.maplibre.compose.style.ImageManager.BitmapKey
+import org.maplibre.compose.style.ImageManager.PainterKey
+
+internal class LayerPropertyImages(
+  private val bitmaps: Map<BitmapKey, String>,
+  private val painters: Map<PainterKey, String>,
+  private val density: Density,
+  private val layoutDirection: LayoutDirection,
+) {
+  fun resolve(bitmap: BitmapLiteral): String = bitmaps.getValue(bitmap.imageKey())
+
+  fun resolve(painter: PainterLiteral): String =
+    painters.getValue(painter.imageKey(density, layoutDirection))
+}
+
+@Composable
+internal fun rememberLayerPropertyImages(
+  expression: Expression<*>,
+  manager: ImageManager,
+  density: Density,
+  layoutDirection: LayoutDirection,
+): LayerPropertyImages? {
+  val (bitmapKeys, painterKeys) =
+    remember(expression, density, layoutDirection) {
+      val bitmaps = mutableSetOf<BitmapKey>()
+      val painters = mutableSetOf<PainterKey>()
+      expression.visit {
+        when (it) {
+          is BitmapLiteral -> bitmaps.add(it.imageKey())
+          is PainterLiteral -> painters.add(it.imageKey(density, layoutDirection))
+          else -> Unit
+        }
+      }
+      bitmaps to painters
+    }
+  // Expressions can change every animation frame while their image inputs stay the same.
+  val painters = rememberPainterImages(manager, painterKeys) ?: return null
+  val bitmaps = remember(manager, bitmapKeys) { bitmapKeys.associateWith(manager::acquireBitmap) }
+  DisposableEffect(manager, bitmaps) {
+    onDispose { bitmaps.keys.forEach(manager::releaseBitmap) }
+  }
+  return remember(bitmaps, painters, density, layoutDirection) {
+    LayerPropertyImages(bitmaps, painters, density, layoutDirection)
+  }
+}
+
+@Composable
+private fun rememberPainterImages(
+  manager: ImageManager,
+  painters: Set<PainterKey>,
+): Map<PainterKey, String>? {
+  if (painters.isEmpty()) return emptyMap()
+  val graphicsContext = LocalGraphicsContext.current
+  // Reset to pending immediately when inputs change, instead of exposing the previous IDs.
+  return key(manager, painters, graphicsContext) {
+    val images by
+      produceState<Map<PainterKey, String>?>(null) {
+        val acquired = mutableMapOf<PainterKey, String>()
+        try {
+          for (painter in painters) {
+            acquired[painter] = manager.acquirePainter(painter, graphicsContext)
+          }
+          value = acquired
+          awaitCancellation()
+        } finally {
+          acquired.keys.forEach(manager::releasePainter)
+        }
+      }
+    images
+  }
+}
+
+private fun BitmapLiteral.imageKey() = BitmapKey(value, sdf, stretch)
+
+private fun PainterLiteral.imageKey(density: Density, layoutDirection: LayoutDirection) =
+  PainterKey(value, density, layoutDirection, size, sdf, stretch, alpha, colorFilter)

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapSnapshotter.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapSnapshotter.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.Recomposer
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalGraphicsContext
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.LayoutDirection
@@ -140,39 +141,46 @@ internal object DefaultStyleCompositionEvaluator : StyleCompositionEvaluator {
     ownership: SnapshotStyleOwnership,
   ): DesiredStyleRevision {
     val frameClock = BroadcastFrameClock()
-    return withContext(frameClock) {
-      coroutineScope {
-        val revision = CompletableDeferred<DesiredStyleRevision>()
-        val recomposer = Recomposer(currentCoroutineContext())
-        val recomposerJob =
-          launch(start = CoroutineStart.UNDISPATCHED) {
-            recomposer.runRecomposeAndApplyChanges()
-          }
-        val root =
-          StyleNode(
-            style,
-            replaceableSourceIds = ownership.sourceIds,
-            replaceableLayerIds = ownership.layerIds,
-          )
-        val evaluator = Composition(MapNodeApplier(root), recomposer)
-        try {
-          evaluator.setContent {
-            CompositionLocalProvider(
-              LocalDensity provides density,
-              LocalLayoutDirection provides layoutDirection,
-              LocalViewport provides viewport,
-            ) {
-              StyleContent(rootNode = root, publish = revision::complete, content = content)
+    return withSnapshotGraphicsContext { graphicsContext ->
+      withContext(frameClock) {
+        coroutineScope {
+          val revision = CompletableDeferred<DesiredStyleRevision>()
+          val recomposer = Recomposer(currentCoroutineContext())
+          val recomposerJob =
+            launch(start = CoroutineStart.UNDISPATCHED) {
+              recomposer.runRecomposeAndApplyChanges()
             }
+          val root =
+            StyleNode(
+              style,
+              replaceableSourceIds = ownership.sourceIds,
+              replaceableLayerIds = ownership.layerIds,
+            )
+          val evaluator = Composition(MapNodeApplier(root), recomposer)
+          try {
+            evaluator.setContent {
+              CompositionLocalProvider(
+                LocalGraphicsContext provides graphicsContext,
+                LocalDensity provides density,
+                LocalLayoutDirection provides layoutDirection,
+                LocalViewport provides viewport,
+              ) {
+                StyleContent(
+                  rootNode = root,
+                  publish = { if (!root.imageManager.hasPendingImages) revision.complete(it) },
+                  content = content,
+                )
+              }
+            }
+            while (!revision.isCompleted) {
+              if (frameClock.hasAwaiters) frameClock.sendFrame(0L) else yield()
+            }
+            revision.await()
+          } finally {
+            evaluator.dispose()
+            recomposer.close()
+            recomposerJob.join()
           }
-          while (!revision.isCompleted) {
-            if (frameClock.hasAwaiters) frameClock.sendFrame(0L) else yield()
-          }
-          revision.await()
-        } finally {
-          evaluator.dispose()
-          recomposer.close()
-          recomposerJob.join()
         }
       }
     }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/SnapshotGraphicsContext.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/SnapshotGraphicsContext.kt
@@ -1,0 +1,7 @@
+package org.maplibre.compose.map
+
+import androidx.compose.ui.graphics.GraphicsContext
+
+internal expect suspend fun <T> withSnapshotGraphicsContext(
+  block: suspend (GraphicsContext) -> T
+): T

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/ImageManager.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/ImageManager.kt
@@ -2,16 +2,18 @@ package org.maplibre.compose.style
 
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.geometry.takeOrElse
-import androidx.compose.ui.graphics.Canvas
 import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.GraphicsContext
 import androidx.compose.ui.graphics.ImageBitmap
-import androidx.compose.ui.graphics.drawscope.CanvasDrawScope
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import kotlin.math.ceil
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import org.maplibre.compose.util.ImageStretch
 import org.maplibre.compose.util.toImageBitmap
 
@@ -32,6 +34,7 @@ internal class ImageManager(private val node: StyleNode) {
   private val bitmapCounter = ReferenceCounter<BitmapKey>()
   private val bitmapContent = mutableMapOf<BitmapKey, ContentKey>()
 
+  private val painterMutex = Mutex()
   private val painterCounter = ReferenceCounter<PainterKey>()
   private val painterContent = mutableMapOf<PainterKey, ContentKey>()
 
@@ -50,14 +53,18 @@ internal class ImageManager(private val node: StyleNode) {
     bitmapCounter.decrement(key) { releaseContent(bitmapContent.remove(key)!!) }
   }
 
-  internal fun acquirePainter(key: PainterKey): String {
-    painterCounter.increment(key) {
-      val bitmap = key.drawToBitmap().let { if (key.drawAsSdf) it.toSdf() else it }
-      painterContent[key] =
-        acquireContent(ContentKey(ImageSnapshot.capture(bitmap), key.drawAsSdf, key.stretch))
+  internal suspend fun acquirePainter(key: PainterKey, graphicsContext: GraphicsContext): String =
+    painterMutex.withLock {
+      val content =
+        painterContent[key]
+          ?: run {
+            val bitmap =
+              key.drawToBitmap(graphicsContext).let { if (key.drawAsSdf) it.toSdf() else it }
+            ContentKey(ImageSnapshot.capture(bitmap), key.drawAsSdf, key.stretch)
+          }
+      painterCounter.increment(key) { painterContent[key] = acquireContent(content) }
+      definitions.getValue(painterContent.getValue(key)).id
     }
-    return definitions.getValue(painterContent.getValue(key)).id
-  }
 
   internal fun releasePainter(key: PainterKey) {
     painterCounter.decrement(key) { releaseContent(painterContent.remove(key)!!) }
@@ -78,17 +85,21 @@ internal class ImageManager(private val node: StyleNode) {
     }
   }
 
-  private fun PainterKey.drawToBitmap(): ImageBitmap {
+  private suspend fun PainterKey.drawToBitmap(graphicsContext: GraphicsContext): ImageBitmap {
     val size =
       with(density) {
         size?.let { Size(it.width.toPx(), it.height.toPx()) }
           ?: painter.intrinsicSize.takeOrElse { Size(16.dp.toPx(), 16.dp.toPx()) }
       }
-    val bitmap = ImageBitmap(size.width.toInt(), size.height.toInt())
-    CanvasDrawScope().draw(density, layoutDirection, Canvas(bitmap), size) {
-      with(painter) { draw(size, alpha, colorFilter) }
+    val layer = graphicsContext.createGraphicsLayer()
+    try {
+      layer.record(density, layoutDirection, IntSize(size.width.toInt(), size.height.toInt())) {
+        with(painter) { draw(size, alpha, colorFilter) }
+      }
+      return layer.toImageBitmap()
+    } finally {
+      graphicsContext.releaseGraphicsLayer(layer)
     }
-    return bitmap
   }
 
   private fun ImageBitmap.toSdf(radius: Double = 8.0, cutoff: Double = 0.25): ImageBitmap {

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/ImageManager.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/ImageManager.kt
@@ -34,12 +34,26 @@ internal class ImageManager(private val node: StyleNode) {
   private val bitmapCounter = ReferenceCounter<BitmapKey>()
   private val bitmapContent = mutableMapOf<BitmapKey, ContentKey>()
 
+  private var pendingProperties = 0
   private val painterMutex = Mutex()
   private val painterCounter = ReferenceCounter<PainterKey>()
   private val painterContent = mutableMapOf<PainterKey, ContentKey>()
 
   internal val desiredImages: List<StyleImageDefinition>
     get() = definitions.values.toList()
+
+  internal val hasPendingImages: Boolean
+    get() = pendingProperties != 0
+
+  internal fun beginImagePreparation() {
+    pendingProperties++
+    node.scheduleApplyChanges()
+  }
+
+  internal fun endImagePreparation() {
+    pendingProperties--
+    node.scheduleApplyChanges()
+  }
 
   internal fun acquireBitmap(key: BitmapKey): String {
     bitmapCounter.increment(key) {

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/layers/SymbolLayerCompositionTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/layers/SymbolLayerCompositionTest.kt
@@ -156,12 +156,10 @@ class SymbolLayerCompositionTest {
   fun keyed_layers_reorder_and_release_shared_images() = runGraphicsTest { graphics ->
     val source =
       GeoJsonSource("features", GeoJsonData.Features(featureCollectionOf()), GeoJsonOptions())
-    val icons =
-      listOf(
-        image(ImageBitmap(2, 2)),
-        image(ColorPainter(Color.Red), size = DpSize(2.dp, 2.dp)),
-      )
-    for (icon in icons) {
+    val bitmap = image(ImageBitmap(2, 2))
+    val painter = image(ColorPainter(Color.Red), size = DpSize(2.dp, 2.dp))
+    val icons = listOf(bitmap to 1, painter to 1, coalesce(bitmap, bitmap, painter) to 2)
+    for ((icon, imageCount) in icons) {
       for (remaining in listOf(listOf("c", "a"), emptyList())) {
         val ids = mutableStateOf(listOf("a", "b", "c"))
         val binding = RecordingStyleBinding()
@@ -169,10 +167,10 @@ class SymbolLayerCompositionTest {
         composeStyle(
           style = binding,
           graphicsContext = graphics,
-          awaitRevision = { it.images.size == if (ids.value.isEmpty()) 0 else 1 },
+          awaitRevision = { it.images.size == if (ids.value.isEmpty()) 0 else imageCount },
           thenChange = {
             assertEquals(ids.value, binding.layerIds())
-            assertEquals(1, binding.imageIds.size)
+            assertEquals(imageCount, binding.imageIds.size)
             initialImageIds = binding.imageIds.toSet()
             ids.value = remaining
           },

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/layers/SymbolLayerCompositionTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/layers/SymbolLayerCompositionTest.kt
@@ -4,9 +4,12 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.painter.ColorPainter
+import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.DpSize
@@ -16,10 +19,12 @@ import androidx.compose.ui.unit.sp
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.contentOrNull
@@ -27,6 +32,7 @@ import kotlinx.serialization.json.double
 import kotlinx.serialization.json.doubleOrNull
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonPrimitive
+import org.maplibre.compose.expressions.dsl.coalesce
 import org.maplibre.compose.expressions.dsl.const
 import org.maplibre.compose.expressions.dsl.image
 import org.maplibre.compose.expressions.dsl.offset
@@ -180,6 +186,53 @@ class SymbolLayerCompositionTest {
         assertEquals(if (remaining.isEmpty()) emptySet() else initialImageIds, binding.imageIds)
       }
     }
+  }
+
+  @Test
+  fun changing_an_expression_keeps_its_unchanged_painter_visible() = runGraphicsTest { graphics ->
+    val source =
+      GeoJsonSource("features", GeoJsonData.Features(featureCollectionOf()), GeoJsonOptions())
+    val frame = mutableStateOf(0)
+    var draws = 0
+    val painter =
+      object : Painter() {
+        override val intrinsicSize = Size(4f, 4f)
+
+        override fun DrawScope.onDraw() {
+          draws++
+          drawRect(Color.Red)
+        }
+      }
+    var ready = false
+    var imageId: String? = null
+    composeStyle(
+      graphicsContext = graphics,
+      awaitRevision = { revision ->
+        val layout = revision.layers.singleOrNull()?.definition?.value?.get("layout") as? JsonObject
+        layout?.get("icon-image")?.let { it != JsonNull } == true
+      },
+      onRevision = { revision ->
+        if (!ready && revision.images.isNotEmpty()) imageId = revision.images.single().id
+        if (ready) {
+          assertEquals(listOf(imageId), revision.images.map { it.id })
+          val layout = revision.layers.single().definition.value["layout"] as JsonObject
+          assertTrue(layout["icon-image"] != null && layout["icon-image"] != JsonNull)
+        }
+      },
+      thenChange = {
+        assertNotNull(imageId)
+        ready = true
+        frame.value++
+      },
+    ) {
+      SymbolLayer(
+        id = "animated",
+        source = source,
+        iconImage = coalesce(image(painter), image("fallback-${frame.value}")),
+        iconSize = const(1f + frame.value * 0.1f),
+      )
+    }
+    assertEquals(1, draws)
   }
 
   private fun JsonElement.normalizeNumbers(): JsonElement =

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/layers/SymbolLayerCompositionTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/layers/SymbolLayerCompositionTest.kt
@@ -42,6 +42,7 @@ import org.maplibre.compose.expressions.value.SymbolAnchor
 import org.maplibre.compose.sources.GeoJsonData
 import org.maplibre.compose.sources.GeoJsonOptions
 import org.maplibre.compose.sources.GeoJsonSource
+import org.maplibre.compose.style.DesiredStyleRevision
 import org.maplibre.compose.style.RecordingStyleBinding
 import org.maplibre.compose.testing.composeStyle
 import org.maplibre.compose.testing.runGraphicsTest
@@ -232,6 +233,54 @@ class SymbolLayerCompositionTest {
     }
     assertEquals(1, draws)
   }
+
+  @Test
+  fun replacing_a_painter_releases_its_image_and_never_exposes_stale_ids() =
+    runGraphicsTest { graphics ->
+      val source =
+        GeoJsonSource("features", GeoJsonData.Features(featureCollectionOf()), GeoJsonOptions())
+      val replace = mutableStateOf(false)
+      val red = ColorPainter(Color.Red)
+      val blue = ColorPainter(Color.Blue)
+      var initialId: String? = null
+      var replacementId: String? = null
+
+      fun DesiredStyleRevision.iconId(): String? {
+        val layout = layers.singleOrNull()?.definition?.value?.get("layout") as? JsonObject
+        return (layout?.get("icon-image") as? JsonArray)?.get(1)?.jsonPrimitive?.contentOrNull
+      }
+
+      composeStyle(
+        graphicsContext = graphics,
+        awaitRevision = { revision ->
+          val id = revision.iconId()
+          id != null && revision.images.size == 1 && (!replace.value || id != initialId)
+        },
+        onRevision = { revision ->
+          val id = revision.iconId()
+          if (id != null) {
+            val image = assertNotNull(revision.images.singleOrNull { it.id == id })
+            val pixels = IntArray(16)
+            image.image.toImageBitmap().readPixels(pixels)
+            val expected = if (replace.value) 0xff0000ff.toInt() else 0xffff0000.toInt()
+            assertEquals(List(16) { expected }, pixels.toList())
+            if (replace.value) replacementId = id else initialId = id
+          }
+        },
+        thenChange = {
+          assertNotNull(initialId)
+          replace.value = true
+        },
+      ) {
+        SymbolLayer(
+          id = "replaced",
+          source = source,
+          iconImage = image(if (replace.value) blue else red, size = DpSize(4.dp, 4.dp)),
+        )
+      }
+      assertNotNull(replacementId)
+      assertTrue(initialId != replacementId)
+    }
 
   private fun JsonElement.normalizeNumbers(): JsonElement =
     when (this) {

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/layers/SymbolLayerCompositionTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/layers/SymbolLayerCompositionTest.kt
@@ -38,6 +38,7 @@ import org.maplibre.compose.sources.GeoJsonOptions
 import org.maplibre.compose.sources.GeoJsonSource
 import org.maplibre.compose.style.RecordingStyleBinding
 import org.maplibre.compose.testing.composeStyle
+import org.maplibre.compose.testing.runGraphicsTest
 import org.maplibre.spatialk.geojson.dsl.featureCollectionOf
 
 class SymbolLayerCompositionTest {
@@ -146,7 +147,7 @@ class SymbolLayerCompositionTest {
   }
 
   @Test
-  fun keyed_layers_reorder_and_release_shared_images() = runTest {
+  fun keyed_layers_reorder_and_release_shared_images() = runGraphicsTest { graphics ->
     val source =
       GeoJsonSource("features", GeoJsonData.Features(featureCollectionOf()), GeoJsonOptions())
     val icons =
@@ -161,6 +162,8 @@ class SymbolLayerCompositionTest {
         var initialImageIds = emptySet<String>()
         composeStyle(
           style = binding,
+          graphicsContext = graphics,
+          awaitRevision = { it.images.size == if (ids.value.isEmpty()) 0 else 1 },
           thenChange = {
             assertEquals(ids.value, binding.layerIds())
             assertEquals(1, binding.imageIds.size)

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/SnapshotCompositionTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/SnapshotCompositionTest.kt
@@ -1,13 +1,61 @@
 package org.maplibre.compose.map
 
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.painter.ColorPainter
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import org.maplibre.compose.expressions.dsl.image
+import org.maplibre.compose.layers.SymbolLayer
+import org.maplibre.compose.sources.GeoJsonData
+import org.maplibre.compose.sources.GeoJsonOptions
+import org.maplibre.compose.sources.GeoJsonSource
 import org.maplibre.compose.style.BaseStyle
+import org.maplibre.spatialk.geojson.dsl.featureCollectionOf
 
 class SnapshotCompositionTest {
+  @Test
+  fun snapshot_waits_for_painter_pixels_and_the_compiled_image_property() = runTest {
+    val adapter =
+      FakeSnapshotterAdapter(
+        capture = { _, revision ->
+          val captured = revision.images.single()
+          val layout = revision.layers.single().definition.value["layout"] as JsonObject
+          assertEquals(
+            JsonArray(listOf(JsonPrimitive("image"), JsonPrimitive(captured.id))),
+            layout["icon-image"],
+          )
+          captured.image.toImageBitmap()
+        }
+      )
+    val runtime = mapRuntimeForTest(createSnapshotterAdapter = { adapter })
+    val source =
+      GeoJsonSource("features", GeoJsonData.Features(featureCollectionOf()), GeoJsonOptions())
+    val painter = ColorPainter(Color.Red)
+    try {
+      val snapshotter =
+        runtime.createSnapshotter(BaseStyle.Empty) {
+          SymbolLayer(
+            id = "pin",
+            source = source,
+            iconImage = image(painter, size = DpSize(4.dp, 4.dp)),
+          )
+        }
+      val bitmap = snapshotter.capture(MapSnapshotRequest(4, 4))
+      val pixels = IntArray(16)
+      bitmap.readPixels(pixels)
+      assertEquals(List(16) { 0xffff0000.toInt() }, pixels.toList())
+    } finally {
+      runtime.close()
+      runtime.awaitClosed()
+    }
+  }
+
   @Test
   fun snapshot_content_reads_the_viewport_of_its_own_request() = runTest {
     val sizes = mutableListOf<DpSize?>()

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/style/ImageManagerPainterTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/style/ImageManagerPainterTest.kt
@@ -1,28 +1,34 @@
 package org.maplibre.compose.style
 
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.DefaultAlpha
+import androidx.compose.ui.graphics.GraphicsContext
 import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.layer.GraphicsLayer
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.LayoutDirection
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
+import kotlinx.coroutines.CancellationException
+import org.maplibre.compose.testing.runGraphicsTest
 
 /** Draws painters to real bitmaps, which the Android host JVM cannot create. */
 class ImageManagerPainterTest {
 
   @Test
-  fun distinct_painters_with_identical_pixels_share_one_image() {
+  fun distinct_painters_with_identical_pixels_share_one_image() = runGraphicsTest { graphics ->
     val manager = ImageManager(StyleNode(RecordingStyleBinding()))
     val first = painterKey(SolidPainter(Color.Red))
     val second = painterKey(SolidPainter(Color.Red))
 
-    val firstId = manager.acquirePainter(first)
-    val secondId = manager.acquirePainter(second)
+    val firstId = manager.acquirePainter(first, graphics)
+    val secondId = manager.acquirePainter(second, graphics)
 
     assertEquals(firstId, secondId)
     assertEquals(listOf(firstId), manager.desiredImages.map { it.id })
@@ -35,14 +41,96 @@ class ImageManagerPainterTest {
   }
 
   @Test
-  fun painters_with_different_pixels_get_separate_images() {
+  fun painters_with_different_pixels_get_separate_images() = runGraphicsTest { graphics ->
     val manager = ImageManager(StyleNode(RecordingStyleBinding()))
 
-    val redId = manager.acquirePainter(painterKey(SolidPainter(Color.Red)))
-    val blueId = manager.acquirePainter(painterKey(SolidPainter(Color.Blue)))
+    val redId = manager.acquirePainter(painterKey(SolidPainter(Color.Red)), graphics)
+    val blueId = manager.acquirePainter(painterKey(SolidPainter(Color.Blue)), graphics)
 
     assertNotEquals(redId, blueId)
     assertEquals(2, manager.desiredImages.size)
+  }
+
+  @Test
+  fun repeated_key_is_drawn_once_and_kept_until_last_release() = runGraphicsTest { graphics ->
+    val manager = ImageManager(StyleNode(RecordingStyleBinding()))
+    var draws = 0
+    val painter =
+      object : Painter() {
+        override val intrinsicSize = Size(2f, 2f)
+
+        override fun DrawScope.onDraw() {
+          draws++
+          drawRect(Color.Red)
+        }
+      }
+    val key = painterKey(painter)
+    val id = manager.acquirePainter(key, graphics)
+    assertEquals(id, manager.acquirePainter(key, graphics))
+    assertEquals(1, draws)
+    manager.releasePainter(key)
+    assertEquals(listOf(id), manager.desiredImages.map { it.id })
+    manager.releasePainter(key)
+    assertTrue(manager.desiredImages.isEmpty())
+  }
+
+  @Test
+  fun capture_preserves_pixel_rows_at_non_aligned_widths() = runGraphicsTest { graphics ->
+    val manager = ImageManager(StyleNode(RecordingStyleBinding()))
+    val painter =
+      object : Painter() {
+        override val intrinsicSize = Size(7f, 3f)
+
+        override fun DrawScope.onDraw() {
+          drawRect(Color.Red)
+          drawRect(Color.Blue, topLeft = Offset(0f, 1f), size = Size(7f, 2f))
+        }
+      }
+    val key = painterKey(painter)
+    manager.acquirePainter(key, graphics)
+    val bitmap = manager.desiredImages.single().image.toImageBitmap()
+    assertEquals(7, bitmap.width)
+    assertEquals(3, bitmap.height)
+    val pixels = IntArray(21)
+    bitmap.readPixels(pixels)
+    assertEquals(List(7) { 0xffff0000.toInt() } + List(14) { 0xff0000ff.toInt() }, pixels.toList())
+    manager.releasePainter(key)
+  }
+
+  @Test
+  fun cancelled_capture_releases_layer_and_does_not_poison_cache() = runGraphicsTest { graphics ->
+    var activeLayers = 0
+    val tracking =
+      object : GraphicsContext by graphics {
+        override fun createGraphicsLayer(): GraphicsLayer =
+          graphics.createGraphicsLayer().also { activeLayers++ }
+
+        override fun releaseGraphicsLayer(layer: GraphicsLayer) {
+          graphics.releaseGraphicsLayer(layer)
+          activeLayers--
+        }
+      }
+    var cancel = true
+    val painter =
+      object : Painter() {
+        override val intrinsicSize = Size(2f, 2f)
+
+        override fun DrawScope.onDraw() {
+          if (cancel) throw CancellationException("cancel capture")
+          drawRect(Color.Red)
+        }
+      }
+    val manager = ImageManager(StyleNode(RecordingStyleBinding()))
+    val key = painterKey(painter)
+    assertFailsWith<CancellationException> { manager.acquirePainter(key, tracking) }
+    assertEquals(0, activeLayers)
+    assertTrue(manager.desiredImages.isEmpty())
+    cancel = false
+    manager.acquirePainter(key, tracking)
+    assertEquals(0, activeLayers)
+    assertEquals(1, manager.desiredImages.size)
+    manager.releasePainter(key)
+    assertTrue(manager.desiredImages.isEmpty())
   }
 
   private fun painterKey(painter: Painter) =

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/testing/GraphicsTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/testing/GraphicsTest.kt
@@ -1,0 +1,20 @@
+package org.maplibre.compose.testing
+
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.graphics.GraphicsContext
+import androidx.compose.ui.platform.LocalGraphicsContext
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.v2.runComposeUiTest
+
+@OptIn(ExperimentalTestApi::class)
+internal fun runGraphicsTest(block: suspend (GraphicsContext) -> Unit) = runComposeUiTest {
+  var completed = false
+  setContent {
+    val graphicsContext = LocalGraphicsContext.current
+    LaunchedEffect(Unit) {
+      block(graphicsContext)
+      completed = true
+    }
+  }
+  waitUntil { completed }
+}

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/testing/StyleComposition.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/testing/StyleComposition.kt
@@ -6,12 +6,14 @@ import androidx.compose.runtime.Composition
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.runtime.withRunningRecomposer
+import androidx.compose.ui.graphics.GraphicsContext
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalGraphicsContext
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.LayoutDirection
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
-import kotlinx.coroutines.yield
 import org.maplibre.compose.style.DesiredStyleRevision
 import org.maplibre.compose.style.MapNodeApplier
 import org.maplibre.compose.style.RecordingStyleBinding
@@ -28,7 +30,9 @@ import org.maplibre.compose.util.MaplibreComposable
 internal suspend fun composeStyle(
   style: RecordingStyleBinding = RecordingStyleBinding(),
   thenChange: (() -> Unit)? = null,
+  graphicsContext: GraphicsContext? = null,
   onRevision: (DesiredStyleRevision) -> Unit = {},
+  awaitRevision: (DesiredStyleRevision) -> Boolean = { true },
   content: @Composable @MaplibreComposable () -> Unit,
 ): RecordingStyleBinding {
   val frameClock = BroadcastFrameClock()
@@ -40,6 +44,8 @@ internal suspend fun composeStyle(
       try {
         composition.setContent {
           CompositionLocalProvider(
+            *if (graphicsContext != null) arrayOf(LocalGraphicsContext provides graphicsContext)
+            else emptyArray(),
             LocalDensity provides Density(1f),
             LocalLayoutDirection provides LayoutDirection.Ltr,
           ) {
@@ -57,10 +63,9 @@ internal suspend fun composeStyle(
         var frame = 0L
         suspend fun pumpFrames() {
           do {
-            while (!frameClock.hasAwaiters) yield()
-            frameClock.sendFrame(frame++)
-            yield()
-          } while (recomposer.hasPendingWork)
+            if (frameClock.hasAwaiters) frameClock.sendFrame(frame++)
+            delay(1)
+          } while (recomposer.hasPendingWork || revision?.let(awaitRevision) != true)
           recomposer.awaitIdle()
         }
         pumpFrames()

--- a/lib/maplibre-compose/src/nonAndroidMain/kotlin/org/maplibre/compose/map/SnapshotGraphicsContext.kt
+++ b/lib/maplibre-compose/src/nonAndroidMain/kotlin/org/maplibre/compose/map/SnapshotGraphicsContext.kt
@@ -1,0 +1,21 @@
+package org.maplibre.compose.map
+
+import androidx.compose.ui.InternalComposeUiApi
+import androidx.compose.ui.graphics.GraphicsContext
+import androidx.compose.ui.graphics.SkiaGraphicsContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+@OptIn(InternalComposeUiApi::class)
+internal actual suspend fun <T> withSnapshotGraphicsContext(
+  block: suspend (GraphicsContext) -> T
+): T =
+  // Keep composition effects and image capture serialized even when the caller uses a thread pool.
+  withContext(Dispatchers.Default.limitedParallelism(1)) {
+    val context = SkiaGraphicsContext()
+    try {
+      block(context)
+    } finally {
+      context.dispose()
+    }
+  }


### PR DESCRIPTION
## Description

Render painter style images through Compose Multiplatform's `GraphicsLayer` API so Android painters using `RuntimeShader` can be rasterized without the software-canvas exception. Keep minSdk 24 and existing pixel-based image sharing and SDF conversion.

`LayerPropertyImages` owns image preparation and references; `LayerPropertyCompiler` compiles against resolved IDs. Image lifetimes follow their inputs independently of expression compilation, so rebuilding expressions during animations keeps images registered. Properties containing painters stay unset until their images are ready.

Snapshot style evaluation creates and releases its own graphics context and waits for painter-backed properties to resolve. Android evaluation runs on the main dispatcher; other platforms serialize composition and capture on one dispatcher.

The Editable Markers demo scales the canvas for its inner pin fill, keeping both vector draws at the same requested size. Drawing the same vector painter at different sizes within one Android capture remains a known limitation: the later draw can overwrite a cached bitmap used by the recorded outline draw. The demo workaround includes an explanatory comment.

## Validation

- Full desktop suite passed: maplibre-compose reported 915 tests, 7 skipped, no failures. Full browser and Android host suites passed.
- API 24 emulator: 13 focused tests passed, including standalone painter snapshots. API 36 attached Samsung phone: 15 focused tests passed, including exact RuntimeShader pixels in both UI and standalone snapshot compositions.
- iOS simulator: 13 focused tests passed. Tests cover image sharing, cancellation cleanup, pixel rows, painter replacement, snapshot readiness, and retaining images through animation expression changes.
- Installed the demo and checked the pin outline against water on the phone. Earlier tap-animation verification retained pin pixels in all 476 decoded frames.
- `mise run check` passed. The shader test now explicitly waits for its captured image.

## AI assistance

Implemented and tested with assistance from GPT-6 in Codex.
