### PR TITLE
Add a cameraForBounds query to MapState

### DIFF
--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Camera.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Camera.kt
@@ -45,6 +45,17 @@ fun Camera() {
   }
   // #endregion fit-bounds
 
+  // #region camera-for-bounds
+  LaunchedEffect(mapState) {
+    val camera =
+      mapState.cameraForBounds(
+        boundingBox = BoundingBox(west = -123.0, south = 47.0, east = -122.0, north = 48.0),
+        padding = PaddingValues(32.dp),
+      )
+    mapState.animateCameraPosition(camera.copy(zoom = minOf(camera.zoom, 12.0)))
+  }
+  // #endregion camera-for-bounds
+
   // #region viewport
   val viewport = mapState.viewport
   if (viewport != null) {

--- a/docs/src/content/docs/camera.mdx
+++ b/docs/src/content/docs/camera.mdx
@@ -38,6 +38,16 @@ viewport. Padding adds space between the box and the map edges:
 Use <Api of="MapState.fitCameraToBounds" /> to fit the same bounding box without
 an animation.
 
+Use <Api of="MapState.cameraForBounds" /> to calculate a position before applying
+it. The query waits for a viewport and leaves the current camera and animation
+unchanged. For example, cap the calculated zoom before animating:
+
+<Code code={region(camera, "camera-for-bounds")} lang="kotlin" title="App.kt" />
+
+On the browser, bounds fitting calculates the target and zoom without tilt,
+then assigns the requested tilt. With nonzero tilt, some bounds may fall outside
+the viewport.
+
 ## Read the visible area
 
 <Api of="MapState.viewport" /> reports the current rendered size,

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapAdapter.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapAdapter.kt
@@ -76,6 +76,13 @@ internal interface MapAdapter {
 
   fun setCameraPadding(padding: PaddingValues)
 
+  fun cameraForBounds(
+    boundingBox: BoundingBox,
+    bearing: Double,
+    tilt: Double,
+    padding: PaddingValues,
+  ): CameraPosition
+
   fun fitCameraToBounds(
     boundingBox: BoundingBox,
     bearing: Double,

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
@@ -652,7 +652,11 @@ internal constructor(
         block()
       }
     select {
-      operation.onAwait { it }
+      operation.onAwait { result ->
+        // An inline operation can finish after invalidation, before select starts listening.
+        if (!owner.isCurrent(this@MapAttachment)) throw MapAttachmentChangedException()
+        result
+      }
       invalidated.onAwait {
         operation.cancelAndJoin()
         throw MapAttachmentChangedException()

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
@@ -507,6 +507,16 @@ internal constructor(
   val cameraMoveReason: CameraMoveReason
     get() = moveReasonState
 
+  suspend fun cameraForBounds(
+    boundingBox: BoundingBox,
+    bearing: Double,
+    tilt: Double,
+    padding: PaddingValues,
+  ): CameraPosition = runLeaseBound {
+    awaitViewportState()
+    adapter.cameraForBounds(boundingBox, bearing, tilt, padding)
+  }
+
   suspend fun fitCameraToBounds(
     boundingBox: BoundingBox,
     bearing: Double = 0.0,
@@ -859,6 +869,26 @@ internal constructor(
     }
     applyAttachmentCameraCommand(command.attachment, command.command)
   }
+
+  /**
+   * Waits for a viewport, then calculates a camera for [boundingBox] without moving the map or
+   * interrupting camera input or animations. Detaching the surface during the query cancels it.
+   *
+   * [padding] adds space around the bounds in addition to the map's camera padding. It does not
+   * change the map's padding. The result uses the current viewport size and camera constraints;
+   * recalculate it if those or the map's padding change before applying it.
+   *
+   * On the browser, fitting calculates the target and zoom without [tilt], then assigns [tilt] to
+   * the result. A nonzero tilt may therefore leave part of the bounds outside the viewport.
+   *
+   * @throws IllegalStateException if the backend cannot calculate a camera for the bounds.
+   */
+  public suspend fun cameraForBounds(
+    boundingBox: BoundingBox,
+    bearing: Double = 0.0,
+    tilt: Double = 0.0,
+    padding: PaddingValues = PaddingValues(0.dp),
+  ): CameraPosition = awaitAttachment().cameraForBounds(boundingBox, bearing, tilt, padding)
 
   /**
    * Waits for a viewport, then fits [boundingBox] without animation. A newer camera command or

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
@@ -1706,6 +1706,43 @@ class MapPresentationTest {
   }
 
   @Test
+  fun a_bounds_query_waits_for_an_attachment_and_its_viewport() = runTest {
+    val runtime = mapRuntimeForTest(physicalScope = backgroundScope)
+    val state = runtime.createMapState(BaseStyle.Demo)
+    val query = async {
+      state.cameraForBounds(BoundingBox(Position(-1.0, -1.0), Position(1.0, 1.0)))
+    }
+    testScheduler.runCurrent()
+    assertFalse(query.isCompleted)
+
+    val token = state.reservePresentation()
+    val adapter = PresentationTestAdapter()
+    state.publishPresentation(token, adapter)
+    testScheduler.runCurrent()
+    assertFalse(query.isCompleted)
+
+    requireNotNull(state.currentMapAttachment).updateViewport(testViewport())
+    assertEquals(adapter.lastCameraPosition, query.await())
+    assertFalse(adapter.boundsFit.isCompleted)
+    state.close()
+    state.awaitClosed()
+    runtime.close()
+  }
+
+  @Test
+  fun detaching_cancels_a_bounds_query_waiting_for_a_viewport() = runTest {
+    val fixture = presentationFixture()
+    val query = async {
+      fixture.state.cameraForBounds(BoundingBox(Position(-1.0, -1.0), Position(1.0, 1.0)))
+    }
+    testScheduler.runCurrent()
+    assertFalse(query.isCompleted)
+    fixture.state.releasePresentation(fixture.token, fixture.adapter)
+    assertFailsWith<CancellationException> { query.await() }
+    fixture.close()
+  }
+
+  @Test
   fun a_bounds_fit_waits_for_an_attachment_and_its_viewport() = runTest {
     val runtime = mapRuntimeForTest(physicalScope = backgroundScope)
     val state = runtime.createMapState(BaseStyle.Demo)
@@ -2084,6 +2121,13 @@ internal open class PresentationTestAdapter(
   }
 
   override fun setCameraPadding(padding: PaddingValues) = Unit
+
+  override fun cameraForBounds(
+    boundingBox: BoundingBox,
+    bearing: Double,
+    tilt: Double,
+    padding: PaddingValues,
+  ): CameraPosition = lastCameraPosition
 
   override fun fitCameraToBounds(
     boundingBox: BoundingBox,

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
@@ -1706,6 +1706,61 @@ class MapPresentationTest {
   }
 
   @Test
+  fun inline_queries_reject_results_from_a_detached_presentation() = runTest {
+    val queries: List<suspend (MapState) -> Any> =
+      listOf(
+        { it.cameraForBounds(BoundingBox(Position(-1.0, -1.0), Position(1.0, 1.0))) },
+        { it.queryRenderedFeatures(DpOffset.Zero) },
+        { it.queryRenderedFeatures(DpRect(0.dp, 0.dp, 10.dp, 10.dp)) },
+      )
+    for (query in queries) {
+      val runtime = mapRuntimeForTest(physicalScope = backgroundScope)
+      val state = runtime.createMapState(BaseStyle.Demo)
+      val token = state.reservePresentation()
+      val adapter =
+        object : PresentationTestAdapter() {
+          override fun cameraForBounds(
+            boundingBox: BoundingBox,
+            bearing: Double,
+            tilt: Double,
+            padding: PaddingValues,
+          ): CameraPosition {
+            state.releasePresentation(token, this)
+            return CameraPosition(zoom = 5.0)
+          }
+
+          override suspend fun queryRenderedFeatures(
+            offset: DpOffset,
+            layerIds: Set<String>?,
+            predicate: CompiledExpression<BooleanValue>?,
+          ): List<Feature<Geometry, JsonObject?>> {
+            state.releasePresentation(token, this)
+            return emptyList()
+          }
+
+          override suspend fun queryRenderedFeatures(
+            rect: DpRect,
+            layerIds: Set<String>?,
+            predicate: CompiledExpression<BooleanValue>?,
+          ): List<Feature<Geometry, JsonObject?>> {
+            state.releasePresentation(token, this)
+            return emptyList()
+          }
+        }
+      try {
+        state.publishPresentation(token, adapter)
+        requireNotNull(state.currentMapAttachment).updateViewport(testViewport())
+        // Both completion and invalidation are ready before runLeaseBound reaches select.
+        assertFailsWith<CancellationException> { query(state) }
+      } finally {
+        state.close()
+        state.awaitClosed()
+        runtime.close()
+      }
+    }
+  }
+
+  @Test
   fun a_bounds_query_waits_for_an_attachment_and_its_viewport() = runTest {
     val runtime = mapRuntimeForTest(physicalScope = backgroundScope)
     val state = runtime.createMapState(BaseStyle.Demo)

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
@@ -821,6 +821,16 @@ internal class GlJsMapSession(
     onMap { map -> map.jumpTo(unsafeJso<JumpToOptions> { this.padding = resolved }) }
   }
 
+  override fun cameraForBounds(
+    boundingBox: BoundingBox,
+    bearing: Double,
+    tilt: Double,
+    padding: PaddingValues,
+  ): CameraPosition =
+    checkNotNull(map?.cameraPositionForBounds(boundingBox, bearing, tilt, padding)) {
+      "The map could not calculate a camera for the bounds"
+    }
+
   override fun fitCameraToBounds(
     boundingBox: BoundingBox,
     bearing: Double,

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/MapCameraTransitionTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/MapCameraTransitionTest.kt
@@ -9,8 +9,11 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
 import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.compose.style.systemAnimatorDurationScale
@@ -26,6 +29,68 @@ import org.maplibre.spatialk.geojson.Position
  * Both backends advance a transition only from inside a render, so every test renders as it waits.
  */
 class MapCameraTransitionTest {
+
+  @Test
+  fun a_bounds_query_can_be_applied_with_transient_padding(): MapTestResult = runMapTest {
+    createMapFixture().use {
+      it.loadStyle(BaseStyle.Empty)
+      it.session.setCameraPadding(CAMERA_PADDING)
+      it.state.setCameraPosition(START)
+      it.awaitMapReady()
+      it.pumpUntil("the camera padding to be applied") {
+        it.cameraTargetMatches(START, CAMERA_PADDING)
+      }
+      val before = it.session.getCameraPosition()
+      val camera = it.state.cameraForBounds(BOUNDS, padding = FIT_PADDING)
+      it.pump(frames = 2)
+      assertSameFit(before, it.session.getCameraPosition(), "the query moved the camera")
+
+      it.state.setCameraPosition(camera)
+      it.pumpUntil("the calculated camera to be applied") {
+        abs(it.session.getCameraPosition().zoom - camera.zoom) < 0.01
+      }
+      it.assertCameraTarget(camera, CAMERA_PADDING)
+      it.assertBoundsInside(CAMERA_PADDING + FIT_PADDING)
+
+      it.state.fitCameraToBounds(BOUNDS, padding = FIT_PADDING)
+      it.pump(frames = 2)
+      assertSameFit(camera, it.session.getCameraPosition(), "the query disagrees with the fit")
+    }
+  }
+
+  @Test
+  fun a_bounds_query_waits_for_the_first_viewport(): MapTestResult = runMapTest {
+    createMapFixture().use { fixture ->
+      val query =
+        async(start = CoroutineStart.UNDISPATCHED) {
+          fixture.state.cameraForBounds(ANTIMERIDIAN_BOUNDS)
+        }
+      assertFalse(query.isCompleted)
+      fixture.awaitMapReady()
+      val camera = withTimeout(30.seconds) { query.await() }
+      assertTrue(abs(abs(camera.target.longitude) - 180.0) < 1.0)
+      assertTrue(camera.zoom > START.zoom)
+    }
+  }
+
+  @Test
+  fun a_bounds_query_does_not_interrupt_an_animation(): MapTestResult = runMapTest {
+    createMapFixture().use {
+      it.startAtOrigin()
+      val animation =
+        launch(Dispatchers.Default) {
+          it.state.animateCameraPosition(TARGET, 2.seconds)
+        }
+      it.awaitCameraMoving()
+      it.state.cameraForBounds(BOUNDS, bearing = 35.0, tilt = 20.0).also { camera ->
+        assertNear(35.0, camera.bearing, "the query bearing")
+        assertNear(20.0, camera.tilt, "the query tilt")
+      }
+      it.pumpUntil("the animation to complete after the query") { animation.isCompleted }
+      assertFalse(animation.isCancelled)
+      assertNear(TARGET.zoom, it.session.getCameraPosition().zoom, "the animation target")
+    }
+  }
 
   @Test
   fun a_bounds_jump_adds_transient_fit_padding_to_camera_padding(): MapTestResult = runMapTest {

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -71,6 +71,7 @@ import org.maplibre.compose.util.VisibleRegion
 import org.maplibre.compose.util.metersPerDpAtLatitude
 import org.maplibre.compose.util.renderedQueryOptions
 import org.maplibre.compose.util.toCameraOptions
+import org.maplibre.compose.util.toCameraPosition
 import org.maplibre.compose.util.toDpOffset
 import org.maplibre.compose.util.toEdgeInsets
 import org.maplibre.compose.util.toGeoJsonFeatures
@@ -1286,6 +1287,20 @@ internal class MlnFfiMapSession(
     map.jumpTo(CameraOptions().also { it.padding = padding })
     appliedCameraPadding = padding
   }
+
+  override fun cameraForBounds(
+    boundingBox: BoundingBox,
+    bearing: Double,
+    tilt: Double,
+    padding: PaddingValues,
+  ): CameraPosition =
+    checkNotNull(
+      runOnMap { map ->
+        cameraForBounds(map, boundingBox, bearing, tilt, padding).toCameraPosition()
+      }
+    ) {
+      "The map became unavailable during the bounds query"
+    }
 
   override fun fitCameraToBounds(
     boundingBox: BoundingBox,


### PR DESCRIPTION
## Description

Add `suspend MapState.cameraForBounds(...): CameraPosition` so apps can inspect or adjust a fitted camera before applying it. The query waits for a viewport, preserves persistent padding, and leaves camera movement and animations running. Detaching during a query cancels it.

Recheck attachment validity before the shared query helper returns a result, including when an inline adapter call detaches the presentation before completing. This also protects both rendered-feature query overloads.

Reuse the existing native and browser fitting calculations. Document the existing browser limitation where tilt is assigned after fitting; #1399 tracks correcting that calculation.

## Validation

- Static checks passed with `mise run check`; `mise run fix` reran formatting and static checks for the attachment-validation fix.
- `mise run test:desktop` passed on macOS: 915 library tests, 7 skipped, no failures.
- `mise run test:js` passed in Chrome: 603 library tests, no failures or skips.
- `mise run build:docs` passed, including internal links; the example compiled in both desktop and JS builds.

Six new tests cover viewport/attachment waiting, detach cancellation, transient padding, antimeridian fitting, querying during an animation, and rejecting inline query results after detachment. The inline-detachment regression failed before the shared-helper fix. Android and iOS runtime tests were not run locally; this uses existing FFI calls shared by the native backends.

## AI assistance

Codex (GPT-6) inspected the APIs, implemented the query, added tests and documentation, and ran validation.

