### PR TITLE
Add an explicit operation to stop camera movement

### DIFF
--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapAdapter.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapAdapter.kt
@@ -74,6 +74,8 @@ internal interface MapAdapter {
 
   fun setCameraPosition(cameraPosition: CameraPosition, guard: CameraCommandGuard? = null)
 
+  fun stopCameraMovement(guard: CameraCommandGuard)
+
   fun setCameraPadding(padding: PaddingValues)
 
   fun cameraForBounds(

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
@@ -909,6 +909,30 @@ internal constructor(
   }
 
   /**
+   * Stops camera movement at the position reached when the backend processes this command.
+   *
+   * Cancels camera commands waiting for a viewport, running animations, gesture momentum, and the
+   * current recognized gesture's camera control. Interrupted suspend calls throw
+   * [kotlinx.coroutines.CancellationException]. New input or camera commands can move the camera
+   * again; a newer command takes precedence over this stop. Pointer events are not cancelled: a
+   * press that has not yet become a recognized gesture may still start one after this call.
+   *
+   * Does not wait for a surface to attach. Without a surface, the retained camera is unchanged.
+   * With a surface, [cameraPosition] updates when the backend reports the stopped position.
+   */
+  public fun stopCameraMovement() {
+    val guard = gestureAuthority.beginProgrammatic()
+    val attachment = lifecycle.serialized {
+      requireOpenLocked()
+      if (!guard.isValid()) return
+      currentMapAttachment ?: return
+    }
+    attachment.adapter.stopCameraMovement(
+      CameraCommandGuard { isCurrent(attachment) && guard.isValid() }
+    )
+  }
+
+  /**
    * Waits for a viewport, then calculates a camera for [boundingBox] without moving the map or
    * interrupting camera input or animations. Detaching the surface during the query cancels it.
    *

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
@@ -1988,6 +1988,59 @@ class MapPresentationTest {
   }
 
   @Test
+  fun a_queued_stop_cannot_cancel_a_newer_command() = runTest {
+    val runtime = mapRuntimeForTest(physicalScope = backgroundScope)
+    val state = runtime.createMapState(BaseStyle.Empty)
+    var stopGuard: CameraCommandGuard? = null
+    val adapter =
+      object : PresentationTestAdapter() {
+        override fun stopCameraMovement(guard: CameraCommandGuard) {
+          stopGuard = guard
+        }
+      }
+    val token = state.reservePresentation()
+    state.publishPresentation(token, adapter)
+    state.stopCameraMovement()
+    val guard = assertNotNull(stopGuard)
+    assertTrue(guard.isValid())
+    state.setCameraPosition(CameraPosition(zoom = 4.0))
+    assertFalse(guard.isValid())
+    state.close()
+    state.awaitClosed()
+    runtime.close()
+  }
+
+  @Test
+  fun stopping_cancels_commands_before_attachment_and_before_a_viewport() = runTest {
+    val runtime = mapRuntimeForTest(physicalScope = backgroundScope)
+    val state = runtime.createMapState(BaseStyle.Empty)
+    val position = CameraPosition(zoom = 3.0)
+    state.setCameraPosition(position)
+    val animation = async { state.animateCameraPosition(CameraPosition(zoom = 8.0)) }
+    testScheduler.runCurrent()
+    state.stopCameraMovement()
+    testScheduler.runCurrent()
+    assertTrue(animation.isCancelled)
+    assertEquals(position, state.cameraPosition)
+
+    val token = state.reservePresentation()
+    val adapter = PresentationTestAdapter()
+    state.publishPresentation(token, adapter)
+    val fit = async {
+      state.fitCameraToBounds(BoundingBox(Position(-1.0, -1.0), Position(1.0, 1.0)))
+    }
+    testScheduler.runCurrent()
+    assertFalse(fit.isCompleted)
+    state.stopCameraMovement()
+    testScheduler.runCurrent()
+    assertTrue(fit.isCancelled)
+    assertFalse(adapter.boundsFit.isCompleted)
+    state.close()
+    state.awaitClosed()
+    runtime.close()
+  }
+
+  @Test
   fun closing_a_map_fails_a_camera_animation_waiting_for_attachment() = runTest {
     val runtime = mapRuntimeForTest(physicalScope = backgroundScope)
     val state = runtime.createMapState(BaseStyle.Demo)
@@ -2208,6 +2261,8 @@ internal open class PresentationTestAdapter(
       presentationWasVisibleWhileConfiguring || currentAttachment() != null
     lastCameraPosition = cameraPosition
   }
+
+  override fun stopCameraMovement(guard: CameraCommandGuard) = Unit
 
   override fun setCameraPadding(padding: PaddingValues) = Unit
 

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
@@ -1166,7 +1166,11 @@ internal class GlJsMapSession(
   }
 
   override fun interruptCamera() {
-    val guard = lifecycleAuthority.gestureCamera.beginProgrammatic()
+    stopCameraMovement(lifecycleAuthority.gestureCamera.beginProgrammatic())
+  }
+
+  override fun stopCameraMovement(guard: CameraCommandGuard) {
+    if (!guard.isValid()) return
     releasePendingCameraTransition()
     onMap { if (guard.isValid()) it.stop() }
   }

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/camera/CameraInputIntegrationTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/camera/CameraInputIntegrationTest.kt
@@ -34,6 +34,39 @@ import org.maplibre.spatialk.geojson.Position
 
 class CameraInputIntegrationTest {
   @Test
+  fun stopping_revokes_active_gestures_and_their_momentum(): MapTestResult = runMapTest {
+    coroutineScope {
+      createMapFixture().use { fixture ->
+        fixture.loadStyle(BaseStyle.Empty)
+        fixture.awaitMapReady()
+        for (momentum in listOf(false, true)) {
+          fixture.state.setCameraPosition(CameraPosition(zoom = 5.0))
+          fixture.settle()
+          val input = GestureInputSession(this, fixture.gestures)
+          fixture.gestures.inputPanBy(20.0, 0.0, gestureToken = input.token)
+          fixture.settle()
+          if (momentum) {
+            input.scope.launch(start = CoroutineStart.UNDISPATCHED) {
+              fixture.gestures.inputPanByAwaitingTransition(500.0, 0.0, 30.seconds, input.token)
+            }
+            input.end()
+            fixture.pump(frames = 3)
+          }
+          fixture.state.stopCameraMovement()
+          fixture.pumpUntil("the gesture to stop") { !fixture.state.isCameraMoving }
+          assertFalse(input.token.canExecute)
+          val stopped = fixture.state.cameraPosition
+          fixture.gestures.inputPanBy(100.0, 0.0, gestureToken = input.token)
+          input.end()
+          fixture.pump(frames = 10)
+          assertEquals(stopped, fixture.state.cameraPosition)
+          assertEquals(stopped, fixture.session.getCameraPosition())
+        }
+      }
+    }
+  }
+
+  @Test
   fun haptic_feedback_tracks_applied_rotation_but_not_momentum_or_settlement(): MapTestResult =
     runMapTest {
       coroutineScope {

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/MapCameraTransitionTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/MapCameraTransitionTest.kt
@@ -571,6 +571,37 @@ class MapCameraTransitionTest {
       }
     }
 
+  @Test
+  fun stopping_an_animation_retains_its_position_and_allows_a_new_command(): MapTestResult =
+    runMapTest {
+      if (systemAnimatorDurationScale() == 0f) skipMapTest("System animations are disabled")
+      createMapFixture().use {
+        it.startAtOrigin()
+        val animation =
+          launch(Dispatchers.Default) {
+            it.state.animateCameraPosition(TARGET, CameraAnimation.Ease(30.seconds))
+          }
+        it.awaitCameraMoving()
+        it.state.stopCameraMovement()
+        it.pumpUntil("the stopped animation to cancel") {
+          animation.isCompleted && !it.state.isCameraMoving
+        }
+        assertTrue(animation.isCancelled)
+        val stopped = it.session.getCameraPosition()
+        assertTrue(stopped.zoom < TARGET.zoom - 0.1)
+        it.pump(frames = 10)
+        assertSameFit(stopped, it.session.getCameraPosition(), "movement after stop")
+        assertSameFit(stopped, it.state.cameraPosition, "retained stopped camera")
+
+        // Queue a stop and a replacement without rendering between them.
+        it.state.stopCameraMovement()
+        it.awaitWhileRendering("the command racing the stop to complete") {
+          it.state.animateCameraPosition(TARGET, CameraAnimation.Ease(200.milliseconds))
+        }
+        it.assertLanded(TARGET, "the newer command")
+      }
+    }
+
   private suspend fun MapFixture.startAtOrigin() = startAt(START)
 
   private suspend fun MapFixture.startAt(position: CameraPosition) {

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -2066,7 +2066,11 @@ internal class MlnFfiMapSession(
   }
 
   override fun interruptCamera() {
-    val guard = lifecycleAuthority.gestureCamera.beginProgrammatic()
+    stopCameraMovement(lifecycleAuthority.gestureCamera.beginProgrammatic())
+  }
+
+  override fun stopCameraMovement(guard: CameraCommandGuard) {
+    if (!guard.isValid()) return
     onMap { map ->
       if (!guard.isValid()) return@onMap
       // Cleared first, so a later cancellation cannot stop a newer transition.


### PR DESCRIPTION
## Description

Add `MapState.stopCameraMovement()` so callers can stop the camera without retaining the coroutine job that started it. It cancels commands waiting for a viewport, running animations, gesture momentum, and the current recognized gesture's camera control. Interrupted suspend calls throw `CancellationException`; newer commands take precedence, and the stopped position is retained.

Reuse the existing guarded Native and GL JS stop operations. Document that pointer events remain active: a press that has not yet become a recognized gesture can still start one afterward.

Closes #1398.

## Validation

- `mise run test:desktop` passed.
- `mise run test:js` passed in Chromium and Firefox.
- `mise run check` passed.
- After rebasing onto current main, reran the desktop camera transition, camera input integration, and map presentation tests.
- Regression coverage includes stopping before attachment or viewport readiness, during animation and gesture momentum, retaining the stopped position, and a newer command superseding a queued stop.
- Android and iOS were not run locally.

## AI assistance

Implemented and tested with OpenAI Codex (GPT-6), including this PR description, at the maintainer's request.
