### PR TITLE
Expose offline packs and progress as StateFlow

### DIFF
--- a/demo-app/common/src/maplibreNativeMain/kotlin/org/maplibre/compose/demoapp/demos/OfflineRegionSection.kt
+++ b/demo-app/common/src/maplibreNativeMain/kotlin/org/maplibre/compose/demoapp/demos/OfflineRegionSection.kt
@@ -6,6 +6,7 @@ import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -28,7 +29,8 @@ actual fun OfflineRegionSection(region: BoundingBox, styleUrl: String, packName:
   val pixelRatio = LocalDensity.current.density
   val scope = rememberCoroutineScope()
   val metadata = remember(packName) { packName.encodeToByteArray() }
-  val pack = offlineManager.packs.firstOrNull { it.metadata?.contentEquals(metadata) == true }
+  val packs by offlineManager.packs.collectAsState()
+  val pack = packs.firstOrNull { it.metadata.value?.contentEquals(metadata) == true }
   var creating by remember { mutableStateOf(false) }
   var errorMessage by remember { mutableStateOf<String?>(null) }
 

--- a/demo-app/common/src/maplibreNativeMain/kotlin/org/maplibre/compose/demoapp/demos/OfflineRegionSection.kt
+++ b/demo-app/common/src/maplibreNativeMain/kotlin/org/maplibre/compose/demoapp/demos/OfflineRegionSection.kt
@@ -8,6 +8,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -30,7 +31,8 @@ actual fun OfflineRegionSection(region: BoundingBox, styleUrl: String, packName:
   val scope = rememberCoroutineScope()
   val metadata = remember(packName) { packName.encodeToByteArray() }
   val packs by offlineManager.packs.collectAsState()
-  val pack = packs.firstOrNull { it.metadata.value?.contentEquals(metadata) == true }
+  val metadataByPack = packs.associateWith { key(it) { it.metadata.collectAsState().value } }
+  val pack = metadataByPack.entries.firstOrNull { it.value?.contentEquals(metadata) == true }?.key
   var creating by remember { mutableStateOf(false) }
   var errorMessage by remember { mutableStateOf<String?>(null) }
 

--- a/demo-app/common/src/maplibreNativeMain/kotlin/org/maplibre/compose/docsnippets/Offline.kt
+++ b/demo-app/common/src/maplibreNativeMain/kotlin/org/maplibre/compose/docsnippets/Offline.kt
@@ -69,8 +69,9 @@ fun Offline() {
   // #region delete
   for (pack in packs) {
     key(pack) {
+      val metadata by pack.metadata.collectAsState()
       Button(onClick = { scope.launch { offlineManager.delete(pack) } }) {
-        Text("Delete ${pack.metadata.value?.decodeToString()}")
+        Text("Delete ${metadata?.decodeToString()}")
       }
     }
   }

--- a/demo-app/common/src/maplibreNativeMain/kotlin/org/maplibre/compose/docsnippets/Offline.kt
+++ b/demo-app/common/src/maplibreNativeMain/kotlin/org/maplibre/compose/docsnippets/Offline.kt
@@ -5,6 +5,9 @@ package org.maplibre.compose.docsnippets
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.platform.LocalDensity
 import kotlinx.coroutines.launch
@@ -46,22 +49,29 @@ fun Offline() {
   // #endregion create
 
   // #region progress
-  for (pack in offlineManager.packs) {
-    val name = pack.metadata?.decodeToString() ?: "Unnamed"
-    when (val progress = pack.downloadProgress) {
-      is DownloadProgress.Healthy ->
-        Text("$name: ${progress.completedResourceCount} resources, ${progress.status}")
-      is DownloadProgress.Error -> Text("$name: ${progress.message}")
-      is DownloadProgress.TileLimitExceeded -> Text("$name: tile limit ${progress.limit}")
-      is DownloadProgress.Unknown -> Text("$name: waiting for status")
+  val packs by offlineManager.packs.collectAsState()
+  for (pack in packs) {
+    key(pack) {
+      val metadata by pack.metadata.collectAsState()
+      val progress by pack.downloadProgress.collectAsState()
+      val name = metadata?.decodeToString() ?: "Unnamed"
+      when (val current = progress) {
+        is DownloadProgress.Healthy ->
+          Text("$name: ${current.completedResourceCount} resources, ${current.status}")
+        is DownloadProgress.Error -> Text("$name: ${current.message}")
+        is DownloadProgress.TileLimitExceeded -> Text("$name: tile limit ${current.limit}")
+        is DownloadProgress.Unknown -> Text("$name: waiting for status")
+      }
     }
   }
   // #endregion progress
 
   // #region delete
-  for (pack in offlineManager.packs) {
-    Button(onClick = { scope.launch { offlineManager.delete(pack) } }) {
-      Text("Delete ${pack.metadata?.decodeToString()}")
+  for (pack in packs) {
+    key(pack) {
+      Button(onClick = { scope.launch { offlineManager.delete(pack) } }) {
+        Text("Delete ${pack.metadata.value?.decodeToString()}")
+      }
     }
   }
   // #endregion delete

--- a/docs/src/content/docs/offline.mdx
+++ b/docs/src/content/docs/offline.mdx
@@ -18,7 +18,8 @@ creates, tracks, and deletes packs.
   platform does not support them.
 </Aside>
 
-Get the manager from the map runtime inside a composition:
+Get the manager from the map runtime. A composable, a view model, a background
+worker, or `main` can hold and use it:
 
 <Code code={region(offline, "manager")} lang="kotlin" title="App.kt" />
 
@@ -39,10 +40,15 @@ GeoJSON geometry instead of a bounding box.
 ## Track download progress
 
 <Api of="OfflineManager.packs" /> and <Api of="OfflinePack.downloadProgress" />
-are backed by Compose state, so a composition that reads them recomposes as
-the download proceeds:
+are `StateFlow`s. A composition collects them with `collectAsState` and
+recomposes as the download proceeds:
 
 <Code code={region(offline, "progress")} lang="kotlin" title="App.kt" />
+
+A background worker can collect `downloadProgress` until the pack reports
+`DownloadStatus.Complete`. The runtime lists stored packs before it becomes
+available, so the first value of `packs` includes every pack from earlier
+sessions.
 
 `pause` and `resume` switch a pack between the `Paused` and `Downloading`
 states. <Api of="OfflineManager.invalidate" /> re-checks a pack's tiles

--- a/lib/maplibre-compose-material3/src/maplibreNativeMain/kotlin/org/maplibre/compose/material3/OfflinePackListItem.kt
+++ b/lib/maplibre-compose-material3/src/maplibreNativeMain/kotlin/org/maplibre/compose/material3/OfflinePackListItem.kt
@@ -22,8 +22,8 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.compositionLocalOf
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
@@ -98,7 +98,7 @@ public fun OfflinePackListItem(
     OfflinePackListItemDefaults.LeadingContent(pack)
   },
   supportingContent: @Composable () -> Unit = {
-    OfflinePackListItemDefaults.SupportingContent(pack.downloadProgress)
+    OfflinePackListItemDefaults.SupportingContent(pack.downloadProgress.collectAsState().value)
   },
   trailingContent: @Composable () -> Unit = {
     OfflinePackListItemDefaults.TrailingContent(pack, offlineManager)
@@ -199,22 +199,18 @@ public object OfflinePackListItemDefaults {
       )
     },
   ) {
-    val icon by
-      remember(pack, completedIcon, pausedIcon, downloadingIcon, errorIcon, warningIcon) {
-        derivedStateOf {
-          val progress = pack.downloadProgress
-          when (progress) {
-            is DownloadProgress.Healthy ->
-              when (progress.status) {
-                DownloadStatus.Complete -> completedIcon
-                DownloadStatus.Paused -> pausedIcon
-                DownloadStatus.Downloading -> downloadingIcon
-              }
-            is DownloadProgress.Error -> errorIcon
-            is DownloadProgress.TileLimitExceeded,
-            is DownloadProgress.Unknown -> warningIcon
+    val progress by pack.downloadProgress.collectAsState()
+    val icon =
+      when (val current = progress) {
+        is DownloadProgress.Healthy ->
+          when (current.status) {
+            DownloadStatus.Complete -> completedIcon
+            DownloadStatus.Paused -> pausedIcon
+            DownloadStatus.Downloading -> downloadingIcon
           }
-        }
+        is DownloadProgress.Error -> errorIcon
+        is DownloadProgress.TileLimitExceeded,
+        is DownloadProgress.Unknown -> warningIcon
       }
     AnimatedContent(icon) { icon -> icon() }
   }
@@ -395,15 +391,11 @@ private fun OfflinePackDeleteConfirmation(
 
 @Composable
 private fun DownloadProgressCircle(pack: OfflinePack) {
-  val progressRatio by
-    remember(pack) {
-      derivedStateOf {
-        val progress = pack.downloadProgress
-        if (progress is DownloadProgress.Healthy && progress.requiredResourceCount != 0L)
-          progress.completedResourceCount.toFloat() / progress.requiredResourceCount
-        else 0f
-      }
-    }
+  val progress by pack.downloadProgress.collectAsState()
+  val progressRatio =
+    (progress as? DownloadProgress.Healthy)
+      ?.takeIf { it.requiredResourceCount != 0L }
+      ?.let { it.completedResourceCount.toFloat() / it.requiredResourceCount } ?: 0f
 
   val animatedProgressRatio by
     animateFloatAsState(
@@ -416,7 +408,8 @@ private fun DownloadProgressCircle(pack: OfflinePack) {
 
 @Composable
 private fun PauseResumeUpdateButton(pack: OfflinePack, offlineManager: OfflineManager) {
-  val status = (pack.downloadProgress as? DownloadProgress.Healthy)?.status ?: return
+  val progress by pack.downloadProgress.collectAsState()
+  val status = (progress as? DownloadProgress.Healthy)?.status ?: return
   val coroutineScope = rememberCoroutineScope()
 
   fun onClick() {

--- a/lib/maplibre-compose/build.gradle.kts
+++ b/lib/maplibre-compose/build.gradle.kts
@@ -65,7 +65,7 @@ kotlin {
       implementation(libs.jetbrains.compose.components.resources)
       implementation(libs.htmlConverterCompose)
       api(libs.lifecycle.runtime.compose)
-      implementation(libs.kotlinx.coroutines.core)
+      api(libs.kotlinx.coroutines.core)
       implementation(libs.kotlinx.atomicfu)
       api(libs.kotlinx.io.core)
       api(libs.spatialk.geojson)

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
@@ -65,6 +65,7 @@ import org.maplibre.compose.layers.LayerHandle
 import org.maplibre.compose.layers.layerHandle
 import org.maplibre.compose.logging.MapLog
 import org.maplibre.compose.offline.OfflineManager
+import org.maplibre.compose.offline.OfflineManagerBackend
 import org.maplibre.compose.offline.RuntimeBoundOfflineManager
 import org.maplibre.compose.offline.UnsupportedOfflineManager
 import org.maplibre.compose.resource.MapResourceConfig
@@ -1929,7 +1930,7 @@ internal class RuntimeImplementation(
   internal val platformContext: Any?,
   private val closeResources: suspend () -> Unit,
   internal val logger: MapLog?,
-  offlineManagerBackend: OfflineManager = UnsupportedOfflineManager,
+  offlineManagerBackend: OfflineManagerBackend = UnsupportedOfflineManager,
   internal val physicalScope: CoroutineScope =
     CoroutineScope(SupervisorJob() + Dispatchers.Default),
   internal val createSnapshotterAdapter: () -> SnapshotterAdapter = ::unsupportedSnapshots,

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/offline/OfflineManager.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/offline/OfflineManager.kt
@@ -1,12 +1,19 @@
 package org.maplibre.compose.offline
 
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.io.files.Path
 
 /** Manages the offline packs and ambient cache that belong to one map runtime. */
 public interface OfflineManager {
 
-  /** All offline packs registered with this manager. Backed by Compose snapshot state. */
-  public val packs: Set<OfflinePack>
+  /**
+   * All offline packs registered with this manager.
+   *
+   * The runtime lists the packs stored in its database before it becomes available, so the first
+   * value is complete.
+   */
+  public val packs: StateFlow<Set<OfflinePack>>
 
   /**
    * Creates a paused offline pack for [definition]. Call [resume] to start its download.
@@ -90,19 +97,32 @@ public interface OfflineManager {
   public suspend fun setMaximumAmbientCacheSize(size: Long)
 }
 
+/** The runtime-independent part of an [OfflineManager] implementation. */
+internal interface OfflineManagerBackend : OfflineManager {
+  /**
+   * Installs the check that every pack operation runs before touching the backend. The runtime
+   * calls this once, before it hands the manager to callers.
+   */
+  fun bindToRuntime(requireRuntimeOpen: () -> Unit)
+}
+
 internal class RuntimeBoundOfflineManager(
-  private val delegate: OfflineManager,
+  private val delegate: OfflineManagerBackend,
   private val requireRuntimeOpen: () -> Unit,
 ) : OfflineManager {
-  override val packs: Set<OfflinePack>
-    get() = delegate.packs.onEach(::bindToRuntime)
+  init {
+    delegate.bindToRuntime(requireRuntimeOpen)
+  }
+
+  override val packs: StateFlow<Set<OfflinePack>>
+    get() = delegate.packs
 
   override suspend fun create(
     definition: OfflinePackDefinition,
     metadata: ByteArray,
   ): OfflinePack {
     requireRuntimeOpen()
-    return bindToRuntime(delegate.create(definition, metadata))
+    return delegate.create(definition, metadata)
   }
 
   override fun resume(pack: OfflinePack) {
@@ -127,7 +147,7 @@ internal class RuntimeBoundOfflineManager(
 
   override suspend fun mergeDatabase(databaseFile: Path): Set<OfflinePack> {
     requireRuntimeOpen()
-    return delegate.mergeDatabase(databaseFile).onEach(::bindToRuntime)
+    return delegate.mergeDatabase(databaseFile)
   }
 
   override suspend fun invalidateAmbientCache() {
@@ -144,12 +164,12 @@ internal class RuntimeBoundOfflineManager(
     requireRuntimeOpen()
     delegate.setMaximumAmbientCacheSize(size)
   }
-
-  private fun bindToRuntime(pack: OfflinePack): OfflinePack = pack.bindToRuntime(requireRuntimeOpen)
 }
 
-internal object UnsupportedOfflineManager : OfflineManager {
-  override val packs: Set<OfflinePack> = emptySet()
+internal object UnsupportedOfflineManager : OfflineManagerBackend {
+  override val packs: StateFlow<Set<OfflinePack>> = MutableStateFlow(emptySet())
+
+  override fun bindToRuntime(requireRuntimeOpen: () -> Unit) {}
 
   override suspend fun create(
     definition: OfflinePackDefinition,

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/offline/OfflinePack.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/offline/OfflinePack.kt
@@ -1,8 +1,13 @@
 package org.maplibre.compose.offline
 
-import androidx.compose.runtime.mutableStateOf
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
-internal fun interface OfflinePackOwner {
+internal interface OfflinePackOwner {
+  /** Throws [IllegalStateException] when the runtime that owns this manager is closed. */
+  fun requireRuntimeOpen()
+
   suspend fun updateMetadata(pack: OfflinePack, metadata: ByteArray)
 }
 
@@ -15,17 +20,18 @@ internal constructor(
   public val definition: OfflinePackDefinition,
   initialMetadata: ByteArray?,
 ) {
-  internal val metadataState = mutableStateOf(initialMetadata)
-  internal val progressState = mutableStateOf<DownloadProgress>(DownloadProgress.Unknown)
-  private var requireRuntimeOpen: () -> Unit = {}
+  internal val metadataState = MutableStateFlow(initialMetadata)
+  internal val progressState = MutableStateFlow<DownloadProgress>(DownloadProgress.Unknown)
 
-  /** Arbitrary data stored alongside the downloaded resources. Backed by Compose snapshot state. */
-  public val metadata: ByteArray?
-    get() = metadataState.value
+  /** Arbitrary data stored alongside the downloaded resources. */
+  public val metadata: StateFlow<ByteArray?> = metadataState.asStateFlow()
 
-  /** The pack's current download progress. Backed by Compose snapshot state. */
-  public val downloadProgress: DownloadProgress
-    get() = progressState.value
+  /**
+   * The pack's current download progress.
+   *
+   * A pack reads as [DownloadProgress.Unknown] until MapLibre reports its first status.
+   */
+  public val downloadProgress: StateFlow<DownloadProgress> = progressState.asStateFlow()
 
   /**
    * Replaces the arbitrary metadata that is associated with this offline pack.
@@ -34,12 +40,8 @@ internal constructor(
    * @throws [OfflineManagerException] if the operation failed.
    */
   public suspend fun setMetadata(metadata: ByteArray) {
-    requireRuntimeOpen()
+    owner.requireRuntimeOpen()
     owner.updateMetadata(this, metadata)
-  }
-
-  internal fun bindToRuntime(requireRuntimeOpen: () -> Unit): OfflinePack = apply {
-    this.requireRuntimeOpen = requireRuntimeOpen
   }
 
   override fun equals(other: Any?): Boolean =

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/offline/RuntimeBoundOfflineManagerTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/offline/RuntimeBoundOfflineManagerTest.kt
@@ -6,6 +6,8 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertSame
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.test.runTest
 import kotlinx.io.files.Path
 import org.maplibre.compose.map.RuntimeImplementation
@@ -18,7 +20,7 @@ class RuntimeBoundOfflineManagerTest {
     val runtime = runtime(UnsupportedOfflineManager)
     val manager = runtime.offlineManager
 
-    assertEquals(emptySet(), manager.packs)
+    assertEquals(emptySet(), manager.packs.value)
     assertFailsWith<UnsupportedOperationException> { manager.create(definition) }
     assertFailsWith<UnsupportedOperationException> { manager.resume(pack) }
     assertFailsWith<UnsupportedOperationException> { manager.pause(pack) }
@@ -38,7 +40,7 @@ class RuntimeBoundOfflineManagerTest {
     val runtime = runtime(backend)
     val manager = runtime.offlineManager
 
-    assertSame(backend.pack, manager.packs.single())
+    assertSame(backend.pack, manager.packs.value.single())
     val metadata = byteArrayOf(1, 2)
     assertSame(backend.createdPack, manager.create(definition, metadata))
     assertEquals(definition, backend.createdDefinition)
@@ -84,7 +86,7 @@ class RuntimeBoundOfflineManagerTest {
         closeResources = { releaseCleanup.await() },
       )
     val manager = runtime.offlineManager
-    val retainedPack = manager.packs.single()
+    val retainedPack = manager.packs.value.single()
     val createdPack = manager.create(definition)
     backend.calls.clear()
 
@@ -108,7 +110,7 @@ class RuntimeBoundOfflineManagerTest {
   }
 
   private fun runtime(
-    backend: OfflineManager,
+    backend: OfflineManagerBackend,
     closeResources: suspend () -> Unit = {},
   ) =
     RuntimeImplementation(
@@ -118,15 +120,26 @@ class RuntimeBoundOfflineManagerTest {
       offlineManagerBackend = backend,
     )
 
-  private class RecordingOfflineManager : OfflineManager {
+  private class RecordingOfflineManager : OfflineManagerBackend, OfflinePackOwner {
     val calls = mutableListOf<String>()
+    private var requireRuntimeOpen: () -> Unit = {}
     var createdDefinition: OfflinePackDefinition? = null
     var createdMetadata: ByteArray? = null
     val pack = pack(regionId = 1)
     val createdPack = pack(regionId = 2)
     val mergedPack = pack(regionId = 3)
 
-    override val packs: Set<OfflinePack> = setOf(pack)
+    override val packs: StateFlow<Set<OfflinePack>> = MutableStateFlow(setOf(pack))
+
+    override fun bindToRuntime(requireRuntimeOpen: () -> Unit) {
+      this.requireRuntimeOpen = requireRuntimeOpen
+    }
+
+    override fun requireRuntimeOpen() = requireRuntimeOpen.invoke()
+
+    override suspend fun updateMetadata(pack: OfflinePack, metadata: ByteArray) {
+      calls += "set metadata"
+    }
 
     override suspend fun create(
       definition: OfflinePackDefinition,
@@ -176,13 +189,7 @@ class RuntimeBoundOfflineManagerTest {
       calls += "set ambient size"
     }
 
-    private fun pack(regionId: Long) =
-      OfflinePack(
-        OfflinePackOwner { _, _ -> calls += "set metadata" },
-        regionId,
-        definition,
-        ByteArray(0),
-      )
+    private fun pack(regionId: Long) = OfflinePack(this, regionId, definition, ByteArray(0))
   }
 
   private companion object {

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserOfflineManagerTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserOfflineManagerTest.kt
@@ -16,7 +16,7 @@ class BrowserOfflineManagerTest {
     val runtime = createMapRuntime(MapRuntimeOptions())
     val manager = runtime.offlineManager
 
-    assertTrue(manager.packs.isEmpty())
+    assertTrue(manager.packs.value.isEmpty())
     assertFailsWith<UnsupportedOperationException> {
       manager.create(
         OfflinePackDefinition.TilePyramid(

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/offline/MlnFfiOfflineManager.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/offline/MlnFfiOfflineManager.kt
@@ -1,10 +1,13 @@
 package org.maplibre.compose.offline
 
-import androidx.compose.runtime.mutableStateOf
 import kotlin.concurrent.atomics.AtomicBoolean
+import kotlin.concurrent.atomics.AtomicReference
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.coroutines.resumeWithException
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -29,15 +32,12 @@ internal class MlnFfiOfflineManager(
   private val options: MlnFfiRuntimeOptions,
   resourceConfig: MapResourceConfig =
     MapResourceConfig(options.requestInterceptor, options.resourceProvider, options.logger),
-) : OfflineManager, OfflinePackOwner {
+) : OfflineManagerBackend, OfflinePackOwner {
 
   private val logger = options.logger
 
-  /**
-   * Compose state updated on the owner thread to preserve status update order and avoid depending
-   * on an AWT dispatcher.
-   */
-  private val packsState = mutableStateOf(emptySet<OfflinePack>())
+  /** Updated on the owner thread only, which preserves the order of status updates. */
+  private val packsState = MutableStateFlow(emptySet<OfflinePack>())
 
   /** Owner-thread state: the packs this manager has seen, keyed by native region id. */
   private val packsById = mutableMapOf<Long, OfflinePack>()
@@ -48,28 +48,63 @@ internal class MlnFfiOfflineManager(
   /** One manager applies one cache-budget change at a time. */
   private val cacheBudgetMutex = Mutex()
 
-  override val packs: Set<OfflinePack>
-    get() = packsState.value
+  @OptIn(ExperimentalAtomicApi::class) private val runtimeGuard = AtomicReference<() -> Unit> {}
+
+  override val packs: StateFlow<Set<OfflinePack>> = packsState.asStateFlow()
 
   init {
     runtime.start()
-    awaitConfiguredRuntime()
-    submit(
-      description = "list the offline packs",
-      start = { it.startOfflineRegions() },
-      finish = { nativeRuntime, handle ->
-        nativeRuntime.takeOfflineRegionsResult(handle).forEach { info ->
-          // One unrepresentable region must not cost the user the rest of their packs.
-          runCatching { registerRegion(info) }
-            .onFailure { logger?.w(it) { "Ignoring offline region ${info.id}" } }
-        }
-      },
+    awaitStartup("configure MapLibre's offline runtime", ::configureCacheBudget)
+    // Callers may read [packs] as soon as the constructor returns, so the listing completes here.
+    awaitStartup("list MapLibre's offline packs") { complete ->
+      submit(
+        description = "list the offline packs",
+        start = { it.startOfflineRegions() },
+        finish = { nativeRuntime, handle ->
+          nativeRuntime.takeOfflineRegionsResult(handle).forEach { info ->
+            // One unrepresentable region must not cost the user the rest of their packs.
+            runCatching { registerRegion(info) }
+              .onFailure { logger?.w(it) { "Ignoring offline region ${info.id}" } }
+          }
+        },
+        onResult = complete,
+      )
+    }
+  }
+
+  @OptIn(ExperimentalAtomicApi::class)
+  override fun bindToRuntime(requireRuntimeOpen: () -> Unit) {
+    runtimeGuard.store(requireRuntimeOpen)
+  }
+
+  @OptIn(ExperimentalAtomicApi::class)
+  override fun requireRuntimeOpen() {
+    runtimeGuard.load()()
+  }
+
+  /** Applies the configured cache budget, or does nothing when there is none. */
+  private fun configureCacheBudget(complete: (Result<Unit>) -> Unit): Boolean {
+    val initialSize = options.maximumCacheSizeBytes
+    if (initialSize == null) {
+      return runtime.post(
+        task = { complete(Result.success(Unit)) },
+        reject = { complete(Result.failure(it)) },
+      )
+    }
+    return submit(
+      description = "set the initial maximum ambient cache size to $initialSize bytes",
+      start = { it.startSetMaximumAmbientCacheSize(initialSize) },
+      finish = { _, _ -> logger?.d { "Ambient cache size set to $initialSize bytes" } },
+      onResult = complete,
     )
   }
 
-  /** Publishes the manager after runtime startup and initial cache-budget configuration succeed. */
+  /**
+   * Blocks the constructing thread until a startup task reports a result, and fails construction
+   * when it fails. [run] returns false when the runtime rejected the task.
+   */
   @OptIn(ExperimentalAtomicApi::class)
-  private fun awaitConfiguredRuntime() {
+  private fun awaitStartup(description: String, run: ((Result<Unit>) -> Unit) -> Boolean) {
     val settled = MlnFfiGate()
     val completed = AtomicBoolean(false)
     var outcome: Result<Unit>? = null
@@ -80,37 +115,19 @@ internal class MlnFfiOfflineManager(
       }
     }
 
-    val initialSize = options.maximumCacheSizeBytes
-    val accepted =
-      if (initialSize == null) {
-        runtime.post(
-          task = { complete(Result.success(Unit)) },
-          reject = { complete(Result.failure(it)) },
-        )
-      } else {
-        submit(
-          description = "set the initial maximum ambient cache size to $initialSize bytes",
-          start = { it.startSetMaximumAmbientCacheSize(initialSize) },
-          finish = { _, _ -> },
-          onResult = { result -> complete(result) },
-        )
-      }
-    if (!accepted) {
-      complete(
-        Result.failure(OfflineManagerException("The offline runtime rejected configuration"))
-      )
+    if (!run(::complete)) {
+      complete(Result.failure(OfflineManagerException("The offline runtime rejected the task")))
     }
 
     settled.awaitUntilOpen()
     val settledOutcome =
       outcome
         ?: failStartup(
-          "Could not configure MapLibre's offline runtime",
-          OfflineManagerException("The offline runtime never reported its configuration"),
+          "Could not $description",
+          OfflineManagerException("The offline runtime never reported a result"),
         )
     val failure = settledOutcome.exceptionOrNull()
-    if (failure != null) failStartup("Could not configure MapLibre's offline runtime", failure)
-    if (initialSize != null) logger?.d { "Ambient cache size set to $initialSize bytes" }
+    if (failure != null) failStartup("Could not $description", failure)
   }
 
   private fun failStartup(message: String, cause: Throwable): Nothing {

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/offline/rememberOfflinePacksSource.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/offline/rememberOfflinePacksSource.kt
@@ -1,6 +1,8 @@
 package org.maplibre.compose.offline
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.key
 import kotlinx.serialization.json.JsonObjectBuilder
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
@@ -31,15 +33,18 @@ public fun rememberOfflinePacksSource(
   options: GeoJsonOptions = GeoJsonOptions(),
   putExtraProperties: JsonObjectBuilder.(OfflinePack) -> Unit = {},
 ): GeoJsonSource {
+  val progressByPack = offlinePacks.associateWith { pack ->
+    key(pack) { pack.downloadProgress.collectAsState().value }
+  }
   return rememberGeoJsonSource(
     options = options,
     data =
       GeoJsonData.Features(
         buildFeatureCollection {
-          offlinePacks.forEach { pack ->
+          progressByPack.forEach { (pack, progress) ->
             addFeature(geometry = pack.definition.geometry) {
               properties = buildJsonObject {
-                putDownloadProgressProperties(pack.downloadProgress)
+                putDownloadProgressProperties(progress)
                 putExtraProperties(pack)
               }
             }

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/offline/rememberOfflinePacksSource.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/offline/rememberOfflinePacksSource.kt
@@ -20,32 +20,38 @@ import org.maplibre.spatialk.geojson.dsl.buildFeatureCollection
  * Specialization of [rememberGeoJsonSource] that contains the list of [OfflinePack] as features.
  * This allows you to implement a UI to manage offline packs directly on the map.
  *
- * By default, each feature has properties corresponding to the [OfflinePack.downloadProgress].
+ * By default, each feature has properties corresponding to the [OfflinePack.downloadProgress]. The
+ * source updates when a pack's progress or metadata changes.
  *
  * @param offlinePacks The collection of offline packs to represent in the source.
- * @param putExtraProperties A function that will be called with each [OfflinePack] to allow you to
- *   add additional properties to the feature. For example, you can use this to add properties based
- *   on the [OfflinePack.metadata].
+ * @param putExtraProperties A function that will be called with each [OfflinePack] and its current
+ *   metadata to allow you to add additional properties to the feature, such as a display name
+ *   decoded from the metadata.
  */
 @Composable
 public fun rememberOfflinePacksSource(
   offlinePacks: Set<OfflinePack>,
   options: GeoJsonOptions = GeoJsonOptions(),
-  putExtraProperties: JsonObjectBuilder.(OfflinePack) -> Unit = {},
+  putExtraProperties: JsonObjectBuilder.(pack: OfflinePack, metadata: ByteArray?) -> Unit =
+    { _, _ ->
+    },
 ): GeoJsonSource {
-  val progressByPack = offlinePacks.associateWith { pack ->
-    key(pack) { pack.downloadProgress.collectAsState().value }
+  val stateByPack = offlinePacks.associateWith { pack ->
+    key(pack) {
+      pack.downloadProgress.collectAsState().value to pack.metadata.collectAsState().value
+    }
   }
   return rememberGeoJsonSource(
     options = options,
     data =
       GeoJsonData.Features(
         buildFeatureCollection {
-          progressByPack.forEach { (pack, progress) ->
+          stateByPack.forEach { (pack, state) ->
+            val (progress, metadata) = state
             addFeature(geometry = pack.definition.geometry) {
               properties = buildJsonObject {
                 putDownloadProgressProperties(progress)
-                putExtraProperties(pack)
+                putExtraProperties(pack, metadata)
               }
             }
           }

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/offline/MlnFfiOfflinePackTest.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/offline/MlnFfiOfflinePackTest.kt
@@ -11,6 +11,7 @@ import kotlin.test.fail
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.TimeSource
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import kotlinx.io.buffered
@@ -57,8 +58,12 @@ class MlnFfiOfflinePackTest {
       // The pack is built from what MapLibre echoed back out of the stored region, not from the
       // definition passed in, so this is a round trip through the database's own columns.
       assertEquals(definition, pack.definition)
-      assertContentEquals(metadata, pack.metadata)
-      assertEquals(setOf(pack), manager.packs, "the created pack should be listed immediately")
+      assertContentEquals(metadata, pack.metadata.value)
+      assertEquals(
+        setOf(pack),
+        manager.packs.value,
+        "the created pack should be listed immediately",
+      )
     }
 
   @Test
@@ -85,19 +90,18 @@ class MlnFfiOfflinePackTest {
     val updated = "after, and longer than before".encodeToByteArray()
     withTimeout(OPERATION_TIMEOUT_MILLIS) { pack.setMetadata(updated) }
 
-    assertContentEquals(updated, pack.metadata)
+    assertContentEquals(updated, pack.metadata.value)
 
     // The manager copies in both directions, so a caller reusing its buffer cannot change what the
     // pack reports.
     updated[0] = '!'.code.toByte()
-    assertContentEquals("after, and longer than before".encodeToByteArray(), pack.metadata)
+    assertContentEquals("after, and longer than before".encodeToByteArray(), pack.metadata.value)
 
     assertTrue(manager.close())
     val reopened = manager()
-    await("the updated metadata to be listed after reopening") { reopened.packs.isNotEmpty() }
     assertContentEquals(
       "after, and longer than before".encodeToByteArray(),
-      reopened.packs.single().metadata,
+      reopened.packs.value.single().metadata.value,
     )
   }
 
@@ -115,11 +119,11 @@ class MlnFfiOfflinePackTest {
       withTimeout(OPERATION_TIMEOUT_MILLIS) {
         manager.create(definition, "removed".encodeToByteArray())
       }
-    assertEquals(setOf(kept, removed), manager.packs)
+    assertEquals(setOf(kept, removed), manager.packs.value)
 
     withTimeout(OPERATION_TIMEOUT_MILLIS) { manager.delete(removed) }
 
-    assertEquals(setOf(kept), manager.packs)
+    assertEquals(setOf(kept), manager.packs.value)
   }
 
   /** A runtime can close its manager and a later runtime can reopen the same persistent cache. */
@@ -136,12 +140,11 @@ class MlnFfiOfflinePackTest {
     val second = manager()
     assertNotSame(first, second)
 
-    await("the reopened manager to list the pack it inherited") { second.packs.isNotEmpty() }
-
-    val restored = second.packs.single()
+    // The manager lists its stored packs before its constructor returns.
+    val restored = second.packs.value.single()
     assertEquals(created.regionId, restored.regionId)
     assertEquals(definition, restored.definition)
-    assertContentEquals(metadata, restored.metadata)
+    assertContentEquals(metadata, restored.metadata.value)
   }
 
   /**
@@ -174,9 +177,7 @@ class MlnFfiOfflinePackTest {
     assertTrue(first.close(), "the first manager should stop")
 
     val second = manager()
-    await("the reopened manager to list the shape pack") { second.packs.isNotEmpty() }
-
-    assertEquals(definition, second.packs.single().definition)
+    assertEquals(definition, second.packs.value.single().definition)
   }
 
   @Test
@@ -194,12 +195,9 @@ class MlnFfiOfflinePackTest {
     assertTrue(first.close(), "the first manager should stop")
 
     val second = manager()
-    await("the reopened manager to list the pack that was kept") {
-      second.packs.any { it.regionId == kept.regionId }
-    }
-    assertTrue(second.close(), "the reopened manager should finish its listing before closing")
+    assertTrue(second.close(), "the reopened manager should stop")
 
-    assertEquals(listOf(kept.regionId), second.packs.map { it.regionId })
+    assertEquals(listOf(kept.regionId), second.packs.value.map { it.regionId })
   }
 
   @Test
@@ -223,10 +221,10 @@ class MlnFfiOfflinePackTest {
 
     assertEquals(2, merged.size)
     assertTrue(existing in merged, "an identical source pack should reuse the destination pack")
-    assertEquals(merged, destination.packs)
+    assertEquals(merged, destination.packs.value)
     assertEquals(
       setOf("same pack", "source-only pack"),
-      merged.map { requireNotNull(it.metadata).decodeToString() }.toSet(),
+      merged.map { requireNotNull(it.metadata.value).decodeToString() }.toSet(),
     )
   }
 
@@ -253,11 +251,14 @@ class MlnFfiOfflinePackTest {
     // A paused pack issues no requests at all, so an error arriving is itself the evidence that
     // resuming reached MapLibre.
     await({
-      "the resumed pack to report a failed fetch, but it reported ${pack.downloadProgress}"
+      "the resumed pack to report a failed fetch, but it reported ${pack.downloadProgress.value}"
     }) {
-      pack.downloadProgress is DownloadProgress.Error
+      pack.downloadProgress.value is DownloadProgress.Error
     }
-    assertEquals("REASON_CONNECTION", (pack.downloadProgress as DownloadProgress.Error).reason)
+    assertEquals(
+      "REASON_CONNECTION",
+      (pack.downloadProgress.value as DownloadProgress.Error).reason,
+    )
 
     manager.pause(pack)
 
@@ -266,6 +267,24 @@ class MlnFfiOfflinePackTest {
         it.status == DownloadStatus.Paused
       }
     assertEquals(DownloadStatus.Paused, paused.status)
+  }
+
+  /** A background worker observes completion through plain flow collection. */
+  @Test
+  fun a_download_completes_for_a_collector_with_no_compose_host() = runBlocking {
+    val manager = manager()
+    val pack = downloadedPack(manager, "collected.json")
+
+    val completed =
+      withTimeout(OPERATION_TIMEOUT_MILLIS) {
+        pack.downloadProgress.first {
+          it is DownloadProgress.Healthy && it.status == DownloadStatus.Complete
+        }
+      }
+
+    assertTrue((completed as DownloadProgress.Healthy).completedResourceCount > 0)
+    val packs = withTimeout(OPERATION_TIMEOUT_MILLIS) { manager.packs.first { pack in it } }
+    assertEquals(setOf(pack), packs)
   }
 
   /** Reopening must restore status from the database through the same code path used on restart. */
@@ -280,8 +299,7 @@ class MlnFfiOfflinePackTest {
     assertTrue(first.close(), "the first manager should stop")
 
     val second = manager()
-    await("the reopened manager to list the finished pack") { second.packs.isNotEmpty() }
-    val restored = second.packs.single()
+    val restored = second.packs.value.single()
 
     val status = awaitHealthy(restored, "the restored pack's status") { true }
     assertEquals(DownloadStatus.Complete, status.status)
@@ -338,10 +356,10 @@ class MlnFfiOfflinePackTest {
     description: String,
     predicate: (DownloadProgress.Healthy) -> Boolean,
   ): DownloadProgress.Healthy {
-    await({ "$description, but it last reported ${pack.downloadProgress}" }) {
-      (pack.downloadProgress as? DownloadProgress.Healthy)?.let(predicate) == true
+    await({ "$description, but it last reported ${pack.downloadProgress.value}" }) {
+      (pack.downloadProgress.value as? DownloadProgress.Healthy)?.let(predicate) == true
     }
-    return pack.downloadProgress as DownloadProgress.Healthy
+    return pack.downloadProgress.value as DownloadProgress.Healthy
   }
 
   private suspend fun await(description: String, condition: () -> Boolean) =


### PR DESCRIPTION
## Description

`OfflineManager.packs`, `OfflinePack.downloadProgress`, and `OfflinePack.metadata` are now `StateFlow`s, so a background worker can observe download completion without a Compose UI host. The native manager lists stored packs before it becomes available, so the first value of `packs` is complete. Compose consumers collect with `collectAsState`.

## Validation

`:lib:maplibre-compose:jvmTest` (offline package, with a new headless collection test), `:lib:maplibre-compose-material3:jvmTest`, demo app JVM compile, JS test compile, and `mise run check`.

## AI assistance

Claude Fable 5.1 via Claude Code.