### PR TITLE
Support eased camera animations around a fixed anchor

### DIFF
--- a/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Camera.kt
+++ b/demo-app/common/src/commonMain/kotlin/org/maplibre/compose/docsnippets/Camera.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
+import org.maplibre.compose.camera.CameraAnchor
 import org.maplibre.compose.camera.CameraAnimation
 import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.map.MaplibreMap
@@ -55,6 +56,17 @@ fun Camera() {
     )
   }
   // #endregion animate-ease
+
+  // #region animate-around
+  LaunchedEffect(mapState) {
+    mapState.animateCameraAround(
+      anchor = CameraAnchor.Screen(DpOffset(120.dp, 200.dp)),
+      zoom = 16.0,
+      bearing = 90.0,
+      animation = CameraAnimation.Ease(500.milliseconds),
+    )
+  }
+  // #endregion animate-around
 
   // #region fit-bounds
   LaunchedEffect(mapState) {

--- a/docs/src/content/docs/camera.mdx
+++ b/docs/src/content/docs/camera.mdx
@@ -52,6 +52,27 @@ Both transitions accept an `easing` timing curve, a <Api of="CubicBezier" />.
 On Android, the system animator duration scale multiplies the duration of
 either transition. A scale of zero jumps to the target.
 
+### Keep a point fixed on screen
+
+<Api of="MapState.animateCameraAround" /> changes zoom, bearing, or tilt while
+keeping a point at its screen location. Use <Api of="CameraAnchor.Screen" /> for
+coordinates in dp from the full map's top-left corner:
+
+<Code code={region(camera, "animate-around")} lang="kotlin" title="App.kt" />
+
+Use <Api of="CameraAnchor.Geographic" /> to keep a selected geographic location
+at its current screen point. The anchor is resolved when the animation starts
+and must be visible on the map. Omitted camera components keep their starting
+values. This operation supports easing; it does not accept a flight or a target
+center because the center moves to keep the anchor fixed.
+
+Persistent camera padding participates in projection. Changing that padding,
+resizing the logical viewport, or losing the attachment cancels the animation.
+The operation does not restart on a replacement attachment. Camera constraints
+take precedence over anchor preservation. The preservation guarantee applies to
+flat Mercator maps, including tilted cameras; it does not extend to globe or
+terrain.
+
 ## Fit a bounding box
 
 <Api of="MapState.animateCameraToBounds" /> fits a `BoundingBox` in the current

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/CameraAnchor.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/CameraAnchor.kt
@@ -1,0 +1,76 @@
+package org.maplibre.compose.camera
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import kotlin.math.abs
+import org.maplibre.spatialk.geojson.Position
+
+/**
+ * A point whose screen location is preserved by
+ * [org.maplibre.compose.map.MapState.animateCameraAround].
+ */
+@Immutable
+public sealed interface CameraAnchor {
+  /** A point in dp from the full map's top-left corner, including its camera padding. */
+  @Immutable
+  public data class Screen(public val point: DpOffset) : CameraAnchor {
+    init {
+      require(point.x.value.isFinite() && point.y.value.isFinite()) { "The anchor must be finite" }
+    }
+  }
+
+  /** A location in the world copy nearest the camera center. Altitude is ignored. */
+  @Immutable
+  public data class Geographic(public val position: Position) : CameraAnchor {
+    init {
+      require(position.longitude.isFinite() && position.latitude.isFinite()) {
+        "The anchor must be finite"
+      }
+      require(position.latitude in -85.0511287798066..85.0511287798066) {
+        "The anchor must be within Mercator latitudes"
+      }
+    }
+  }
+}
+
+/** Resolve on the engine thread, using one live transform for both conversions. */
+internal fun CameraAnchor.resolveScreenPoint(
+  size: DpSize,
+  centerLongitude: Double,
+  project: (Position) -> DpOffset,
+  unproject: (DpOffset) -> Position,
+): DpOffset {
+  val point =
+    when (this) {
+      is CameraAnchor.Screen -> point
+      is CameraAnchor.Geographic -> project(position)
+    }
+  require(
+    point.x.value.isFinite() &&
+      point.y.value.isFinite() &&
+      point.x >= 0.dp &&
+      point.y >= 0.dp &&
+      point.x <= size.width &&
+      point.y <= size.height
+  ) {
+    "The anchor must be inside the map viewport"
+  }
+  val location = unproject(point)
+  require(location.longitude.isFinite() && location.latitude.isFinite()) {
+    "The anchor must project onto the map"
+  }
+  // A point above the horizon can unproject to a clamped ground location. Native projects
+  // geographic positions into the nearest world copy; comparing that copy with a screen anchor
+  // in another visible copy would reject valid points, particularly on rotated, wide maps.
+  if (abs(location.longitude - centerLongitude) <= 180.0) {
+    val roundTrip = project(location)
+    require(
+      abs(roundTrip.x.value - point.x.value) < 0.5f && abs(roundTrip.y.value - point.y.value) < 0.5f
+    ) {
+      "The anchor must project onto the map"
+    }
+  }
+  return point
+}

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/CameraAnchor.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/camera/CameraAnchor.kt
@@ -61,9 +61,10 @@ internal fun CameraAnchor.resolveScreenPoint(
   require(location.longitude.isFinite() && location.latitude.isFinite()) {
     "The anchor must project onto the map"
   }
-  // A point above the horizon can unproject to a clamped ground location. Native projects
+  // Finite unprojection alone does not guarantee a screen point round-trips. Native projects
   // geographic positions into the nearest world copy; comparing that copy with a screen anchor
   // in another visible copy would reject valid points, particularly on rotated, wide maps.
+  // GL JS additionally checks its map-surface predicate, independently of the world copy.
   if (abs(location.longitude - centerLongitude) <= 180.0) {
     val roundTrip = project(location)
     require(

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapAdapter.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapAdapter.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.DpRect
 import kotlinx.coroutines.Deferred
 import kotlinx.serialization.json.JsonObject
+import org.maplibre.compose.camera.CameraAnchor
 import org.maplibre.compose.camera.CameraAnimation
 import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.camera.Viewport
@@ -47,6 +48,15 @@ internal interface MapAdapter {
   suspend fun animateCameraPosition(
     finalPosition: CameraPosition,
     animation: CameraAnimation,
+    guard: CameraCommandGuard? = null,
+  )
+
+  suspend fun animateCameraAround(
+    anchor: CameraAnchor,
+    zoom: Double?,
+    bearing: Double?,
+    tilt: Double?,
+    animation: CameraAnimation.Ease,
     guard: CameraCommandGuard? = null,
   )
 

--- a/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
+++ b/lib/maplibre-compose/src/commonMain/kotlin/org/maplibre/compose/map/MapRuntime.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.unit.dp
 import kotlin.concurrent.atomics.AtomicReference
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.jvm.JvmInline
+import kotlin.time.Duration
 import kotlinx.atomicfu.locks.reentrantLock
 import kotlinx.atomicfu.locks.withLock
 import kotlinx.coroutines.CancellationException
@@ -47,6 +48,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.selects.select
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
+import org.maplibre.compose.camera.CameraAnchor
 import org.maplibre.compose.camera.CameraAnimation
 import org.maplibre.compose.camera.CameraMoveReason
 import org.maplibre.compose.camera.CameraPosition
@@ -550,6 +552,18 @@ internal constructor(
     adapter.animateCameraPosition(position, animation.forPathTo(position), boundGuard(guard))
   }
 
+  suspend fun animateCameraAround(
+    anchor: CameraAnchor,
+    zoom: Double?,
+    bearing: Double?,
+    tilt: Double?,
+    animation: CameraAnimation.Ease,
+    guard: CameraCommandGuard? = null,
+  ): Unit = runLeaseBound {
+    awaitViewportState()
+    adapter.animateCameraAround(anchor, zoom, bearing, tilt, animation, boundGuard(guard))
+  }
+
   suspend fun animateCameraToBounds(
     boundingBox: BoundingBox,
     bearing: Double = 0.0,
@@ -1030,6 +1044,49 @@ internal constructor(
     retryAcrossAttachments {
       it.animateCameraPosition(position, animation.scaledBy(systemAnimatorDurationScale()), guard)
     }
+  }
+
+  /**
+   * Changes zoom, bearing, or tilt while keeping [anchor] at its screen location at animation
+   * start. Null camera components retain their starting values. The camera target moves to preserve
+   * the anchor; this operation does not accept a destination target or a flight animation.
+   *
+   * Waits for an attached viewport. The anchor must resolve to a visible point on the map, or this
+   * call throws [IllegalArgumentException]. Persistent camera padding participates in projection
+   * and is not changed. Screen coordinates are relative to the full map, not its padded area.
+   *
+   * A newer camera command, accepted input, coroutine cancellation, a logical viewport resize,
+   * changed camera padding, or attachment loss cancels this call. It does not restart on another
+   * attachment. The camera remains where it was interrupted, subject to the new geometry.
+   *
+   * Anchor preservation applies to flat Mercator maps, including tilted cameras. Camera constraints
+   * take precedence and can move the anchor. Globe and terrain do not have this guarantee. On
+   * Android, the system animator duration scale multiplies the duration. Zero duration applies the
+   * anchored endpoint immediately.
+   */
+  public suspend fun animateCameraAround(
+    anchor: CameraAnchor,
+    zoom: Double? = null,
+    bearing: Double? = null,
+    tilt: Double? = null,
+    animation: CameraAnimation.Ease = CameraAnimation.Ease(),
+  ): Unit = coroutineScope {
+    require(zoom == null || zoom.isFinite()) { "Zoom must be finite" }
+    require(bearing == null || bearing.isFinite()) { "Bearing must be finite" }
+    require(tilt == null || tilt.isFinite()) { "Tilt must be finite" }
+    require(animation.duration.isFinite() && animation.duration >= Duration.ZERO) {
+      "Duration must be finite and nonnegative"
+    }
+    val guard = gestureAuthority.beginProgrammatic(currentCoroutineContext()[Job])
+    awaitAttachment()
+      .animateCameraAround(
+        anchor,
+        zoom,
+        bearing,
+        tilt,
+        animation.copy(duration = animation.duration.scaledBy(systemAnimatorDurationScale())),
+        guard,
+      )
   }
 
   /**

--- a/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
+++ b/lib/maplibre-compose/src/commonTest/kotlin/org/maplibre/compose/map/MapPresentationTest.kt
@@ -33,6 +33,7 @@ import kotlinx.serialization.json.double
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
+import org.maplibre.compose.camera.CameraAnchor
 import org.maplibre.compose.camera.CameraAnimation
 import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.camera.Viewport
@@ -1914,6 +1915,35 @@ class MapPresentationTest {
   }
 
   @Test
+  fun an_anchored_animation_waits_for_a_viewport_but_does_not_restart_after_detach() = runTest {
+    val runtime = mapRuntimeForTest(physicalScope = backgroundScope)
+    val state = runtime.createMapState(BaseStyle.Empty)
+    val animation = async {
+      state.animateCameraAround(CameraAnchor.Screen(DpOffset(10.dp, 10.dp)), zoom = 4.0)
+    }
+    testScheduler.runCurrent()
+    assertFalse(animation.isCompleted)
+    val token = state.reservePresentation()
+    val first = PresentationTestAdapter()
+    state.publishPresentation(token, first)
+    testScheduler.runCurrent()
+    assertFalse(first.animationStarted.isCompleted)
+    requireNotNull(state.currentMapAttachment).updateViewport(testViewport())
+    first.animationStarted.await()
+    state.releasePresentation(token, first)
+    testScheduler.runCurrent()
+    assertTrue(animation.isCancelled)
+    val replacement = PresentationTestAdapter()
+    state.publishPresentation(state.reservePresentation(), replacement)
+    requireNotNull(state.currentMapAttachment).updateViewport(testViewport())
+    testScheduler.runCurrent()
+    assertFalse(replacement.animationStarted.isCompleted)
+    state.close()
+    state.awaitClosed()
+    runtime.close()
+  }
+
+  @Test
   fun the_latest_camera_animation_waits_for_a_viewport_and_restarts_on_replacement() = runTest {
     val runtime = mapRuntimeForTest(physicalScope = backgroundScope)
     val state = runtime.createMapState(BaseStyle.Demo)
@@ -2227,6 +2257,18 @@ internal open class PresentationTestAdapter(
   override suspend fun animateCameraPosition(
     finalPosition: CameraPosition,
     animation: CameraAnimation,
+    guard: CameraCommandGuard?,
+  ) {
+    animationStarted.complete(Unit)
+    finishAnimation.await()
+  }
+
+  override suspend fun animateCameraAround(
+    anchor: CameraAnchor,
+    zoom: Double?,
+    bearing: Double?,
+    tilt: Double?,
+    animation: CameraAnimation.Ease,
     guard: CameraCommandGuard?,
   ) {
     animationStarted.complete(Unit)

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsTypes.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/gljs/GlJsTypes.kt
@@ -256,6 +256,17 @@ internal fun MaplibreMap.isCameraEasing(): Boolean {
 }
 
 /**
+ * Use the transform's surface test: projecting an intersection behind the camera can round-trip.
+ */
+internal fun MaplibreMap.isPointOnMapSurface(point: Point): Boolean {
+  val transform = asDynamic()._camera.transform
+  check(jsTypeOf(transform.isPointOnMapSurface) == "function") {
+    "MapLibre's transform no longer has an isPointOnMapSurface method"
+  }
+  return transform.isPointOnMapSurface(point, asDynamic().terrain) as Boolean
+}
+
+/**
  * Returns `[x, y]`. GL JS treats only an `Array` or a `Point` instance as query geometry. A plain
  * `{x, y}` object is not geometry, so the query uses the whole viewport.
  */

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.asPromise
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.serialization.json.JsonObject
+import org.maplibre.compose.camera.CameraAnchor
 import org.maplibre.compose.camera.CameraAnimation
 import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.camera.CubicBezier
@@ -29,6 +30,7 @@ import org.maplibre.compose.camera.internal.CameraCommandGuard
 import org.maplibre.compose.camera.internal.CameraInputTarget
 import org.maplibre.compose.camera.internal.CameraInputToken
 import org.maplibre.compose.camera.internal.runCameraCommand
+import org.maplibre.compose.camera.resolveScreenPoint
 import org.maplibre.compose.expressions.ast.CompiledExpression
 import org.maplibre.compose.expressions.value.BooleanValue
 import org.maplibre.compose.gljs.CameraForBoundsOptions
@@ -417,6 +419,8 @@ internal class GlJsMapSession(
 
   private fun applyExtent(map: MaplibreMap, extent: MapExtent) {
     if (extent == appliedExtent) return
+    if (appliedExtent.width != extent.width || appliedExtent.height != extent.height)
+      cancelAnchoredTransition()
     appliedExtent = extent
     container?.let { host ->
       host.style.width = "${extent.width}px"
@@ -822,6 +826,7 @@ internal class GlJsMapSession(
   override fun setCameraPadding(padding: PaddingValues) {
     val resolved = padding.toPaddingOptions(layoutDirection)
     if (cameraPadding.sameAs(resolved)) return
+    cancelAnchoredTransition()
     cameraPadding = resolved
     onMap { map -> map.jumpTo(unsafeJso<JumpToOptions> { this.padding = resolved }) }
   }
@@ -884,6 +889,40 @@ internal class GlJsMapSession(
     guard: CameraCommandGuard?,
   ) {
     awaitCameraRelease(guard = guard) { map -> map.animateTo(finalPosition, animation) }
+  }
+
+  override suspend fun animateCameraAround(
+    anchor: CameraAnchor,
+    zoom: Double?,
+    bearing: Double?,
+    tilt: Double?,
+    animation: CameraAnimation.Ease,
+    guard: CameraCommandGuard?,
+  ) {
+    awaitCameraRelease(guard = guard, anchored = true) { map ->
+      val extent = appliedExtent
+      val point =
+        anchor.resolveScreenPoint(
+          androidx.compose.ui.unit.DpSize(extent.width.dp, extent.height.dp),
+          centerLongitude = map.getCenter().lng,
+          project = { position ->
+            val longitude =
+              with(AngleMath) { map.getCenter().lng + position.longitude.diff(map.getCenter().lng) }
+            map.project(LngLat(lng = longitude, lat = position.latitude)).toDpOffset()
+          },
+          unproject = { map.unprojectAt(it.x.value.toDouble(), it.y.value.toDouble()) },
+        )
+      map.easeTo(
+        unsafeJso<EaseToOptions> {
+          around = map.unprojectAt(point.x.value.toDouble(), point.y.value.toDouble()).toLngLat()
+          zoom?.let { this.zoom = it }
+          bearing?.let { this.bearing = it }
+          tilt?.let { pitch = it }
+          duration = animation.duration.inWholeMilliseconds.toDouble()
+          easing = animation.easing.toEasingFunction()
+        }
+      )
+    }
   }
 
   override suspend fun animateCameraToBounds(
@@ -1099,6 +1138,7 @@ internal class GlJsMapSession(
   private suspend fun awaitCameraRelease(
     gestureToken: CameraInputToken? = null,
     guard: CameraCommandGuard? = null,
+    anchored: Boolean = false,
     start: (MaplibreMap) -> Unit,
   ) = suspendCancellableCoroutine { continuation ->
     val pending =
@@ -1112,6 +1152,7 @@ internal class GlJsMapSession(
                 activate = { activateGesture(gestureToken) },
               ) {
                 startTransitionOnMap(current, start, continuation)
+                if (anchored && continuation.isActive) anchoredTransition = continuation
               }
           if (!started && continuation.isActive) continuation.resume(Unit)
         },
@@ -1122,6 +1163,7 @@ internal class GlJsMapSession(
         pendingInitialStyleAction = null
         return@invokeOnCancellation
       }
+      if (anchoredTransition === continuation) anchoredTransition = null
       if (transitionWaiters.remove(continuation)) map?.stop()
     }
     val enqueue: () -> Unit = {
@@ -1158,10 +1200,19 @@ internal class GlJsMapSession(
     else if (continuation.isActive) continuation.resume(Unit)
   }
 
+  private var anchoredTransition: CancellableContinuation<Unit>? = null
+
+  private fun cancelAnchoredTransition() {
+    val continuation = anchoredTransition
+    anchoredTransition = null
+    continuation?.cancel(kotlinx.coroutines.CancellationException("The anchor viewport changed"))
+  }
+
   private fun resumeTransitions() {
     if (transitionWaiters.isEmpty()) return
     val resuming = transitionWaiters.toList()
     transitionWaiters.clear()
+    if (anchoredTransition in resuming) anchoredTransition = null
     resuming.forEach { waiter -> if (waiter.isActive) runCatching { waiter.resume(Unit) } }
   }
 

--- a/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
+++ b/lib/maplibre-compose/src/jsMain/kotlin/org/maplibre/compose/map/GlJsMapSession.kt
@@ -55,6 +55,7 @@ import org.maplibre.compose.gljs.QueryGeometry
 import org.maplibre.compose.gljs.QueryRenderedFeaturesOptions
 import org.maplibre.compose.gljs.SetStyleOptions
 import org.maplibre.compose.gljs.isCameraEasing
+import org.maplibre.compose.gljs.isPointOnMapSurface
 import org.maplibre.compose.gljs.isTerminalStyleLoadFailure
 import org.maplibre.compose.gljs.queryBox
 import org.maplibre.compose.gljs.queryPoint
@@ -912,6 +913,9 @@ internal class GlJsMapSession(
           },
           unproject = { map.unprojectAt(it.x.value.toDouble(), it.y.value.toDouble()) },
         )
+      // A behind-camera intersection can round-trip through project/unproject. Ask the engine
+      // whether this screen point is on the map, independently of its visible world copy.
+      require(map.isPointOnMapSurface(point.toPoint())) { "The anchor must project onto the map" }
       map.easeTo(
         unsafeJso<EaseToOptions> {
           around = map.unprojectAt(point.x.value.toDouble(), point.y.value.toDouble()).toLngLat()

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserCameraTransitionLifecycleTest.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/map/BrowserCameraTransitionLifecycleTest.kt
@@ -2,9 +2,13 @@ package org.maplibre.compose.map
 
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.dp
 import js.objects.unsafeJso
 import kotlin.js.Promise
+import kotlin.math.abs
 import kotlin.test.Test
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
@@ -12,10 +16,12 @@ import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
+import org.maplibre.compose.camera.CameraAnchor
 import org.maplibre.compose.camera.CameraAnimation
 import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.gljs.GlJsMapEvent
 import org.maplibre.compose.gljs.isNear
+import org.maplibre.compose.gljs.isPointOnMapSurface
 import org.maplibre.compose.gljs.runBrowserMapTest
 import org.maplibre.compose.gljs.setBrowserMapContent
 import org.maplibre.compose.gljs.waitUntilMap
@@ -23,10 +29,44 @@ import org.maplibre.compose.style.BaseStyle
 import org.maplibre.compose.testing.MapTestResult
 import org.maplibre.compose.testing.createMapFixture
 import org.maplibre.compose.testing.runMapTest
+import org.maplibre.compose.util.toPoint
 import org.maplibre.spatialk.geojson.Position
 
 @OptIn(ExperimentalTestApi::class)
 class BrowserCameraTransitionLifecycleTest {
+
+  @Test
+  fun a_screen_anchor_above_the_horizon_is_rejected_in_a_distant_world_copy(): MapTestResult =
+    runMapTest {
+      createMapFixture(MapExtent.fromLogical(width = 2048, height = 512, scaleFactor = 1.0)).use {
+        fixture ->
+        fixture.loadStyle(BaseStyle.Empty)
+        fixture.awaitMapReady()
+        fixture.session.setCameraConstraints(CameraConstraints(maxPitch = 85.0))
+        fixture.state.setCameraPosition(CameraPosition(zoom = 1.0, tilt = 80.0))
+        fixture.pumpUntil("the pitched camera to apply") {
+          abs(fixture.session.getCameraPosition().tilt - 80.0) < 0.01
+        }
+        val point = DpOffset(50.dp, 0.dp)
+        val map = requireNotNull((fixture.session as GlJsMapSession).engineMapForTest())
+        assertFalse(
+          map.isPointOnMapSurface(point.toPoint()),
+          "the anchor must lie above the horizon",
+        )
+        val location = requireNotNull(fixture.state.positionFromScreenLocation(point))
+        val before = fixture.session.getCameraPosition()
+        assertTrue(
+          abs(location.longitude - before.target.longitude) > 180.0,
+          "the unprojected location must lie in a distant world copy: $location",
+        )
+        assertFailsWith<IllegalArgumentException> {
+          fixture.awaitWhileRendering("anchor validation") {
+            fixture.state.animateCameraAround(CameraAnchor.Screen(point), zoom = 3.0)
+          }
+        }
+        assertTrue(fixture.session.getCameraPosition().isNear(before))
+      }
+    }
 
   @Test
   fun cancelling_transitions_releases_an_animation_queued_before_the_first_style(): MapTestResult =

--- a/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/testing/GlJsMapFixture.kt
+++ b/lib/maplibre-compose/src/jsTest/kotlin/org/maplibre/compose/testing/GlJsMapFixture.kt
@@ -28,7 +28,7 @@ import org.maplibre.compose.style.DesiredStyleRevision
 import org.maplibre.compose.style.StyleBinding
 
 /** A [GlJsMapSession] on a canvas of its own, with no Compose or skiko, never composited. */
-internal class GlJsMapFixture(private val extent: MapExtent) : MapFixture {
+internal class GlJsMapFixture(private var extent: MapExtent) : MapFixture {
 
   private val recorder = RecordingMapCallbacks()
   private val runtime = mapRuntimeForTest()
@@ -110,6 +110,10 @@ internal class GlJsMapFixture(private val extent: MapExtent) : MapFixture {
 
   override suspend fun awaitMapReady(timeout: Duration) {
     pumpUntil("the map to render its first frame", timeout) { hasRendered }
+  }
+
+  override fun resize(extent: MapExtent) {
+    this.extent = extent
   }
 
   override suspend fun pump(frames: Int) {

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/MapCameraTransitionTest.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/map/MapCameraTransitionTest.kt
@@ -1,10 +1,12 @@
 package org.maplibre.compose.map
 
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import kotlin.math.abs
 import kotlin.test.Test
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.milliseconds
@@ -15,6 +17,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
+import org.maplibre.compose.camera.CameraAnchor
 import org.maplibre.compose.camera.CameraAnimation
 import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.style.BaseStyle
@@ -601,6 +604,230 @@ class MapCameraTransitionTest {
         it.assertLanded(TARGET, "the newer command")
       }
     }
+
+  @Test
+  fun anchored_easing_preserves_a_screen_point_through_zoom_rotation_and_tilt(): MapTestResult =
+    runMapTest {
+      if (systemAnimatorDurationScale() == 0f) skipMapTest("System animations are disabled")
+      createMapFixture().use { fixture ->
+        fixture.startAt(START.copy(zoom = 8.0, bearing = 25.0, tilt = 35.0))
+        fixture.session.setCameraPadding(CAMERA_PADDING)
+        fixture.pump(frames = 3)
+        val point = DpOffset(190.dp, 300.dp)
+        val location = requireNotNull(fixture.session.positionFromScreenLocation(point))
+        val animation =
+          launch(Dispatchers.Default) {
+            fixture.state.animateCameraAround(
+              CameraAnchor.Screen(point),
+              zoom = 10.0,
+              bearing = 110.0,
+              tilt = 55.0,
+              animation = CameraAnimation.Ease(1.seconds),
+            )
+          }
+        var intermediate = false
+        fixture.pumpUntil("the anchored ease to finish") {
+          fixture.assertAnchor(location, point)
+          val zoom = fixture.session.getCameraPosition().zoom
+          intermediate = intermediate || zoom in 8.1..9.9
+          animation.isCompleted
+        }
+        assertFalse(animation.isCancelled)
+        assertTrue(intermediate, "the animation must preserve the anchor between endpoints")
+        fixture.assertAnchor(location, point)
+        val camera = fixture.session.getCameraPosition()
+        assertNear(10.0, camera.zoom, "zoom")
+        assertNear(110.0, camera.bearing, "bearing")
+        assertNear(55.0, camera.tilt, "tilt")
+        fixture.assertCameraTarget(camera, CAMERA_PADDING)
+      }
+    }
+
+  @Test
+  fun a_geographic_anchor_uses_the_nearest_world_copy_and_an_instant_anchored_endpoint():
+    MapTestResult = runMapTest {
+    createMapFixture().use { fixture ->
+      fixture.startAt(START.copy(target = Position(179.0, 0.0), zoom = 3.0, tilt = 40.0))
+      val location = Position(-179.0, 1.0)
+      val point = requireNotNull(fixture.session.screenLocationFromPosition(location))
+      fixture.awaitWhileRendering("the instant anchored zoom") {
+        fixture.state.animateCameraAround(
+          CameraAnchor.Geographic(location),
+          zoom = 5.0,
+          animation = CameraAnimation.Ease(0.milliseconds),
+        )
+      }
+      fixture.assertAnchor(location, point)
+      assertNear(5.0, fixture.session.getCameraPosition().zoom, "zoom")
+      assertNear(40.0, fixture.session.getCameraPosition().tilt, "omitted tilt")
+      assertNear(0.0, fixture.session.getCameraPosition().bearing, "omitted bearing")
+      val unwrapped = requireNotNull(fixture.session.positionFromScreenLocation(point))
+      val center = fixture.session.getCameraPosition().target.longitude
+      val expectedLongitude =
+        location.longitude + 360.0 * kotlin.math.round((center - location.longitude) / 360.0)
+      assertNear(
+        expectedLongitude,
+        unwrapped.longitude,
+        "unprojection must retain the actual world copy",
+      )
+      fixture.awaitWhileRendering("another anchored move from the unwrapped center") {
+        fixture.state.animateCameraAround(
+          CameraAnchor.Geographic(location),
+          bearing = 45.0,
+          animation = CameraAnimation.Ease(0.milliseconds),
+        )
+      }
+      fixture.assertAnchor(location, point)
+      assertNear(5.0, fixture.session.getCameraPosition().zoom, "omitted zoom")
+    }
+  }
+
+  @Test
+  fun a_screen_anchor_can_select_a_distant_visible_world_copy(): MapTestResult = runMapTest {
+    createMapFixture(MapExtent.fromLogical(width = 2048, height = 512, scaleFactor = 1.0)).use {
+      fixture ->
+      fixture.startAt(START.copy(zoom = 1.0, bearing = 15.0))
+      val point = DpOffset(50.dp, 256.dp)
+      val location = requireNotNull(fixture.session.positionFromScreenLocation(point))
+      assertTrue(abs(location.longitude) > 180.0, "the anchor must select another world copy")
+      val animation =
+        launch(Dispatchers.Default) {
+          fixture.state.animateCameraAround(
+            CameraAnchor.Screen(point),
+            zoom = 2.0,
+            animation = CameraAnimation.Ease(500.milliseconds),
+          )
+        }
+      fixture.pumpUntil("the anchored zoom in a repeated world") {
+        val actual = requireNotNull(fixture.session.positionFromScreenLocation(point))
+        val delta =
+          ((actual.longitude - location.longitude + 180.0) % 360.0 + 360.0) % 360.0 - 180.0
+        assertNear(0.0, delta, "anchor longitude")
+        assertNear(location.latitude, actual.latitude, "anchor latitude")
+        animation.isCompleted
+      }
+      assertFalse(animation.isCancelled)
+      assertNear(2.0, fixture.session.getCameraPosition().zoom, "zoom")
+    }
+  }
+
+  @Test
+  fun changing_padding_cancels_an_anchored_animation(): MapTestResult = runMapTest {
+    createMapFixture().use { fixture ->
+      fixture.assertAnchoredCancellation { fixture.session.setCameraPadding(CAMERA_PADDING) }
+    }
+  }
+
+  @Test
+  fun resizing_cancels_an_anchored_animation(): MapTestResult = runMapTest {
+    createMapFixture().use { fixture ->
+      fixture.assertAnchoredCancellation {
+        fixture.resize(MapExtent.fromLogical(width = 600, height = 400, scaleFactor = 1.0))
+      }
+    }
+  }
+
+  @Test
+  fun changing_only_pixel_density_keeps_the_anchor_animation_running(): MapTestResult = runMapTest {
+    if (systemAnimatorDurationScale() == 0f) skipMapTest("System animations are disabled")
+    createMapFixture().use { fixture ->
+      fixture.startAtOrigin()
+      val point = DpOffset(190.dp, 300.dp)
+      val location = requireNotNull(fixture.session.positionFromScreenLocation(point))
+      val animation =
+        launch(Dispatchers.Default) {
+          fixture.state.animateCameraAround(
+            CameraAnchor.Screen(point),
+            zoom = 5.0,
+            animation = CameraAnimation.Ease(1.seconds),
+          )
+        }
+      fixture.awaitCameraMoving()
+      fixture.resize(MapFixture.RETINA_EXTENT)
+      fixture.pumpUntil("the animation to complete after changing density") {
+        fixture.assertAnchor(location, point)
+        animation.isCompleted
+      }
+      assertFalse(animation.isCancelled)
+      assertNear(5.0, fixture.session.getCameraPosition().zoom, "target zoom")
+    }
+  }
+
+  @Test
+  fun an_anchored_animation_obeys_zoom_and_tilt_constraints(): MapTestResult = runMapTest {
+    createMapFixture().use { fixture ->
+      fixture.startAtOrigin()
+      fixture.session.setCameraConstraints(TEST_CONSTRAINTS.copy(maxZoom = 4.0, maxPitch = 45.0))
+      fixture.pump(frames = 3)
+      val point = DpOffset(190.dp, 300.dp)
+      val location = requireNotNull(fixture.session.positionFromScreenLocation(point))
+      fixture.awaitWhileRendering("the constrained anchored animation") {
+        fixture.state.animateCameraAround(
+          CameraAnchor.Screen(point),
+          zoom = 10.0,
+          tilt = 60.0,
+          animation = CameraAnimation.Ease(0.milliseconds),
+        )
+      }
+      assertNear(4.0, fixture.session.getCameraPosition().zoom, "constrained zoom")
+      assertNear(45.0, fixture.session.getCameraPosition().tilt, "constrained tilt")
+      fixture.assertAnchor(location, point)
+    }
+  }
+
+  @Test
+  fun a_new_camera_command_cancels_an_anchored_animation(): MapTestResult = runMapTest {
+    createMapFixture().use { fixture ->
+      fixture.assertAnchoredCancellation { fixture.state.setCameraPosition(START) }
+    }
+  }
+
+  @Test
+  fun an_anchor_outside_the_viewport_is_rejected_without_moving_the_camera(): MapTestResult =
+    runMapTest {
+      createMapFixture().use { fixture ->
+        fixture.startAtOrigin()
+        assertFailsWith<IllegalArgumentException> {
+          fixture.awaitWhileRendering("anchor validation") {
+            fixture.state.animateCameraAround(
+              CameraAnchor.Screen(DpOffset((-1).dp, 100.dp)),
+              zoom = 10.0,
+            )
+          }
+        }
+        assertNear(START.zoom, fixture.session.getCameraPosition().zoom, "unchanged zoom")
+      }
+    }
+
+  private suspend fun MapFixture.assertAnchoredCancellation(change: () -> Unit) = coroutineScope {
+    if (systemAnimatorDurationScale() == 0f) skipMapTest("System animations are disabled")
+    startAtOrigin()
+    val animation =
+      launch(Dispatchers.Default) {
+        state.animateCameraAround(
+          CameraAnchor.Screen(DpOffset(190.dp, 300.dp)),
+          zoom = 10.0,
+          animation = CameraAnimation.Ease(30.seconds),
+        )
+      }
+    awaitCameraMoving()
+    change()
+    pumpUntil("the anchored animation to cancel") { animation.isCompleted }
+    assertTrue(animation.isCancelled)
+    val stopped = session.getCameraPosition()
+    assertTrue(stopped.zoom < 9.0, "cancellation must not jump to the destination")
+    var frames = 0
+    pumpUntil("the camera to stay stopped") { ++frames >= 10 }
+    assertNear(stopped.zoom, session.getCameraPosition().zoom, "stopped zoom")
+  }
+
+  private fun MapFixture.assertAnchor(location: Position, point: DpOffset) {
+    val actual = requireNotNull(session.screenLocationFromPosition(location))
+    assertTrue(
+      abs(actual.x.value - point.x.value) < 0.5f && abs(actual.y.value - point.y.value) < 0.5f,
+      "anchor moved from $point to $actual at ${session.getCameraPosition()}",
+    )
+  }
 
   private suspend fun MapFixture.startAtOrigin() = startAt(START)
 

--- a/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/testing/MapFixture.kt
+++ b/lib/maplibre-compose/src/liveMapTest/kotlin/org/maplibre/compose/testing/MapFixture.kt
@@ -51,6 +51,9 @@ internal interface MapFixture : AutoCloseable {
   /** Renders until the map has drawn once. */
   suspend fun awaitMapReady(timeout: Duration = 30.seconds)
 
+  /** Changes the logical viewport on the next rendered frame. */
+  fun resize(extent: MapExtent)
+
   suspend fun pump(frames: Int = 30)
 
   /** A camera transition and a tile load both advance from inside a render. */

--- a/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
+++ b/lib/maplibre-compose/src/maplibreNativeMain/kotlin/org/maplibre/compose/map/MlnFfiMapSession.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.DpRect
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
 import kotlin.concurrent.Volatile
 import kotlin.concurrent.atomics.AtomicBoolean
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
@@ -24,6 +25,7 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.io.files.Path
 import kotlinx.serialization.json.JsonObject
+import org.maplibre.compose.camera.CameraAnchor
 import org.maplibre.compose.camera.CameraAnimation
 import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.camera.Viewport
@@ -33,6 +35,7 @@ import org.maplibre.compose.camera.internal.CameraInputTarget
 import org.maplibre.compose.camera.internal.CameraInputToken
 import org.maplibre.compose.camera.internal.boxZoomFit
 import org.maplibre.compose.camera.internal.runCameraCommand
+import org.maplibre.compose.camera.resolveScreenPoint
 import org.maplibre.compose.expressions.ast.CompiledExpression
 import org.maplibre.compose.expressions.value.BooleanValue
 import org.maplibre.compose.interaction.BearingSnapping
@@ -877,6 +880,10 @@ internal class MlnFfiMapSession(
           val id = payload.transitionId
           if (currentTransitionId == id) currentTransitionId = null
           val waiter = transitionWaiters.remove(id)
+          if (anchoredTransition === waiter) {
+            anchoredTransition = null
+            anchoredSize = null
+          }
           if (waiter == null) {
             // Expected after a cancellation: the caller withdrew before native finished.
             logger?.d { "Ignoring the end of unknown camera transition $id" }
@@ -1055,6 +1062,8 @@ internal class MlnFfiMapSession(
     val request = viewportRequest?.takeUnless { it === appliedViewportRequest } ?: return
     val size = map.size
     if (size.width != request.extent.width || size.height != request.extent.height) return
+    if (anchoredSize?.let { it.width != size.width.dp || it.height != size.height.dp } == true)
+      cancelAnchoredTransition()
     applyCameraPadding(map)
     snapshotViewport(map)
     // Keep the last usable viewport during resize and surface loss. A detached presentation
@@ -1221,6 +1230,7 @@ internal class MlnFfiMapSession(
       VisibleRegion(Position(0.0, 0.0), Position(0.0, 0.0), Position(0.0, 0.0), Position(0.0, 0.0)),
     val visibleBounds: VisibleBounds = VisibleBounds(Position(0.0, 0.0), Position(0.0, 0.0)),
     val projection: MapProjectionHandle? = null,
+    val wrappedProjection: MapProjectionHandle? = null,
   )
 
   @Volatile private var mirroredViewport = MirroredViewport()
@@ -1252,6 +1262,10 @@ internal class MlnFfiMapSession(
         visibleBounds = geometry.visibleBounds,
         // A fresh handle per snapshot: createProjection freezes the transform at creation.
         projection = map.createProjection(),
+        wrappedProjection =
+          if (geometry.camera.target.longitude !in -180.0..<180.0) {
+            map.createWrappedProjection()
+          } else null,
       )
     )
   }
@@ -1259,10 +1273,11 @@ internal class MlnFfiMapSession(
   private fun retireProjection() {
     val previous = projectionLock.withLock {
       val current = mirroredViewport
-      mirroredViewport = current.copy(projection = null)
+      mirroredViewport = current.copy(projection = null, wrappedProjection = null)
       current
     }
     runCatching { previous.projection?.close() }
+    runCatching { previous.wrappedProjection?.close() }
   }
 
   private fun publishViewport(next: MirroredViewport) {
@@ -1272,6 +1287,7 @@ internal class MlnFfiMapSession(
       current
     }
     runCatching { previous.projection?.close() }
+    runCatching { previous.wrappedProjection?.close() }
   }
 
   override fun getCameraPosition(): CameraPosition = mirroredViewport.camera
@@ -1296,6 +1312,7 @@ internal class MlnFfiMapSession(
   private fun applyCameraPadding(map: MapHandle) {
     val padding = cameraPadding
     if (padding == appliedCameraPadding) return
+    cancelAnchoredTransition()
     map.jumpTo(CameraOptions().also { it.padding = padding })
     appliedCameraPadding = padding
   }
@@ -1415,6 +1432,42 @@ internal class MlnFfiMapSession(
     }
   }
 
+  override suspend fun animateCameraAround(
+    anchor: CameraAnchor,
+    zoom: Double?,
+    bearing: Double?,
+    tilt: Double?,
+    animation: CameraAnimation.Ease,
+    guard: CameraCommandGuard?,
+  ) {
+    startTransitionAwaitingRelease(
+      animation.toAnimationOptions(),
+      guard = guard,
+      anchored = true,
+    ) { map, options ->
+      val size = map.size
+      val point =
+        map.createWrappedProjection().use { projection ->
+          anchor.resolveScreenPoint(
+            DpSize(size.width.dp, size.height.dp),
+            centerLongitude = checkNotNull(projection.camera.center).longitude,
+            project = { projection.pixelForLatLng(it.toLatLng()).toDpOffset() },
+            unproject = { projection.latLngForPixelUnwrapped(it.toScreenPoint()).toPosition() },
+          )
+        }
+      map.easeTo(
+        CameraOptions().also {
+          it.anchor = point.toScreenPoint()
+          it.zoom = zoom
+          it.bearing = bearing
+          it.pitch = tilt
+          it.padding = appliedCameraPadding
+        },
+        options,
+      )
+    }
+  }
+
   override suspend fun animateCameraToBounds(
     boundingBox: BoundingBox,
     bearing: Double,
@@ -1495,6 +1548,7 @@ internal class MlnFfiMapSession(
     animation: AnimationOptions,
     gestureToken: CameraInputToken? = null,
     guard: CameraCommandGuard? = null,
+    anchored: Boolean = false,
     shouldStart: (MapHandle) -> Boolean = { true },
     start: (MapHandle, AnimationOptions) -> Unit,
   ): Unit = suspendCancellableCoroutine { continuation ->
@@ -1509,8 +1563,13 @@ internal class MlnFfiMapSession(
                   guard,
                   activate = { gestureToken?.let { activateGesture(map, it) } },
                 ) {
-                  if (shouldStart(map)) startTransitionOnMap(map, animation, start, continuation)
-                  else if (continuation.isActive) continuation.resume(Unit)
+                  if (shouldStart(map)) {
+                    startTransitionOnMap(map, animation, start, continuation)
+                    if (anchored && continuation.isActive) {
+                      anchoredTransition = continuation
+                      anchoredSize = DpSize(map.size.width.dp, map.size.height.dp)
+                    }
+                  } else if (continuation.isActive) continuation.resume(Unit)
                 }
             if (!started && continuation.isActive) continuation.resume(Unit)
           },
@@ -1546,6 +1605,17 @@ internal class MlnFfiMapSession(
     continuation.invokeOnCancellation { abandonTransition(id) }
   }
 
+  private var anchoredTransition: CancellableContinuation<Unit>? = null
+  private var anchoredSize: DpSize? = null
+
+  /** Owner thread only. Cancellation stops only the transition registered to this continuation. */
+  private fun cancelAnchoredTransition() {
+    val continuation = anchoredTransition
+    anchoredTransition = null
+    anchoredSize = null
+    continuation?.cancel(kotlinx.coroutines.CancellationException("The anchor viewport changed"))
+  }
+
   /** Owner-thread state, like the two maps below. */
   private var lastTransitionId = 0L
 
@@ -1568,7 +1638,11 @@ internal class MlnFfiMapSession(
   }
 
   private fun forgetTransition(id: Long) {
-    transitionWaiters.remove(id)
+    val waiter = transitionWaiters.remove(id)
+    if (anchoredTransition === waiter) {
+      anchoredTransition = null
+      anchoredSize = null
+    }
     if (currentTransitionId == id) currentTransitionId = null
   }
 
@@ -1583,6 +1657,8 @@ internal class MlnFfiMapSession(
 
   /** Closing a map discards its queued events, so no finish event will follow. */
   private fun resumeStrandedTransitions() {
+    anchoredTransition = null
+    anchoredSize = null
     val waiters = transitionWaiters.values.toList()
     transitionWaiters.clear()
     currentTransitionId = null
@@ -1725,8 +1801,34 @@ internal class MlnFfiMapSession(
     }
   }
 
-  override fun screenLocationFromPosition(position: Position): DpOffset? = withSnapshotProjection {
-    it.pixelForLatLng(position.toLatLng()).toDpOffset()
+  override fun screenLocationFromPosition(position: Position): DpOffset? = projectionLock.withLock {
+    val snapshot = mirroredViewport
+    val projection = snapshot.wrappedProjection ?: snapshot.projection ?: return@withLock null
+    projection.pixelForLatLng(position.toLatLng()).toDpOffset()
+  }
+
+  /**
+   * Native projects against a wrapped center, but anchored moves can leave the transform in another
+   * world. Normalize a standalone projection for geographic-to-screen conversion. Keep the raw
+   * snapshot separately so screen-to-geographic conversion still preserves the actual world copy.
+   */
+  private fun MapHandle.createWrappedProjection(): MapProjectionHandle {
+    val projection = createProjection()
+    try {
+      val center = camera.center
+      if (center != null && center.longitude !in -180.0..<180.0) {
+        val longitude = ((center.longitude + 180.0) % 360.0 + 360.0) % 360.0 - 180.0
+        projection.setCamera(
+          CameraOptions().also {
+            it.center = Position(longitude, center.latitude).toLatLng()
+          }
+        )
+      }
+      return projection
+    } catch (error: Throwable) {
+      projection.close()
+      throw error
+    }
   }
 
   /**

--- a/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/testing/MlnFfiMapFixture.kt
+++ b/lib/maplibre-compose/src/maplibreNativeTest/kotlin/org/maplibre/compose/testing/MlnFfiMapFixture.kt
@@ -14,7 +14,7 @@ import org.maplibre.compose.style.DesiredStyleRevision
 import org.maplibre.compose.style.StyleBinding
 
 /** The map runs on threads of its own, so blocking the test thread in a wait stops nothing. */
-internal class MlnFfiMapFixture(val bridge: BridgeMapFixture, private val extent: MapExtent) :
+internal class MlnFfiMapFixture(val bridge: BridgeMapFixture, private var extent: MapExtent) :
   MapFixture {
 
   override val state = bridge.state
@@ -59,6 +59,10 @@ internal class MlnFfiMapFixture(val bridge: BridgeMapFixture, private val extent
 
   override suspend fun awaitMapReady(timeout: Duration) {
     bridge.pumpUntilRendered(extent, timeout)
+  }
+
+  override fun resize(extent: MapExtent) {
+    this.extent = extent
   }
 
   override suspend fun pump(frames: Int) {


### PR DESCRIPTION
## Description

Fixes #1397.

Add `MapState.animateCameraAround` with screen or geographic anchors and optional zoom, bearing, and tilt. Anchors resolve when easing starts. Persistent padding participates in projection; logical resizing, padding changes, and attachment loss cancel the animation without restarting it. Camera constraints take precedence over anchor preservation.

Keep Native coordinate conversion consistent after anchored moves cross the antimeridian, using a separate wrapped projection without changing the live camera or unwrapped coordinate reads. Add API documentation and a compiled usage example.

## Validation

- `mise run test:desktop` on macOS/Metal: 962 library tests, 7 platform skips. After the final repeated-world validation change, the focused camera suite passed all 33 tests.
- `mise run test:js`: 1,294 library tests passed across Chromium and Firefox.
- `mise run build:docs`: passed, including internal API links and shared/native metadata compilation.
- `mise run check`, final `mise run fix`, and `git diff --check`: passed.

The above-horizon anchor regression fails without the browser surface check in both browsers.

Tests sample intermediate anchor positions, tilted cameras with asymmetric padding, repeated worlds, zero duration, omitted values, camera constraints, cancellation, and density changes. Android/iOS device execution and other desktop platforms were not run locally.

## AI assistance

Codex (GPT-6) assisted with the API design, implementation, documentation, tests, and PR text.
