### PR TITLE
Expose consistent ease and fly camera animations

### DIFF
--- a/demo-app/android-auto/src/main/kotlin/org/maplibre/compose/demoapp/auto/PlacesScreen.kt
+++ b/demo-app/android-auto/src/main/kotlin/org/maplibre/compose/demoapp/auto/PlacesScreen.kt
@@ -22,6 +22,7 @@ import androidx.lifecycle.lifecycleScope
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
+import org.maplibre.compose.camera.CameraAnimation
 import org.maplibre.compose.camera.CameraMoveReason
 import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.demoapp.Protomaps
@@ -119,7 +120,7 @@ internal class PlacesScreen(carContext: CarContext, runtime: MapRuntime) : Scree
     inFlightZoom = null
     cameraAnimation?.cancel()
     cameraAnimation = lifecycleScope.launch {
-      state.animateCameraPosition(place.camera, duration = 650.milliseconds)
+      state.animateCameraPosition(place.camera, CameraAnimation.Fly(650.milliseconds))
     }
     invalidate()
   }
@@ -131,7 +132,7 @@ internal class PlacesScreen(carContext: CarContext, runtime: MapRuntime) : Scree
     inFlightZoom = request
     cameraAnimation = lifecycleScope.launch {
       try {
-        state.animateCameraPosition(request.target)
+        state.animateCameraPosition(request.target, CameraAnimation.Ease())
       } finally {
         if (inFlightZoom === request) inFlightZoom = null
       }

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoLocation.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoLocation.kt
@@ -111,7 +111,7 @@ internal fun DemoLocationMapContent(location: DemoLocationUi, locationState: Loc
           zoom = 16.0,
           bearing = followBearing,
         ),
-        duration = DemoFlightDuration,
+        animation = DemoFlight,
       )
     } else {
       updateCamera(mapState, updateBearing = bearingUpdate)

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoMap.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/DemoMap.kt
@@ -52,6 +52,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.jetbrains.compose.resources.DrawableResource
 import org.jetbrains.compose.resources.vectorResource
+import org.maplibre.compose.camera.CameraAnimation
 import org.maplibre.compose.demoapp.generated.Res
 import org.maplibre.compose.demoapp.generated.brightness_auto_24px
 import org.maplibre.compose.demoapp.generated.dark_mode_24px
@@ -82,8 +83,8 @@ import org.maplibre.compose.overlay.ZoomButtonsDefaults
 import org.maplibre.compose.overlay.include
 import org.maplibre.spatialk.geojson.Position
 
-/** How long the camera takes to fly to a newly selected demo. */
-val DemoFlightDuration = 2.seconds
+/** The camera flight to a newly selected demo. */
+val DemoFlight = CameraAnimation.Fly(2.seconds)
 
 /** Padding between fitted bounds and the edge of the map viewport. */
 val DemoBoundsPadding = PaddingValues(48.dp)
@@ -93,13 +94,13 @@ internal suspend fun MapState.flyTo(destination: DemoDestination) {
     is DemoDestination.ExactCamera ->
       animateCameraPosition(
         position = destination.position,
-        duration = DemoFlightDuration,
+        animation = DemoFlight,
       )
     is DemoDestination.FitBounds ->
       animateCameraToBounds(
         boundingBox = destination.bounds,
         padding = DemoBoundsPadding,
-        duration = DemoFlightDuration,
+        animation = DemoFlight,
       )
     DemoDestination.None -> Unit
   }

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/benchmark/BenchmarkMap.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/benchmark/BenchmarkMap.kt
@@ -37,6 +37,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
+import org.maplibre.compose.camera.CameraAnimation
 import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.demoapp.DemoAppState
 import org.maplibre.compose.map.DefaultMapRuntime
@@ -107,8 +108,8 @@ internal fun BenchmarkRun(
       onStatus("Warming up", true)
       delay(3000)
       // Run the same animation once before measurement to warm the map and Compose paths.
-      state.animateCameraPosition(camera(1.0), 500.milliseconds)
-      state.animateCameraPosition(camera(-1.0), 500.milliseconds)
+      state.animateCameraPosition(camera(1.0), CameraAnimation.Fly(500.milliseconds))
+      state.animateCameraPosition(camera(-1.0), CameraAnimation.Fly(500.milliseconds))
       delay(500)
       benchmarkTrace(true)
       traced = true
@@ -118,7 +119,10 @@ internal fun BenchmarkRun(
       when (config.scenario) {
         BenchmarkScenario.Animation ->
           repeat(8) {
-            state.animateCameraPosition(camera(if (it % 2 == 0) 1.0 else -1.0), 1500.milliseconds)
+            state.animateCameraPosition(
+              camera(if (it % 2 == 0) 1.0 else -1.0),
+              CameraAnimation.Fly(1500.milliseconds),
+            )
           }
         BenchmarkScenario.Setters -> {
           val start = withFrameNanos { it }

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/MapControlsDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/MapControlsDemo.kt
@@ -6,14 +6,24 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import kotlin.math.roundToInt
+import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.launch
+import org.maplibre.compose.camera.CameraAnimation
 import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.demoapp.Demo
 import org.maplibre.compose.demoapp.DemoAppState
 import org.maplibre.compose.demoapp.DemoDestination
+import org.maplibre.compose.demoapp.design.ButtonRow
 import org.maplibre.compose.demoapp.design.DropdownRow
+import org.maplibre.compose.demoapp.design.SectionHeader
+import org.maplibre.compose.demoapp.design.SegmentedRow
+import org.maplibre.compose.demoapp.design.SliderRow
+import org.maplibre.compose.demoapp.design.SwitchRow
 import org.maplibre.compose.interaction.KeyModifier
 import org.maplibre.compose.interaction.MapInteractions
 import org.maplibre.compose.interaction.ModifierMatch.Containing
@@ -80,6 +90,36 @@ object MapControlsDemo : Demo {
 
   private var recipe by mutableStateOf(Recipe.Standard)
 
+  private enum class Transition(val title: String) {
+    Fly("Fly"),
+    Ease("Ease"),
+  }
+
+  private enum class City(val title: String, val camera: CameraPosition) {
+    Seattle("Seattle", CameraPosition(target = Position(-122.3352, 47.6205), zoom = 14.0)),
+    NewYork("New York", CameraPosition(target = Position(-74.006, 40.7128), zoom = 13.0)),
+    London("London", CameraPosition(target = Position(-0.1276, 51.5072), zoom = 12.0)),
+  }
+
+  private var transition by mutableStateOf(Transition.Fly)
+  private var paceBySpeed by mutableStateOf(true)
+  private var durationMillis by mutableStateOf(2000f)
+  private var speed by mutableStateOf(CameraAnimation.Fly.DefaultSpeed.toFloat())
+  /** Zero means no limit. */
+  private var minZoom by mutableStateOf(0f)
+
+  private val animation: CameraAnimation
+    get() =
+      when (transition) {
+        Transition.Ease -> CameraAnimation.Ease(durationMillis.roundToInt().milliseconds)
+        Transition.Fly ->
+          CameraAnimation.Fly(
+            duration = if (paceBySpeed) null else durationMillis.roundToInt().milliseconds,
+            speed = if (paceBySpeed) speed.toDouble() else null,
+            minZoom = minZoom.toDouble().takeIf { it > 0.0 },
+          )
+      }
+
   override fun interactions(mapState: MapState): MapInteractions = recipe.interactions
 
   override fun uiOptions(settings: MapUiOptions): MapUiOptions = recipe.bindings(settings)
@@ -105,5 +145,55 @@ object MapControlsDemo : Demo {
       modifier = Modifier.padding(16.dp),
       style = MaterialTheme.typography.bodyMedium,
     )
+
+    SectionHeader("Camera animation")
+    SegmentedRow(
+      options = Transition.entries,
+      selected = transition,
+      optionLabel = { it.title },
+      onSelect = { transition = it },
+    )
+    if (transition == Transition.Fly) {
+      SwitchRow("Pace by speed", checked = paceBySpeed) { paceBySpeed = it }
+    }
+    if (transition == Transition.Fly && paceBySpeed) {
+      SliderRow(
+        label = "Speed",
+        value = speed,
+        range = 0.5f..10f,
+        valueLabel = { "${(it * 10).roundToInt() / 10f} screens/s" },
+        onChange = { speed = it },
+      )
+    } else {
+      SliderRow(
+        label = "Duration",
+        value = durationMillis,
+        range = 200f..5000f,
+        valueLabel = { "${it.roundToInt()} ms" },
+        onChange = { durationMillis = it },
+      )
+    }
+    if (transition == Transition.Fly) {
+      SliderRow(
+        label = "Minimum zoom",
+        value = minZoom,
+        range = 0f..12f,
+        valueLabel = { if (it > 0f) it.roundToInt().toString() else "None" },
+        onChange = { minZoom = it.roundToInt().toFloat() },
+      )
+    }
+    val scope = rememberCoroutineScope()
+    val mapState = state.mapState
+    for (city in City.entries) {
+      ButtonRow("Go to ${city.title}") {
+        scope.launch { mapState.animateCameraPosition(city.camera, animation) }
+      }
+    }
+    ButtonRow("Turn 90°") {
+      scope.launch {
+        val camera = mapState.cameraPosition
+        mapState.animateCameraPosition(camera.copy(bearing = camera.bearing + 90.0), animation)
+      }
+    }
   }
 }

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/TransitNetworkDemo.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/demoapp/demos/TransitNetworkDemo.kt
@@ -58,6 +58,7 @@ import kotlinx.datetime.toLocalDateTime
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
+import org.maplibre.compose.camera.CameraAnimation
 import org.maplibre.compose.demoapp.Demo
 import org.maplibre.compose.demoapp.DemoAppState
 import org.maplibre.compose.demoapp.DemoDestination
@@ -371,7 +372,7 @@ object TransitNetworkDemo : Demo {
       mapState.animateCameraToBounds(
         boundingBox = route.bounds,
         padding = RouteFitPadding,
-        duration = 1.seconds,
+        animation = CameraAnimation.Fly(1.seconds),
       )
     }
 

--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Camera.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Camera.kt
@@ -8,7 +8,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
+import org.maplibre.compose.camera.CameraAnimation
 import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.map.MaplibreMap
 import org.maplibre.compose.map.rememberMapState
@@ -30,11 +32,29 @@ fun Camera() {
   LaunchedEffect(mapState) {
     mapState.animateCameraPosition(
       position =
-        mapState.cameraPosition.copy(target = Position(latitude = 47.607, longitude = -122.342)),
-      duration = 3.seconds,
+        mapState.cameraPosition.copy(target = Position(latitude = 47.607, longitude = -122.342))
     )
   }
   // #endregion animate
+
+  // #region animate-fly
+  LaunchedEffect(mapState) {
+    mapState.animateCameraPosition(
+      position =
+        CameraPosition(target = Position(latitude = 40.713, longitude = -74.006), zoom = 12.0),
+      animation = CameraAnimation.Fly(duration = 3.seconds, minZoom = 4.0),
+    )
+  }
+  // #endregion animate-fly
+
+  // #region animate-ease
+  LaunchedEffect(mapState) {
+    mapState.animateCameraPosition(
+      position = mapState.cameraPosition.copy(zoom = mapState.cameraPosition.zoom + 1.0),
+      animation = CameraAnimation.Ease(duration = 500.milliseconds),
+    )
+  }
+  // #endregion animate-ease
 
   // #region fit-bounds
   LaunchedEffect(mapState) {

--- a/docs/src/content/docs/camera.mdx
+++ b/docs/src/content/docs/camera.mdx
@@ -19,8 +19,8 @@ initial <Api of="CameraPosition" /> to set the camera at startup:
 ## Animate the camera
 
 <Api of="MapState.animateCameraPosition" /> is a suspend function that moves
-the map to a new position over a duration. Call it from a coroutine. The
-function waits until the map is attached:
+the map to a new position. Call it from a coroutine. The function waits until
+the map is attached, and returns when the transition ends:
 
 <Code code={region(camera, "animate")} lang="kotlin" title="App.kt" />
 
@@ -28,10 +28,34 @@ Use <Api of="MapState.setCameraPosition" /> to move without an animation. The
 position is retained when the map is detached and restored when it is displayed
 again.
 
+### Choose the transition
+
+The `animation` parameter selects one of two transitions, which behave the same
+on every platform.
+
+<Api of="CameraAnimation.Fly" /> is the default. The camera zooms out, crosses
+the ground, and zooms back in, so the map stays legible over any distance.
+Without a duration, the flight takes as long as its path length and speed
+require. Set `duration` for a fixed time, `speed` in screenfuls per second for a
+constant pace, and `minZoom` to keep the flight from zooming out too far:
+
+<Code code={region(camera, "animate-fly")} lang="kotlin" title="App.kt" />
+
+<Api of="CameraAnimation.Ease" /> moves the camera directly to its target over a
+fixed duration, with zoom changing at a steady rate. Use it for short moves,
+such as changing zoom in place or following a location:
+
+<Code code={region(camera, "animate-ease")} lang="kotlin" title="App.kt" />
+
+Both transitions accept an `easing` timing curve, a <Api of="CubicBezier" />.
+On Android, the system animator duration scale multiplies the duration of
+either transition. A scale of zero jumps to the target.
+
 ## Fit a bounding box
 
 <Api of="MapState.animateCameraToBounds" /> fits a `BoundingBox` in the current
-viewport. Padding adds space between the box and the map edges:
+viewport with the same `animation` choices. Padding adds space between the box
+and the map edges:
 
 <Code code={region(camera, "fit-bounds")} lang="kotlin" title="App.kt" />
 

--- a/docs/src/content/docs/camera.mdx
+++ b/docs/src/content/docs/camera.mdx
@@ -30,20 +30,21 @@ again.
 
 ### Choose the transition
 
-The `animation` parameter selects one of two transitions, which behave the same
-on every platform.
+The `animation` parameter selects one of two transitions. Each platform
+implements both with the same controls.
 
 <Api of="CameraAnimation.Fly" /> is the default. The camera zooms out, crosses
 the ground, and zooms back in, so the map stays legible over any distance.
 Without a duration, the flight takes as long as its path length and speed
 require. Set `duration` for a fixed time, `speed` in screenfuls per second for a
-constant pace, and `minZoom` to keep the flight from zooming out too far:
+constant pace, and `minZoom` to keep the flight path from zooming out past a
+zoom. The path peaks near `minZoom` rather than stopping exactly at it:
 
 <Code code={region(camera, "animate-fly")} lang="kotlin" title="App.kt" />
 
 <Api of="CameraAnimation.Ease" /> moves the camera directly to its target over a
-fixed duration, with zoom changing at a steady rate. Use it for short moves,
-such as changing zoom in place or following a location:
+fixed duration, without zooming out on the way. Use it for short moves, such as
+changing zoom in place or following a location:
 
 <Code code={region(camera, "animate-ease")} lang="kotlin" title="App.kt" />
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/CameraAnimation.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/CameraAnimation.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Immutable
 import kotlin.math.abs
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
+import org.maplibre.compose.util.mercatorPixelDistance
 
 /**
  * How the camera moves from its current position to a new one.
@@ -93,19 +94,21 @@ public data class CubicBezier(
 }
 
 /**
- * Returns the animation to run from [from] to [to]. A speed-paced flight between the same center
- * and zoom has no path length to derive a duration from, and the engines disagree about it:
- * MapLibre Native jumps and MapLibre GL JS eases for its own default duration. Both instead run an
- * [CameraAnimation.Ease] with the default duration.
+ * Returns the animation to run from [from] to [to], where [to] has the zoom the map will apply. A
+ * speed-paced flight between the same center and zoom has no path length to derive a duration from,
+ * and the engines disagree about it: MapLibre Native jumps and MapLibre GL JS eases for its own
+ * default duration. Both instead run an [CameraAnimation.Ease] with the default duration. The path
+ * test is the engines' own: the projected distance at the current zoom, in pixels.
  */
 internal fun CameraAnimation.forPath(from: CameraPosition, to: CameraPosition): CameraAnimation {
   if (this !is CameraAnimation.Fly || duration != null) return this
-  val longitudeDelta = abs((to.target.longitude - from.target.longitude).mod(360.0))
   val hasPath =
-    abs(to.zoom - from.zoom) > PATH_EPSILON ||
-      abs(to.target.latitude - from.target.latitude) > PATH_EPSILON ||
-      minOf(longitudeDelta, 360.0 - longitudeDelta) > PATH_EPSILON
+    abs(to.zoom - from.zoom) > PATH_ZOOM_EPSILON ||
+      mercatorPixelDistance(from.zoom, from.target, to.target) > PATH_PIXEL_EPSILON
   return if (hasPath) this else CameraAnimation.Ease(easing = easing)
 }
 
-private const val PATH_EPSILON = 1e-9
+/** GL JS treats a shorter projected path as too short to fly; MapLibre Native uses half this. */
+private const val PATH_PIXEL_EPSILON = 2e-6
+
+private const val PATH_ZOOM_EPSILON = 1e-6

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/CameraAnimation.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/CameraAnimation.kt
@@ -1,6 +1,7 @@
 package org.maplibre.compose.camera
 
 import androidx.compose.runtime.Immutable
+import kotlin.math.abs
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -34,7 +35,9 @@ public sealed interface CameraAnimation {
    * remains legible over any distance.
    *
    * The flight takes [duration] when one is given. Otherwise its duration follows from the length
-   * of the path and [speed]. Set at most one of the two.
+   * of the path and [speed]. Set at most one of the two. A flight that changes only bearing or
+   * tilt, or nothing, has no path to pace: without a duration it becomes an [Ease] with the default
+   * duration and the same [easing].
    *
    * @param duration The total time of the flight. Null derives it from [speed].
    * @param speed The average speed in screenfuls per second, where a screenful is the visible span
@@ -88,3 +91,21 @@ public data class CubicBezier(
     public val Linear: CubicBezier = CubicBezier(0.0, 0.0, 1.0, 1.0)
   }
 }
+
+/**
+ * Returns the animation to run from [from] to [to]. A speed-paced flight between the same center
+ * and zoom has no path length to derive a duration from, and the engines disagree about it:
+ * MapLibre Native jumps and MapLibre GL JS eases for its own default duration. Both instead run an
+ * [CameraAnimation.Ease] with the default duration.
+ */
+internal fun CameraAnimation.forPath(from: CameraPosition, to: CameraPosition): CameraAnimation {
+  if (this !is CameraAnimation.Fly || duration != null) return this
+  val longitudeDelta = abs((to.target.longitude - from.target.longitude).mod(360.0))
+  val hasPath =
+    abs(to.zoom - from.zoom) > PATH_EPSILON ||
+      abs(to.target.latitude - from.target.latitude) > PATH_EPSILON ||
+      minOf(longitudeDelta, 360.0 - longitudeDelta) > PATH_EPSILON
+  return if (hasPath) this else CameraAnimation.Ease(easing = easing)
+}
+
+private const val PATH_EPSILON = 1e-9

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/CameraAnimation.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/CameraAnimation.kt
@@ -1,0 +1,87 @@
+package org.maplibre.compose.camera
+
+import androidx.compose.runtime.Immutable
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * How the camera moves from its current position to a new one.
+ *
+ * [Ease] travels directly. [Fly] zooms out, travels, and zooms back in. Both engines implement both
+ * transitions from the same model, so a transition looks the same on MapLibre Native and on the
+ * browser.
+ */
+@Immutable
+public sealed interface CameraAnimation {
+  /** The timing curve of the transition. */
+  public val easing: CubicBezier
+
+  /**
+   * Interpolates the camera directly from its current position to the new position over [duration].
+   * Zoom changes at a steady rate, so an ease between distant positions crosses the ground quickly
+   * at the current zoom. Use it for short moves, such as following a location or changing zoom in
+   * place.
+   */
+  @Immutable
+  public data class Ease(
+    val duration: Duration = 300.milliseconds,
+    override val easing: CubicBezier = CubicBezier.Default,
+  ) : CameraAnimation
+
+  /**
+   * Follows a flight path: the camera zooms out, crosses the ground, and zooms back in, so the map
+   * remains legible over any distance.
+   *
+   * The flight takes [duration] when one is given. Otherwise its duration follows from the length
+   * of the path and [speed]. Set at most one of the two.
+   *
+   * @param duration The total time of the flight. Null derives it from [speed].
+   * @param speed The average speed in screenfuls per second, where a screenful is the visible span
+   *   of the map. Null uses [DefaultSpeed]. Ignored when [duration] is set.
+   * @param minZoom The lowest zoom the flight path may reach. Null lets the path zoom out as far as
+   *   it needs to.
+   */
+  @Immutable
+  public data class Fly(
+    val duration: Duration? = null,
+    val speed: Double? = null,
+    val minZoom: Double? = null,
+    override val easing: CubicBezier = CubicBezier.Default,
+  ) : CameraAnimation {
+    init {
+      require(duration == null || speed == null) { "Set a flight duration or a speed, not both" }
+      require(speed == null || speed > 0.0) { "Flight speed must be positive: $speed" }
+    }
+
+    public companion object {
+      /** The flight speed when [speed] is null, in screenfuls per second. */
+      public const val DefaultSpeed: Double = 1.2 * 1.42
+    }
+  }
+}
+
+/**
+ * A cubic bezier timing curve from (0, 0) to (1, 1) with control points ([x1], [y1]) and ([x2],
+ * [y2]). [x1] and [x2] must lie in `[0, 1]` so that every time maps to one progress value.
+ */
+@Immutable
+public data class CubicBezier(
+  val x1: Double,
+  val y1: Double,
+  val x2: Double,
+  val y2: Double,
+) {
+  init {
+    require(x1 in 0.0..1.0 && x2 in 0.0..1.0) {
+      "Bezier control point x values must lie in [0, 1]: $x1, $x2"
+    }
+  }
+
+  public companion object {
+    /** The CSS `ease` curve: control points (0.25, 0.1) and (0.25, 1). */
+    public val Default: CubicBezier = CubicBezier(0.25, 0.1, 0.25, 1.0)
+
+    /** A constant rate of change. */
+    public val Linear: CubicBezier = CubicBezier(0.0, 0.0, 1.0, 1.0)
+  }
+}

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/CameraAnimation.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/CameraAnimation.kt
@@ -42,7 +42,7 @@ public sealed interface CameraAnimation {
    *
    * @param duration The total time of the flight. Null derives it from [speed].
    * @param speed The average speed in screenfuls per second, where a screenful is the visible span
-   *   of the map. Null uses [DefaultSpeed]. Ignored when [duration] is set.
+   *   of the map. Null uses [DefaultSpeed]. Must be null when [duration] is set.
    * @param minZoom Keeps the flight path from zooming out past this zoom. The engines fit the
    *   flight curve so that its peak lands near this value rather than clamping, so the path can
    *   pass up to about half a zoom level below it. A value below the map's minimum zoom or below

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/CameraAnimation.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/CameraAnimation.kt
@@ -7,9 +7,10 @@ import kotlin.time.Duration.Companion.milliseconds
 /**
  * How the camera moves from its current position to a new one.
  *
- * [Ease] travels directly. [Fly] zooms out, travels, and zooms back in. Both engines implement both
- * transitions from the same model, so a transition looks the same on MapLibre Native and on the
- * browser.
+ * [Ease] travels directly. [Fly] zooms out, travels, and zooms back in. MapLibre Native and
+ * MapLibre GL JS each implement both transitions with the same controls. Their paths and timing are
+ * close but not identical: the engines interpolate the center differently and GL JS measures the
+ * viewport without camera padding.
  */
 @Immutable
 public sealed interface CameraAnimation {
@@ -17,10 +18,10 @@ public sealed interface CameraAnimation {
   public val easing: CubicBezier
 
   /**
-   * Interpolates the camera directly from its current position to the new position over [duration].
-   * Zoom changes at a steady rate, so an ease between distant positions crosses the ground quickly
-   * at the current zoom. Use it for short moves, such as following a location or changing zoom in
-   * place.
+   * Moves the camera directly from its current position to the new position over [duration]. Zoom
+   * interpolates straight to its target, so the transition never zooms out on the way, and an ease
+   * between distant positions crosses the ground quickly at the current zoom. Use it for short
+   * moves, such as following a location or changing zoom in place.
    */
   @Immutable
   public data class Ease(
@@ -38,8 +39,10 @@ public sealed interface CameraAnimation {
    * @param duration The total time of the flight. Null derives it from [speed].
    * @param speed The average speed in screenfuls per second, where a screenful is the visible span
    *   of the map. Null uses [DefaultSpeed]. Ignored when [duration] is set.
-   * @param minZoom The lowest zoom the flight path may reach. Null lets the path zoom out as far as
-   *   it needs to.
+   * @param minZoom Keeps the flight path from zooming out past this zoom. The engines fit the
+   *   flight curve so that its peak lands near this value rather than clamping, so the path can
+   *   pass up to about half a zoom level below it. A value below the map's minimum zoom or below
+   *   the natural path has no effect.
    */
   @Immutable
   public data class Fly(

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/location/UpdateCamera.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/location/UpdateCamera.kt
@@ -1,7 +1,6 @@
 package org.maplibre.compose.location
 
-import kotlin.time.Duration
-import kotlin.time.Duration.Companion.milliseconds
+import org.maplibre.compose.camera.CameraAnimation
 import org.maplibre.compose.map.MapState
 import org.maplibre.spatialk.units.Bearing
 import org.maplibre.spatialk.units.extensions.inDegrees
@@ -10,13 +9,13 @@ import org.maplibre.spatialk.units.extensions.inDegrees
  * Convenience method for keeping [mapState] in sync with the location change that triggered this
  * [LocationTrackingEffect] callback.
  *
- * @param animationDuration if `null`, updates the camera directly without animation; otherwise,
- *   specifies the duration of the camera animation.
+ * @param animation the camera transition to the new location, or `null` to move the camera without
+ *   one.
  * @param updateBearing determines how the bearing affects the camera state.
  */
 public suspend fun LocationChangeScope.updateCamera(
   mapState: MapState,
-  animationDuration: Duration? = 300.milliseconds,
+  animation: CameraAnimation? = CameraAnimation.Ease(),
   updateBearing: BearingUpdate = BearingUpdate.TRACK_AUTOMATIC,
 ) {
   val selectedBearing =
@@ -40,8 +39,8 @@ public suspend fun LocationChangeScope.updateCamera(
         },
     )
 
-  if (animationDuration == null) mapState.setCameraPosition(newPosition)
-  else mapState.animateCameraPosition(newPosition, animationDuration)
+  if (animation == null) mapState.setCameraPosition(newPosition)
+  else mapState.animateCameraPosition(newPosition, animation)
 }
 
 /** How [updateCamera] updates camera bearing. */

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapAdapter.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapAdapter.kt
@@ -3,9 +3,9 @@ package org.maplibre.compose.map
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.DpRect
-import kotlin.time.Duration
 import kotlinx.coroutines.Deferred
 import kotlinx.serialization.json.JsonObject
+import org.maplibre.compose.camera.CameraAnimation
 import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.camera.Viewport
 import org.maplibre.compose.camera.internal.CameraCommandGuard
@@ -46,7 +46,7 @@ internal interface MapAdapter {
 
   suspend fun animateCameraPosition(
     finalPosition: CameraPosition,
-    duration: Duration,
+    animation: CameraAnimation,
     guard: CameraCommandGuard? = null,
   )
 
@@ -55,7 +55,7 @@ internal interface MapAdapter {
     bearing: Double,
     tilt: Double,
     padding: PaddingValues,
-    duration: Duration,
+    animation: CameraAnimation,
     guard: CameraCommandGuard? = null,
   )
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapAdapter.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapAdapter.kt
@@ -93,6 +93,9 @@ internal interface MapAdapter {
 
   fun setCameraConstraints(value: CameraConstraints)
 
+  /** The constraints last applied with [setCameraConstraints], or the defaults before any. */
+  fun getCameraConstraints(): CameraConstraints
+
   fun getVisibleBounds(): VisibleBounds
 
   fun getVisibleRegion(): VisibleRegion

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
@@ -558,11 +558,15 @@ internal constructor(
   }
 
   /**
-   * [animation] arrives already scaled by the animator duration scale, so a fallback ease it turns
-   * into is scaled here.
+   * Resolves [CameraAnimation.forPath] against the zoom the map will apply. The engines also keep
+   * the center inside a bounding box constraint, which is not mirrored here. [animation] arrives
+   * already scaled by the animator duration scale, so a fallback ease it turns into is scaled here.
    */
   private fun CameraAnimation.forPathTo(target: CameraPosition): CameraAnimation {
-    val resolved = forPath(adapter.getCameraPosition(), target)
+    val constraints = adapter.getCameraConstraints()
+    val constrained =
+      target.copy(zoom = target.zoom.coerceIn(constraints.minZoom, constraints.maxZoom))
+    val resolved = forPath(adapter.getCameraPosition(), constrained)
     return if (resolved === this) this else resolved.scaledBy(systemAnimatorDurationScale())
   }
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
@@ -25,8 +25,6 @@ import androidx.compose.ui.unit.dp
 import kotlin.concurrent.atomics.AtomicReference
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.jvm.JvmInline
-import kotlin.time.Duration
-import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.atomicfu.locks.reentrantLock
 import kotlinx.atomicfu.locks.withLock
 import kotlinx.coroutines.CancellationException
@@ -49,6 +47,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.selects.select
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
+import org.maplibre.compose.camera.CameraAnimation
 import org.maplibre.compose.camera.CameraMoveReason
 import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.camera.Viewport
@@ -530,11 +529,11 @@ internal constructor(
 
   suspend fun animateCameraPosition(
     position: CameraPosition,
-    duration: Duration = 300.milliseconds,
+    animation: CameraAnimation = CameraAnimation.Fly(),
     guard: CameraCommandGuard? = null,
   ): Unit = runLeaseBound {
     awaitViewportState()
-    adapter.animateCameraPosition(position, duration, boundGuard(guard))
+    adapter.animateCameraPosition(position, animation, boundGuard(guard))
   }
 
   suspend fun animateCameraToBounds(
@@ -542,11 +541,11 @@ internal constructor(
     bearing: Double = 0.0,
     tilt: Double = 0.0,
     padding: PaddingValues = PaddingValues(0.dp),
-    duration: Duration = 300.milliseconds,
+    animation: CameraAnimation = CameraAnimation.Fly(),
     guard: CameraCommandGuard? = null,
   ): Unit = runLeaseBound {
     awaitViewportState()
-    adapter.animateCameraToBounds(boundingBox, bearing, tilt, padding, duration, boundGuard(guard))
+    adapter.animateCameraToBounds(boundingBox, bearing, tilt, padding, animation, boundGuard(guard))
   }
 
   fun getVisibleRegion(): VisibleRegion? = withViewport { it.getVisibleRegion() }
@@ -909,35 +908,35 @@ internal constructor(
   }
 
   /**
-   * Waits for a viewport, then animates to [position]. A newer camera command or accepted input
-   * cancels this call.
+   * Waits for a viewport, then moves the camera to [position] with [animation]. A newer camera
+   * command or accepted input cancels this call.
    *
-   * On Android, the system animator duration scale multiplies [duration]. A scale of zero jumps to
-   * [position].
+   * On Android, the system animator duration scale multiplies the duration of [animation]. A scale
+   * of zero jumps to [position].
    */
   public suspend fun animateCameraPosition(
     position: CameraPosition,
-    duration: Duration = 300.milliseconds,
+    animation: CameraAnimation = CameraAnimation.Fly(),
   ): Unit = coroutineScope {
     val guard = gestureAuthority.beginProgrammatic(currentCoroutineContext()[Job])
     retryAcrossAttachments {
-      it.animateCameraPosition(position, duration.scaledBy(systemAnimatorDurationScale()), guard)
+      it.animateCameraPosition(position, animation.scaledBy(systemAnimatorDurationScale()), guard)
     }
   }
 
   /**
-   * Waits for a viewport, then animates to fit [boundingBox]. A newer camera command or accepted
-   * input cancels this call.
+   * Waits for a viewport, then moves the camera to fit [boundingBox] with [animation]. A newer
+   * camera command or accepted input cancels this call.
    *
-   * On Android, the system animator duration scale multiplies [duration]. A scale of zero jumps to
-   * fit [boundingBox].
+   * On Android, the system animator duration scale multiplies the duration of [animation]. A scale
+   * of zero jumps to fit [boundingBox].
    */
   public suspend fun animateCameraToBounds(
     boundingBox: BoundingBox,
     bearing: Double = 0.0,
     tilt: Double = 0.0,
     padding: PaddingValues = PaddingValues(0.dp),
-    duration: Duration = 300.milliseconds,
+    animation: CameraAnimation = CameraAnimation.Fly(),
   ): Unit = coroutineScope {
     val guard = gestureAuthority.beginProgrammatic(currentCoroutineContext()[Job])
     retryAcrossAttachments {
@@ -946,7 +945,7 @@ internal constructor(
         bearing,
         tilt,
         padding,
-        duration.scaledBy(systemAnimatorDurationScale()),
+        animation.scaledBy(systemAnimatorDurationScale()),
         guard,
       )
     }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
@@ -51,6 +51,7 @@ import org.maplibre.compose.camera.CameraAnimation
 import org.maplibre.compose.camera.CameraMoveReason
 import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.camera.Viewport
+import org.maplibre.compose.camera.forPath
 import org.maplibre.compose.camera.internal.CameraCommandGuard
 import org.maplibre.compose.camera.internal.CameraInputAuthority
 import org.maplibre.compose.expressions.ast.CompiledExpression
@@ -533,7 +534,7 @@ internal constructor(
     guard: CameraCommandGuard? = null,
   ): Unit = runLeaseBound {
     awaitViewportState()
-    adapter.animateCameraPosition(position, animation, boundGuard(guard))
+    adapter.animateCameraPosition(position, animation.forPathTo(position), boundGuard(guard))
   }
 
   suspend fun animateCameraToBounds(
@@ -545,7 +546,24 @@ internal constructor(
     guard: CameraCommandGuard? = null,
   ): Unit = runLeaseBound {
     awaitViewportState()
-    adapter.animateCameraToBounds(boundingBox, bearing, tilt, padding, animation, boundGuard(guard))
+    val target = adapter.cameraForBounds(boundingBox, bearing, tilt, padding)
+    adapter.animateCameraToBounds(
+      boundingBox,
+      bearing,
+      tilt,
+      padding,
+      animation.forPathTo(target),
+      boundGuard(guard),
+    )
+  }
+
+  /**
+   * [animation] arrives already scaled by the animator duration scale, so a fallback ease it turns
+   * into is scaled here.
+   */
+  private fun CameraAnimation.forPathTo(target: CameraPosition): CameraAnimation {
+    val resolved = forPath(adapter.getCameraPosition(), target)
+    return if (resolved === this) this else resolved.scaledBy(systemAnimatorDurationScale())
   }
 
   fun getVisibleRegion(): VisibleRegion? = withViewport { it.getVisibleRegion() }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
@@ -559,7 +559,7 @@ internal constructor(
 
   /**
    * Resolves [CameraAnimation.forPath] against the zoom the map will apply. The engines also keep
-   * the center inside a bounding box constraint, which is not mirrored here. [animation] arrives
+   * the center inside a bounding box constraint, which is not mirrored here. The receiver arrives
    * already scaled by the animator duration scale, so a fallback ease it turns into is scaled here.
    */
   private fun CameraAnimation.forPathTo(target: CameraPosition): CameraAnimation {

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/CompassButton.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/CompassButton.kt
@@ -46,6 +46,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
+import org.maplibre.compose.camera.CameraAnimation
 import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.generated.Res
 import org.maplibre.compose.generated.compass
@@ -97,7 +98,10 @@ public fun MapOverlayScope.CompassButton(
         role = Role.Button,
       ) {
         coroutineScope.launch {
-          currentMapState.animateCameraPosition(getHomePosition(currentMapState.cameraPosition))
+          currentMapState.animateCameraPosition(
+            getHomePosition(currentMapState.cameraPosition),
+            CameraAnimation.Ease(),
+          )
         }
         onClick()
       }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/ZoomButtons.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/overlay/ZoomButtons.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
+import org.maplibre.compose.camera.CameraAnimation
 import org.maplibre.compose.camera.CameraMoveReason
 import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.generated.Res
@@ -109,7 +110,7 @@ public fun MapOverlayScope.ZoomButtons(
     inFlight = request
     coroutineScope.launch {
       try {
-        currentMapState.animateCameraPosition(request.target)
+        currentMapState.animateCameraPosition(request.target, CameraAnimation.Ease())
       } finally {
         if (inFlight === request) inFlight = null
       }

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/AnimatorDurationScale.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/style/AnimatorDurationScale.kt
@@ -5,6 +5,7 @@ import kotlin.time.Duration
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.doubleOrNull
+import org.maplibre.compose.camera.CameraAnimation
 
 /**
  * The platform's animator duration scale: the value of Android's
@@ -25,6 +26,25 @@ internal fun Duration.scaledBy(scale: Float): Duration {
   requireScale(scale)
   if (scale == 1f) return this
   return this * scale.toDouble()
+}
+
+/**
+ * Returns [this] with its timing multiplied by [scale], or [this] unchanged when the scale is 1f. A
+ * flight without a duration divides its speed by [scale] instead. A scale of zero makes the
+ * transition a jump.
+ */
+internal fun CameraAnimation.scaledBy(scale: Float): CameraAnimation {
+  requireScale(scale)
+  if (scale == 1f) return this
+  return when (this) {
+    is CameraAnimation.Ease -> copy(duration = duration.scaledBy(scale))
+    is CameraAnimation.Fly ->
+      when {
+        duration != null -> copy(duration = duration.scaledBy(scale))
+        scale == 0f -> copy(duration = Duration.ZERO, speed = null)
+        else -> copy(speed = (speed ?: CameraAnimation.Fly.DefaultSpeed) / scale)
+      }
+  }
 }
 
 /**

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/util/Projection.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/util/Projection.kt
@@ -2,7 +2,11 @@ package org.maplibre.compose.util
 
 import kotlin.math.PI
 import kotlin.math.cos
+import kotlin.math.hypot
+import kotlin.math.ln
 import kotlin.math.pow
+import kotlin.math.tan
+import org.maplibre.spatialk.geojson.Position
 
 /** MapLibre projects with 512px tiles, not the more common 256. */
 private const val TILE_SIZE = 512.0
@@ -28,4 +32,25 @@ internal fun metersPerDpAtLatitude(zoom: Double, latitude: Double): Double {
   val clampedLatitude = latitude.coerceIn(-MERCATOR_MAX_LATITUDE, MERCATOR_MAX_LATITUDE)
   return cos(clampedLatitude * PI / 180.0) * EARTH_CIRCUMFERENCE_METERS /
     (2.0.pow(clampedZoom) * TILE_SIZE)
+}
+
+/**
+ * The Web Mercator distance in logical pixels between [from] and [to] at [zoom], along the shorter
+ * way around the world. Transcribed from `mbgl::Projection::project` with the unwrap that
+ * `Transform::flyTo` applies to its start point.
+ */
+internal fun mercatorPixelDistance(zoom: Double, from: Position, to: Position): Double {
+  val worldSize = 2.0.pow(zoom.coerceIn(MIN_PROJECTION_ZOOM, MAX_PROJECTION_ZOOM)) * TILE_SIZE
+  var deltaLongitude = (to.longitude - from.longitude) % 360.0
+  if (deltaLongitude > 180.0) deltaLongitude -= 360.0
+  if (deltaLongitude < -180.0) deltaLongitude += 360.0
+  val deltaX = worldSize * deltaLongitude / 360.0
+  val deltaY = worldSize * (mercatorY(from.latitude) - mercatorY(to.latitude))
+  return hypot(deltaX, deltaY)
+}
+
+/** The Web Mercator y of [latitude] as a fraction of the world, from 0 at the north edge. */
+private fun mercatorY(latitude: Double): Double {
+  val clamped = latitude.coerceIn(-MERCATOR_MAX_LATITUDE, MERCATOR_MAX_LATITUDE)
+  return 0.5 - ln(tan(PI / 4.0 + clamped * PI / 360.0)) / (2.0 * PI)
 }

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/camera/CameraAnimationTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/camera/CameraAnimationTest.kt
@@ -20,6 +20,16 @@ class CameraAnimationTest {
     assertSame(flight, flight.forPath(START, START.copy(target = Position(1.0, 0.0))))
   }
 
+  /** The path test is projected distance, so the same move counts at one zoom and not another. */
+  @Test
+  fun a_path_is_measured_in_pixels_at_the_current_zoom() {
+    val flight = CameraAnimation.Fly()
+    val nudged = START.copy(target = Position(START.target.longitude + 1e-9, 0.0))
+
+    assertEquals(CameraAnimation.Ease(), flight.forPath(START, nudged))
+    assertSame(flight, flight.forPath(START.copy(zoom = 22.0), nudged.copy(zoom = 22.0)))
+  }
+
   @Test
   fun a_timed_flight_and_an_ease_keep_their_animation() {
     val timed = CameraAnimation.Fly(1.seconds)

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/camera/CameraAnimationTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/camera/CameraAnimationTest.kt
@@ -1,0 +1,44 @@
+package org.maplibre.compose.camera
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+import kotlin.time.Duration.Companion.seconds
+import org.maplibre.spatialk.geojson.Position
+
+class CameraAnimationTest {
+
+  /** Only a speed-paced flight with no ground to cover falls back to an ease. */
+  @Test
+  fun a_speed_paced_flight_without_a_path_becomes_an_ease() {
+    val flight = CameraAnimation.Fly(easing = CubicBezier.Linear)
+    val turned = START.copy(bearing = 90.0, tilt = 30.0)
+
+    assertEquals(CameraAnimation.Ease(easing = CubicBezier.Linear), flight.forPath(START, turned))
+    assertEquals(CameraAnimation.Ease(easing = CubicBezier.Linear), flight.forPath(START, START))
+    assertSame(flight, flight.forPath(START, START.copy(zoom = 5.0)))
+    assertSame(flight, flight.forPath(START, START.copy(target = Position(1.0, 0.0))))
+  }
+
+  @Test
+  fun a_timed_flight_and_an_ease_keep_their_animation() {
+    val timed = CameraAnimation.Fly(1.seconds)
+    val ease = CameraAnimation.Ease()
+
+    assertSame(timed, timed.forPath(START, START))
+    assertSame(ease, ease.forPath(START, START))
+  }
+
+  /** The same longitude in another world copy is no path to fly. */
+  @Test
+  fun a_flight_to_the_same_longitude_in_another_world_copy_has_no_path() {
+    val flight = CameraAnimation.Fly()
+    val wrapped = START.copy(target = Position(START.target.longitude + 360.0, 0.0))
+
+    assertEquals(CameraAnimation.Ease(), flight.forPath(START, wrapped))
+  }
+
+  private companion object {
+    val START = CameraPosition(target = Position(170.0, 0.0), zoom = 3.0)
+  }
+}

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
@@ -16,7 +16,6 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
-import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CancellationException
@@ -34,6 +33,7 @@ import kotlinx.serialization.json.double
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
+import org.maplibre.compose.camera.CameraAnimation
 import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.camera.Viewport
 import org.maplibre.compose.camera.internal.CameraCommandGuard
@@ -1864,11 +1864,17 @@ class MapPresentationTest {
     val fixture = presentationFixture()
     fixture.attachment.updateViewport(testViewport())
     val first = async {
-      fixture.state.animateCameraPosition(CameraPosition(zoom = 2.0), 1.seconds)
+      fixture.state.animateCameraPosition(
+        CameraPosition(zoom = 2.0),
+        CameraAnimation.Fly(1.seconds),
+      )
     }
     fixture.adapter.animationStarted.await()
     val second = async {
-      fixture.state.animateCameraPosition(CameraPosition(zoom = 3.0), 1.seconds)
+      fixture.state.animateCameraPosition(
+        CameraPosition(zoom = 3.0),
+        CameraAnimation.Fly(1.seconds),
+      )
     }
     testScheduler.runCurrent()
 
@@ -1886,11 +1892,11 @@ class MapPresentationTest {
     val runtime = mapRuntimeForTest(physicalScope = backgroundScope)
     val state = runtime.createMapState(BaseStyle.Demo)
     val superseded = async {
-      state.animateCameraPosition(CameraPosition(zoom = 2.0), 1.seconds)
+      state.animateCameraPosition(CameraPosition(zoom = 2.0), CameraAnimation.Fly(1.seconds))
     }
     testScheduler.runCurrent()
     val animation = async {
-      state.animateCameraPosition(CameraPosition(zoom = 4.0), 1.seconds)
+      state.animateCameraPosition(CameraPosition(zoom = 4.0), CameraAnimation.Fly(1.seconds))
     }
     testScheduler.runCurrent()
     assertTrue(superseded.isCancelled)
@@ -1961,7 +1967,7 @@ class MapPresentationTest {
     val state = runtime.createMapState(BaseStyle.Demo)
     supervisorScope {
       val animation = async {
-        state.animateCameraPosition(CameraPosition(zoom = 4.0), 1.seconds)
+        state.animateCameraPosition(CameraPosition(zoom = 4.0), CameraAnimation.Fly(1.seconds))
       }
       testScheduler.runCurrent()
 
@@ -2141,7 +2147,7 @@ internal open class PresentationTestAdapter(
 
   override suspend fun animateCameraPosition(
     finalPosition: CameraPosition,
-    duration: Duration,
+    animation: CameraAnimation,
     guard: CameraCommandGuard?,
   ) {
     animationStarted.complete(Unit)
@@ -2153,7 +2159,7 @@ internal open class PresentationTestAdapter(
     bearing: Double,
     tilt: Double,
     padding: PaddingValues,
-    duration: Duration,
+    animation: CameraAnimation,
     guard: CameraCommandGuard?,
   ) = awaitCancellation()
 

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
@@ -2175,6 +2175,8 @@ internal open class PresentationTestAdapter(
 
   override fun getCameraPosition(): CameraPosition = lastCameraPosition
 
+  override fun getCameraConstraints(): CameraConstraints = CameraConstraints()
+
   override fun setCameraPosition(cameraPosition: CameraPosition, guard: CameraCommandGuard?) {
     presentationWasVisibleWhileConfiguring =
       presentationWasVisibleWhileConfiguring || currentAttachment() != null

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/style/AnimatorDurationScaleTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/style/AnimatorDurationScaleTest.kt
@@ -2,10 +2,14 @@ package org.maplibre.compose.style
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.double
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import org.maplibre.compose.camera.CameraAnimation
 
 class AnimatorDurationScaleTest {
 
@@ -34,5 +38,28 @@ class AnimatorDurationScaleTest {
         value.jsonPrimitive.double
       },
     )
+  }
+
+  /** A flight without a duration slows its speed instead, so the flight still takes longer. */
+  @Test
+  fun scaling_a_camera_animation_scales_its_timing() {
+    assertEquals(
+      CameraAnimation.Ease(600.milliseconds),
+      CameraAnimation.Ease(300.milliseconds).scaledBy(2f),
+    )
+    assertEquals(CameraAnimation.Fly(2.seconds), CameraAnimation.Fly(1.seconds).scaledBy(2f))
+    assertEquals(CameraAnimation.Fly(speed = 1.0), CameraAnimation.Fly(speed = 2.0).scaledBy(2f))
+    assertEquals(
+      CameraAnimation.Fly(speed = CameraAnimation.Fly.DefaultSpeed / 2),
+      CameraAnimation.Fly().scaledBy(2f),
+    )
+  }
+
+  /** A scale of zero turns every transition into a jump, including a flight paced by speed. */
+  @Test
+  fun a_zero_scale_makes_a_camera_animation_a_jump() {
+    assertEquals(CameraAnimation.Ease(Duration.ZERO), CameraAnimation.Ease(1.seconds).scaledBy(0f))
+    assertEquals(CameraAnimation.Fly(Duration.ZERO), CameraAnimation.Fly(1.seconds).scaledBy(0f))
+    assertEquals(CameraAnimation.Fly(Duration.ZERO), CameraAnimation.Fly(speed = 2.0).scaledBy(0f))
   }
 }

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsTypes.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsTypes.kt
@@ -210,24 +210,25 @@ internal external interface CenterZoomBearing {
 
 internal external interface AnimationOptions {
   var duration: Double?
+  var easing: ((Double) -> Double)?
 }
 
-internal external interface JumpToOptions : CameraOptions {
+internal external interface PaddedCameraOptions : CameraOptions {
   var padding: PaddingOptions?
 }
 
-internal external interface EaseToOptions : CameraOptions, AnimationOptions {
+internal external interface JumpToOptions : PaddedCameraOptions
+
+internal external interface EaseToOptions : PaddedCameraOptions, AnimationOptions {
   var around: LngLat?
-  var padding: PaddingOptions?
 }
 
-internal external interface FlyToOptions : CameraOptions, AnimationOptions {
-  var padding: PaddingOptions?
+internal external interface FlyToOptions : PaddedCameraOptions, AnimationOptions {
+  var screenSpeed: Double?
+  var minZoom: Double?
 }
 
-internal external interface CameraForBoundsOptions : CameraOptions {
-  var padding: PaddingOptions?
-}
+internal external interface CameraForBoundsOptions : PaddedCameraOptions
 
 internal external interface Painter {
   val context: Context

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
@@ -1,5 +1,6 @@
 package org.maplibre.compose.map
 
+import androidx.compose.animation.core.CubicBezierEasing
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -19,7 +20,9 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.asPromise
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.serialization.json.JsonObject
+import org.maplibre.compose.camera.CameraAnimation
 import org.maplibre.compose.camera.CameraPosition
+import org.maplibre.compose.camera.CubicBezier
 import org.maplibre.compose.camera.Viewport
 import org.maplibre.compose.camera.internal.BoxZoomFit
 import org.maplibre.compose.camera.internal.CameraCommandGuard
@@ -43,6 +46,7 @@ import org.maplibre.compose.gljs.JumpToOptions
 import org.maplibre.compose.gljs.LngLat
 import org.maplibre.compose.gljs.MapOptions
 import org.maplibre.compose.gljs.MaplibreMap
+import org.maplibre.compose.gljs.PaddedCameraOptions
 import org.maplibre.compose.gljs.PaddingOptions
 import org.maplibre.compose.gljs.Point
 import org.maplibre.compose.gljs.QueryGeometry
@@ -850,21 +854,10 @@ internal class GlJsMapSession(
 
   override suspend fun animateCameraPosition(
     finalPosition: CameraPosition,
-    duration: Duration,
+    animation: CameraAnimation,
     guard: CameraCommandGuard?,
   ) {
-    awaitCameraRelease(guard = guard) { map ->
-      map.flyTo(
-        unsafeJso<FlyToOptions> {
-          center = finalPosition.target.toLngLat()
-          zoom = finalPosition.zoom
-          bearing = finalPosition.bearing
-          pitch = finalPosition.tilt
-          padding = cameraPadding
-          this.duration = duration.inWholeMilliseconds.toDouble()
-        }
-      )
-    }
+    awaitCameraRelease(guard = guard) { map -> map.animateTo(finalPosition, animation) }
   }
 
   override suspend fun animateCameraToBounds(
@@ -872,14 +865,42 @@ internal class GlJsMapSession(
     bearing: Double,
     tilt: Double,
     padding: PaddingValues,
-    duration: Duration,
+    animation: CameraAnimation,
     guard: CameraCommandGuard?,
   ) {
     awaitCameraRelease(guard = guard) { map ->
       map.cameraPositionForBounds(boundingBox, bearing, tilt, padding)?.let {
-        map.easeTo(it.toEaseToOptions(duration))
+        map.animateTo(it, animation)
       }
     }
+  }
+
+  private fun MaplibreMap.animateTo(position: CameraPosition, animation: CameraAnimation) {
+    when (animation) {
+      is CameraAnimation.Ease ->
+        easeTo(
+          unsafeJso<EaseToOptions> {
+            applyTarget(position)
+            duration = animation.duration.inWholeMilliseconds.toDouble()
+            easing = animation.easing.toEasingFunction()
+          }
+        )
+      is CameraAnimation.Fly ->
+        flyTo(
+          unsafeJso<FlyToOptions> {
+            applyTarget(position)
+            duration = animation.duration?.inWholeMilliseconds?.toDouble()
+            screenSpeed = animation.speed ?: CameraAnimation.Fly.DefaultSpeed
+            minZoom = animation.minZoom
+            easing = animation.easing.toEasingFunction()
+          }
+        )
+    }
+  }
+
+  private fun CubicBezier.toEasingFunction(): (Double) -> Double {
+    val curve = CubicBezierEasing(x1.toFloat(), y1.toFloat(), x2.toFloat(), y2.toFloat())
+    return { t -> curve.transform(t.toFloat()).toDouble() }
   }
 
   private fun MaplibreMap.cameraPositionForBounds(
@@ -1339,20 +1360,21 @@ internal class GlJsMapSession(
   // endregion
 
   private fun CameraPosition.toJumpToOptions(): JumpToOptions = unsafeJso {
-    center = target.toLngLat()
-    zoom = this@toJumpToOptions.zoom
-    bearing = this@toJumpToOptions.bearing
-    pitch = tilt
-    padding = cameraPadding
+    applyTarget(this@toJumpToOptions)
   }
 
   private fun CameraPosition.toEaseToOptions(duration: Duration): EaseToOptions = unsafeJso {
-    center = target.toLngLat()
-    zoom = this@toEaseToOptions.zoom
-    bearing = this@toEaseToOptions.bearing
-    pitch = tilt
-    padding = cameraPadding
+    applyTarget(this@toEaseToOptions)
     this.duration = duration.inWholeMilliseconds.toDouble()
+  }
+
+  /** Sets the camera fields of an options object, with the persistent camera padding. */
+  private fun PaddedCameraOptions.applyTarget(position: CameraPosition) {
+    center = position.target.toLngLat()
+    zoom = position.zoom
+    bearing = position.bearing
+    pitch = position.tilt
+    padding = cameraPadding
   }
 
   private fun PaddingOptions.sameAs(other: PaddingOptions): Boolean =

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
@@ -936,6 +936,8 @@ internal class GlJsMapSession(
     map?.let { applyCameraConstraints(it, value) }
   }
 
+  override fun getCameraConstraints(): CameraConstraints = cameraConstraints ?: CameraConstraints()
+
   private fun applyCameraConstraints(map: MaplibreMap, value: CameraConstraints) {
     if (map.getMaxBounds()?.toBoundingBox() != value.boundingBox) {
       map.setMaxBounds(value.boundingBox?.toLngLatBounds())

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
@@ -889,9 +889,10 @@ internal class GlJsMapSession(
         flyTo(
           unsafeJso<FlyToOptions> {
             applyTarget(position)
-            duration = animation.duration?.inWholeMilliseconds?.toDouble()
+            // A null property is not an absent one: GL JS reads `duration: null` as zero.
+            animation.duration?.let { duration = it.inWholeMilliseconds.toDouble() }
             screenSpeed = animation.speed ?: CameraAnimation.Fly.DefaultSpeed
-            minZoom = animation.minZoom
+            animation.minZoom?.let { minZoom = it }
             easing = animation.easing.toEasingFunction()
           }
         )

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserCameraTransitionLifecycleTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserCameraTransitionLifecycleTest.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
+import org.maplibre.compose.camera.CameraAnimation
 import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.gljs.GlJsMapEvent
 import org.maplibre.compose.gljs.isNear
@@ -34,7 +35,7 @@ class BrowserCameraTransitionLifecycleTest {
         it.session.setBaseStyle(BaseStyle.Empty)
         val animation =
           launch(start = CoroutineStart.UNDISPATCHED) {
-            it.session.animateCameraPosition(STALE_CAMERA, 60.seconds)
+            it.session.animateCameraPosition(STALE_CAMERA, CameraAnimation.Fly(60.seconds))
           }
 
         assertFalse(animation.isCompleted, "the animation should be queued before cancellation")
@@ -60,7 +61,7 @@ class BrowserCameraTransitionLifecycleTest {
           fixture.session.setBaseStyle(BaseStyle.Empty)
           val animation =
             launch(start = CoroutineStart.UNDISPATCHED) {
-              fixture.state.animateCameraPosition(STALE_CAMERA, 60.seconds)
+              fixture.state.animateCameraPosition(STALE_CAMERA, CameraAnimation.Fly(60.seconds))
             }
           assertFalse(animation.isCompleted)
           fixture.state.setCameraPosition(CURRENT_CAMERA)
@@ -79,7 +80,7 @@ class BrowserCameraTransitionLifecycleTest {
       it.session.setBaseStyle(BaseStyle.Json("{ this is not json"))
       val animation =
         launch(start = CoroutineStart.UNDISPATCHED) {
-          it.session.animateCameraPosition(STALE_CAMERA, 60.seconds)
+          it.session.animateCameraPosition(STALE_CAMERA, CameraAnimation.Fly(60.seconds))
         }
 
       assertFalse(animation.isCompleted, "the animation should wait for the initial style result")

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/camera/CameraInputIntegrationTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/camera/CameraInputIntegrationTest.kt
@@ -166,7 +166,10 @@ class CameraInputIntegrationTest {
           // Exercise backend interruption even when Android system animations are disabled.
           val animation =
             launch(start = CoroutineStart.UNDISPATCHED) {
-              fixture.session.animateCameraPosition(CameraPosition(zoom = 8.0), 30.seconds)
+              fixture.session.animateCameraPosition(
+                CameraPosition(zoom = 8.0),
+                CameraAnimation.Fly(30.seconds),
+              )
             }
           fixture.pumpUntil("the programmatic animation to start") { fixture.state.isCameraMoving }
           val input = GestureInputSession(this, fixture.gestures)

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/EngineEventTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/EngineEventTest.kt
@@ -6,6 +6,7 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
+import org.maplibre.compose.camera.CameraAnimation
 import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.compose.testing.MapLibreFlavor
@@ -67,7 +68,7 @@ class EngineEventTest {
       fixture.engineEvents.clear()
 
       fixture.awaitWhileRendering("the camera animation to finish") {
-        fixture.session.animateCameraPosition(DESTINATION, ANIMATION_DURATION)
+        fixture.session.animateCameraPosition(DESTINATION, CameraAnimation.Fly(ANIMATION_DURATION))
       }
 
       val started = fixture.engineEvents.indexOfFirst { it is MapEvent.CameraMoveStarted }

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/MapCameraTransitionTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/MapCameraTransitionTest.kt
@@ -215,19 +215,36 @@ class MapCameraTransitionTest {
     }
   }
 
-  /** A flight without a duration paces itself by speed, so it still completes and lands. */
+  /**
+   * A flight without a duration paces itself by speed. The camera must be seen part way, since a
+   * flight that jumps also lands on its target.
+   */
   @Test
-  fun a_flight_paced_by_speed_completes_and_lands_on_its_target(): MapTestResult = runMapTest {
-    createMapFixture().use {
-      it.startAt(FLIGHT_START)
+  fun a_flight_paced_by_speed_moves_over_time_and_lands_on_its_target(): MapTestResult =
+    runMapTest {
+      if (systemAnimatorDurationScale() == 0f) skipMapTest("System animations are disabled")
+      createMapFixture().use {
+        it.startAt(FLIGHT_START)
 
-      it.awaitWhileRendering("the flight to complete") {
-        it.state.animateCameraPosition(FLIGHT_TARGET, CameraAnimation.Fly(speed = 20.0))
+        val flight =
+          launch(Dispatchers.Default) {
+            it.state.animateCameraPosition(FLIGHT_TARGET, CameraAnimation.Fly(speed = 20.0))
+          }
+        it.pumpUntil("the flight to move the camera") {
+          flight.isCompleted ||
+            abs(it.session.getCameraPosition().target.latitude - FLIGHT_START.target.latitude) > 1.0
+        }
+        assertFalse(flight.isCompleted, "the flight jumped to its target")
+        val partWay = it.session.getCameraPosition()
+        assertTrue(
+          abs(partWay.target.latitude - FLIGHT_TARGET.target.latitude) > 1.0,
+          "the flight had already arrived at $partWay",
+        )
+
+        it.pumpUntil("the flight to complete") { flight.isCompleted }
+        it.assertLanded(FLIGHT_TARGET, "the flight")
       }
-
-      it.assertLanded(FLIGHT_TARGET, "the flight")
     }
-  }
 
   /**
    * A minimum zoom at the start zoom keeps a flight that would zoom out from doing so. Both engines
@@ -235,7 +252,7 @@ class MapCameraTransitionTest {
    * it, rather than clamping the zoom.
    */
   @Test
-  fun a_flight_respects_its_minimum_zoom(): MapTestResult = runMapTest {
+  fun a_flight_peaks_near_its_minimum_zoom(): MapTestResult = runMapTest {
     if (systemAnimatorDurationScale() == 0f) skipMapTest("System animations are disabled")
     createMapFixture().use {
       it.startAt(FLIGHT_START)
@@ -245,6 +262,22 @@ class MapCameraTransitionTest {
           FLIGHT_TARGET,
           CameraAnimation.Fly(1.seconds, minZoom = FLIGHT_START.zoom),
         )
+
+      assertTrue(lowestZoom > FLIGHT_START.zoom - 0.5, "the flight zoomed out to $lowestZoom")
+      it.assertLanded(FLIGHT_TARGET, "the flight")
+    }
+  }
+
+  /** The map's own minimum zoom shapes a flight the same way as a requested minimum. */
+  @Test
+  fun a_flight_peaks_near_the_maps_minimum_zoom(): MapTestResult = runMapTest {
+    if (systemAnimatorDurationScale() == 0f) skipMapTest("System animations are disabled")
+    createMapFixture().use {
+      it.startAt(FLIGHT_START)
+      it.session.setCameraConstraints(TEST_CONSTRAINTS.copy(minZoom = FLIGHT_START.zoom))
+      it.pump(frames = 2)
+
+      val lowestZoom = it.lowestZoomWhileAnimating(FLIGHT_TARGET, CameraAnimation.Fly(1.seconds))
 
       assertTrue(lowestZoom > FLIGHT_START.zoom - 0.5, "the flight zoomed out to $lowestZoom")
       it.assertLanded(FLIGHT_TARGET, "the flight")

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/MapCameraTransitionTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/MapCameraTransitionTest.kt
@@ -268,19 +268,46 @@ class MapCameraTransitionTest {
     }
   }
 
-  /** The map's own minimum zoom shapes a flight the same way as a requested minimum. */
+  /**
+   * The map's own minimum zoom shapes a flight the same way as a requested minimum: the path peaks
+   * near it, part way along the route. A flight fit without it dives past the minimum early, so its
+   * displayed zoom sits clamped at the minimum while the camera is still near its start.
+   */
   @Test
-  fun a_flight_peaks_near_the_maps_minimum_zoom(): MapTestResult = runMapTest {
+  fun the_maps_minimum_zoom_shapes_a_flight(): MapTestResult = runMapTest {
     if (systemAnimatorDurationScale() == 0f) skipMapTest("System animations are disabled")
     createMapFixture().use {
       it.startAt(FLIGHT_START)
-      it.session.setCameraConstraints(TEST_CONSTRAINTS.copy(minZoom = FLIGHT_START.zoom))
+      it.session.setCameraConstraints(TEST_CONSTRAINTS.copy(minZoom = FLIGHT_START.zoom - 2.0))
       it.pump(frames = 2)
 
-      val lowestZoom = it.lowestZoomWhileAnimating(FLIGHT_TARGET, CameraAnimation.Fly(1.seconds))
+      val trace = it.cameraTraceWhileAnimating(FLIGHT_TARGET, CameraAnimation.Fly(1.seconds))
 
-      assertTrue(lowestZoom > FLIGHT_START.zoom - 0.5, "the flight zoomed out to $lowestZoom")
+      val peak = trace.minBy { camera -> camera.zoom }
+      assertTrue(peak.zoom > FLIGHT_START.zoom - 2.5, "the flight zoomed out to ${peak.zoom}")
+      assertTrue(
+        peak.target.longitude > 2.0,
+        "the flight reached its lowest zoom at longitude ${peak.target.longitude}, near its start",
+      )
       it.assertLanded(FLIGHT_TARGET, "the flight")
+    }
+  }
+
+  /** A flight that changes only the bearing has no path to pace, so it eases instead of jumping. */
+  @Test
+  fun a_flight_with_no_path_eases_its_orientation(): MapTestResult = runMapTest {
+    if (systemAnimatorDurationScale() == 0f) skipMapTest("System animations are disabled")
+    createMapFixture().use {
+      it.startAt(FLIGHT_START)
+      val turned = FLIGHT_START.copy(bearing = 90.0)
+
+      val trace = it.cameraTraceWhileAnimating(turned, CameraAnimation.Fly())
+
+      assertTrue(
+        trace.any { camera -> camera.bearing > 5.0 && camera.bearing < 85.0 },
+        "the turn jumped to its target",
+      )
+      assertNear(turned.bearing, it.session.getCameraPosition().bearing, "the turn target bearing")
     }
   }
 
@@ -485,14 +512,20 @@ class MapCameraTransitionTest {
   private suspend fun MapFixture.lowestZoomWhileAnimating(
     target: CameraPosition,
     animation: CameraAnimation,
-  ): Double = coroutineScope {
+  ): Double = cameraTraceWhileAnimating(target, animation).minOf { camera -> camera.zoom }
+
+  /** Runs an animation to [target] and returns the camera at every frame rendered on the way. */
+  private suspend fun MapFixture.cameraTraceWhileAnimating(
+    target: CameraPosition,
+    animation: CameraAnimation,
+  ): List<CameraPosition> = coroutineScope {
     val job = launch(Dispatchers.Default) { state.animateCameraPosition(target, animation) }
-    var lowest = session.getCameraPosition().zoom
+    val trace = mutableListOf(session.getCameraPosition())
     pumpUntil("the animation to complete") {
-      lowest = minOf(lowest, session.getCameraPosition().zoom)
+      trace += session.getCameraPosition()
       job.isCompleted
     }
-    lowest
+    trace
   }
 
   private fun MapFixture.assertLanded(target: CameraPosition, description: String) {

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/MapCameraTransitionTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/MapCameraTransitionTest.kt
@@ -12,8 +12,10 @@ import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
+import org.maplibre.compose.camera.CameraAnimation
 import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.compose.style.systemAnimatorDurationScale
@@ -79,7 +81,7 @@ class MapCameraTransitionTest {
       it.startAtOrigin()
       val animation =
         launch(Dispatchers.Default) {
-          it.state.animateCameraPosition(TARGET, 2.seconds)
+          it.state.animateCameraPosition(TARGET, CameraAnimation.Fly(2.seconds))
         }
       it.awaitCameraMoving()
       it.state.cameraForBounds(BOUNDS, bearing = 35.0, tilt = 20.0).also { camera ->
@@ -148,7 +150,13 @@ class MapCameraTransitionTest {
       }
 
       it.awaitWhileRendering("the bounds animation to complete") {
-        it.state.animateCameraToBounds(BOUNDS, 0.0, 0.0, FIT_PADDING, 200.milliseconds)
+        it.state.animateCameraToBounds(
+          BOUNDS,
+          0.0,
+          0.0,
+          FIT_PADDING,
+          CameraAnimation.Fly(200.milliseconds),
+        )
       }
 
       val firstFit = it.session.getCameraPosition()
@@ -156,7 +164,13 @@ class MapCameraTransitionTest {
       it.assertBoundsInside(CAMERA_PADDING + FIT_PADDING)
 
       it.awaitWhileRendering("the repeated bounds animation to complete") {
-        it.state.animateCameraToBounds(BOUNDS, 0.0, 0.0, FIT_PADDING, 200.milliseconds)
+        it.state.animateCameraToBounds(
+          BOUNDS,
+          0.0,
+          0.0,
+          FIT_PADDING,
+          CameraAnimation.Fly(200.milliseconds),
+        )
       }
 
       assertSameFit(
@@ -173,7 +187,7 @@ class MapCameraTransitionTest {
       it.startAtOrigin()
 
       it.awaitWhileRendering("the animation to complete") {
-        it.state.animateCameraPosition(TARGET, 200.milliseconds)
+        it.state.animateCameraPosition(TARGET, CameraAnimation.Fly(200.milliseconds))
       }
 
       assertNear(
@@ -181,6 +195,110 @@ class MapCameraTransitionTest {
         it.session.getCameraPosition().zoom,
         "the camera should have reached the target zoom",
       )
+    }
+  }
+
+  /** A flight over a distance zooms out before it zooms back in to its target. */
+  @Test
+  fun a_flight_zooms_out_on_its_way_to_the_target(): MapTestResult = runMapTest {
+    if (systemAnimatorDurationScale() == 0f) skipMapTest("System animations are disabled")
+    createMapFixture().use {
+      it.startAt(FLIGHT_START)
+
+      val lowestZoom = it.lowestZoomWhileAnimating(FLIGHT_TARGET, CameraAnimation.Fly(1.seconds))
+
+      assertTrue(
+        lowestZoom < FLIGHT_START.zoom - 1.0,
+        "the flight did not zoom out, lowest $lowestZoom",
+      )
+      it.assertLanded(FLIGHT_TARGET, "the flight")
+    }
+  }
+
+  /** A flight without a duration paces itself by speed, so it still completes and lands. */
+  @Test
+  fun a_flight_paced_by_speed_completes_and_lands_on_its_target(): MapTestResult = runMapTest {
+    createMapFixture().use {
+      it.startAt(FLIGHT_START)
+
+      it.awaitWhileRendering("the flight to complete") {
+        it.state.animateCameraPosition(FLIGHT_TARGET, CameraAnimation.Fly(speed = 20.0))
+      }
+
+      it.assertLanded(FLIGHT_TARGET, "the flight")
+    }
+  }
+
+  /**
+   * A minimum zoom at the start zoom keeps a flight that would zoom out from doing so. Both engines
+   * fit the zoom curve so that the path peaks near the minimum, about a third of a zoom level past
+   * it, rather than clamping the zoom.
+   */
+  @Test
+  fun a_flight_respects_its_minimum_zoom(): MapTestResult = runMapTest {
+    if (systemAnimatorDurationScale() == 0f) skipMapTest("System animations are disabled")
+    createMapFixture().use {
+      it.startAt(FLIGHT_START)
+
+      val lowestZoom =
+        it.lowestZoomWhileAnimating(
+          FLIGHT_TARGET,
+          CameraAnimation.Fly(1.seconds, minZoom = FLIGHT_START.zoom),
+        )
+
+      assertTrue(lowestZoom > FLIGHT_START.zoom - 0.5, "the flight zoomed out to $lowestZoom")
+      it.assertLanded(FLIGHT_TARGET, "the flight")
+    }
+  }
+
+  /**
+   * A minimum zoom below the natural path leaves the path alone. MapLibre Native would otherwise
+   * zoom out to reach it.
+   */
+  @Test
+  fun a_flight_ignores_a_minimum_zoom_below_its_path(): MapTestResult = runMapTest {
+    if (systemAnimatorDurationScale() == 0f) skipMapTest("System animations are disabled")
+    createMapFixture().use {
+      it.startAt(START)
+
+      val lowestZoom =
+        it.lowestZoomWhileAnimating(TARGET, CameraAnimation.Fly(1.seconds, minZoom = 0.0))
+
+      assertTrue(lowestZoom > START.zoom - 0.5, "the flight zoomed out to $lowestZoom")
+      it.assertLanded(TARGET, "the flight")
+    }
+  }
+
+  /** An ease changes zoom steadily toward its target, so it never zooms out on the way. */
+  @Test
+  fun an_ease_zooms_directly_to_the_target(): MapTestResult = runMapTest {
+    if (systemAnimatorDurationScale() == 0f) skipMapTest("System animations are disabled")
+    createMapFixture().use {
+      it.startAt(FLIGHT_START)
+
+      val lowestZoom = it.lowestZoomWhileAnimating(FLIGHT_TARGET, CameraAnimation.Ease(1.seconds))
+
+      assertTrue(lowestZoom > FLIGHT_START.zoom - 0.05, "the ease zoomed out to $lowestZoom")
+      it.assertLanded(FLIGHT_TARGET, "the ease")
+    }
+  }
+
+  /** An eased bounds animation lands on the same fit as a flight to the same bounds. */
+  @Test
+  fun an_eased_bounds_animation_lands_on_the_fit(): MapTestResult = runMapTest {
+    createMapFixture().use {
+      it.startAtOrigin()
+      val fit = it.state.cameraForBounds(BOUNDS, padding = FIT_PADDING)
+
+      it.awaitWhileRendering("the eased bounds animation to complete") {
+        it.state.animateCameraToBounds(
+          BOUNDS,
+          padding = FIT_PADDING,
+          animation = CameraAnimation.Ease(200.milliseconds),
+        )
+      }
+
+      assertSameFit(fit, it.session.getCameraPosition(), "the eased bounds animation")
     }
   }
 
@@ -194,7 +312,7 @@ class MapCameraTransitionTest {
 
         val animation =
           launch(Dispatchers.Default) {
-            it.state.animateCameraPosition(TARGET, 2.seconds)
+            it.state.animateCameraPosition(TARGET, CameraAnimation.Fly(2.seconds))
           }
         it.awaitCameraMoving()
         it.session.applyTestConstraints()
@@ -232,7 +350,7 @@ class MapCameraTransitionTest {
       it.startAtOrigin()
 
       it.awaitWhileRendering("the instant animation to complete") {
-        it.state.animateCameraPosition(TARGET, 0.milliseconds)
+        it.state.animateCameraPosition(TARGET, CameraAnimation.Fly(0.milliseconds))
       }
       assertNear(
         TARGET.zoom,
@@ -255,13 +373,13 @@ class MapCameraTransitionTest {
 
       val superseded =
         launch(Dispatchers.Default) {
-          it.state.animateCameraPosition(TARGET, 10.seconds)
+          it.state.animateCameraPosition(TARGET, CameraAnimation.Fly(10.seconds))
         }
       it.awaitCameraMoving()
 
       val replacement =
         launch(Dispatchers.Default) {
-          it.state.animateCameraPosition(MIDPOINT, 2.seconds)
+          it.state.animateCameraPosition(MIDPOINT, CameraAnimation.Fly(2.seconds))
         }
       it.pumpUntil("the superseded animation to cancel") { superseded.isCompleted }
 
@@ -292,7 +410,7 @@ class MapCameraTransitionTest {
 
         val animation =
           launch(Dispatchers.Default) {
-            it.state.animateCameraPosition(TARGET, 30.seconds)
+            it.state.animateCameraPosition(TARGET, CameraAnimation.Fly(30.seconds))
           }
         it.awaitCameraMoving()
         animation.cancel()
@@ -305,7 +423,7 @@ class MapCameraTransitionTest {
         )
 
         it.awaitWhileRendering("a later animation to complete") {
-          it.state.animateCameraPosition(TARGET, 200.milliseconds)
+          it.state.animateCameraPosition(TARGET, CameraAnimation.Fly(200.milliseconds))
         }
         assertNear(
           TARGET.zoom,
@@ -315,15 +433,40 @@ class MapCameraTransitionTest {
       }
     }
 
-  private suspend fun MapFixture.startAtOrigin() {
+  private suspend fun MapFixture.startAtOrigin() = startAt(START)
+
+  private suspend fun MapFixture.startAt(position: CameraPosition) {
     // GL JS renders nothing without a style.
     loadStyle(BaseStyle.Empty)
-    state.setCameraPosition(START)
+    state.setCameraPosition(position)
     // Render first: before the map exists, a camera read echoes back whatever was last set.
     awaitMapReady()
     pumpUntil("the map to reach its starting camera") {
-      abs(session.getCameraPosition().zoom - START.zoom) < 0.001
+      val camera = session.getCameraPosition()
+      abs(camera.zoom - position.zoom) < 0.001 &&
+        abs(camera.target.latitude - position.target.latitude) < 0.001
     }
+  }
+
+  /** Runs an animation to [target] and returns the lowest zoom rendered on the way. */
+  private suspend fun MapFixture.lowestZoomWhileAnimating(
+    target: CameraPosition,
+    animation: CameraAnimation,
+  ): Double = coroutineScope {
+    val job = launch(Dispatchers.Default) { state.animateCameraPosition(target, animation) }
+    var lowest = session.getCameraPosition().zoom
+    pumpUntil("the animation to complete") {
+      lowest = minOf(lowest, session.getCameraPosition().zoom)
+      job.isCompleted
+    }
+    lowest
+  }
+
+  private fun MapFixture.assertLanded(target: CameraPosition, description: String) {
+    val camera = session.getCameraPosition()
+    assertNear(target.zoom, camera.zoom, "$description target zoom")
+    assertNear(target.target.latitude, camera.target.latitude, "$description target latitude")
+    assertNear(target.target.longitude, camera.target.longitude, "$description target longitude")
   }
 
   private suspend fun MapFixture.awaitCameraMoving() {
@@ -340,6 +483,9 @@ class MapCameraTransitionTest {
     val START = CameraPosition(target = Position(0.0, 0.0), zoom = 2.0)
     val TARGET = CameraPosition(target = Position(11.0, 47.0), zoom = 8.0)
     val MIDPOINT = CameraPosition(target = Position(5.0, 20.0), zoom = 5.0)
+    // Far apart at their zoom, so a flight has to zoom out to cross the distance.
+    val FLIGHT_START = CameraPosition(target = Position(0.0, 0.0), zoom = 10.0)
+    val FLIGHT_TARGET = CameraPosition(target = Position(11.0, 47.0), zoom = 12.0)
     val BOUNDS =
       BoundingBox(
         southwest = Position(longitude = -5.0, latitude = -5.0),

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/MapCameraTransitionTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/MapCameraTransitionTest.kt
@@ -311,6 +311,32 @@ class MapCameraTransitionTest {
     }
   }
 
+  /** A zoom the map's range rejects leaves no path either, so the turn still eases. */
+  @Test
+  fun a_flight_whose_only_path_is_a_rejected_zoom_eases_its_orientation(): MapTestResult =
+    runMapTest {
+      if (systemAnimatorDurationScale() == 0f) skipMapTest("System animations are disabled")
+      createMapFixture().use {
+        it.startAt(FLIGHT_START)
+        it.session.setCameraConstraints(TEST_CONSTRAINTS.copy(maxZoom = FLIGHT_START.zoom))
+        it.pump(frames = 2)
+        val turned = FLIGHT_START.copy(bearing = 90.0, zoom = FLIGHT_START.zoom + 1.0)
+
+        val trace = it.cameraTraceWhileAnimating(turned, CameraAnimation.Fly())
+
+        assertTrue(
+          trace.any { camera -> camera.bearing > 5.0 && camera.bearing < 85.0 },
+          "the turn jumped to its target",
+        )
+        assertNear(
+          turned.bearing,
+          it.session.getCameraPosition().bearing,
+          "the turn target bearing",
+        )
+        assertNear(FLIGHT_START.zoom, it.session.getCameraPosition().zoom, "the constrained zoom")
+      }
+    }
+
   /**
    * A minimum zoom below the natural path leaves the path alone. MapLibre Native would otherwise
    * zoom out to reach it.

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -13,6 +13,8 @@ import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.math.PI
+import kotlin.math.pow
+import kotlin.math.sqrt
 import kotlin.time.Duration
 import kotlin.time.DurationUnit
 import kotlin.time.TimeSource
@@ -22,6 +24,7 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.io.files.Path
 import kotlinx.serialization.json.JsonObject
+import org.maplibre.compose.camera.CameraAnimation
 import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.camera.Viewport
 import org.maplibre.compose.camera.internal.BoxZoomFit
@@ -68,6 +71,7 @@ import org.maplibre.compose.style.StyleRequestId
 import org.maplibre.compose.style.StyleResourceChanges
 import org.maplibre.compose.util.VisibleBounds
 import org.maplibre.compose.util.VisibleRegion
+import org.maplibre.compose.util.mercatorPixelDistance
 import org.maplibre.compose.util.metersPerDpAtLatitude
 import org.maplibre.compose.util.renderedQueryOptions
 import org.maplibre.compose.util.toCameraOptions
@@ -84,6 +88,7 @@ import org.maplibre.nativeffi.camera.BoundsConstraint
 import org.maplibre.nativeffi.camera.CameraFitOptions
 import org.maplibre.nativeffi.camera.CameraOptions
 import org.maplibre.nativeffi.camera.EdgeInsets
+import org.maplibre.nativeffi.camera.UnitBezier
 import org.maplibre.nativeffi.error.InvalidArgumentException
 import org.maplibre.nativeffi.error.MaplibreException
 import org.maplibre.nativeffi.error.NativeErrorException
@@ -125,6 +130,12 @@ private const val MIN_PITCH_DEGREES = 0.0
 
 /** MapLibre rejects a pitch beyond this, so the drag is clamped rather than throwing. */
 private const val MAX_PITCH_DEGREES = 60.0
+
+/** `util::MAX_ZOOM`, the zoom MapLibre Native clamps to when the map has no maximum. */
+private const val MAX_NATIVE_ZOOM = 25.5
+
+/** The zoom curve of a flight, `rho` in `Transform::flyTo`. */
+private const val FLIGHT_CURVE = 1.42
 
 /** The events [MlnFfiMapSession.handleEvent] consumes. */
 private val HANDLED_MAP_EVENTS: RuntimeEventMask =
@@ -1370,11 +1381,11 @@ internal class MlnFfiMapSession(
 
   override suspend fun animateCameraPosition(
     finalPosition: CameraPosition,
-    duration: Duration,
+    animation: CameraAnimation,
     guard: CameraCommandGuard?,
   ) {
-    startTransitionAwaitingRelease(duration, guard = guard) { map, animation ->
-      map.flyTo(finalPosition.toCameraOptions(appliedCameraPadding), animation)
+    startTransitionAwaitingRelease(animation.toAnimationOptions(), guard = guard) { map, options ->
+      map.animateTo(finalPosition.toCameraOptions(appliedCameraPadding), animation, options)
     }
   }
 
@@ -1383,20 +1394,76 @@ internal class MlnFfiMapSession(
     bearing: Double,
     tilt: Double,
     padding: PaddingValues,
-    duration: Duration,
+    animation: CameraAnimation,
     guard: CameraCommandGuard?,
   ) {
     check(hasViewport) {
       "A bounds animation requires the current presentation viewport"
     }
-    startTransitionAwaitingRelease(duration, guard = guard) { map, animation ->
-      map.flyTo(cameraForBounds(map, boundingBox, bearing, tilt, padding), animation)
+    startTransitionAwaitingRelease(animation.toAnimationOptions(), guard = guard) { map, options ->
+      map.animateTo(cameraForBounds(map, boundingBox, bearing, tilt, padding), animation, options)
     }
   }
 
+  /** Owner thread only. */
+  private fun MapHandle.animateTo(
+    camera: CameraOptions,
+    animation: CameraAnimation,
+    options: AnimationOptions,
+  ) {
+    when (animation) {
+      is CameraAnimation.Ease -> easeTo(camera, options)
+      is CameraAnimation.Fly ->
+        flyTo(camera, options.copy { minZoom = flightMinZoom(camera, animation.minZoom) })
+    }
+  }
+
+  /**
+   * MapLibre Native treats a flight's minimum zoom as the zoom the path peaks at, and zooms out to
+   * reach it even when the natural path would stay closer. MapLibre GL JS treats it as a ceiling
+   * that only shortens the zoom-out. This returns the minimum zoom to pass so that native matches:
+   * [minZoom] when the natural path would pass it, null otherwise. Mirrors the setup of
+   * `Transform::flyTo`.
+   */
+  private fun MapHandle.flightMinZoom(camera: CameraOptions, minZoom: Double?): Double? {
+    if (minZoom == null) return null
+    val current = this.camera
+    val size = size
+    val padding = camera.padding ?: current.padding ?: EdgeInsets(0.0, 0.0, 0.0, 0.0)
+    val startZoom = current.zoom ?: return null
+    val start = current.center ?: return null
+    val end = camera.center ?: start
+    val zoomRange = (bounds.minZoom ?: 0.0)..(bounds.maxZoom ?: MAX_NATIVE_ZOOM)
+    val zoom = (camera.zoom ?: startZoom).coerceIn(zoomRange)
+    val peakZoom = minOf(minZoom, startZoom, zoom).coerceIn(zoomRange)
+    val pathLength =
+      mercatorPixelDistance(startZoom, start.toPosition(), end.toPosition()).takeIf { it > 0.0 }
+        ?: return null
+    // Screenfuls in pixels at the start scale: the visible span now and at the peak.
+    val startSpan =
+      maxOf(
+        size.width - padding.left - padding.right,
+        size.height - padding.top - padding.bottom,
+      )
+    val peakSpan = startSpan / 2.0.pow(peakZoom - startZoom)
+    return minZoom.takeIf { sqrt(peakSpan / pathLength * 2.0) < FLIGHT_CURVE }
+  }
+
+  private fun CameraAnimation.toAnimationOptions(): AnimationOptions =
+    AnimationOptions().also {
+      it.easing = UnitBezier(easing.x1, easing.y1, easing.x2, easing.y2)
+      when (this) {
+        is CameraAnimation.Ease -> it.durationMs = duration.inWholeMilliseconds.toDouble()
+        is CameraAnimation.Fly -> {
+          it.durationMs = duration?.inWholeMilliseconds?.toDouble()
+          it.velocity = speed ?: CameraAnimation.Fly.DefaultSpeed
+        }
+      }
+    }
+
   /** Resumes normally however the transition ended. */
   private suspend fun startTransitionAwaitingRelease(
-    duration: Duration,
+    animation: AnimationOptions,
     gestureToken: CameraInputToken? = null,
     guard: CameraCommandGuard? = null,
     shouldStart: (MapHandle) -> Boolean = { true },
@@ -1413,7 +1480,7 @@ internal class MlnFfiMapSession(
                   guard,
                   activate = { gestureToken?.let { activateGesture(map, it) } },
                 ) {
-                  if (shouldStart(map)) startTransitionOnMap(map, duration, start, continuation)
+                  if (shouldStart(map)) startTransitionOnMap(map, animation, start, continuation)
                   else if (continuation.isActive) continuation.resume(Unit)
                 }
             if (!started && continuation.isActive) continuation.resume(Unit)
@@ -1430,7 +1497,7 @@ internal class MlnFfiMapSession(
   /** Owner thread only. */
   private fun startTransitionOnMap(
     map: MapHandle,
-    duration: Duration,
+    animation: AnimationOptions,
     start: (MapHandle, AnimationOptions) -> Unit,
     continuation: CancellableContinuation<Unit>,
   ) {
@@ -1440,13 +1507,7 @@ internal class MlnFfiMapSession(
     transitionWaiters[id] = continuation
     currentTransitionId = id
     try {
-      start(
-        map,
-        AnimationOptions().also {
-          it.durationMs = duration.inWholeMilliseconds.toDouble()
-          it.transitionId = id
-        },
-      )
+      start(map, animation.copy { transitionId = id })
     } catch (error: Throwable) {
       // A rejected command emits no event, so nothing else would resume the continuation.
       forgetTransition(id)
@@ -1625,7 +1686,9 @@ internal class MlnFfiMapSession(
     gestureToken: CameraInputToken,
   ) {
     if (!acceptsGestures) return
-    startTransitionAwaitingRelease(duration, gestureToken = gestureToken) { map, animation ->
+    startTransitionAwaitingRelease(duration.toAnimationOptions(), gestureToken = gestureToken) {
+      map,
+      animation ->
       val camera = cameraForBounds(map, fit.bounds, fit.bearing, fit.tilt, PaddingValues())
       map.easeTo(camera, animation)
     }
@@ -1846,7 +1909,9 @@ internal class MlnFfiMapSession(
     gestureToken: CameraInputToken,
   ) {
     if (!acceptsGestures) return
-    startTransitionAwaitingRelease(duration, gestureToken = gestureToken) { map, animation ->
+    startTransitionAwaitingRelease(duration.toAnimationOptions(), gestureToken = gestureToken) {
+      map,
+      animation ->
       map.moveByAnimated(deltaX, deltaY, animation)
     }
   }
@@ -1871,7 +1936,9 @@ internal class MlnFfiMapSession(
     gestureToken: CameraInputToken,
   ) {
     if (!acceptsGestures) return
-    startTransitionAwaitingRelease(duration, gestureToken = gestureToken) { map, animation ->
+    startTransitionAwaitingRelease(duration.toAnimationOptions(), gestureToken = gestureToken) {
+      map,
+      animation ->
       map.scaleByAnimated(scale, anchor?.toScreenPoint(), animation)
     }
   }
@@ -1917,7 +1984,7 @@ internal class MlnFfiMapSession(
     if (!acceptsGestures) return
     var bearing = 0.0
     startTransitionAwaitingRelease(
-      duration,
+      duration.toAnimationOptions(),
       gestureToken = gestureToken,
       shouldStart = { map ->
         val current = map.camera.bearing ?: 0.0
@@ -1939,7 +2006,9 @@ internal class MlnFfiMapSession(
     anchor: DpOffset?,
   ) {
     if (!acceptsGestures) return
-    startTransitionAwaitingRelease(duration, gestureToken = gestureToken) { map, animation ->
+    startTransitionAwaitingRelease(duration.toAnimationOptions(), gestureToken = gestureToken) {
+      map,
+      animation ->
       val camera = map.camera
       map.easeTo(
         CameraOptions().also {

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -1564,6 +1564,8 @@ internal class MlnFfiMapSession(
     flushTransitionResumes()
   }
 
+  override fun getCameraConstraints(): CameraConstraints = cameraConstraints ?: CameraConstraints()
+
   override fun setCameraConstraints(value: CameraConstraints) {
     if (value == cameraConstraints) return
     cameraConstraints = value

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -1419,23 +1419,26 @@ internal class MlnFfiMapSession(
   }
 
   /**
-   * MapLibre Native treats a flight's minimum zoom as the zoom the path peaks at, and zooms out to
-   * reach it even when the natural path would stay closer. MapLibre GL JS treats it as a ceiling
-   * that only shortens the zoom-out. This returns the minimum zoom to pass so that native matches:
-   * [minZoom] when the natural path would pass it, null otherwise. Mirrors the setup of
-   * `Transform::flyTo`.
+   * The minimum zoom to pass to `flyTo`, or null to leave the flight path alone.
+   *
+   * MapLibre GL JS fits the flight curve to the higher of the requested minimum and the map's
+   * minimum zoom, and only when the natural path would pass below it. MapLibre Native fits the
+   * curve to the requested minimum whenever one is given, zooming out to reach it, and otherwise
+   * ignores the map's minimum until it clamps each frame. This mirrors the GL JS decision, using
+   * the setup of `Transform::flyTo`.
    */
   private fun MapHandle.flightMinZoom(camera: CameraOptions, minZoom: Double?): Double? {
-    if (minZoom == null) return null
     val current = this.camera
     val size = size
     val padding = camera.padding ?: current.padding ?: EdgeInsets(0.0, 0.0, 0.0, 0.0)
     val startZoom = current.zoom ?: return null
     val start = current.center ?: return null
     val end = camera.center ?: start
-    val zoomRange = (bounds.minZoom ?: 0.0)..(bounds.maxZoom ?: MAX_NATIVE_ZOOM)
+    val mapMinZoom = bounds.minZoom ?: 0.0
+    val zoomRange = mapMinZoom..(bounds.maxZoom ?: MAX_NATIVE_ZOOM)
     val zoom = (camera.zoom ?: startZoom).coerceIn(zoomRange)
-    val peakZoom = minOf(minZoom, startZoom, zoom).coerceIn(zoomRange)
+    val floor = maxOf(minZoom ?: mapMinZoom, mapMinZoom)
+    val peakZoom = minOf(floor, startZoom, zoom).coerceIn(zoomRange)
     val pathLength =
       mercatorPixelDistance(startZoom, start.toPosition(), end.toPosition()).takeIf { it > 0.0 }
         ?: return null
@@ -1446,7 +1449,7 @@ internal class MlnFfiMapSession(
         size.height - padding.top - padding.bottom,
       )
     val peakSpan = startSpan / 2.0.pow(peakZoom - startZoom)
-    return minZoom.takeIf { sqrt(peakSpan / pathLength * 2.0) < FLIGHT_CURVE }
+    return floor.takeIf { sqrt(peakSpan / pathLength * 2.0) < FLIGHT_CURVE }
   }
 
   private fun CameraAnimation.toAnimationOptions(): AnimationOptions =

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/MlnFfiProjectionTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/MlnFfiProjectionTest.kt
@@ -10,6 +10,7 @@ import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import org.maplibre.compose.camera.CameraAnimation
 import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.mlnffi.BridgeMapFixture
 import org.maplibre.compose.style.BaseStyle
@@ -126,7 +127,7 @@ class MlnFfiProjectionTest {
 
       val flight =
         launch(Dispatchers.Default) {
-          fixture.session.animateCameraPosition(ROTATED_CAMERA, 2.seconds)
+          fixture.session.animateCameraPosition(ROTATED_CAMERA, CameraAnimation.Fly(2.seconds))
         }
       fixture.pumpUntil("the camera to start moving") {
         abs(fixture.session.getCameraPosition().zoom - START_CAMERA.zoom) > 0.01

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/MlnFfiViewportTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/map/MlnFfiViewportTest.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
+import org.maplibre.compose.camera.CameraAnimation
 import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.mlnffi.BridgeMapFixture
 import org.maplibre.compose.style.BaseStyle
@@ -37,7 +38,7 @@ class MlnFfiViewportTest {
       val target = CameraPosition(target = Position(-74.006, 40.7128), zoom = 5.0)
       val animation =
         async(Dispatchers.Default, start = CoroutineStart.UNDISPATCHED) {
-          state.animateCameraPosition(target, 200.milliseconds)
+          state.animateCameraPosition(target, CameraAnimation.Fly(200.milliseconds))
         }
       // Let the owner accept the animation before any render target has attached.
       fixture.session.readMap {}


### PR DESCRIPTION
## Description

Adds `CameraAnimation` with `Ease` and `Fly` variants so `animateCameraPosition` and `animateCameraToBounds` run the same transition on MapLibre Native and the browser, where bounds animations previously eased on the browser and flew on native. `Fly` is paced by duration or by speed, can cap its zoom-out with `minZoom`, and both variants take a cubic bezier easing. Two engine differences are papered over in the sessions: native only fits the flight curve to a minimum zoom when one is passed, and a speed-paced flight with nothing to fly over jumped on native but eased on the browser. Closes #1395.

## Validation

`mise run test:desktop` (Metal), `test:js` (Chromium and Firefox), and `test:android` pass, including new live tests for both modes, speed pacing, minimum zoom, and path-less flights. The map-minimum test was checked by mutation. The Map Controls demo has a new section to try the options; not launched visually.

## AI assistance

Implemented with Claude Code (Fable 5.1). Adversarially reviewed over four rounds by Codex (gpt-6-astra); its findings drove the engine-difference fixes and the test sensitivity work.